### PR TITLE
Add support for MinGW-w64

### DIFF
--- a/modules-ext/map/src/cminpack/cminpack.h
+++ b/modules-ext/map/src/cminpack/cminpack.h
@@ -54,7 +54,7 @@ building a DLL on windows.
 #define CMINPACK_DECLSPEC_IMPORT  _Import
 #endif
 
-#if !defined(CMINPACK_NO_DLL) && (defined(__WIN32__) || defined(WIN32) || defined (_WIN32))
+#if !defined(CMINPACK_NO_DLL) && (defined(__WIN32__) || defined(WIN32) || defined (_WIN32)) && !defined (__MINGW32__)
 #if defined(cminpack_EXPORTS) || defined(CMINPACK_EXPORTS) || defined(CMINPACK_DLL_EXPORTS)
     #define  CMINPACK_EXPORT CMINPACK_DECLSPEC_EXPORT
   #else

--- a/modules-ext/map/src/outputstream.c
+++ b/modules-ext/map/src/outputstream.c
@@ -934,7 +934,7 @@ MAP_ERROR_CODE write_expanded_input_file_to_summary_file(FILE* file, Initializat
 };
 
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 MAP_ERROR_CODE fopen_s(FILE** f, const char* name, const char* mode)
 {
   assert(f);

--- a/modules-ext/map/src/outputstream.h
+++ b/modules-ext/map/src/outputstream.h
@@ -32,7 +32,7 @@
 #include "MAP_Types.h"
 
 
-#if !defined(_MSC_VER)
+#if !defined(_MSC_VER) && !defined(__MINGW32__)
 MAP_ERROR_CODE fopen_s(FILE** f, const char* name, const char* mode);
 #endif
 

--- a/modules-local/fast-library/CMakeLists.txt
+++ b/modules-local/fast-library/CMakeLists.txt
@@ -57,6 +57,10 @@ add_library(openfastlib
   src/FAST_Library.f90)
 target_link_libraries(openfastlib
   openfast_postlib openfast_prelib scfastlib foamfastlib)
+if(CMAKE_COMPILER_IS_MINGW)
+  set_target_properties(openfastlib
+                        PROPERTIES LINK_FLAGS "-Wl,--export-all-symbols")
+endif(CMAKE_COMPILER_IS_MINGW)
 
 install(TARGETS openfastlib openfast_prelib openfast_postlib
   EXPORT ${CMAKE_PROJECT_NAME}Libraries


### PR DESCRIPTION
Fix bugs when compile openfast using mingw-w64 on Windows.

Now openfast can be compiled using mingw-w64 with the cmd command below,

```
cmake ^
   -DCMAKE_INSTALL_PREFIX=%install_folder% ^
   -DBUILD_SHARED_LIBS=ON ^
   -G "MinGW Makefiles" ^
   -DBLAS_LIBRARIES:FILEPATH="-lblas -L%folder_of_blas%" ^
   -DLAPACK_LIBRARIES:FILEPATH="-lblas -llapack -L%folder_of_lapack%" ^
   -DCMAKE_BUILD_TYPE=RELEASE ^
../
```

It has been tested on windows 10 using mingw-w64 7.2.0, with the Lapack [here](https://github.com/Reference-LAPACK/lapack).

I don't know why BLAS_LIBRARIES and LAPACK_LIBRARIES here cannot be set the full path of blas and lapack libraries.