### PR TITLE
Output format for CR

### DIFF
--- a/modules-local/nwtc-library/src/SysGnuLinux.f90
+++ b/modules-local/nwtc-library/src/SysGnuLinux.f90
@@ -468,7 +468,7 @@ CONTAINS
 
    ELSE
       ! bjj: note that this will almost certainly write more than MaxWrScrLen characters on a line
-      WRITE (CU,'(A)',ADVANCE='NO')  CR, Str
+      WRITE (CU,'(2A)',ADVANCE='NO')  CR, Str
    END IF
 
 


### PR DESCRIPTION
Just tiny fix of write format in WrOver.
CR (ACHAR(13)) can work fine.
This fix may be applicable for the other Sys*.f90.
But I hove no such work environments.