### PR TITLE
Backup HDF5 velocity data file whenever OpenFAST dumps a restart file

### DIFF
--- a/glue-codes/fast-cpp/src/OpenFAST.H
+++ b/glue-codes/fast-cpp/src/OpenFAST.H
@@ -170,6 +170,7 @@ class OpenFAST {
   void readVelocityData(int nTimesteps);
   void writeVelocityData(hid_t h5file, int iTurb, int iTimestep, OpFM_InputType_t iData, OpFM_OutputType_t oData);
   herr_t closeVelocityDataFile(int nt_global, hid_t velDataFile);
+  void backupVelocityDataFile(int curTimeStep, hid_t & velDataFile);
 
   void setTurbineProcNo(int iTurbGlob, int procNo) { turbineMapGlobToProc[iTurbGlob] = procNo; }
   void allocateTurbinesToProcsSimple();

--- a/glue-codes/fast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/fast-cpp/src/OpenFAST.cpp
@@ -228,6 +228,8 @@ void fast::OpenFAST::step() {
    nt_global = nt_global + 1;
   
   if ( (((nt_global - ntStart) % nEveryCheckPoint) == 0 )  && (nt_global != ntStart) ) {
+    if (nTurbinesProc > 0) backupVelocityDataFile(nt_global, velNodeDataFile);
+      
     //sprintf(CheckpointFileRoot, "../../CertTest/Test18.%d", nt_global);
     for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
       CheckpointFileRoot[iTurb] = " "; // if blank, it will use FAST convention <RootName>.nt_global
@@ -850,6 +852,20 @@ herr_t fast::OpenFAST::closeVelocityDataFile(int nt_global, hid_t velDataFile) {
   return status;
 }
 
+
+void fast::OpenFAST::backupVelocityDataFile(int curTimeStep, hid_t & velDataFile) {
+
+    closeVelocityDataFile(curTimeStep, velDataFile);
+        
+    std::ifstream source("velDatafile." + std::to_string(worldMPIRank) + ".h5", std::ios::binary);
+    std::ofstream dest("velDatafile." + std::to_string(worldMPIRank) + ".h5." + std::to_string(curTimeStep) + ".bak", std::ios::binary);
+
+    dest << source.rdbuf();
+    source.close();
+    dest.close();
+
+    velDataFile = openVelocityDataFile(false);
+}
 
 void fast::OpenFAST::writeVelocityData(hid_t h5File, int iTurb, int iTimestep, OpFM_InputType_t iData, OpFM_OutputType_t oData) {
 


### PR DESCRIPTION
HDF5 files get corrupted and become unusable if the code is interrupted when running due to any reason. This commit provides a work around by backing up the velocity data file whenever OpenFAST is asked to write out restart files through the C++ API.