### PR TITLE
CMake: Change logic for default install location

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,12 +150,9 @@ install(FILES ${CMAKE_CURRENT_BINARY_DIR}/OpenFASTConfig.cmake
 
 ########################################################################
 # Configure the default install path to openfast/install
-string(FIND ${CMAKE_Fortran_MODULE_DIRECTORY} "build/ftnmods" found)
-if(${found} GREATER 0)
-  string(REPLACE "build/ftnmods" "install" install_path ${CMAKE_Fortran_MODULE_DIRECTORY})
-  if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-    set(CMAKE_INSTALL_PREFIX ${install_path} CACHE PATH "..." FORCE)
-  endif()
+if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
+  set(CMAKE_INSTALL_PREFIX "${CMAKE_SOURCE_DIR}/install" CACHE PATH
+    "OpenFAST install directory" FORCE)
 endif()
 
 # Option configuration


### PR DESCRIPTION
Change default installation logic in top-level CMakeLists.txt so that the installation directory not dependent on the value of `CMAKE_Fortran_MODULE_DIRECTORY`. The default location will be configured correctly even if the user does not name the build directory `build`, but
instead chooses some other name for the build directory.