### PR TITLE
update the solution before the convergence criteria control flow

### DIFF
--- a/modules-local/beamdyn/src/BeamDyn.f90
+++ b/modules-local/beamdyn/src/BeamDyn.f90
@@ -3697,14 +3697,14 @@ SUBROUTINE BD_DynamicSolutionGA2( x, OtherState, u, p, m, ErrStat, ErrMsg)
          ! Check for convergence
        Enorm = SQRT(abs(DOT_PRODUCT(m%LP_RHS_LU, m%LP_RHS(7:p%dof_total))))
 
+       CALL BD_UpdateDynamicGA2(p,m,x,OtherState)
+
        IF(i==1) THEN
            Eref = Enorm*p%tol
            IF(Enorm .LE. 1.0_DbKi) RETURN       !FIXME: Do we want a hardcoded limit like this?
        ELSE
            IF(Enorm .LE. Eref) RETURN
        ENDIF
-
-       CALL BD_UpdateDynamicGA2(p,m,x,OtherState)
 
    ENDDO
 


### PR DESCRIPTION
This pull request modifies `SUBROUTINE BD_DynamicSolutionGA2` to update the dynamic quantities before entering the control flow for checking convergence rather than after. Since the convergence control flow returns immediately if the convergence criteria is met, this pull request ensures that the solution will be properly updated **during** the iteration that reaches convergence.