### PR TITLE
Adds performance optimization to NWTC Lib and BeamDyn

### DIFF
--- a/modules-local/nwtc-library/src/ModMesh.f90
+++ b/modules-local/nwtc-library/src/ModMesh.f90
@@ -3238,7 +3238,8 @@ SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputF
 
     REAL(DbKi)                          :: t(SIZE(tin))              ! Times associated with the inputs
     REAL(DbKi)                          :: t_out                     ! Time to which to be extrap/interpd                                                                     
-    REAL(DbKi)                          :: scaleFactor               ! temporary for extrapolation/interpolation    
+    REAL(DbKi)                          :: scaleFactor               ! temporary for extrapolation/interpolation  
+    REAL(DbKi)                          :: scaleF1,scaleF2,scaleF3
     REAL(DbKi)                          :: tensor(3, order+1)        ! for extrapolation of orientations 
     REAL(DbKi)                          :: tensor_interp(3)          ! for extrapolation of orientations 
     REAL(DbKi)                          :: Orient(3,3)               ! for extrapolation of orientations    
@@ -3285,60 +3286,74 @@ SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputF
          ! Now let's interpolate/extrapolate:
 
       scaleFactor = t_out / ( t(2) * t(3) * (t(2) - t(3)) )
+      scaleF1 = 1 + scaleFactor * (t(3)-t(2)) * (t(3)+t(2)-t_out)
+      scaleF2 = scaleFactor * t(3) * (-t(3)+t_out)
+      scaleF3 = scaleFactor * t(2) * (t(2)-t_out)
+
 
       IF ( ALLOCATED(u1%Force) ) THEN
 
-         u_out%Force =   u1%Force &
-                       + ( t(3)**2 * (u1%Force - u2%Force) + t(2)**2*(-u1%Force + u3%Force) ) * scaleFactor &
-                       + ( (t(2)-t(3))*u1%Force + t(3)*u2%Force - t(2)*u3%Force ) *scaleFactor * t_out
+         u_out%Force = u1%Force * scaleF1 + u2%Force * scaleF2 + u3%Force * scaleF3
+         !write(*,*) 'A',u_out%Force
+         !u_out%Force =   u1%Force &
+         !              + ( t(3)**2 * (u1%Force - u2%Force) + t(2)**2*(-u1%Force + u3%Force) ) * scaleFactor &
+         !              + ( (t(2)-t(3))*u1%Force + t(3)*u2%Force - t(2)*u3%Force ) *scaleFactor * t_out
+         !write(*,*) 'B', u_out%Force
 
       END IF
       IF ( ALLOCATED(u1%Moment) ) THEN
-         u_out%Moment =   u1%Moment &
-                       + ( t(3)**2 * (u1%Moment - u2%Moment) + t(2)**2*(-u1%Moment + u3%Moment) ) * scaleFactor &
-                       + ( (t(2)-t(3))*u1%Moment + t(3)*u2%Moment - t(2)*u3%Moment ) *scaleFactor * t_out
+         u_out%Moment = u1%Moment * scaleF1 + u2%Moment * scaleF2 + u3%Moment * scaleF3
+         !u_out%Moment =   u1%Moment &
+         !              + ( t(3)**2 * (u1%Moment - u2%Moment) + t(2)**2*(-u1%Moment + u3%Moment) ) * scaleFactor &
+         !              + ( (t(2)-t(3))*u1%Moment + t(3)*u2%Moment - t(2)*u3%Moment ) *scaleFactor * t_out
       END IF
 
       IF ( ALLOCATED(u1%TranslationDisp) ) THEN
-         u_out%TranslationDisp =   u1%TranslationDisp &
-                               + ( t(3)**2 * ( u1%TranslationDisp - u2%TranslationDisp) &
-                                 + t(2)**2 * (-u1%TranslationDisp + u3%TranslationDisp) ) * scaleFactor &
-                               + ( (t(2)-t(3))*u1%TranslationDisp + t(3)*u2%TranslationDisp &
-                                                                  - t(2)*u3%TranslationDisp )*scaleFactor*t_out
+         u_out%TranslationDisp = u1%TranslationDisp * scaleF1 + u2%TranslationDisp * scaleF2 + u3%TranslationDisp * scaleF3
+         !u_out%TranslationDisp =   u1%TranslationDisp &
+         !                      + ( t(3)**2 * ( u1%TranslationDisp - u2%TranslationDisp) &
+         !                        + t(2)**2 * (-u1%TranslationDisp + u3%TranslationDisp) ) * scaleFactor &
+         !                      + ( (t(2)-t(3))*u1%TranslationDisp + t(3)*u2%TranslationDisp &
+         !                                                         - t(2)*u3%TranslationDisp )*scaleFactor*t_out
       END IF
 
       IF ( ALLOCATED(u1%RotationVel) ) THEN
-         u_out%RotationVel =   u1%RotationVel &
-                           + ( t(3)**2 * ( u1%RotationVel - u2%RotationVel) &
-                             + t(2)**2 * (-u1%RotationVel + u3%RotationVel) ) * scaleFactor &
-                           + ( (t(2)-t(3))*u1%RotationVel + t(3)*u2%RotationVel - t(2)*u3%RotationVel )*scaleFactor*t_out
+         u_out%RotationVel = u1%RotationVel * scaleF1 + u2%RotationVel * scaleF2 + u3%RotationVel * scaleF3
+         !u_out%RotationVel =   u1%RotationVel &
+         !                  + ( t(3)**2 * ( u1%RotationVel - u2%RotationVel) &
+         !                    + t(2)**2 * (-u1%RotationVel + u3%RotationVel) ) * scaleFactor &
+         !                  + ( (t(2)-t(3))*u1%RotationVel + t(3)*u2%RotationVel - t(2)*u3%RotationVel )*scaleFactor*t_out
       END IF
 
       IF ( ALLOCATED(u1%TranslationVel) ) THEN
-         u_out%TranslationVel =   u1%TranslationVel &
-                              +( t(3)**2 * ( u1%TranslationVel - u2%TranslationVel) &
-                               + t(2)**2 * (-u1%TranslationVel + u3%TranslationVel) ) * scaleFactor &
-                              +( (t(2)-t(3))*u1%TranslationVel + t(3)*u2%TranslationVel - t(2)*u3%TranslationVel)*scaleFactor*t_out
+         u_out%TranslationVel = u1%TranslationVel * scaleF1 + u2%TranslationVel * scaleF2 + u3%TranslationVel * scaleF3
+         !u_out%TranslationVel =   u1%TranslationVel &
+         !                     +( t(3)**2 * ( u1%TranslationVel - u2%TranslationVel) &
+         !                      + t(2)**2 * (-u1%TranslationVel + u3%TranslationVel) ) * scaleFactor &
+         !                     +( (t(2)-t(3))*u1%TranslationVel + t(3)*u2%TranslationVel - t(2)*u3%TranslationVel)*scaleFactor*t_out
       END IF
 
       IF ( ALLOCATED(u1%RotationAcc) ) THEN
-         u_out%RotationAcc =   u1%RotationAcc &
-                             + ( t(3)**2 * ( u1%RotationAcc - u2%RotationAcc) &
-                               + t(2)**2 * (-u1%RotationAcc + u3%RotationAcc) ) * scaleFactor &
-                            + ( (t(2)-t(3))*u1%RotationAcc  + t(3)*u2%RotationAcc - t(2)*u3%RotationAcc )*scaleFactor*t_out
+         u_out%RotationAcc = u1%RotationAcc * scaleF1 + u2%RotationAcc * scaleF2 + u3%RotationAcc * scaleF3
+         !u_out%RotationAcc =   u1%RotationAcc &
+         !                    + ( t(3)**2 * ( u1%RotationAcc - u2%RotationAcc) &
+         !                      + t(2)**2 * (-u1%RotationAcc + u3%RotationAcc) ) * scaleFactor &
+         !                   + ( (t(2)-t(3))*u1%RotationAcc  + t(3)*u2%RotationAcc - t(2)*u3%RotationAcc )*scaleFactor*t_out
       END IF
 
       IF ( ALLOCATED(u1%TranslationAcc) ) THEN
-         u_out%TranslationAcc =   u1%TranslationAcc &
-                              +( t(3)**2 * ( u1%TranslationAcc - u2%TranslationAcc) &
-                               + t(2)**2 * (-u1%TranslationAcc + u3%TranslationAcc) ) * scaleFactor &
-                              +( (t(2)-t(3))*u1%TranslationAcc + t(3)*u2%TranslationAcc - t(2)*u3%TranslationAcc)*scaleFactor*t_out
+         u_out%TranslationAcc = u1%TranslationAcc * scaleF1 + u2%TranslationAcc * scaleF2 + u3%TranslationAcc * scaleF3
+         !u_out%TranslationAcc =   u1%TranslationAcc &
+         !                     +( t(3)**2 * ( u1%TranslationAcc - u2%TranslationAcc) &
+         !                      + t(2)**2 * (-u1%TranslationAcc + u3%TranslationAcc) ) * scaleFactor &
+         !                     +( (t(2)-t(3))*u1%TranslationAcc + t(3)*u2%TranslationAcc - t(2)*u3%TranslationAcc)*scaleFactor*t_out
       END IF
 
       IF ( ALLOCATED(u1%Scalars) ) THEN
-         u_out%Scalars =   u1%Scalars &
-                       + ( t(3)**2 * (u1%Scalars - u2%Scalars) + t(2)**2*(-u1%Scalars + u3%Scalars) )*scaleFactor &
-                       + ( (t(2)-t(3))*u1%Scalars + t(3)*u2%Scalars - t(2)*u3%Scalars )*scaleFactor * t_out
+         u_out%Scalars = u1%Scalars * scaleF1 + u2%Scalars * scaleF2 + u3%Scalars * scaleF3
+         !u_out%Scalars =   u1%Scalars &
+         !              + ( t(3)**2 * (u1%Scalars - u2%Scalars) + t(2)**2*(-u1%Scalars + u3%Scalars) )*scaleFactor &
+         !              + ( (t(2)-t(3))*u1%Scalars + t(3)*u2%Scalars - t(2)*u3%Scalars )*scaleFactor * t_out
       END IF
 
       IF ( ALLOCATED(u1%Orientation) ) THEN

--- a/modules-local/nwtc-library/src/NWTC_Num.f90
+++ b/modules-local/nwtc-library/src/NWTC_Num.f90
@@ -923,6 +923,7 @@ CONTAINS
    REAL(DbKi)              :: theta          ! angle of rotation   
    REAL(DbKi)              :: theta2         ! angle of rotation squared
    REAL(DbKi)              :: tmp_Mat(3,3)
+   REAL(DbKi)              :: tmp1, tmp2, plambda(3),qlambda(3)
    
    INTEGER(IntKi)          :: ErrStat
    CHARACTER(30)           :: ErrMsg  
@@ -939,15 +940,15 @@ CONTAINS
    ELSE   
       
          ! convert lambda to skew-symmetric matrix:
-      tmp_mat(1,1) =  0.0_DbKi                                            
-      tmp_mat(2,1) = -lambda(3)                                           
-      tmp_mat(3,1) =  lambda(2)                                           
-      tmp_mat(1,2) =              lambda(3)                               
-      tmp_mat(2,2) =              0.0_DbKi                                
-      tmp_mat(3,2) =             -lambda(1)                               
-      tmp_mat(1,3) =                               -lambda(2)             
-      tmp_mat(2,3) =                                lambda(1)             
-      tmp_mat(3,3) =                                0.0_DbKi            
+      !tmp_mat(1,1) =  0.0_DbKi                                            
+      !tmp_mat(2,1) = -lambda(3)                                           
+      !tmp_mat(3,1) =  lambda(2)                                           
+      !tmp_mat(1,2) =              lambda(3)                               
+      !tmp_mat(2,2) =              0.0_DbKi                                
+      !tmp_mat(3,2) =             -lambda(1)                               
+      !tmp_mat(1,3) =                               -lambda(2)             
+      !tmp_mat(2,3) =                                lambda(1)             
+      !tmp_mat(3,3) =                                0.0_DbKi            
       
       
          ! Eq. 33b
@@ -959,17 +960,42 @@ CONTAINS
       !DCM_exp = DCM_exp + (1-cos(theta))/theta2 * MATMUL(tmp_mat, tmp_mat) 
       
          ! hopefully this order of calculations gives better numerical results:
-      stheta = sin(theta)
-      DCM_expD      = (1-cos(theta))/theta * tmp_mat      
-      DCM_expD(1,1) = DCM_expD(1,1) + stheta
-      DCM_expD(2,2) = DCM_expD(2,2) + stheta
-      DCM_expD(3,3) = DCM_expD(3,3) + stheta
+      !stheta = sin(theta)
+      !DCM_expD      = (1-cos(theta))/theta * tmp_mat      
+      !DCM_expD(1,1) = DCM_expD(1,1) + stheta
+      !DCM_expD(2,2) = DCM_expD(2,2) + stheta
+      !DCM_expD(3,3) = DCM_expD(3,3) + stheta
       
-      DCM_expD = matmul( DCM_expD, tmp_mat )
-      DCM_expD = DCM_expD / theta
-      DCM_expD(1,1) = DCM_expD(1,1) + 1.0_DbKi ! add identity
-      DCM_expD(2,2) = DCM_expD(2,2) + 1.0_DbKi
-      DCM_expD(3,3) = DCM_expD(3,3) + 1.0_DbKi
+      !DCM_expD = matmul( DCM_expD, tmp_mat )
+      !DCM_expD = DCM_expD / theta
+      !DCM_expD(1,1) = DCM_expD(1,1) + 1.0_DbKi ! add identity
+      !DCM_expD(2,2) = DCM_expD(2,2) + 1.0_DbKi
+      !DCM_expD(3,3) = DCM_expD(3,3) + 1.0_DbKi
+
+      tmp1=sin(theta)/theta
+      tmp2=(1-cos(theta))/theta/theta
+      ! Calculate every element in matrix directly using Eq.33b to have better numerical efficiency
+      !DCM_expD(1,1) =  1.0_DbKi - tmp2*lambda(3)*lambda(3) - tmp2*lambda(2)*lambda(2)                                           
+      !DCM_expD(2,1) = -tmp1*lambda(3) + tmp2*lambda(1)*lambda(2)                                          
+      !DCM_expD(3,1) =  tmp1*lambda(2) + tmp2*lambda(1)*lambda(3)                                           
+      !DCM_expD(1,2) =  tmp1*lambda(3) + tmp2*lambda(1)*lambda(2)                                             
+      !DCM_expD(2,2) =  1.0_DbKi - tmp2*lambda(3)*lambda(3) - tmp2*lambda(1)*lambda(1)                                             
+      !DCM_expD(3,2) = -tmp1*lambda(1) + tmp2*lambda(2)*lambda(3)                             
+      !DCM_expD(1,3) = -tmp1*lambda(2) + tmp2*lambda(1)*lambda(3)              
+      !DCM_expD(2,3) =  tmp1*lambda(1) + tmp2*lambda(2)*lambda(3)             
+      !DCM_expD(3,3) =  1.0_DbKi - tmp2*lambda(2)*lambda(2) - tmp2*lambda(1)*lambda(1) 
+ 
+      plambda=lambda*tmp1
+      qlambda=lambda*tmp2
+      DCM_expD(1,1) =  1.0_DbKi - qlambda(3)*lambda(3) - qlambda(2)*lambda(2)                                           
+      DCM_expD(2,1) = -plambda(3) + qlambda(1)*lambda(2)                                          
+      DCM_expD(3,1) =  plambda(2) + qlambda(1)*lambda(3)                                           
+      DCM_expD(1,2) =  plambda(3) + qlambda(1)*lambda(2)                                             
+      DCM_expD(2,2) =  1.0_DbKi - qlambda(3)*lambda(3) - qlambda(1)*lambda(1)                                             
+      DCM_expD(3,2) = -plambda(1) + qlambda(2)*lambda(3)                             
+      DCM_expD(1,3) = -plambda(2) + qlambda(1)*lambda(3)              
+      DCM_expD(2,3) =  plambda(1) + qlambda(2)*lambda(3)             
+      DCM_expD(3,3) =  1.0_DbKi - qlambda(2)*lambda(2) - qlambda(1)*lambda(1)     
             
    END IF
 


### PR DESCRIPTION
For beamdyn and modmesh changes: Some values are calculated repeatedly. The straight forward idea is to calculate it and store in a temporary variable and use it later.
For nwtc_num change: calculate the 3X3 matrix directly instead of doing matrix multiply.

**This pull request is currently being modified.**