### PR TITLE
Move pFUnit submodule to OpenFAST's fork

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/openfast/r-test.git
 [submodule "unit_tests/pfunit"]
 	path = unit_tests/pfunit
-	url = https://git.code.sf.net/p/pfunit/code
+	url = https://github.com/openfast/pfunit.git


### PR DESCRIPTION
The unit testing framework used in OpenFAST, pFUnit, is hosted on sourceforge. However, it is common to encounter SSL errors or time outs when cloning this repo. A fork of pFUnit has been created under the OpenFAST GitHub team, and this pull request changes the submodule reference to the GitHub hosted pFUnit.

For reference, the OpenFAST fork of pFUnit is at:
https://github.com/openfast/pfunit