### PR TITLE
beamdyn and orcaflex updates

### DIFF
--- a/modules-local/beamdyn/src/Driver_Beam_Subs.f90
+++ b/modules-local/beamdyn/src/Driver_Beam_Subs.f90
@@ -83,6 +83,7 @@ module BeamDyn_driver_subs
    INTEGER(IntKi)               :: UnEc
    
    CHARACTER(1024)              :: FTitle                       ! "File Title": the 2nd line of the input file, which contains a description of its contents
+   CHARACTER(1024)              :: PriPath                      ! Path name of the primary file
 
    INTEGER(IntKi)               :: i
 !------------------------------------------------------------------------------------
@@ -98,6 +99,8 @@ module BeamDyn_driver_subs
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF (ErrStat >= AbortErrLev) RETURN
       
+   CALL GetPath( DvrInputFile, PriPath )     ! Input files will be relative to the path where the primary input file is located.
+
    !-------------------------- HEADER ---------------------------------------------
    CALL ReadCom(UnIn,DvrInputFile,'File Header: Module Version (line 1)',ErrStat2,ErrMsg2,UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
@@ -270,6 +273,8 @@ module BeamDyn_driver_subs
       !---------------------- BEAM SECTIONAL PARAMETER ----------------------------------------
    CALL ReadVar ( UnIn, DvrInputFile, InitInputData%InputFile, 'InputFile', 'Name of the primary input file', ErrStat2,ErrMsg2, UnEc )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      IF ( PathIsRelative( InitInputData%InputFile ) ) InitInputData%InputFile = TRIM(PriPath)//TRIM(InitInputData%InputFile)
+
    if (ErrStat >= AbortErrLev) then
        call cleanup()
        return

--- a/modules-local/beamdyn/src/Driver_Beam_Subs.f90
+++ b/modules-local/beamdyn/src/Driver_Beam_Subs.f90
@@ -27,26 +27,22 @@ module BeamDyn_driver_subs
    TYPE , PUBLIC :: BD_DriverInternalType
       REAL(ReKi)     , DIMENSION(1:6)               :: DistrLoad        !< Constant distributed load along beam axis, 3 forces and 3 moments [-]
       REAL(ReKi)     , DIMENSION(1:6)               :: TipLoad          !< Constant point load applied at tip, 3 forces and 3 moments [-]
-      INTEGER(IntKi)                                :: NumPointLoads    !< Number of constant point loads applied along beam axis, 3 forces and 3 moments [-]
-      REAL(ReKi) ,     DIMENSION(:,:), ALLOCATABLE  :: MultiPointLoad   !< Constant point loads applied along beam axis (index 1= Relative position along blade span; indices 2-7 = Fx, Fy, Fz, Mx, My, Mz) [-]
-!  INTEGER(IntKi)                :: NumPointLoads               !< Number of multi-point loads in the driver input file
-!  REAL(DbKi)                    :: MultiPointLoads{:}{:}       !< The array of multipoint loads Index 1: [1, NumPointLoads]; 
-                                                                !< Index 2: [1,7] (index of Loads 1   = Relative position along blade span;
-                                                                !!                                2-7 = Fx, Fy, Fz, Mx, My, Mz )
-            
-      TYPE(MeshType)                   :: mplMotion  ! Mesh for blade motion at multipoint loads locations
-      TYPE(MeshType)                   :: mplLoads   ! Mesh for multipoint loads
-      TYPE(MeshMapType)                :: Map_BldMotion_to_mplMotion
-      TYPE(MeshMapType)                :: Map_mplLoads_to_PointLoad
-      TYPE(MeshType)                   :: y_BldMotion_at_u_point ! Intermediate mesh to transfer motion from output mesh to input mesh
-      TYPE(MeshMapType)                :: Map_y_BldMotion_to_u_point
-            
-      TYPE(MeshType)                   :: RotationCenter
-      TYPE(MeshMapType)                :: Map_RotationCenter_to_RootMotion
+      INTEGER(IntKi)                                :: NumPointLoads    !< Number of constant point loads applied along beam axis, 3 forces and 3 moments, from the driver input file [-]
+      REAL(BDKi) ,     DIMENSION(:,:), ALLOCATABLE  :: MultiPointLoad   !< Constant point loads applied along beam axis, size (NumPointLoads,7); (dimension 2: index 1=Relative position along blade span; indices 2-7 = Fx, Fy, Fz, Mx, My, Mz) [-]            
       
-      REAL(DbKi)                       :: t_initial
-      REAL(DbKi)                       :: t_final
-      REAL(ReKi)                       :: w           ! magnitude of rotational velocity vector
+      TYPE(MeshType)                                :: mplMotion        ! Mesh for blade motion at multipoint loads locations
+      TYPE(MeshType)                                :: mplLoads         ! Mesh for multipoint loads
+      TYPE(MeshMapType)                             :: Map_BldMotion_to_mplMotion
+      TYPE(MeshMapType)                             :: Map_mplLoads_to_PointLoad
+      TYPE(MeshType)                                :: y_BldMotion_at_u_point ! Intermediate mesh to transfer motion from output mesh to input mesh
+      TYPE(MeshMapType)                             :: Map_y_BldMotion_to_u_point
+      
+      TYPE(MeshType)                                :: RotationCenter
+      TYPE(MeshMapType)                             :: Map_RotationCenter_to_RootMotion
+      
+      REAL(DbKi)                                    :: t_initial
+      REAL(DbKi)                                    :: t_final
+      REAL(R8Ki)                                    :: w           ! magnitude of rotational velocity vector
       
    END TYPE
    
@@ -591,8 +587,8 @@ SUBROUTINE Init_RotationCenterMesh(DvrData, InitInputData, RootMotionMesh, ErrSt
 
    DvrData%w = TwoNorm( InitInputData%RootVel(4:6) )
    
-   if (EqualRealNos(DvrData%w,0.0_ReKi)) then
-      DvrData%w = 0.0_ReKi
+   if (EqualRealNos(DvrData%w,0.0_R8Ki)) then
+      DvrData%w = 0.0_R8Ki
          ! the beam is not rotating, so pick an orientation
       call eye(orientation, ErrStat2, ErrMsg2)
    else

--- a/modules-local/beamdyn/src/Driver_Beam_Subs.f90
+++ b/modules-local/beamdyn/src/Driver_Beam_Subs.f90
@@ -594,13 +594,13 @@ SUBROUTINE Init_RotationCenterMesh(DvrData, InitInputData, RootMotionMesh, ErrSt
    else
       z_hat = InitInputData%RootVel(4:6) / DvrData%w
       
-      if ( EqualRealNos( z_hat(3), 1.0_ReKi ) ) then
+      if ( EqualRealNos( z_hat(3), 1.0_R8Ki ) ) then
          call eye(orientation, ErrStat2, ErrMsg2)
-      elseif ( EqualRealNos( z_hat(3), -1.0_ReKi ) ) then
+      elseif ( EqualRealNos( z_hat(3), -1.0_R8Ki ) ) then
          orientation = 0.0_ReKi
-         orientation(1,1) = -1.0_ReKi
-         orientation(2,2) =  1.0_ReKi
-         orientation(3,3) = -1.0_ReKi
+         orientation(1,1) = -1.0_R8Ki
+         orientation(2,2) =  1.0_R8Ki
+         orientation(3,3) = -1.0_R8Ki
       else
          
          Z_unit = (/0, 0, 1/)

--- a/modules-local/orcaflex-interface/src/OrcaDriver_Subs.f90
+++ b/modules-local/orcaflex-interface/src/OrcaDriver_Subs.f90
@@ -1907,12 +1907,13 @@ SUBROUTINE PointsForce_OutputWrite(ProgInfo, OutUnit, OutFileName, InputFileName
 
          ! Temporary local variables
    INTEGER(IntKi)                                     :: ErrStatTmp           !< Temporary variable for the status of error message
-   CHARACTER(*),              PARAMETER               :: RoutineName = 'PointsForce_OutputWrite'
+   CHARACTER(*),                       PARAMETER      :: RoutineName = 'PointsForce_OutputWrite'
    CHARACTER(2048)                                    :: ErrMsgTmp            !< Temporary variable for the error message
    INTEGER(IntKi)                                     :: LenErrMsgTmp         !< Length of ErrMsgTmp (for getting WindGrid info)
    REAL(ReKi)                                         :: rotdisp(3)           !< Rotational displacement (euler angles)
    INTEGER(IntKi)                                     :: I                    !< Generic counter
-
+   REAL(ReKi)                                         :: outputArray(13)
+   
    CHARACTER(47)                                      :: PointsOutputFmt      !< Format specifier for the output file for wave elevation series
    CHARACTER(3)                                       :: AngleUnit            !< Units for the angle
 
@@ -1972,32 +1973,30 @@ SUBROUTINE PointsForce_OutputWrite(ProgInfo, OutUnit, OutFileName, InputFileName
       WRITE (OutUnit,'(A)', IOSTAT=ErrStatTmp ) ''
    ENDIF
 
-
    rotdisp = GetSmllRotAngs ( u%PtfmMesh%Orientation(:,:,1), ErrStatTmp, ErrMsgTmp )
    CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName )
 
-
    IF ( AnglesInDegrees ) THEN
-      CALL WrNumAryFileNR( OutUnit,   (/ REAL(Time, ReKi),                                                                    &
-                     u%PtfmMesh%TranslationDisp(1,1), u%PtfmMesh%TranslationDisp(2,1), u%PtfmMesh%TranslationDisp(3,1),       &
-                     rotdisp(1)*R2D,                  rotdisp(2)*R2D,                  rotdisp(3)*R2D,                        &
-                     u%PtfmMesh%TranslationVel(1,1),  u%PtfmMesh%TranslationVel(2,1),  u%PtfmMesh%TranslationVel(3,1),        &
-                     u%PtfmMesh%RotationVel(1,1)*R2D, u%PtfmMesh%RotationVel(2,1)*R2D, u%PtfmMesh%RotationVel(3,1)*R2D  /),   &
-                     '3x,ES10.3E2', ErrStatTmp, ErrMsgTmp )
-      CALL WrNumAryFileNR( OutUnit, y%WriteOutput, '3x,ES10.3E2', ErrStatTmp, ErrMsgTmp )
-      WRITE (OutUnit,'(A)', IOSTAT=ErrStatTmp ) ''
+      outputArray = (/ REAL(Time, ReKi),                                                                                     &
+                    REAL(u%PtfmMesh%TranslationDisp(1,1), ReKi),                                                             &
+                    REAL(u%PtfmMesh%TranslationDisp(2,1), ReKi),                                                             &
+                    REAL(u%PtfmMesh%TranslationDisp(3,1), ReKi),                                                             &
+                    rotdisp(1)*R2D,                  rotdisp(2)*R2D,                  rotdisp(3)*R2D,                        &
+                    u%PtfmMesh%TranslationVel(1,1),  u%PtfmMesh%TranslationVel(2,1),  u%PtfmMesh%TranslationVel(3,1),        &
+                    u%PtfmMesh%RotationVel(1,1)*R2D, u%PtfmMesh%RotationVel(2,1)*R2D, u%PtfmMesh%RotationVel(3,1)*R2D  /)
    ELSE
-      CALL WrNumAryFileNR( OutUnit,   (/ REAL(Time, ReKi),                                                                    &
-                     u%PtfmMesh%TranslationDisp(1,1), u%PtfmMesh%TranslationDisp(2,1), u%PtfmMesh%TranslationDisp(3,1),       &
-                     rotdisp(1),                      rotdisp(2),                      rotdisp(3),                            &
-                     u%PtfmMesh%TranslationVel(1,1),  u%PtfmMesh%TranslationVel(2,1),  u%PtfmMesh%TranslationVel(3,1),        &
-                     u%PtfmMesh%RotationVel(1,1),     u%PtfmMesh%RotationVel(2,1),     u%PtfmMesh%RotationVel(3,1)      /),   &
-                     '3x,ES10.3E2', ErrStatTmp, ErrMsgTmp )
-      CALL WrNumAryFileNR( OutUnit, y%WriteOutput, '3x,ES10.3E2', ErrStatTmp, ErrMsgTmp )
-      WRITE (OutUnit,'(A)', IOSTAT=ErrStatTmp ) ''
+      outputArray = (/ REAL(Time, ReKi),                                                                                     &
+                    REAL(u%PtfmMesh%TranslationDisp(1,1), ReKi),                                                             &
+                    REAL(u%PtfmMesh%TranslationDisp(2,1), ReKi),                                                             &
+                    REAL(u%PtfmMesh%TranslationDisp(3,1), ReKi),                                                             &
+                    rotdisp(1),                      rotdisp(2),                      rotdisp(3),                            &
+                    u%PtfmMesh%TranslationVel(1,1),  u%PtfmMesh%TranslationVel(2,1),  u%PtfmMesh%TranslationVel(3,1),        &
+                    u%PtfmMesh%RotationVel(1,1),     u%PtfmMesh%RotationVel(2,1),     u%PtfmMesh%RotationVel(3,1)      /)
    ENDIF
-
-
+   
+   CALL WrNumAryFileNR( OutUnit, outputArray, '3x,ES10.3E2', ErrStatTmp, ErrMsgTmp )
+   CALL WrNumAryFileNR( OutUnit, y%WriteOutput, '3x,ES10.3E2', ErrStatTmp, ErrMsgTmp )
+   WRITE (OutUnit,'(A)', IOSTAT=ErrStatTmp ) ''
 
 END SUBROUTINE PointsForce_OutputWrite
 


### PR DESCRIPTION
This pull request updates beamdyn_driver and orcaflex_driver with handling for single precision builds. Currently, building in single precision causes compiler errors in these two module drivers due to type mismatches.

Also in this pull request is an update to BD_CrvExtractCrv which improves upon the arithmetic set up in #31. 

All of the BeamDyn updates were adapted from @bjonkman's fork at [f/Envision-BeamDyn](https://github.com/bjonkman/openfast/tree/f/Envision-BeamDyn).

The regression test completed with these results:
```
96% tests passed, 1 tests failed out of 27

Label Time Summary:
aerodyn14     = 3145.73 sec (7 tests)
aerodyn15     = 14563.32 sec (19 tests)
beamdyn       = 1359.88 sec (2 tests)
elastodyn     = 16350.83 sec (25 tests)
hydrodyn      = 8735.51 sec (7 tests)
map           = 1403.95 sec (3 tests)
moordyn       = 841.59 sec (1 test)
openfast      = 17709.05 sec (26 tests)
regression    =   1.67 sec (1 test)
servodyn      = 17697.20 sec (25 tests)
subdyn        = 6489.97 sec (3 tests)

Total Test time (real) = 3388.56 sec

The following tests FAILED:
	 26 - 5MW_Land_BD_DLL_WTurb (Failed)
Errors while running CTest

```

It is expected that the test case running BeamDyn would have very small changes in the solution. Further investigation reveals that the three failing channels contained negligible differences in the solutions:

![b1rootfyr](https://user-images.githubusercontent.com/28060019/28703470-828d4db6-7321-11e7-822b-cc4d41956433.png)
![twrbsfxt](https://user-images.githubusercontent.com/28060019/28703471-82afe0e2-7321-11e7-8bcc-0cbbfdf809b1.png)
![twrbsmzt](https://user-images.githubusercontent.com/28060019/28703472-82b22334-7321-11e7-9186-4e5691b9362a.png)

