### PR TITLE
Move initialization of static variable from header file to a .cpp file

### DIFF
--- a/glue-codes/fast-cpp/src/OpenFAST.H
+++ b/glue-codes/fast-cpp/src/OpenFAST.H
@@ -2,9 +2,6 @@
 #define OpenFAST_h
 #include "FAST_Library.h"
 #include "sys/stat.h"
-#include "math.h"
-#include <iostream>
-#include <fstream>
 #include <string>
 #include <cstring>
 #include <stdexcept>
@@ -12,6 +9,7 @@
 #include <set>
 #include <map>
 #include "dlfcn.h"
+//TODO: The skip MPICXX is put in place primarily to get around errors in OpenFOAM. This will cause problems if the driver program uses C++ API for MPI.
 #ifndef OMPI_SKIP_MPICXX
  #define OMPI_SKIP_MPICXX
 #endif
@@ -147,6 +145,7 @@ class OpenFAST {
   MPI_Group worldMPIGroup;
   int worldMPIRank;
 
+  static int AbortErrLev;
   int ErrStat;
   char ErrMsg[INTERFACE_STRING_LENGTH];  // make sure this is the same size as IntfStrLen in FAST_Library.f90
 

--- a/glue-codes/fast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/fast-cpp/src/OpenFAST.cpp
@@ -1,4 +1,9 @@
 #include "OpenFAST.H"
+#include <iostream>
+#include <fstream>
+#include "math.h"
+
+int fast::OpenFAST::AbortErrLev = ErrID_Fatal; // abort error level; compare with NWTC Library
 
 //Constructor 
 fast::fastInputs::fastInputs():

--- a/glue-codes/fast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/fast-cpp/src/OpenFAST.cpp
@@ -1,7 +1,7 @@
 #include "OpenFAST.H"
 #include <iostream>
 #include <fstream>
-#include "math.h"
+#include <cmath>
 
 int fast::OpenFAST::AbortErrLev = ErrID_Fatal; // abort error level; compare with NWTC Library
 
@@ -480,7 +480,7 @@ void fast::OpenFAST::interpolateVel_ForceToVelNodes() {
       std::vector<double> rDistForce(nForcePtsBlade) ;
       for(int j=0; j < nForcePtsBlade; j++) {
 	int iNodeForce = 1 + iBlade * nForcePtsBlade + j ; //The number of actuator force points is always the same for all blades
-	rDistForce[j] = sqrt( 
+	rDistForce[j] = std::sqrt( 
                              (cDriver_Input_from_FAST[iTurb].pxForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pxForce[0])*(cDriver_Input_from_FAST[iTurb].pxForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pxForce[0])  
 		           + (cDriver_Input_from_FAST[iTurb].pyForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pyForce[0])*(cDriver_Input_from_FAST[iTurb].pyForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pyForce[0])  
 		           + (cDriver_Input_from_FAST[iTurb].pzForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pzForce[0])*(cDriver_Input_from_FAST[iTurb].pzForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pzForce[0])  			
@@ -491,7 +491,7 @@ void fast::OpenFAST::interpolateVel_ForceToVelNodes() {
       int nVelPtsBlade = get_numVelPtsBladeLoc(iTurb);
       for(int j=0; j < nVelPtsBlade; j++) {
 	int iNodeVel = 1 + iBlade * nVelPtsBlade + j ; //Assumes the same number of velocity (Aerodyn) nodes for all blades
-	double rDistVel = sqrt( 
+	double rDistVel = std::sqrt( 
 			      (cDriver_Input_from_FAST[iTurb].pxVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pxVel[0])*(cDriver_Input_from_FAST[iTurb].pxVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pxVel[0])  
 		            + (cDriver_Input_from_FAST[iTurb].pyVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pyVel[0])*(cDriver_Input_from_FAST[iTurb].pyVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pyVel[0])  
 		            + (cDriver_Input_from_FAST[iTurb].pzVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pzVel[0])*(cDriver_Input_from_FAST[iTurb].pzVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pzVel[0])  			
@@ -519,7 +519,7 @@ void fast::OpenFAST::interpolateVel_ForceToVelNodes() {
       int iNodeBotTowerForce = 1 + nBlades * get_numForcePtsBladeLoc(iTurb); // The number of actuator force points is always the same for all blades
       for(int j=0; j < nForcePtsTower; j++) {
 	int iNodeForce = iNodeBotTowerForce + j ; 
-	hDistForce[j] = sqrt( 
+	hDistForce[j] = std::sqrt( 
 			     (cDriver_Input_from_FAST[iTurb].pxForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pxForce[iNodeBotTowerForce])*(cDriver_Input_from_FAST[iTurb].pxForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pxForce[iNodeBotTowerForce])  
                            + (cDriver_Input_from_FAST[iTurb].pyForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pyForce[iNodeBotTowerForce])*(cDriver_Input_from_FAST[iTurb].pyForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pyForce[iNodeBotTowerForce])  
 			   + (cDriver_Input_from_FAST[iTurb].pzForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pzForce[iNodeBotTowerForce])*(cDriver_Input_from_FAST[iTurb].pzForce[iNodeForce] - cDriver_Input_from_FAST[iTurb].pzForce[iNodeBotTowerForce])	
@@ -530,7 +530,7 @@ void fast::OpenFAST::interpolateVel_ForceToVelNodes() {
       int iNodeBotTowerVel = 1 + nBlades * get_numVelPtsBladeLoc(iTurb); // Assumes the same number of velocity (Aerodyn) nodes for all blades
       for(int j=0; j < nVelPtsTower; j++) {
 	int iNodeVel = iNodeBotTowerVel + j ; 
-	double hDistVel = sqrt( 
+	double hDistVel = std::sqrt( 
 			       (cDriver_Input_from_FAST[iTurb].pxVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pxVel[iNodeBotTowerVel])*(cDriver_Input_from_FAST[iTurb].pxVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pxVel[iNodeBotTowerVel])  
                              + (cDriver_Input_from_FAST[iTurb].pyVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pyVel[iNodeBotTowerVel])*(cDriver_Input_from_FAST[iTurb].pyVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pyVel[iNodeBotTowerVel])  
                              + (cDriver_Input_from_FAST[iTurb].pzVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pzVel[iNodeBotTowerVel])*(cDriver_Input_from_FAST[iTurb].pzVel[iNodeVel] - cDriver_Input_from_FAST[iTurb].pzVel[iNodeBotTowerVel])  			

--- a/glue-codes/simulink/src/FAST_SFunc.c
+++ b/glue-codes/simulink/src/FAST_SFunc.c
@@ -49,6 +49,7 @@ static int ErrStat = 0;
 static char ErrMsg[INTERFACE_STRING_LENGTH];        // make sure this is the same size as IntfStrLen in FAST_Library.f90
 static char InputFileName[INTERFACE_STRING_LENGTH]; // make sure this is the same size as IntfStrLen in FAST_Library.f90
 static int n_t_global = -2;  // counter to determine which fixed-step simulation time we are at currently (start at -2 for initialization)
+static int AbortErrLev = ErrID_Fatal;      // abort error level; compare with NWTC Library
 
 // function definitions
 static int checkError(SimStruct *S);

--- a/modules-local/fast-library/src/FAST_Library.h
+++ b/modules-local/fast-library/src/FAST_Library.h
@@ -1,3 +1,6 @@
+#ifndef FAST_LIBRARY_H
+#define FAST_LIBRARY_H
+
 // routines in FAST_Library_$(PlatformName).dll
 #include "OpenFOAM_Types.h"
 #include "SuperController_Types.h"
@@ -34,7 +37,6 @@ EXTERNAL_ROUTINE void FAST_CreateCheckpoint(int * iTurb, const char *CheckpointR
 #define ErrID_Severe 3 
 #define ErrID_Fatal 4 
 
-static int AbortErrLev = ErrID_Fatal;      // abort error level; compare with NWTC Library
 
 #define SensorType_None -1
 
@@ -45,3 +47,6 @@ static int AbortErrLev = ErrID_Fatal;      // abort error level; compare with NW
 #define MAXInitINPUTS 10
 
 #define NumFixedInputs  2 + 2 + MAXIMUM_BLADES + 1
+
+
+#endif


### PR DESCRIPTION
@jrood-nrel  Fixes issue https://github.com/OpenFAST/openfast/issues/73

@jjonkman @ghaymanNREL : Do we know of any one who uses FAST_Library.h? I moved the definition of "AbortErrLev" into the OpenFAST class and initialized in the C++ file. 

Other minor edits to move some header includes into the .cpp file. 