### PR TITLE
Move matplotlib import to the public function that uses it

### DIFF
--- a/reg_tests/executeOpenfastRegressionCase.py
+++ b/reg_tests/executeOpenfastRegressionCase.py
@@ -175,7 +175,11 @@ if not pass_fail.passRegressionTest(normalizedNorm, tolerance):
         failMaxNorm = [maxNorm[i] for i,channel in enumerate(testInfo["attribute_names"]) if normalizedNorm[i] > tolerance]
         initializePlotDirectory(localOutFile, failChannels, failRelNorm, failMaxNorm)
         for channel in failChannels:
-            plotOpenfastError(localOutFile, baselineOutFile, channel)
+            try:
+                plotOpenfastError(localOutFile, baselineOutFile, channel)
+            except:
+                error = sys.exc_info()[1]
+                print("Error generating plots: {}".format(error.msg))
     sys.exit(1)
 
 # passing case

--- a/reg_tests/lib/errorPlotting.py
+++ b/reg_tests/lib/errorPlotting.py
@@ -25,10 +25,6 @@ import sys
 import os
 import numpy as np
 from fast_io import load_output
-import matplotlib
-matplotlib.use("Agg")
-import matplotlib.pyplot as plt
-from matplotlib.ticker import FormatStrFormatter
 import rtestlib as rtl
 
 def _validateAndExpandInputs(argv):
@@ -48,8 +44,13 @@ def _parseSolution(solution):
         rtl.exitWithError("Error: {}".format(e))
 
 def _plotError(xseries, y1series, y2series, xlabel, title1, title2):
+    import matplotlib
+    matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+    from matplotlib.ticker import FormatStrFormatter
+
     plt.figure()
-    
+
     ax = plt.subplot(211)
     plt.title(title1)
     plt.grid(True)


### PR DESCRIPTION
Importing matplotlib for the entire module causes an error if matplotlib is not available. The plotting functionality is not currently supported by NREL so it should remain optional. Moving the import statement to a function moves the failure to that function call rather than the module import.

With this pull request, if matplotlib is not available and plotting is off, the result summaries in html format are still exported correctly. If matplotlib is not available and plotting is on, the html files are written but the plotting routine fails.

When running the regression test through CTest, this python `ModuleNotFoundError` fails silently. Users can see the error with the verbose flag in the CTest call: `ctest -V`

This fixes issue #83 .