### PR TITLE
bug fix in searching for SysIVF

### DIFF
--- a/modules-local/nwtc-library/CMakeLists.txt
+++ b/modules-local/nwtc-library/CMakeLists.txt
@@ -51,7 +51,7 @@ elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel")
   if (APPLE OR UNIX)
     set(NWTC_SYS_FILE src/SysIFL.f90)
   elseif (WIN32)
-    set(NWTC_SYS_FILE src/SysIFV.f90)
+    set(NWTC_SYS_FILE src/SysIVF.f90)
   endif (APPLE OR UNIX)
 endif ()
 


### PR DESCRIPTION
CMake was looking for `SysIFV.f90` but the correct file is `SysIVF.f90`. This only affects CMake for Visual Studio, so current CMake users would not have experienced a problem and won't experience any change going forward.