### PR TITLE
Add minimum compiler versions to the cmake configuration

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,6 +41,13 @@ option(FPE_TRAP_ENABLED "Enable FPE trap in compiler options" off)
 option(ORCA_DLL_LOAD "Enable OrcaFlex Library Load" off)
 option(BUILD_FAST_CPP_API "Enable building FAST - C++ API" off)
 
+# Verify proper compiler versions are available
+if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "4.6.0")
+    message(FATAL_ERROR "A version of GNU gfortran greater than 4.6.0 is required.")
+  endif()
+endif()
+
 # Setup Fortran Compiler options based on architecture/compiler
 set_fast_fortran()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,9 +42,14 @@ option(ORCA_DLL_LOAD "Enable OrcaFlex Library Load" off)
 option(BUILD_FAST_CPP_API "Enable building FAST - C++ API" off)
 
 # Verify proper compiler versions are available
+# see https://github.com/OpenFAST/openfast/issues/88
 if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
   if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "4.6.0")
     message(FATAL_ERROR "A version of GNU gfortran greater than 4.6.0 is required.")
+  endif()
+elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "11")
+    message(FATAL_ERROR "A version of Intel ifort greater than 11 is required.")
   endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,18 +41,6 @@ option(FPE_TRAP_ENABLED "Enable FPE trap in compiler options" off)
 option(ORCA_DLL_LOAD "Enable OrcaFlex Library Load" off)
 option(BUILD_FAST_CPP_API "Enable building FAST - C++ API" off)
 
-# Verify proper compiler versions are available
-# see https://github.com/OpenFAST/openfast/issues/88
-if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
-  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "4.6.0")
-    message(FATAL_ERROR "A version of GNU gfortran greater than 4.6.0 is required.")
-  endif()
-elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
-  if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "11")
-    message(FATAL_ERROR "A version of Intel ifort greater than 11 is required.")
-  endif()
-endif()
-
 # Setup Fortran Compiler options based on architecture/compiler
 set_fast_fortran()
 

--- a/cmake/FastFortranOptions.cmake
+++ b/cmake/FastFortranOptions.cmake
@@ -43,7 +43,19 @@ macro(set_fast_fortran)
   # Abort if we do not have gfortran or Intel Fortran Compiler.
   if (NOT (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU" OR
         ${CMAKE_Fortran_COMPILER_ID} STREQUAL "Intel"))
-    message(FATAL_ERROR "OpenFAST requires either GFortran or Intel Fortran Compiler. Compiler detected by CMake: ${FCNAME}")
+    message(FATAL_ERROR "OpenFAST requires either GFortran or Intel Fortran Compiler. Compiler detected by CMake: ${FCNAME}.")
+  endif()
+
+  # Verify proper compiler versions are available
+  # see https://github.com/OpenFAST/openfast/issues/88
+  if(CMAKE_Fortran_COMPILER_ID STREQUAL "GNU")
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "4.6.0")
+      message(FATAL_ERROR "A version of GNU GFortran greater than 4.6.0 is required. GFortran version detected by CMake: ${CMAKE_Fortran_COMPILER_VERSION}.")
+    endif()
+  elseif(CMAKE_Fortran_COMPILER_ID STREQUAL "Intel")
+    if(CMAKE_Fortran_COMPILER_VERSION VERSION_LESS "11")
+      message(FATAL_ERROR "A version of Intel ifort greater than 11 is required. ifort version detected by CMake: ${CMAKE_Fortran_COMPILER_VERSION}.")
+    endif()
   endif()
 
   # Set the preprocessor for all source files by default

--- a/docs/source/install/install_cmake_linux.rst
+++ b/docs/source/install/install_cmake_linux.rst
@@ -13,7 +13,7 @@ Required software for building OpenFAST
 
 In order to build OpenFAST using CMake, one needs the following minimum set of packages installed:
 
-- Fortran compiler (e.g., gcc version 6.1.0 or Intel)
+- Fortran compiler (GNU compiler version above 4.6.0 or Intel compiler version above 11)
 
 - C/C++ compiler
 


### PR DESCRIPTION
This pull request adds minimum version requirements for the GNU gfortran and Intel ifort compilers. 

As @bjonkman points out [here](https://github.com/OpenFAST/openfast/issues/87#issuecomment-363187357):
```
There are some known compiling errors that were documented in the Compiling Instructions for FAST8:

1. The version of gfortran must be at least 4.6.0. NWTC Library uses some quad-precision 
variables, which are not supported in earlier versions of gfortran.

Possible workarounds: You might be able to set QuKi to some other supported real kind that is not 
4 or 8 (not sure REAL(2) is supported, but you could try); otherwise, you'd have to set QuKi to 4 or 
8 and remove the QuKi MODULE PROCEDURE lines from all the INTERFACE blocks at the top of the 
NWTC Library source files.

2. Intel Fortran must be version 11 or later. NWTC Library uses the gamma() function, which is not 
provided in earlier versions.

Possible workarounds: You can write your own gamma() function in the SysI*.f90 files, or remove 
the calls to gamma() (e.g., set nwtc_gamma = 1) and avoid using IceDyn and the wave spreading 
features of HydroDyn.

It is recommended to put a minimum version requirement for both gfortran and ifort compilers in 
cmake.
```

This pull request is a fix for issue #88 and regression tests are not required as this does not affect the calculations.