### PR TITLE
TurbSim bug fixes

### DIFF
--- a/modules-local/turbsim/src/BlankModVKM.f90
+++ b/modules-local/turbsim/src/BlankModVKM.f90
@@ -18,6 +18,7 @@ SUBROUTINE Mod_vKrm ( Ht, Ucmp, Spec )
    REAL(ReKi), INTENT(IN)    :: UCmp                 ! wind speed
    REAL(ReKi), INTENT(  OUT) :: Spec   (:,:)
  
+   Spec = 0.0_ReKi
 
 RETURN
 END SUBROUTINE Mod_vKrm

--- a/modules-local/turbsim/src/TS_FileIO.f90
+++ b/modules-local/turbsim/src/TS_FileIO.f90
@@ -572,7 +572,7 @@ CALL DefaultMetBndryCndtns(p)     ! Requires turbModel (some require RICH_NO, wh
    getDefaultZJetMax = getDefaultZJetMax .AND. .NOT. IsUnusedParameter ! Jet height for 
 
    ! ------------ Read in the power law exponent, PLExp ---------------------------------------------
-   IsUnusedParameter = (TRIM(p%met%WindProfileType) /= "PL" .AND. TRIM(p%met%WindProfileType) /= "IEC")  .OR. p%IEC%IEC_WindType > IEC_ETM
+   IsUnusedParameter = (TRIM(p%met%WindProfileType) /= "PL" .AND. TRIM(p%met%WindProfileType) /= "IEC")
    CALL ReadRVarDefault( UI, InFile, p%met%PLExp, "PLExp", "Power law exponent [-]", UnEc, getDefaultPLExp, ErrStat2, ErrMsg2, IGNORE=IsUnusedParameter)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
 

--- a/modules-local/turbsim/src/TSsubs.f90
+++ b/modules-local/turbsim/src/TSsubs.f90
@@ -1829,7 +1829,7 @@ SUBROUTINE TimeSeriesScaling_IEC(p, V)
 
       HubFactor(IVec) = p%IEC%SigmaIEC(IVec)/ActualSigma(IVec)  ! factor = Target / actual
                   
-      IF (p%IEC%ScaleIEC == 1 .OR. IVec > 1) THEN ! v and w have no coherence, thus all points have same std, so we'll save some calculations
+      IF (p%IEC%ScaleIEC == 1 .OR. p%met%SCMod(IVec) == CohMod_None) THEN ! with no coherence, all points have same std, so we'll save some calculations
                
          V(:,:,IVec) =     HubFactor(IVec) * V(:,:,IVec)
                


### PR DESCRIPTION
This fixes two minor problems in TurbSim
- The default power law exponent (PLExp) was set to 0 if you used any of the EWM models.
- If ScaleIEC=2 was used with the IEC spectra and the coherence for v- or w- components was *not* the default model (i.e., not "NONE"), you wouldn't get the same TI at all points in the v- and w- components. It would effectively use ScaleIEC=1 instead.