### PR TITLE
Fix a C compiler warning

### DIFF
--- a/modules-local/fast-registry/src/gen_c_types.c
+++ b/modules-local/fast-registry/src/gen_c_types.c
@@ -354,7 +354,7 @@ gen_c_module( FILE * fph, node_t * ModName )
     for ( q = ModName->module_ddt_list ; q ; q = q->next )
     {
       if ( q->usefrom == 0 ) {
-        if (q->mapsto) remove_nickname(ModName->nickname, make_lower_temp(q->mapsto), nonick);
+        if (*q->mapsto) remove_nickname(ModName->nickname, make_lower_temp(q->mapsto), nonick);
         fprintf(fph,  "  typedef struct %s {\n",q->mapsto) ;
         //if (!strcmp(make_lower_temp(nonick), "otherstatetype") !strcmp(make_lower_temp(nonick), "initinputtype")){
            fprintf(fph, "    void * object ;\n");
@@ -372,7 +372,7 @@ gen_c_module( FILE * fph, node_t * ModName )
               }
             } else {
               char tmp[NAMELEN] ; tmp[0] = '\0' ;
-              if ( q->mapsto) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , tmp ) ;
+              if (*q->mapsto) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , tmp ) ;
               if (r->ndims > 0 && has_deferred_dim(r, 0)) {
                 fprintf(fph,"    %s * %s ; ",C_type( r->type->mapsto), r->name ) ;
                 fprintf(fph,"    int %s_Len ;",r->name ) ;

--- a/modules-local/fast-registry/src/gen_module_files.c
+++ b/modules-local/fast-registry/src/gen_module_files.c
@@ -2092,7 +2092,7 @@ gen_module( FILE * fp , node_t * ModName, char * prog_ver )
 // generate each derived data type
     for ( q = ModName->module_ddt_list ; q ; q = q->next )
     {
-      if ( q->mapsto) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , nonick ) ;
+      if (*q->mapsto) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , nonick ) ;
       fprintf(fp, "! =========  %s%s  =======\n", q->mapsto, (sw_ccode) ? "_C" : "");
     for ( ipass = (sw_ccode)?0:1 ; ipass < 2 ; ipass++ ) {   // 2 passes for C code, 1st pass generates bound ddt
       if ( q->usefrom == 0 ) {
@@ -2146,13 +2146,13 @@ gen_module( FILE * fp , node_t * ModName, char * prog_ver )
 
                // bjj: we need to make sure these types map to reals, too
                tmp[0] = '\0' ;
-               if ( q->mapsto ) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , tmp ) ;
+               if (*q->mapsto) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , tmp ) ;
                if ( must_have_real_or_double(tmp) ) checkOnlyReals( q->mapsto, r );
 
 
             } else {
               tmp[0] = '\0' ;
-              if ( q->mapsto ) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , tmp ) ;
+              if (*q->mapsto) remove_nickname( ModName->nickname, make_lower_temp(q->mapsto) , tmp ) ;
               if ( must_have_real_or_double(tmp) ) {
                 if ( strncmp(r->type->mapsto,"REAL",4) ) {
                   fprintf(stderr,"Registry warning: %s contains a field (%s) whose type is not real or double: %s\n",


### PR DESCRIPTION
The compiler warning is:
```warning: address of array 'q->mapsto' will always evaluate to 'true'```

This is saying that the `mapsto` attribute of `q` which is type `node_struct` is a pointer to memory. So, if `q` is instantiated then `q->mapsto` is allocated. The type definition for this struct is found in data.h at [line 4](https://github.com/OpenFAST/openfast/blob/master/modules-local/fast-registry/src/data.h#L4) and `mapsto` is at [line 9](https://github.com/OpenFAST/openfast/blob/master/modules-local/fast-registry/src/data.h#L9).