### PR TITLE
fix intel compiler warnings on *nix systems

### DIFF
--- a/modules-local/fast-library/CMakeLists.txt
+++ b/modules-local/fast-library/CMakeLists.txt
@@ -14,7 +14,7 @@
 # limitations under the License.
 #
 
-if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+if(APPLE OR UNIX)
   add_definitions(-DIMPLICIT_DLLEXPORT)
 endif()
 

--- a/modules-local/fast-library/CMakeLists.txt
+++ b/modules-local/fast-library/CMakeLists.txt
@@ -14,11 +14,9 @@
 # limitations under the License.
 #
 
-if (APPLE OR UNIX)
-  if (FCNAME MATCHES "gfortran.*")
-    add_definitions(-DIMPLICIT_DLLEXPORT)
-  endif (FCNAME MATCHES "gfortran.*")
-endif (APPLE OR UNIX)
+if(${CMAKE_SYSTEM_NAME} MATCHES "Darwin" OR ${CMAKE_SYSTEM_NAME} MATCHES "Linux")
+  add_definitions(-DIMPLICIT_DLLEXPORT)
+endif()
 
 generate_f90_types(src/FAST_Registry.txt FAST_Types.f90 -noextrap)
 

--- a/modules-local/fast-library/src/FAST_Library.f90
+++ b/modules-local/fast-library/src/FAST_Library.f90
@@ -1,53 +1,53 @@
-!  FAST_Library.f90
+!  FAST_Library.f90 
 !
 !  FUNCTIONS/SUBROUTINES exported from FAST_Library.dll:
-!  FAST_Start  - subroutine
-!  FAST_Update - subroutine
-!  FAST_End    - subroutine
-!
+!  FAST_Start  - subroutine 
+!  FAST_Update - subroutine 
+!  FAST_End    - subroutine 
+!   
 ! DO NOT REMOVE or MODIFY LINES starting with "!DEC$" or "!GCC$"
 ! !DEC$ specifies attributes for IVF and !GCC$ specifies attributes for gfortran
 !
-!==================================================================================================================================
+!==================================================================================================================================  
 MODULE FAST_Data
 
    USE, INTRINSIC :: ISO_C_Binding
    USE FAST_Subs   ! all of the ModuleName and ModuleName_types modules are inherited from FAST_Subs
-
+                       
    IMPLICIT  NONE
    SAVE
-
+   
       ! Local parameters:
    REAL(DbKi),     PARAMETER             :: t_initial = 0.0_DbKi     ! Initial time
-   INTEGER(IntKi)                        :: NumTurbines
+   INTEGER(IntKi)                        :: NumTurbines 
    INTEGER,        PARAMETER             :: IntfStrLen  = 1025       ! length of strings through the C interface
    INTEGER(IntKi), PARAMETER             :: MAXOUTPUTS = 1000        ! Maximum number of outputs
    INTEGER(IntKi), PARAMETER             :: MAXInitINPUTS = 10       ! Maximum number of initialization values from Simulink
    INTEGER(IntKi), PARAMETER             :: NumFixedInputs = 8
-
-
+   
+   
       ! Global (static) data:
    TYPE(FAST_TurbineType), ALLOCATABLE   :: Turbine(:)               ! Data for each turbine
    INTEGER(IntKi)                        :: n_t_global               ! simulation time step, loop counter for global (FAST) simulation
    INTEGER(IntKi)                        :: ErrStat                  ! Error status
    CHARACTER(IntfStrLen-1)               :: ErrMsg                   ! Error message  (this needs to be static so that it will print in Matlab's mex library)
-
+   
 contains
-!==================================================================================================================================
+!================================================================================================================================== 
 subroutine FAST_AllocateTurbines(nTurbines, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_AllocateTurbines')
-   IMPLICIT NONE
+   IMPLICIT NONE 
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_AllocateTurbines
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_AllocateTurbines
 #endif
    INTEGER(C_INT),         INTENT(IN   ) :: nTurbines
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
+   
    if (nTurbines .gt. 0) then
       NumTurbines = nTurbines
    end if
-
+   
    if (nTurbines .gt. 10) then
       call wrscr1('Number of turbines is > 10! Are you sure you have enough memory?')
       call wrscr1('Proceeding anyway')
@@ -58,64 +58,64 @@ subroutine FAST_AllocateTurbines(nTurbines, ErrStat_c, ErrMsg_c) BIND (C, NAME='
 end subroutine FAST_AllocateTurbines
 
 subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, NumOuts_c, dt_c, ErrStat_c, ErrMsg_c, ChannelNames_c) BIND (C, NAME='FAST_Sizes')
-   IMPLICIT NONE
+   IMPLICIT NONE 
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_Sizes
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Sizes
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax
-   REAL(C_DOUBLE),         INTENT(IN   ) :: InitInpAry(MAXInitINPUTS)
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
-   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax      
+   REAL(C_DOUBLE),         INTENT(IN   ) :: InitInpAry(MAXInitINPUTS)      
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)      
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c      
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
    CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ChannelNames_c(ChanLen*MAXOUTPUTS+1)
-
+   
    ! local
-   CHARACTER(IntfStrLen)               :: InputFileName
+   CHARACTER(IntfStrLen)               :: InputFileName   
    INTEGER                             :: i, j, k
    TYPE(FAST_ExternInitType)           :: ExternInitData
-
-      ! transfer the character array from C to a Fortran string:
+   
+      ! transfer the character array from C to a Fortran string:   
    InputFileName = TRANSFER( InputFileName_c, InputFileName )
    I = INDEX(InputFileName,C_NULL_CHAR) - 1            ! if this has a c null character at the end...
    IF ( I > 0 ) InputFileName = InputFileName(1:I)     ! remove it
-
-      ! initialize variables:
+   
+      ! initialize variables:   
    n_t_global = 0
-
+   
    ExternInitData%TMax       = TMax
    ExternInitData%TurbineID  = -1        ! we're not going to use this to simulate a wind farm
    ExternInitData%TurbinePos = 0.0_ReKi  ! turbine position is at the origin
    ExternInitData%NumCtrl2SC = 0
    ExternInitData%NumSC2Ctrl = 0
-   ExternInitData%SensorType = NINT(InitInpAry(1))
-
+   ExternInitData%SensorType = NINT(InitInpAry(1))   
+   
    IF ( NINT(InitInpAry(2)) == 1 ) THEN
       ExternInitData%LidRadialVel = .true.
    ELSE
       ExternInitData%LidRadialVel = .false.
    END IF
-
-
-
+   
+   
+   
    CALL FAST_InitializeAll_T( t_initial, 1_IntKi, Turbine(iTurb), ErrStat, ErrMsg, InputFileName, ExternInitData )
-
-   AbortErrLev_c = AbortErrLev
+                  
+   AbortErrLev_c = AbortErrLev   
    NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
    dt_c          = Turbine(iTurb)%p_FAST%dt
 
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-
-#ifdef CONSOLE_FILE
+   
+#ifdef CONSOLE_FILE   
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif
-
+#endif   
+    
       ! return the names of the output channels
    IF ( ALLOCATED( Turbine(iTurb)%y_FAST%ChannelNames ) )  then
       k = 1;
@@ -129,36 +129,36 @@ subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, N
    ELSE
       ChannelNames_c = C_NULL_CHAR
    END IF
-
+      
 end subroutine FAST_Sizes
 !==================================================================================================================================
 subroutine FAST_Start(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_Start')
-   IMPLICIT NONE
+   IMPLICIT NONE 
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_Start
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Start
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c
-   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c      
+   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c      
    REAL(C_DOUBLE),         INTENT(IN   ) :: InputAry(NumInputs_c)
    REAL(C_DOUBLE),         INTENT(  OUT) :: OutputAry(NumOutputs_c)
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
 
-
+   
    ! local
-   CHARACTER(IntfStrLen)                 :: InputFileName
+   CHARACTER(IntfStrLen)                 :: InputFileName   
    INTEGER                               :: i
    REAL(ReKi)                            :: Outputs(NumOutputs_c-1)
-
+     
    INTEGER(IntKi)                        :: ErrStat2                                ! Error status
    CHARACTER(IntfStrLen-1)               :: ErrMsg2                                 ! Error message  (this needs to be static so that it will print in Matlab's mex library)
-
-      ! initialize variables:
+   
+      ! initialize variables:   
    n_t_global = 0
 
-#ifdef SIMULINK_DirectFeedThrough
+#ifdef SIMULINK_DirectFeedThrough   
    IF(  NumInputs_c /= NumFixedInputs .AND. NumInputs_c /= NumFixedInputs+3 ) THEN
       ErrStat_c = ErrID_Fatal
       ErrMsg_c  = TRANSFER( "FAST_Start:size of InputAry is invalid."//C_NULL_CHAR, ErrMsg_c )
@@ -167,42 +167,42 @@ subroutine FAST_Start(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Err
 
    CALL FAST_SetExternalInputs(iTurb, NumInputs_c, InputAry, Turbine(iTurb)%m_FAST)
 
-#endif
+#endif      
    !...............................................................................................................................
    ! Initialization of solver: (calculate outputs based on states at t=t_initial as well as guesses of inputs and constraint states)
-   !...............................................................................................................................
-   CALL FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg )
-
+   !...............................................................................................................................  
+   CALL FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg )      
+   
    if (ErrStat <= AbortErrLev) then
          ! return outputs here, too
       IF(NumOutputs_c /= SIZE(Turbine(iTurb)%y_FAST%ChannelNames) ) THEN
          ErrStat = ErrID_Fatal
          ErrMsg  = trim(ErrMsg)//NewLine//"FAST_Start:size of NumOutputs is invalid."
       ELSE
-
-         CALL FillOutputAry_T(Turbine(iTurb), Outputs)
-         OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global
-         OutputAry(2:NumOutputs_c) = Outputs
+      
+         CALL FillOutputAry_T(Turbine(iTurb), Outputs)   
+         OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global 
+         OutputAry(2:NumOutputs_c) = Outputs 
 
          CALL FAST_Linearize_T(t_initial, 0, Turbine(iTurb), ErrStat, ErrMsg)
          if (ErrStat2 /= ErrID_None) then
             ErrStat = max(ErrStat,ErrStat2)
             ErrMsg = TRIM(ErrMsg)//NewLine//TRIM(ErrMsg2)
          end if
-
-
+         
+                  
       END IF
    end if
-
-
+   
+   
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-
-#ifdef CONSOLE_FILE
+   
+#ifdef CONSOLE_FILE   
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif
-
+#endif   
+      
 end subroutine FAST_Start
 !==================================================================================================================================
 subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_Update')
@@ -211,23 +211,23 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_Update
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Update
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c
-   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c      
+   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c      
    REAL(C_DOUBLE),         INTENT(IN   ) :: InputAry(NumInputs_c)
    REAL(C_DOUBLE),         INTENT(  OUT) :: OutputAry(NumOutputs_c)
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
+   
       ! local variables
    REAL(ReKi)                            :: Outputs(NumOutputs_c-1)
    INTEGER(IntKi)                        :: i
    INTEGER(IntKi)                        :: ErrStat2                                ! Error status
    CHARACTER(IntfStrLen-1)               :: ErrMsg2                                 ! Error message  (this needs to be static so that it will print in Matlab's mex library)
-
-
-   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish
-
+                 
+   
+   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish 
+      
       ! we can't continue because we might over-step some arrays that are allocated to the size of the simulation
 
       IF (n_t_global == Turbine(iTurb)%p_FAST%n_TMax_m1 + 1) THEN  ! we call update an extra time in Simulink, which we can ignore until the time shift with outputs is solved
@@ -235,12 +235,12 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
          ErrStat_c = ErrID_None
          ErrMsg = C_NULL_CHAR
          ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-      ELSE
+      ELSE     
          ErrStat_c = ErrID_Info
          ErrMsg = "Simulation completed."//C_NULL_CHAR
          ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
       END IF
-
+      
    ELSEIF(NumOutputs_c /= SIZE(Turbine(iTurb)%y_FAST%ChannelNames) ) THEN
       ErrStat_c = ErrID_Fatal
       ErrMsg    = "FAST_Update:size of OutputAry is invalid or FAST has too many outputs."//C_NULL_CHAR
@@ -255,7 +255,7 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
 
       CALL FAST_SetExternalInputs(iTurb, NumInputs_c, InputAry, Turbine(iTurb)%m_FAST)
 
-      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
+      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )                  
       n_t_global = n_t_global + 1
 
       CALL FAST_Linearize_T( t_initial, n_t_global, Turbine(iTurb), ErrStat2, ErrMsg2)
@@ -263,55 +263,55 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
          ErrStat = max(ErrStat,ErrStat2)
          ErrMsg = TRIM(ErrMsg)//NewLine//TRIM(ErrMsg2)
       end if
-
-
+      
+      
       ! set the outputs for external code here...
       ! return y_FAST%ChannelNames
-
+      
       ErrStat_c     = ErrStat
       ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
       ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
    END IF
+   
+   CALL FillOutputAry_T(Turbine(iTurb), Outputs)   
+   OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global 
+   OutputAry(2:NumOutputs_c) = Outputs 
 
-   CALL FillOutputAry_T(Turbine(iTurb), Outputs)
-   OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global
-   OutputAry(2:NumOutputs_c) = Outputs
-
-#ifdef CONSOLE_FILE
+#ifdef CONSOLE_FILE   
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif
-
-end subroutine FAST_Update
+#endif   
+      
+end subroutine FAST_Update 
 !==================================================================================================================================
 subroutine FAST_SetExternalInputs(iTurb, NumInputs_c, InputAry, m_FAST)
 
    USE, INTRINSIC :: ISO_C_Binding
    USE FAST_Types
 !   USE FAST_Data, only: NumFixedInputs
-
+   
    IMPLICIT  NONE
 
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c      
    REAL(C_DOUBLE),         INTENT(IN   ) :: InputAry(NumInputs_c)                   ! Inputs from Simulink
    TYPE(FAST_MiscVarType), INTENT(INOUT) :: m_FAST                                  ! Miscellaneous variables
-
+   
          ! set the inputs from external code here...
          ! transfer inputs from Simulink to FAST
       IF ( NumInputs_c < NumFixedInputs ) RETURN ! This is an error
-
+      
       m_FAST%ExternInput%GenTrq      = InputAry(1)
       m_FAST%ExternInput%ElecPwr     = InputAry(2)
       m_FAST%ExternInput%YawPosCom   = InputAry(3)
       m_FAST%ExternInput%YawRateCom  = InputAry(4)
       m_FAST%ExternInput%BlPitchCom  = InputAry(5:7)
-      m_FAST%ExternInput%HSSBrFrac   = InputAry(8)
-
+      m_FAST%ExternInput%HSSBrFrac   = InputAry(8)         
+            
       IF ( NumInputs_c > NumFixedInputs ) THEN  ! NumFixedInputs is the fixed number of inputs
          IF ( NumInputs_c == NumFixedInputs + 3 ) &
              m_FAST%ExternInput%LidarFocus = InputAry(9:11)
-      END IF
-
+      END IF   
+      
 end subroutine FAST_SetExternalInputs
 !==================================================================================================================================
 subroutine FAST_End(iTurb, StopTheProgram) BIND (C, NAME='FAST_End')
@@ -320,11 +320,11 @@ subroutine FAST_End(iTurb, StopTheProgram) BIND (C, NAME='FAST_End')
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_End
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_End
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
    LOGICAL(C_BOOL),        INTENT(IN)    :: StopTheProgram   ! flag indicating if the program should end (false if there are more turbines to end)
 
    CALL ExitThisProgram_T( Turbine(iTurb), ErrID_None, LOGICAL(StopTheProgram))
-
+   
 end subroutine FAST_End
 !==================================================================================================================================
 subroutine FAST_CreateCheckpoint(iTurb, CheckpointRootName_c, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_CreateCheckpoint')
@@ -333,41 +333,41 @@ subroutine FAST_CreateCheckpoint(iTurb, CheckpointRootName_c, ErrStat_c, ErrMsg_
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_CreateCheckpoint
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_CreateCheckpoint
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)      
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
+   
    ! local
-   CHARACTER(IntfStrLen)                 :: CheckpointRootName
+   CHARACTER(IntfStrLen)                 :: CheckpointRootName   
    INTEGER(IntKi)                        :: I
    INTEGER(IntKi)                        :: Unit
-
-
-      ! transfer the character array from C to a Fortran string:
+             
+   
+      ! transfer the character array from C to a Fortran string:   
    CheckpointRootName = TRANSFER( CheckpointRootName_c, CheckpointRootName )
    I = INDEX(CheckpointRootName,C_NULL_CHAR) - 1                 ! if this has a c null character at the end...
    IF ( I > 0 ) CheckpointRootName = CheckpointRootName(1:I)     ! remove it
-
+   
    if ( LEN_TRIM(CheckpointRootName) == 0 ) then
       CheckpointRootName = TRIM(Turbine(iTurb)%p_FAST%OutFileRoot)//'.'//trim( Num2LStr(n_t_global) )
    end if
-
-
+   
+      
    Unit = -1
    CALL FAST_CreateCheckpoint_T(t_initial, n_t_global, 1, Turbine(iTurb), CheckpointRootName, ErrStat, ErrMsg, Unit )
 
-      ! transfer Fortran variables to C:
+      ! transfer Fortran variables to C:      
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
 
 
-#ifdef CONSOLE_FILE
+#ifdef CONSOLE_FILE   
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif
-
-end subroutine FAST_CreateCheckpoint
+#endif   
+      
+end subroutine FAST_CreateCheckpoint 
 !==================================================================================================================================
 subroutine FAST_Restart(iTurb, CheckpointRootName_c, AbortErrLev_c, NumOuts_c, dt_c, n_t_global_c, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_Restart')
    IMPLICIT NONE
@@ -375,52 +375,52 @@ subroutine FAST_Restart(iTurb, CheckpointRootName_c, AbortErrLev_c, NumOuts_c, d
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_Restart
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Restart
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
-   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
-   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)      
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c      
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
+   
    ! local
-   CHARACTER(IntfStrLen)                 :: CheckpointRootName
+   CHARACTER(IntfStrLen)                 :: CheckpointRootName   
    INTEGER(IntKi)                        :: I
    INTEGER(IntKi)                        :: Unit
    REAL(DbKi)                            :: t_initial_out
    INTEGER(IntKi)                        :: NumTurbines_out
-   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart'
-
-
-      ! transfer the character array from C to a Fortran string:
+   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart' 
+             
+   
+      ! transfer the character array from C to a Fortran string:   
    CheckpointRootName = TRANSFER( CheckpointRootName_c, CheckpointRootName )
    I = INDEX(CheckpointRootName,C_NULL_CHAR) - 1                 ! if this has a c null character at the end...
    IF ( I > 0 ) CheckpointRootName = CheckpointRootName(1:I)     ! remove it
-
+   
    Unit = -1
    CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(iTurb), CheckpointRootName, ErrStat, ErrMsg, Unit )
-
+   
       ! check that these are valid:
       IF (t_initial_out /= t_initial) CALL SetErrStat(ErrID_Fatal, "invalid value of t_initial.", ErrStat, ErrMsg, RoutineName )
       IF (NumTurbines_out /= 1) CALL SetErrStat(ErrID_Fatal, "invalid value of NumTurbines.", ErrStat, ErrMsg, RoutineName )
-
-
-      ! transfer Fortran variables to C:
+   
+   
+      ! transfer Fortran variables to C: 
    n_t_global_c  = n_t_global
-   AbortErrLev_c = AbortErrLev
+   AbortErrLev_c = AbortErrLev   
    NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
-   dt_c          = Turbine(iTurb)%p_FAST%dt
-
+   dt_c          = Turbine(iTurb)%p_FAST%dt      
+      
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
 
-#ifdef CONSOLE_FILE
+#ifdef CONSOLE_FILE   
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif
-
-end subroutine FAST_Restart
+#endif   
+      
+end subroutine FAST_Restart 
 !==================================================================================================================================
 subroutine FAST_OpFM_Init(iTurb, TMax, InputFileName_c, TurbID, NumSC2Ctrl, NumCtrl2SC, NumActForcePtsBlade, NumActForcePtsTower, TurbPosn, AbortErrLev_c, dt_c, NumBl_c, NumBlElem_c, &
                           OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Init')
@@ -429,41 +429,41 @@ subroutine FAST_OpFM_Init(iTurb, TMax, InputFileName_c, TurbID, NumSC2Ctrl, NumC
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Init
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Init
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax      
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)      
    INTEGER(C_INT),         INTENT(IN   ) :: TurbID           ! Need not be same as iTurb
    INTEGER(C_INT),         INTENT(IN   ) :: NumSC2Ctrl       ! Supercontroller outputs = controller inputs
    INTEGER(C_INT),         INTENT(IN   ) :: NumCtrl2SC       ! controller outputs = Supercontroller inputs
    INTEGER(C_INT),         INTENT(IN   ) :: NumActForcePtsBlade ! number of actuator line force points in blade
    INTEGER(C_INT),         INTENT(IN   ) :: NumActForcePtsTower ! number of actuator line force points in tower
-   REAL(C_FLOAT),          INTENT(IN   ) :: TurbPosn(3)
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
-   INTEGER(C_INT),         INTENT(  OUT) :: NumBl_c
-   INTEGER(C_INT),         INTENT(  OUT) :: NumBlElem_c
+   REAL(C_FLOAT),          INTENT(IN   ) :: TurbPosn(3)      
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: NumBl_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: NumBlElem_c      
    TYPE(OpFM_InputType_C), INTENT(  OUT) :: OpFM_Input_from_FAST
    TYPE(OpFM_OutputType_C),INTENT(  OUT) :: OpFM_Output_to_FAST
    TYPE(SC_InputType_C),   INTENT(INOUT) :: SC_Input_from_FAST
    TYPE(SC_OutputType_C),  INTENT(INOUT) :: SC_Output_to_FAST
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
+      
    ! local
-   CHARACTER(IntfStrLen)                 :: InputFileName
-   INTEGER(C_INT)                        :: i
+   CHARACTER(IntfStrLen)                 :: InputFileName   
+   INTEGER(C_INT)                        :: i    
    TYPE(FAST_ExternInitType)             :: ExternInitData
-
-      ! transfer the character array from C to a Fortran string:
+   
+      ! transfer the character array from C to a Fortran string:   
    InputFileName = TRANSFER( InputFileName_c, InputFileName )
    I = INDEX(InputFileName,C_NULL_CHAR) - 1            ! if this has a c null character at the end...
    IF ( I > 0 ) InputFileName = InputFileName(1:I)     ! remove it
-
-      ! initialize variables:
-   n_t_global = 0
+   
+      ! initialize variables:   
+   n_t_global = 0   
    ErrStat = ErrID_None
    ErrMsg = ""
-
+   
    ExternInitData%TMax = TMax
    ExternInitData%TurbineID = TurbID
    ExternInitData%TurbinePos = TurbPosn
@@ -474,30 +474,30 @@ subroutine FAST_OpFM_Init(iTurb, TMax, InputFileName_c, TurbID, NumSC2Ctrl, NumC
    ExternInitData%NumActForcePtsTower = NumActForcePtsTower
 
    CALL FAST_InitializeAll_T( t_initial, 1_IntKi, Turbine(iTurb), ErrStat, ErrMsg, InputFileName, ExternInitData )
-
+   
       ! set values for return to OpenFOAM
-   AbortErrLev_c = AbortErrLev
+   AbortErrLev_c = AbortErrLev   
    dt_c          = Turbine(iTurb)%p_FAST%dt
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-
+   
    call SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST)
-
-   ! 7-Sep-2015: Sang wants these integers for the OpenFOAM mapping, which is tied to the AeroDyn nodes. FAST doesn't restrict the number of nodes on each
+                        
+   ! 7-Sep-2015: Sang wants these integers for the OpenFOAM mapping, which is tied to the AeroDyn nodes. FAST doesn't restrict the number of nodes on each 
    ! blade mesh to be the same, so if this DOES ever change, we'll need to make OpenFOAM less tied to the AeroDyn mapping.
-   IF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD14) THEN
+   IF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD14) THEN   
       NumBl_c     = SIZE(Turbine(iTurb)%AD14%Input(1)%InputMarkers)
       NumBlElem_c = Turbine(iTurb)%AD14%Input(1)%InputMarkers(1)%Nnodes
-   ELSEIF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD) THEN
+   ELSEIF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD) THEN  
       NumBl_c     = SIZE(Turbine(iTurb)%AD%Input(1)%BladeMotion)
       NumBlElem_c = Turbine(iTurb)%AD%Input(1)%BladeMotion(1)%Nnodes
    ELSE
       NumBl_c     = 0
       NumBlElem_c = 0
-   END IF
-
-end subroutine
+   END IF   
+   
+end subroutine   
 !==================================================================================================================================
 subroutine FAST_OpFM_Solution0(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Solution0')
    IMPLICIT NONE
@@ -505,26 +505,26 @@ subroutine FAST_OpFM_Solution0(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_O
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Solution0
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Solution0
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
 
    if(Turbine(iTurb)%SC%p%scOn) then
       CALL SC_SetOutputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%Input(1), Turbine(iTurb)%SC, ErrStat, ErrMsg)
    end if
-
-   call FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg )
+   
+   call FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg ) 
 
    if(Turbine(iTurb)%SC%p%scOn) then
       CALL SC_SetInputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%y, Turbine(iTurb)%SC, ErrStat, ErrMsg)
    end if
-
+   
       ! set values for return to OpenFOAM
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-
-
+   
+                        
 end subroutine FAST_OpFM_Solution0
 !==================================================================================================================================
 subroutine FAST_OpFM_Restart(iTurb, CheckpointRootName_c, AbortErrLev_c, dt_c, numblades_c, numElementsPerBlade_c, n_t_global_c, &
@@ -534,57 +534,57 @@ subroutine FAST_OpFM_Restart(iTurb, CheckpointRootName_c, AbortErrLev_c, dt_c, n
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Restart
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Restart
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)      
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
    INTEGER(C_INT),         INTENT(  OUT) :: numblades_c
    INTEGER(C_INT),         INTENT(  OUT) :: numElementsPerBlade_c
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
-   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
+   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c      
    TYPE(OpFM_InputType_C), INTENT(  OUT) :: OpFM_Input_from_FAST
    TYPE(OpFM_OutputType_C),INTENT(  OUT) :: OpFM_Output_to_FAST
    TYPE(SC_InputType_C),   INTENT(INOUT) :: SC_Input_from_FAST
    TYPE(SC_OutputType_C),  INTENT(INOUT) :: SC_Output_to_FAST
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
+   
    ! local variables
-   INTEGER(C_INT)                        :: NumOuts_c
-   CHARACTER(IntfStrLen)                 :: CheckpointRootName
+   INTEGER(C_INT)                        :: NumOuts_c      
+   CHARACTER(IntfStrLen)                 :: CheckpointRootName   
    INTEGER(IntKi)                        :: I
    INTEGER(IntKi)                        :: Unit
    REAL(DbKi)                            :: t_initial_out
    INTEGER(IntKi)                        :: NumTurbines_out
-   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart'
-
+   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart' 
+             
    CALL NWTC_Init()
-      ! transfer the character array from C to a Fortran string:
+      ! transfer the character array from C to a Fortran string:   
    CheckpointRootName = TRANSFER( CheckpointRootName_c, CheckpointRootName )
    I = INDEX(CheckpointRootName,C_NULL_CHAR) - 1                 ! if this has a c null character at the end...
    IF ( I > 0 ) CheckpointRootName = CheckpointRootName(1:I)     ! remove it
-
+   
    Unit = -1
    CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(iTurb), CheckpointRootName, ErrStat, ErrMsg, Unit )
-
+   
       ! check that these are valid:
       IF (t_initial_out /= t_initial) CALL SetErrStat(ErrID_Fatal, "invalid value of t_initial.", ErrStat, ErrMsg, RoutineName )
       IF (NumTurbines_out /= 1) CALL SetErrStat(ErrID_Fatal, "invalid value of NumTurbines.", ErrStat, ErrMsg, RoutineName )
-
-       ! transfer Fortran variables to C:
+   
+       ! transfer Fortran variables to C: 
    n_t_global_c  = n_t_global
-   AbortErrLev_c = AbortErrLev
+   AbortErrLev_c = AbortErrLev   
    NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
    numBlades_c   = Turbine(iTurb)%ad%p%numblades
    numElementsPerBlade_c = Turbine(iTurb)%ad%p%numblnds ! I'm not sure if FASTv8 can handle different number of blade nodes for each blade.
-   dt_c          = Turbine(iTurb)%p_FAST%dt
-
+   dt_c          = Turbine(iTurb)%p_FAST%dt      
+      
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
 
-#ifdef CONSOLE_FILE
+#ifdef CONSOLE_FILE   
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif
+#endif   
 
    call SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST)
 
@@ -593,7 +593,7 @@ end subroutine FAST_OpFM_Restart
 subroutine SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST)
 
    IMPLICIT NONE
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
    TYPE(OpFM_InputType_C), INTENT(INOUT) :: OpFM_Input_from_FAST
    TYPE(OpFM_OutputType_C),INTENT(INOUT) :: OpFM_Output_to_FAST
    TYPE(SC_InputType_C),   INTENT(INOUT) :: SC_Input_from_FAST
@@ -618,16 +618,16 @@ subroutine SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST
 
    SC_Input_from_FAST%toSC_Len = Turbine(iTurb)%SC%u%c_obj%toSC_Len
    SC_Input_from_FAST%toSC     = Turbine(iTurb)%SC%u%c_obj%toSC
-
-   OpFM_Output_to_FAST%u_Len   = Turbine(iTurb)%OpFM%y%c_obj%u_Len;  OpFM_Output_to_FAST%u = Turbine(iTurb)%OpFM%y%c_obj%u
-   OpFM_Output_to_FAST%v_Len   = Turbine(iTurb)%OpFM%y%c_obj%v_Len;  OpFM_Output_to_FAST%v = Turbine(iTurb)%OpFM%y%c_obj%v
-   OpFM_Output_to_FAST%w_Len   = Turbine(iTurb)%OpFM%y%c_obj%w_Len;  OpFM_Output_to_FAST%w = Turbine(iTurb)%OpFM%y%c_obj%w
+   
+   OpFM_Output_to_FAST%u_Len   = Turbine(iTurb)%OpFM%y%c_obj%u_Len;  OpFM_Output_to_FAST%u = Turbine(iTurb)%OpFM%y%c_obj%u 
+   OpFM_Output_to_FAST%v_Len   = Turbine(iTurb)%OpFM%y%c_obj%v_Len;  OpFM_Output_to_FAST%v = Turbine(iTurb)%OpFM%y%c_obj%v 
+   OpFM_Output_to_FAST%w_Len   = Turbine(iTurb)%OpFM%y%c_obj%w_Len;  OpFM_Output_to_FAST%w = Turbine(iTurb)%OpFM%y%c_obj%w 
    OpFM_Output_to_FAST%SuperController_Len = Turbine(iTurb)%OpFM%y%c_obj%SuperController_Len
    OpFM_Output_to_FAST%SuperController     = Turbine(iTurb)%OpFM%y%c_obj%SuperController
 
    SC_Output_to_FAST%fromSC_Len = Turbine(iTurb)%SC%y%c_obj%fromSC_Len
    SC_Output_to_FAST%fromSC     = Turbine(iTurb)%SC%y%c_obj%fromSC
-
+      
 end subroutine SetOpenFOAM_pointers
 !==================================================================================================================================
 subroutine FAST_OpFM_Step(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Step')
@@ -636,50 +636,50 @@ subroutine FAST_OpFM_Step(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_S
 !DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Step
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Step
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
-
-
-   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish
-
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
+                    
+   
+   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish 
+      
       ! we can't continue because we might over-step some arrays that are allocated to the size of the simulation
-
+      
       if (iTurb .eq. (NumTurbines-1) ) then
          IF (n_t_global == Turbine(iTurb)%p_FAST%n_TMax_m1 + 1) THEN  ! we call update an extra time in Simulink, which we can ignore until the time shift with outputs is solved
             n_t_global = n_t_global + 1
             ErrStat_c = ErrID_None
             ErrMsg = C_NULL_CHAR
             ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-         ELSE
+         ELSE     
             ErrStat_c = ErrID_Info
             ErrMsg = "Simulation completed."//C_NULL_CHAR
             ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
          END IF
       end if
-
+      
    ELSE
 
       if(Turbine(iTurb)%SC%p%scOn) then
          CALL SC_SetOutputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%Input(1), Turbine(iTurb)%SC, ErrStat, ErrMsg)
       end if
 
-      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
+      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )                  
 
       if(Turbine(iTurb)%SC%p%scOn) then
          CALL SC_SetInputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%y, Turbine(iTurb)%SC, ErrStat, ErrMsg)
       end if
-
+      
       if (iTurb .eq. (NumTurbines-1) ) then
          n_t_global = n_t_global + 1
       end if
-
+            
       ErrStat_c = ErrStat
       ErrMsg = TRIM(ErrMsg)//C_NULL_CHAR
       ErrMsg_c  = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
    END IF
-
-
-end subroutine FAST_OpFM_Step
-!==================================================================================================================================
+   
+      
+end subroutine FAST_OpFM_Step 
+!==================================================================================================================================   
 END MODULE FAST_Data

--- a/modules-local/fast-library/src/FAST_Library.f90
+++ b/modules-local/fast-library/src/FAST_Library.f90
@@ -1,53 +1,53 @@
-!  FAST_Library.f90 
+!  FAST_Library.f90
 !
 !  FUNCTIONS/SUBROUTINES exported from FAST_Library.dll:
-!  FAST_Start  - subroutine 
-!  FAST_Update - subroutine 
-!  FAST_End    - subroutine 
-!   
+!  FAST_Start  - subroutine
+!  FAST_Update - subroutine
+!  FAST_End    - subroutine
+!
 ! DO NOT REMOVE or MODIFY LINES starting with "!DEC$" or "!GCC$"
 ! !DEC$ specifies attributes for IVF and !GCC$ specifies attributes for gfortran
 !
-!==================================================================================================================================  
+!==================================================================================================================================
 MODULE FAST_Data
 
    USE, INTRINSIC :: ISO_C_Binding
    USE FAST_Subs   ! all of the ModuleName and ModuleName_types modules are inherited from FAST_Subs
-                       
+
    IMPLICIT  NONE
    SAVE
-   
+
       ! Local parameters:
    REAL(DbKi),     PARAMETER             :: t_initial = 0.0_DbKi     ! Initial time
-   INTEGER(IntKi)                        :: NumTurbines 
+   INTEGER(IntKi)                        :: NumTurbines
    INTEGER,        PARAMETER             :: IntfStrLen  = 1025       ! length of strings through the C interface
    INTEGER(IntKi), PARAMETER             :: MAXOUTPUTS = 1000        ! Maximum number of outputs
    INTEGER(IntKi), PARAMETER             :: MAXInitINPUTS = 10       ! Maximum number of initialization values from Simulink
    INTEGER(IntKi), PARAMETER             :: NumFixedInputs = 8
-   
-   
+
+
       ! Global (static) data:
    TYPE(FAST_TurbineType), ALLOCATABLE   :: Turbine(:)               ! Data for each turbine
    INTEGER(IntKi)                        :: n_t_global               ! simulation time step, loop counter for global (FAST) simulation
    INTEGER(IntKi)                        :: ErrStat                  ! Error status
    CHARACTER(IntfStrLen-1)               :: ErrMsg                   ! Error message  (this needs to be static so that it will print in Matlab's mex library)
-   
+
 contains
-!================================================================================================================================== 
+!==================================================================================================================================
 subroutine FAST_AllocateTurbines(nTurbines, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_AllocateTurbines')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_AllocateTurbines
-   IMPLICIT NONE 
+   IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_AllocateTurbines
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_AllocateTurbines
 #endif
    INTEGER(C_INT),         INTENT(IN   ) :: nTurbines
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
-   
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
    if (nTurbines .gt. 0) then
       NumTurbines = nTurbines
    end if
-   
+
    if (nTurbines .gt. 10) then
       call wrscr1('Number of turbines is > 10! Are you sure you have enough memory?')
       call wrscr1('Proceeding anyway')
@@ -58,64 +58,64 @@ subroutine FAST_AllocateTurbines(nTurbines, ErrStat_c, ErrMsg_c) BIND (C, NAME='
 end subroutine FAST_AllocateTurbines
 
 subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, NumOuts_c, dt_c, ErrStat_c, ErrMsg_c, ChannelNames_c) BIND (C, NAME='FAST_Sizes')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_Sizes
-   IMPLICIT NONE 
+   IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_Sizes
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Sizes
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax      
-   REAL(C_DOUBLE),         INTENT(IN   ) :: InitInpAry(MAXInitINPUTS)      
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)      
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c      
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax
+   REAL(C_DOUBLE),         INTENT(IN   ) :: InitInpAry(MAXInitINPUTS)
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
+   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
    CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ChannelNames_c(ChanLen*MAXOUTPUTS+1)
-   
+
    ! local
-   CHARACTER(IntfStrLen)               :: InputFileName   
+   CHARACTER(IntfStrLen)               :: InputFileName
    INTEGER                             :: i, j, k
    TYPE(FAST_ExternInitType)           :: ExternInitData
-   
-      ! transfer the character array from C to a Fortran string:   
+
+      ! transfer the character array from C to a Fortran string:
    InputFileName = TRANSFER( InputFileName_c, InputFileName )
    I = INDEX(InputFileName,C_NULL_CHAR) - 1            ! if this has a c null character at the end...
    IF ( I > 0 ) InputFileName = InputFileName(1:I)     ! remove it
-   
-      ! initialize variables:   
+
+      ! initialize variables:
    n_t_global = 0
-   
+
    ExternInitData%TMax       = TMax
    ExternInitData%TurbineID  = -1        ! we're not going to use this to simulate a wind farm
    ExternInitData%TurbinePos = 0.0_ReKi  ! turbine position is at the origin
    ExternInitData%NumCtrl2SC = 0
    ExternInitData%NumSC2Ctrl = 0
-   ExternInitData%SensorType = NINT(InitInpAry(1))   
-   
+   ExternInitData%SensorType = NINT(InitInpAry(1))
+
    IF ( NINT(InitInpAry(2)) == 1 ) THEN
       ExternInitData%LidRadialVel = .true.
    ELSE
       ExternInitData%LidRadialVel = .false.
    END IF
-   
-   
-   
+
+
+
    CALL FAST_InitializeAll_T( t_initial, 1_IntKi, Turbine(iTurb), ErrStat, ErrMsg, InputFileName, ExternInitData )
-                  
-   AbortErrLev_c = AbortErrLev   
+
+   AbortErrLev_c = AbortErrLev
    NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
    dt_c          = Turbine(iTurb)%p_FAST%dt
 
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-   
-#ifdef CONSOLE_FILE   
+
+#ifdef CONSOLE_FILE
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif   
-    
+#endif
+
       ! return the names of the output channels
    IF ( ALLOCATED( Turbine(iTurb)%y_FAST%ChannelNames ) )  then
       k = 1;
@@ -129,36 +129,36 @@ subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, N
    ELSE
       ChannelNames_c = C_NULL_CHAR
    END IF
-      
+
 end subroutine FAST_Sizes
 !==================================================================================================================================
 subroutine FAST_Start(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_Start')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_Start
-   IMPLICIT NONE 
+   IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_Start
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Start
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c      
-   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c      
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c
+   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c
    REAL(C_DOUBLE),         INTENT(IN   ) :: InputAry(NumInputs_c)
    REAL(C_DOUBLE),         INTENT(  OUT) :: OutputAry(NumOutputs_c)
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
 
-   
+
    ! local
-   CHARACTER(IntfStrLen)                 :: InputFileName   
+   CHARACTER(IntfStrLen)                 :: InputFileName
    INTEGER                               :: i
    REAL(ReKi)                            :: Outputs(NumOutputs_c-1)
-     
+
    INTEGER(IntKi)                        :: ErrStat2                                ! Error status
    CHARACTER(IntfStrLen-1)               :: ErrMsg2                                 ! Error message  (this needs to be static so that it will print in Matlab's mex library)
-   
-      ! initialize variables:   
+
+      ! initialize variables:
    n_t_global = 0
 
-#ifdef SIMULINK_DirectFeedThrough   
+#ifdef SIMULINK_DirectFeedThrough
    IF(  NumInputs_c /= NumFixedInputs .AND. NumInputs_c /= NumFixedInputs+3 ) THEN
       ErrStat_c = ErrID_Fatal
       ErrMsg_c  = TRANSFER( "FAST_Start:size of InputAry is invalid."//C_NULL_CHAR, ErrMsg_c )
@@ -167,67 +167,67 @@ subroutine FAST_Start(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Err
 
    CALL FAST_SetExternalInputs(iTurb, NumInputs_c, InputAry, Turbine(iTurb)%m_FAST)
 
-#endif      
+#endif
    !...............................................................................................................................
    ! Initialization of solver: (calculate outputs based on states at t=t_initial as well as guesses of inputs and constraint states)
-   !...............................................................................................................................  
-   CALL FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg )      
-   
+   !...............................................................................................................................
+   CALL FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg )
+
    if (ErrStat <= AbortErrLev) then
          ! return outputs here, too
       IF(NumOutputs_c /= SIZE(Turbine(iTurb)%y_FAST%ChannelNames) ) THEN
          ErrStat = ErrID_Fatal
          ErrMsg  = trim(ErrMsg)//NewLine//"FAST_Start:size of NumOutputs is invalid."
       ELSE
-      
-         CALL FillOutputAry_T(Turbine(iTurb), Outputs)   
-         OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global 
-         OutputAry(2:NumOutputs_c) = Outputs 
+
+         CALL FillOutputAry_T(Turbine(iTurb), Outputs)
+         OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global
+         OutputAry(2:NumOutputs_c) = Outputs
 
          CALL FAST_Linearize_T(t_initial, 0, Turbine(iTurb), ErrStat, ErrMsg)
          if (ErrStat2 /= ErrID_None) then
             ErrStat = max(ErrStat,ErrStat2)
             ErrMsg = TRIM(ErrMsg)//NewLine//TRIM(ErrMsg2)
          end if
-         
-                  
+
+
       END IF
    end if
-   
-   
+
+
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-   
-#ifdef CONSOLE_FILE   
+
+#ifdef CONSOLE_FILE
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif   
-      
+#endif
+
 end subroutine FAST_Start
 !==================================================================================================================================
 subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_Update')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_Update
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_Update
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Update
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c      
-   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c      
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c
+   INTEGER(C_INT),         INTENT(IN   ) :: NumOutputs_c
    REAL(C_DOUBLE),         INTENT(IN   ) :: InputAry(NumInputs_c)
    REAL(C_DOUBLE),         INTENT(  OUT) :: OutputAry(NumOutputs_c)
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
-   
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
       ! local variables
    REAL(ReKi)                            :: Outputs(NumOutputs_c-1)
    INTEGER(IntKi)                        :: i
    INTEGER(IntKi)                        :: ErrStat2                                ! Error status
    CHARACTER(IntfStrLen-1)               :: ErrMsg2                                 ! Error message  (this needs to be static so that it will print in Matlab's mex library)
-                 
-   
-   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish 
-      
+
+
+   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish
+
       ! we can't continue because we might over-step some arrays that are allocated to the size of the simulation
 
       IF (n_t_global == Turbine(iTurb)%p_FAST%n_TMax_m1 + 1) THEN  ! we call update an extra time in Simulink, which we can ignore until the time shift with outputs is solved
@@ -235,12 +235,12 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
          ErrStat_c = ErrID_None
          ErrMsg = C_NULL_CHAR
          ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-      ELSE     
+      ELSE
          ErrStat_c = ErrID_Info
          ErrMsg = "Simulation completed."//C_NULL_CHAR
          ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
       END IF
-      
+
    ELSEIF(NumOutputs_c /= SIZE(Turbine(iTurb)%y_FAST%ChannelNames) ) THEN
       ErrStat_c = ErrID_Fatal
       ErrMsg    = "FAST_Update:size of OutputAry is invalid or FAST has too many outputs."//C_NULL_CHAR
@@ -255,7 +255,7 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
 
       CALL FAST_SetExternalInputs(iTurb, NumInputs_c, InputAry, Turbine(iTurb)%m_FAST)
 
-      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )                  
+      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
       n_t_global = n_t_global + 1
 
       CALL FAST_Linearize_T( t_initial, n_t_global, Turbine(iTurb), ErrStat2, ErrMsg2)
@@ -263,207 +263,207 @@ subroutine FAST_Update(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Er
          ErrStat = max(ErrStat,ErrStat2)
          ErrMsg = TRIM(ErrMsg)//NewLine//TRIM(ErrMsg2)
       end if
-      
-      
+
+
       ! set the outputs for external code here...
       ! return y_FAST%ChannelNames
-      
+
       ErrStat_c     = ErrStat
       ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
       ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
    END IF
-   
-   CALL FillOutputAry_T(Turbine(iTurb), Outputs)   
-   OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global 
-   OutputAry(2:NumOutputs_c) = Outputs 
 
-#ifdef CONSOLE_FILE   
+   CALL FillOutputAry_T(Turbine(iTurb), Outputs)
+   OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global
+   OutputAry(2:NumOutputs_c) = Outputs
+
+#ifdef CONSOLE_FILE
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif   
-      
-end subroutine FAST_Update 
+#endif
+
+end subroutine FAST_Update
 !==================================================================================================================================
 subroutine FAST_SetExternalInputs(iTurb, NumInputs_c, InputAry, m_FAST)
 
    USE, INTRINSIC :: ISO_C_Binding
    USE FAST_Types
 !   USE FAST_Data, only: NumFixedInputs
-   
+
    IMPLICIT  NONE
 
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c      
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(IN   ) :: NumInputs_c
    REAL(C_DOUBLE),         INTENT(IN   ) :: InputAry(NumInputs_c)                   ! Inputs from Simulink
    TYPE(FAST_MiscVarType), INTENT(INOUT) :: m_FAST                                  ! Miscellaneous variables
-   
+
          ! set the inputs from external code here...
          ! transfer inputs from Simulink to FAST
       IF ( NumInputs_c < NumFixedInputs ) RETURN ! This is an error
-      
+
       m_FAST%ExternInput%GenTrq      = InputAry(1)
       m_FAST%ExternInput%ElecPwr     = InputAry(2)
       m_FAST%ExternInput%YawPosCom   = InputAry(3)
       m_FAST%ExternInput%YawRateCom  = InputAry(4)
       m_FAST%ExternInput%BlPitchCom  = InputAry(5:7)
-      m_FAST%ExternInput%HSSBrFrac   = InputAry(8)         
-            
+      m_FAST%ExternInput%HSSBrFrac   = InputAry(8)
+
       IF ( NumInputs_c > NumFixedInputs ) THEN  ! NumFixedInputs is the fixed number of inputs
          IF ( NumInputs_c == NumFixedInputs + 3 ) &
              m_FAST%ExternInput%LidarFocus = InputAry(9:11)
-      END IF   
-      
+      END IF
+
 end subroutine FAST_SetExternalInputs
 !==================================================================================================================================
 subroutine FAST_End(iTurb, StopTheProgram) BIND (C, NAME='FAST_End')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_End
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_End
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_End
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
    LOGICAL(C_BOOL),        INTENT(IN)    :: StopTheProgram   ! flag indicating if the program should end (false if there are more turbines to end)
 
    CALL ExitThisProgram_T( Turbine(iTurb), ErrID_None, LOGICAL(StopTheProgram))
-   
+
 end subroutine FAST_End
 !==================================================================================================================================
 subroutine FAST_CreateCheckpoint(iTurb, CheckpointRootName_c, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_CreateCheckpoint')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_CreateCheckpoint
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_CreateCheckpoint
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_CreateCheckpoint
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)      
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
-   
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
    ! local
-   CHARACTER(IntfStrLen)                 :: CheckpointRootName   
+   CHARACTER(IntfStrLen)                 :: CheckpointRootName
    INTEGER(IntKi)                        :: I
    INTEGER(IntKi)                        :: Unit
-             
-   
-      ! transfer the character array from C to a Fortran string:   
+
+
+      ! transfer the character array from C to a Fortran string:
    CheckpointRootName = TRANSFER( CheckpointRootName_c, CheckpointRootName )
    I = INDEX(CheckpointRootName,C_NULL_CHAR) - 1                 ! if this has a c null character at the end...
    IF ( I > 0 ) CheckpointRootName = CheckpointRootName(1:I)     ! remove it
-   
+
    if ( LEN_TRIM(CheckpointRootName) == 0 ) then
       CheckpointRootName = TRIM(Turbine(iTurb)%p_FAST%OutFileRoot)//'.'//trim( Num2LStr(n_t_global) )
    end if
-   
-      
+
+
    Unit = -1
    CALL FAST_CreateCheckpoint_T(t_initial, n_t_global, 1, Turbine(iTurb), CheckpointRootName, ErrStat, ErrMsg, Unit )
 
-      ! transfer Fortran variables to C:      
+      ! transfer Fortran variables to C:
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
 
 
-#ifdef CONSOLE_FILE   
+#ifdef CONSOLE_FILE
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif   
-      
-end subroutine FAST_CreateCheckpoint 
+#endif
+
+end subroutine FAST_CreateCheckpoint
 !==================================================================================================================================
 subroutine FAST_Restart(iTurb, CheckpointRootName_c, AbortErrLev_c, NumOuts_c, dt_c, n_t_global_c, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_Restart')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_Restart
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_Restart
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_Restart
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)      
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c      
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
-   
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
+   INTEGER(C_INT),         INTENT(  OUT) :: NumOuts_c
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
+   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
    ! local
-   CHARACTER(IntfStrLen)                 :: CheckpointRootName   
+   CHARACTER(IntfStrLen)                 :: CheckpointRootName
    INTEGER(IntKi)                        :: I
    INTEGER(IntKi)                        :: Unit
    REAL(DbKi)                            :: t_initial_out
    INTEGER(IntKi)                        :: NumTurbines_out
-   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart' 
-             
-   
-      ! transfer the character array from C to a Fortran string:   
+   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart'
+
+
+      ! transfer the character array from C to a Fortran string:
    CheckpointRootName = TRANSFER( CheckpointRootName_c, CheckpointRootName )
    I = INDEX(CheckpointRootName,C_NULL_CHAR) - 1                 ! if this has a c null character at the end...
    IF ( I > 0 ) CheckpointRootName = CheckpointRootName(1:I)     ! remove it
-   
+
    Unit = -1
    CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(iTurb), CheckpointRootName, ErrStat, ErrMsg, Unit )
-   
+
       ! check that these are valid:
       IF (t_initial_out /= t_initial) CALL SetErrStat(ErrID_Fatal, "invalid value of t_initial.", ErrStat, ErrMsg, RoutineName )
       IF (NumTurbines_out /= 1) CALL SetErrStat(ErrID_Fatal, "invalid value of NumTurbines.", ErrStat, ErrMsg, RoutineName )
-   
-   
-      ! transfer Fortran variables to C: 
+
+
+      ! transfer Fortran variables to C:
    n_t_global_c  = n_t_global
-   AbortErrLev_c = AbortErrLev   
+   AbortErrLev_c = AbortErrLev
    NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
-   dt_c          = Turbine(iTurb)%p_FAST%dt      
-      
+   dt_c          = Turbine(iTurb)%p_FAST%dt
+
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
 
-#ifdef CONSOLE_FILE   
+#ifdef CONSOLE_FILE
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif   
-      
-end subroutine FAST_Restart 
+#endif
+
+end subroutine FAST_Restart
 !==================================================================================================================================
 subroutine FAST_OpFM_Init(iTurb, TMax, InputFileName_c, TurbID, NumSC2Ctrl, NumCtrl2SC, NumActForcePtsBlade, NumActForcePtsTower, TurbPosn, AbortErrLev_c, dt_c, NumBl_c, NumBlElem_c, &
                           OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Init')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_OpFM_Init
-   IMPLICIT NONE 
+   IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Init
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Init
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax      
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)      
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   REAL(C_DOUBLE),         INTENT(IN   ) :: TMax
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: InputFileName_c(IntfStrLen)
    INTEGER(C_INT),         INTENT(IN   ) :: TurbID           ! Need not be same as iTurb
    INTEGER(C_INT),         INTENT(IN   ) :: NumSC2Ctrl       ! Supercontroller outputs = controller inputs
    INTEGER(C_INT),         INTENT(IN   ) :: NumCtrl2SC       ! controller outputs = Supercontroller inputs
    INTEGER(C_INT),         INTENT(IN   ) :: NumActForcePtsBlade ! number of actuator line force points in blade
    INTEGER(C_INT),         INTENT(IN   ) :: NumActForcePtsTower ! number of actuator line force points in tower
-   REAL(C_FLOAT),          INTENT(IN   ) :: TurbPosn(3)      
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: NumBl_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: NumBlElem_c      
+   REAL(C_FLOAT),          INTENT(IN   ) :: TurbPosn(3)
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
+   INTEGER(C_INT),         INTENT(  OUT) :: NumBl_c
+   INTEGER(C_INT),         INTENT(  OUT) :: NumBlElem_c
    TYPE(OpFM_InputType_C), INTENT(  OUT) :: OpFM_Input_from_FAST
    TYPE(OpFM_OutputType_C),INTENT(  OUT) :: OpFM_Output_to_FAST
    TYPE(SC_InputType_C),   INTENT(INOUT) :: SC_Input_from_FAST
    TYPE(SC_OutputType_C),  INTENT(INOUT) :: SC_Output_to_FAST
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
-      
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
    ! local
-   CHARACTER(IntfStrLen)                 :: InputFileName   
-   INTEGER(C_INT)                        :: i    
+   CHARACTER(IntfStrLen)                 :: InputFileName
+   INTEGER(C_INT)                        :: i
    TYPE(FAST_ExternInitType)             :: ExternInitData
-   
-      ! transfer the character array from C to a Fortran string:   
+
+      ! transfer the character array from C to a Fortran string:
    InputFileName = TRANSFER( InputFileName_c, InputFileName )
    I = INDEX(InputFileName,C_NULL_CHAR) - 1            ! if this has a c null character at the end...
    IF ( I > 0 ) InputFileName = InputFileName(1:I)     ! remove it
-   
-      ! initialize variables:   
-   n_t_global = 0   
+
+      ! initialize variables:
+   n_t_global = 0
    ErrStat = ErrID_None
    ErrMsg = ""
-   
+
    ExternInitData%TMax = TMax
    ExternInitData%TurbineID = TurbID
    ExternInitData%TurbinePos = TurbPosn
@@ -474,117 +474,117 @@ subroutine FAST_OpFM_Init(iTurb, TMax, InputFileName_c, TurbID, NumSC2Ctrl, NumC
    ExternInitData%NumActForcePtsTower = NumActForcePtsTower
 
    CALL FAST_InitializeAll_T( t_initial, 1_IntKi, Turbine(iTurb), ErrStat, ErrMsg, InputFileName, ExternInitData )
-   
+
       ! set values for return to OpenFOAM
-   AbortErrLev_c = AbortErrLev   
+   AbortErrLev_c = AbortErrLev
    dt_c          = Turbine(iTurb)%p_FAST%dt
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-   
+
    call SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST)
-                        
-   ! 7-Sep-2015: Sang wants these integers for the OpenFOAM mapping, which is tied to the AeroDyn nodes. FAST doesn't restrict the number of nodes on each 
+
+   ! 7-Sep-2015: Sang wants these integers for the OpenFOAM mapping, which is tied to the AeroDyn nodes. FAST doesn't restrict the number of nodes on each
    ! blade mesh to be the same, so if this DOES ever change, we'll need to make OpenFOAM less tied to the AeroDyn mapping.
-   IF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD14) THEN   
+   IF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD14) THEN
       NumBl_c     = SIZE(Turbine(iTurb)%AD14%Input(1)%InputMarkers)
       NumBlElem_c = Turbine(iTurb)%AD14%Input(1)%InputMarkers(1)%Nnodes
-   ELSEIF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD) THEN  
+   ELSEIF (Turbine(iTurb)%p_FAST%CompAero == MODULE_AD) THEN
       NumBl_c     = SIZE(Turbine(iTurb)%AD%Input(1)%BladeMotion)
       NumBlElem_c = Turbine(iTurb)%AD%Input(1)%BladeMotion(1)%Nnodes
    ELSE
       NumBl_c     = 0
       NumBlElem_c = 0
-   END IF   
-   
-end subroutine   
+   END IF
+
+end subroutine
 !==================================================================================================================================
 subroutine FAST_OpFM_Solution0(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Solution0')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_OpFM_Solution0
-   IMPLICIT NONE 
+   IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Solution0
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Solution0
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
 
    if(Turbine(iTurb)%SC%p%scOn) then
       CALL SC_SetOutputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%Input(1), Turbine(iTurb)%SC, ErrStat, ErrMsg)
    end if
-   
-   call FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg ) 
+
+   call FAST_Solution0_T(Turbine(iTurb), ErrStat, ErrMsg )
 
    if(Turbine(iTurb)%SC%p%scOn) then
       CALL SC_SetInputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%y, Turbine(iTurb)%SC, ErrStat, ErrMsg)
    end if
-   
+
       ! set values for return to OpenFOAM
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-   
-                        
+
+
 end subroutine FAST_OpFM_Solution0
 !==================================================================================================================================
 subroutine FAST_OpFM_Restart(iTurb, CheckpointRootName_c, AbortErrLev_c, dt_c, numblades_c, numElementsPerBlade_c, n_t_global_c, &
                       OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Restart')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_OpFM_Restart
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Restart
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Restart
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)      
-   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c      
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   CHARACTER(KIND=C_CHAR), INTENT(IN   ) :: CheckpointRootName_c(IntfStrLen)
+   INTEGER(C_INT),         INTENT(  OUT) :: AbortErrLev_c
    INTEGER(C_INT),         INTENT(  OUT) :: numblades_c
    INTEGER(C_INT),         INTENT(  OUT) :: numElementsPerBlade_c
-   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c      
-   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c      
+   REAL(C_DOUBLE),         INTENT(  OUT) :: dt_c
+   INTEGER(C_INT),         INTENT(  OUT) :: n_t_global_c
    TYPE(OpFM_InputType_C), INTENT(  OUT) :: OpFM_Input_from_FAST
    TYPE(OpFM_OutputType_C),INTENT(  OUT) :: OpFM_Output_to_FAST
    TYPE(SC_InputType_C),   INTENT(INOUT) :: SC_Input_from_FAST
    TYPE(SC_OutputType_C),  INTENT(INOUT) :: SC_Output_to_FAST
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen) 
-   
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
    ! local variables
-   INTEGER(C_INT)                        :: NumOuts_c      
-   CHARACTER(IntfStrLen)                 :: CheckpointRootName   
+   INTEGER(C_INT)                        :: NumOuts_c
+   CHARACTER(IntfStrLen)                 :: CheckpointRootName
    INTEGER(IntKi)                        :: I
    INTEGER(IntKi)                        :: Unit
    REAL(DbKi)                            :: t_initial_out
    INTEGER(IntKi)                        :: NumTurbines_out
-   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart' 
-             
+   CHARACTER(*),           PARAMETER     :: RoutineName = 'FAST_Restart'
+
    CALL NWTC_Init()
-      ! transfer the character array from C to a Fortran string:   
+      ! transfer the character array from C to a Fortran string:
    CheckpointRootName = TRANSFER( CheckpointRootName_c, CheckpointRootName )
    I = INDEX(CheckpointRootName,C_NULL_CHAR) - 1                 ! if this has a c null character at the end...
    IF ( I > 0 ) CheckpointRootName = CheckpointRootName(1:I)     ! remove it
-   
+
    Unit = -1
    CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(iTurb), CheckpointRootName, ErrStat, ErrMsg, Unit )
-   
+
       ! check that these are valid:
       IF (t_initial_out /= t_initial) CALL SetErrStat(ErrID_Fatal, "invalid value of t_initial.", ErrStat, ErrMsg, RoutineName )
       IF (NumTurbines_out /= 1) CALL SetErrStat(ErrID_Fatal, "invalid value of NumTurbines.", ErrStat, ErrMsg, RoutineName )
-   
-       ! transfer Fortran variables to C: 
+
+       ! transfer Fortran variables to C:
    n_t_global_c  = n_t_global
-   AbortErrLev_c = AbortErrLev   
+   AbortErrLev_c = AbortErrLev
    NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
    numBlades_c   = Turbine(iTurb)%ad%p%numblades
    numElementsPerBlade_c = Turbine(iTurb)%ad%p%numblnds ! I'm not sure if FASTv8 can handle different number of blade nodes for each blade.
-   dt_c          = Turbine(iTurb)%p_FAST%dt      
-      
+   dt_c          = Turbine(iTurb)%p_FAST%dt
+
    ErrStat_c     = ErrStat
    ErrMsg        = TRIM(ErrMsg)//C_NULL_CHAR
    ErrMsg_c      = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
 
-#ifdef CONSOLE_FILE   
+#ifdef CONSOLE_FILE
    if (ErrStat /= ErrID_None) call wrscr1(trim(ErrMsg))
-#endif   
+#endif
 
    call SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST)
 
@@ -593,7 +593,7 @@ end subroutine FAST_OpFM_Restart
 subroutine SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST, SC_Input_from_FAST, SC_Output_to_FAST)
 
    IMPLICIT NONE
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
    TYPE(OpFM_InputType_C), INTENT(INOUT) :: OpFM_Input_from_FAST
    TYPE(OpFM_OutputType_C),INTENT(INOUT) :: OpFM_Output_to_FAST
    TYPE(SC_InputType_C),   INTENT(INOUT) :: SC_Input_from_FAST
@@ -618,69 +618,68 @@ subroutine SetOpenFOAM_pointers(iTurb, OpFM_Input_from_FAST, OpFM_Output_to_FAST
 
    SC_Input_from_FAST%toSC_Len = Turbine(iTurb)%SC%u%c_obj%toSC_Len
    SC_Input_from_FAST%toSC     = Turbine(iTurb)%SC%u%c_obj%toSC
-   
-   OpFM_Output_to_FAST%u_Len   = Turbine(iTurb)%OpFM%y%c_obj%u_Len;  OpFM_Output_to_FAST%u = Turbine(iTurb)%OpFM%y%c_obj%u 
-   OpFM_Output_to_FAST%v_Len   = Turbine(iTurb)%OpFM%y%c_obj%v_Len;  OpFM_Output_to_FAST%v = Turbine(iTurb)%OpFM%y%c_obj%v 
-   OpFM_Output_to_FAST%w_Len   = Turbine(iTurb)%OpFM%y%c_obj%w_Len;  OpFM_Output_to_FAST%w = Turbine(iTurb)%OpFM%y%c_obj%w 
+
+   OpFM_Output_to_FAST%u_Len   = Turbine(iTurb)%OpFM%y%c_obj%u_Len;  OpFM_Output_to_FAST%u = Turbine(iTurb)%OpFM%y%c_obj%u
+   OpFM_Output_to_FAST%v_Len   = Turbine(iTurb)%OpFM%y%c_obj%v_Len;  OpFM_Output_to_FAST%v = Turbine(iTurb)%OpFM%y%c_obj%v
+   OpFM_Output_to_FAST%w_Len   = Turbine(iTurb)%OpFM%y%c_obj%w_Len;  OpFM_Output_to_FAST%w = Turbine(iTurb)%OpFM%y%c_obj%w
    OpFM_Output_to_FAST%SuperController_Len = Turbine(iTurb)%OpFM%y%c_obj%SuperController_Len
    OpFM_Output_to_FAST%SuperController     = Turbine(iTurb)%OpFM%y%c_obj%SuperController
 
    SC_Output_to_FAST%fromSC_Len = Turbine(iTurb)%SC%y%c_obj%fromSC_Len
    SC_Output_to_FAST%fromSC     = Turbine(iTurb)%SC%y%c_obj%fromSC
-      
+
 end subroutine SetOpenFOAM_pointers
 !==================================================================================================================================
 subroutine FAST_OpFM_Step(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_OpFM_Step')
-!DEC$ ATTRIBUTES DLLEXPORT::FAST_OpFM_Step
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Step
 !GCC$ ATTRIBUTES DLLEXPORT :: FAST_OpFM_Step
 #endif
-   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number 
-   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c      
-   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)      
-                    
-   
-   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish 
-      
+   INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
+
+   IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish
+
       ! we can't continue because we might over-step some arrays that are allocated to the size of the simulation
-      
+
       if (iTurb .eq. (NumTurbines-1) ) then
          IF (n_t_global == Turbine(iTurb)%p_FAST%n_TMax_m1 + 1) THEN  ! we call update an extra time in Simulink, which we can ignore until the time shift with outputs is solved
             n_t_global = n_t_global + 1
             ErrStat_c = ErrID_None
             ErrMsg = C_NULL_CHAR
             ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
-         ELSE     
+         ELSE
             ErrStat_c = ErrID_Info
             ErrMsg = "Simulation completed."//C_NULL_CHAR
             ErrMsg_c = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
          END IF
       end if
-      
+
    ELSE
 
       if(Turbine(iTurb)%SC%p%scOn) then
          CALL SC_SetOutputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%Input(1), Turbine(iTurb)%SC, ErrStat, ErrMsg)
       end if
 
-      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )                  
+      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
 
       if(Turbine(iTurb)%SC%p%scOn) then
          CALL SC_SetInputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%y, Turbine(iTurb)%SC, ErrStat, ErrMsg)
       end if
-      
+
       if (iTurb .eq. (NumTurbines-1) ) then
          n_t_global = n_t_global + 1
       end if
-            
+
       ErrStat_c = ErrStat
       ErrMsg = TRIM(ErrMsg)//C_NULL_CHAR
       ErrMsg_c  = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
    END IF
-   
-      
-end subroutine FAST_OpFM_Step 
-!==================================================================================================================================   
-END MODULE FAST_Data
 
+
+end subroutine FAST_OpFM_Step
+!==================================================================================================================================
+END MODULE FAST_Data


### PR DESCRIPTION
This pull request fixes issue #3 

- Move compiler directives regarding DLLEXPORT into the ifndef since DLL is already handled for non windows systems
- Fix CMake config that was not catching Linux build systems

```
[rmudafor@n2466 build]$ ctest -j 26
Test project /home/rmudafor/openfast/build
      Start  1: AWT_YFix_WSt
      Start  2: AWT_WSt_StartUp_HighSpShutDown
      Start  3: AWT_YFree_WSt
      Start  4: AWT_YFree_WTurb
      Start  5: AWT_WSt_StartUpShutDown
      Start  6: AOC_WSt
      Start  7: AOC_YFree_WTurb
      Start  8: AOC_YFix_WSt
      Start  9: UAE_Dnwind_YRamp_WSt
      Start 10: UAE_Upwind_Rigid_WRamp_PwrCurve
      Start 11: WP_VSP_WTurb_PitchFail
      Start 12: WP_VSP_ECD
      Start 13: WP_VSP_WTurb
      Start 14: WP_Stationary_Linear
      Start 15: SWRT_YFree_VS_EDG01
      Start 16: SWRT_YFree_VS_EDC01
      Start 17: SWRT_YFree_VS_WTurb
      Start 18: 5MW_Land_DLL_WTurb
      Start 19: 5MW_OC3Mnpl_DLL_WTurb_WavesIrr
      Start 20: 5MW_OC3Trpd_DLL_WSt_WavesReg
      Start 21: 5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth
      Start 22: 5MW_ITIBarge_DLL_WTurb_WavesIrr
      Start 23: 5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti
      Start 24: 5MW_OC3Spar_DLL_WTurb_WavesIrr
      Start 25: 5MW_OC4Semi_WSt_WavesWN
      Start 26: 5MW_Land_BD_DLL_WTurb
 1/30 Test #14: WP_Stationary_Linear .....................   Passed    6.63 sec
      Start 27: static_cantilever_beam
 2/30 Test #27: static_cantilever_beam ...................   Passed    1.42 sec
      Start 28: isotropic_rollup
 3/30 Test #28: isotropic_rollup .........................   Passed    6.62 sec
      Start 29: curved_beam
 4/30 Test  #1: AWT_YFix_WSt .............................   Passed   18.31 sec
 5/30 Test #29: curved_beam ..............................   Passed    1.31 sec
      Start 30: 5MW_dynamic
 6/30 Test  #6: AOC_WSt ..................................   Passed   23.22 sec
 7/30 Test #11: WP_VSP_WTurb_PitchFail ...................   Passed   28.52 sec
 8/30 Test #12: WP_VSP_ECD ...............................   Passed   28.62 sec
 9/30 Test  #2: AWT_WSt_StartUp_HighSpShutDown ...........   Passed   30.55 sec
10/30 Test  #3: AWT_YFree_WSt ............................   Passed   32.57 sec
11/30 Test  #8: AOC_YFix_WSt .............................   Passed   33.07 sec
12/30 Test  #5: AWT_WSt_StartUpShutDown ..................   Passed   38.98 sec
13/30 Test #22: 5MW_ITIBarge_DLL_WTurb_WavesIrr ..........   Passed   45.67 sec
14/30 Test #10: UAE_Upwind_Rigid_WRamp_PwrCurve ..........   Passed   53.10 sec
15/30 Test #30: 5MW_dynamic ..............................   Passed   32.90 sec
16/30 Test #13: WP_VSP_WTurb .............................   Passed   68.21 sec
17/30 Test #24: 5MW_OC3Spar_DLL_WTurb_WavesIrr ...........   Passed   74.50 sec
18/30 Test  #9: UAE_Dnwind_YRamp_WSt .....................   Passed   77.53 sec
19/30 Test #23: 5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti ....   Passed   85.32 sec
20/30 Test #16: SWRT_YFree_VS_EDC01 ......................   Passed  113.36 sec
21/30 Test  #7: AOC_YFree_WTurb ..........................   Passed  118.18 sec
22/30 Test  #4: AWT_YFree_WTurb ..........................   Passed  118.18 sec
23/30 Test #18: 5MW_Land_DLL_WTurb .......................   Passed  126.27 sec
24/30 Test #15: SWRT_YFree_VS_EDG01 ......................   Passed  210.37 sec
25/30 Test #25: 5MW_OC4Semi_WSt_WavesWN ..................   Passed  216.76 sec
26/30 Test #19: 5MW_OC3Mnpl_DLL_WTurb_WavesIrr ...........   Passed  533.93 sec
27/30 Test #17: SWRT_YFree_VS_WTurb ......................   Passed  579.78 sec
28/30 Test #26: 5MW_Land_BD_DLL_WTurb ....................   Passed  699.80 sec
29/30 Test #20: 5MW_OC3Trpd_DLL_WSt_WavesReg .............   Passed  1466.52 sec
30/30 Test #21: 5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth ...   Passed  1811.67 sec

100% tests passed, 0 tests failed out of 30

Label Time Summary:
aerodyn14    = 891.22 sec (7 tests)
aerodyn15    = 5748.43 sec (19 tests)
beamdyn      = 742.05 sec (5 tests)
dynamic      =  32.90 sec (1 test)
elastodyn    = 5939.85 sec (25 tests)
hydrodyn     = 4234.38 sec (7 tests)
map          = 205.49 sec (3 tests)
moordyn      = 216.76 sec (1 test)
openfast     = 6639.65 sec (26 tests)
servodyn     = 6633.02 sec (25 tests)
static       =   9.35 sec (3 tests)
subdyn       = 3812.12 sec (3 tests)

Total Test time (real) = 1811.73 sec
```