### PR TITLE
Fix TravisCI configuration - homebrew installs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@
 # macOS
 os: osx
 
-# before_install:
+before_install:
     - brew update
     - brew install gcc
     - brew link --overwrite gcc

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ os: osx
 
 before_install:
     - brew update
+    - brew uninstall gcc
     - brew install gcc
     - brew link --overwrite gcc
     # - brew install cmake # cmake is already installed in the default mac image

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,10 +4,12 @@
 os: osx
 
 before_install:
+    # first uninstall a conflicting package
+    - brew cask uninstall oclint
+
+    # update and install required packages
     - brew update
-    - brew uninstall gcc
     - brew install gcc
-    - brew link --overwrite gcc
     # - brew install cmake # cmake is already installed in the default mac image
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,9 @@
 os: osx
 
 # before_install:
-    # - brew update
-    # - brew install gcc
+    - brew update
+    - brew install gcc
+    - brew link --overwrite gcc
     # - brew install cmake # cmake is already installed in the default mac image
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@
 # macOS
 os: osx
 
-before_install:
-    - brew update
-    - brew install gcc
+# before_install:
+    # - brew update
+    # - brew install gcc
     # - brew install cmake # cmake is already installed in the default mac image
 
 before_script:


### PR DESCRIPTION
An update to the default Mac image for TravisCI caused an error in the existing TravisCI configuration file. This pull request corrects the error.

It is required to install gcc with homebrew. However, a default package, oclint, causes a conflict with gcc. Uninstalling oclint before installing gcc resolves the conflict.