### PR TITLE
Documentation update regarding building the documentation

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -5,4 +5,5 @@ pyparsing==2.1.9
 Sphinx==1.5.2
 sphinxcontrib-bibtex==0.3.4
 sphinxcontrib-doxylink==1.3
+sphinx_rtd_theme==0.3.1
 requests[security]

--- a/docs/source/dev/build_doc.rst
+++ b/docs/source/dev/build_doc.rst
@@ -10,7 +10,7 @@ to publish your changes to the public facing site.
 
 Dependencies
 ------------
-The documentation is built in `Sphinx <http://www.sphinx-doc.org/en/master/>`__ with
+The documentation is built in `Sphinx <http://www.sphinx-doc.org/en/master/>`__ with optional support for 
 `Doxygen <http://www.stack.nl/~dimitri/doxygen/>`__, `Doxylink <https://pythonhosted.org/sphinxcontrib-doxylink/>`__, and
 `Graphviz <http://www.graphviz.org>`__. Therefore users will need to install these tools as well as several extensions of Sphinx that are utilized.
 

--- a/docs/source/dev/build_doc.rst
+++ b/docs/source/dev/build_doc.rst
@@ -3,48 +3,34 @@
 Building this documentation locally
 ===================================
 
-This document describes how to build the OpenFAST documentation on your local   machine.  Documentation is automatically built and updated on readthedocs when  new material is pushed to the github repo. However, while developing            documentation, one should build locally to see changes quickly, and without the need to push your changes to see them on readthedocs.
+This document describes how to build the OpenFAST documentation on your local machine. The official documentation is automatically built
+and updated on `readthedocs <http://openfast.readthedocs.io/en/latest/>`__ when new material is pushed to the github repo.
+However, while developing documentation, it is helpful to build locally in order to see changes quickly and without needing
+to publish your changes to the public facing site.
 
-The documentation is based on the use of Doxygen, Sphinx,
-and Doxylink. Therefore users will need to install these tools
-as well as several extensions of Sphinx that are utilized.
+Dependencies
+------------
+The documentation is built in `Sphinx <http://www.sphinx-doc.org/en/master/>`__ with
+`Doxygen <http://www.stack.nl/~dimitri/doxygen/>`__, `Doxylink <https://pythonhosted.org/sphinxcontrib-doxylink/>`__, and
+`Graphviz <http://www.graphviz.org>`__. Therefore users will need to install these tools as well as several extensions of Sphinx that are utilized.
 
+Doxygen and Graphviz can be installed directly from their website or with a package manager like ``brew``, ``yum``, or ``apt``.
 
-Install the Tools
------------------
+The remaining tools are Python based and should be installed with `pip` using the requirements file at
+``docs/requirements.txt``.
 
-Install CMake, Doxygen, Sphinx, Doxylink, and the
-extensions used. Doxygen uses the ``dot`` application
-installed with GraphViz. Sphinx uses a combination
-of extensions installed with ``pip install`` as well as some
-that come with OpenFAST located in the ``_extensions``
-directory. Using Homebrew on Mac OS X,
-this would look something like:
-
-::
-
-  brew install cmake
-  brew install python
-  brew install doxygen
-  brew install graphviz
-  pip install sphinx
-  pip install sphinxcontrib-doxylink
-  pip install sphinxcontrib-bibtex
-  pip install sphinx_rtd_theme
-
-Run CMake Configure and Make the Docs
--------------------------------------
-
+With CMake and Make
+-------------------
 In the OpenFAST repository checkout, if it has not been created yet,
 create a ``build`` directory.  Change
 to the build directory and run CMake with ``BUILD_DOCUMENTATION`` on.  If all
-of the main tools are found successfully, CMake should configure with the
+of the required tools are found successfully, CMake will configure with the
 ability to build the documentation. If Sphinx or Doxygen aren't found, the
 configure will skip the documentation.
 
-Issue the command ``make docs`` which should first build the Doxygen
+Issue the command ``make docs`` which will first build the Doxygen
 documentation and then the Sphinx documentation. If this completes
-successfully, the entry point to the documentation should be in
+successfully, the entry point to the documentation will be in
 ``build/docs/html/index.html``.
 
 For example, from the OpenFAST directory:
@@ -53,7 +39,7 @@ For example, from the OpenFAST directory:
 
     mkdir build
     cd build
-    cmake -DBUILD_DOCUMENTATION:BOOL=ON ..
+    cmake .. -DBUILD_DOCUMENTATION=ON
     make docs
 
 If you modify document source files in ``OpenFAST/docs/source``, you can simply update the html files through another ``make docs`` in ``OpenFAST/build``:
@@ -61,6 +47,23 @@ If you modify document source files in ``OpenFAST/docs/source``, you can simply 
 ::
 
     make docs
+
+Pure python
+-----------
+If CMake and Make are not available on your system, the documentation can be generated directly
+with `sphinx`. **Note: This method does not generate the API documentation through Doxygen.**
+
+First, align your build structure to the standard OpenFAST build by creating a directory 
+at ``openfast/build``.
+
+If all tools are available, move into ``openfast/build`` and run the `sphinx` command:
+
+::
+
+    # sphinx-build -b <builder-name> <source-directory> <output-directory>
+    sphinx-build -b html ../docs ./docs/html
+
+
 
 Documentation Output
 --------------------

--- a/docs/source/dev/build_doc.rst
+++ b/docs/source/dev/build_doc.rst
@@ -68,7 +68,7 @@ If all tools are available, move into ``openfast/build`` and run the `sphinx` co
 Documentation Output
 --------------------
 
-After building the documentation, it can be access by opening the output in a browser.
+After building the documentation, it can be accessed by opening the output in a browser.
 Open the high level html file generated at ``openfast/build/docs/html/index.html``
 and begin using the page as any other web page.
 

--- a/docs/source/dev/build_doc.rst
+++ b/docs/source/dev/build_doc.rst
@@ -25,8 +25,7 @@ In the OpenFAST repository checkout, if it has not been created yet,
 create a ``build`` directory.  Change
 to the build directory and run CMake with ``BUILD_DOCUMENTATION`` on.  If all
 of the required tools are found successfully, CMake will configure with the
-ability to build the documentation. If Sphinx or Doxygen aren't found, the
-configure will skip the documentation.
+ability to build the documentation.
 
 Issue the command ``make docs`` which will first build the Doxygen
 documentation and then the Sphinx documentation. If this completes

--- a/docs/source/install/install_cmake_linux.rst
+++ b/docs/source/install/install_cmake_linux.rst
@@ -21,8 +21,8 @@ In order to build OpenFAST using CMake, one needs the following minimum set of p
 
 - CMake (version 2.8.12 or later)
 
-OpenFAST third-party-library (TPL) dependencies
------------------------------------------------
+OpenFAST third party library dependencies
+-----------------------------------------
 
 OpenFAST has the following dependencies:
 
@@ -35,7 +35,7 @@ OpenFAST has the following dependencies:
 CMake build instructions
 ------------------------
 
-If one has the appropriate TPLs, CMake, and git installed, obtaining and building OpenFAST can be accomplished as follows:
+If one has the appropriate third party libraries, CMake, and git installed, obtaining and building OpenFAST can be accomplished as follows:
 
 .. code-block:: bash
 
@@ -51,7 +51,7 @@ If one has the appropriate TPLs, CMake, and git installed, obtaining and buildin
     # go to the build directory
     cd build
 
-    # execute CMake with the default options, which will create a Makefile
+    # execute CMake with the default options, which will create a series of Makefiles
     cmake ../ 
 
     # execute a make command (with no target provided, equivalent to `make all`
@@ -79,6 +79,7 @@ Below is a list of current CMake options including their default settings (which
 -  ``BUILD_DOCUMENTATION`` -  Build documentation (Default: OFF)
 -  ``BUILD_FAST_CPP_API`` - Enable building OpenFAST - C++ API (Default: OFF)
 -  ``BUILD_SHARED_LIBS`` - Enable building shared libraries (Default: OFF)
+-  ``BUILD_TESTING`` - Build the testing tree (Default: OFF)
 -  ``CMAKE_BUILD_TYPE`` - Choose the build type: Debug Release (Default: Release)
 -  ``CMAKE_INSTALL_PREFIX`` - Install path prefix, prepended onto install directories.
 -  ``DOUBLE_PRECISION`` - Treat REAL as double precision (Default: ON)
@@ -86,14 +87,14 @@ Below is a list of current CMake options including their default settings (which
 -  ``ORCA_DLL_LOAD`` - Enable OrcaFlex library load (Default: OFF)
 -  ``USE_DLL_INTERFACE`` - Enable runtime loading of dynamic libraries (Default: ON)
 
-CMake options can be executed from the command line as, e.g., the CMake command above could be exectuted as
+CMake options can be configured through command line, e.g.
 
 .. code-block:: bash
 
-    # e.g., to enable Makefile for local building of sphinx-based documentation
+    # to enable Makefile for local building of sphinx-based documentation
     cmake -DBUILD_DOCUMENTATION:BOOL=ON ..
 
-    # e.g., to compile OpenFAST in single precision
+    # to compile OpenFAST in single precision
     cmake -D:DOUBLE_PRECISION:BOOL=OFF ..
  
 

--- a/docs/source/testing/index.rst
+++ b/docs/source/testing/index.rst
@@ -19,7 +19,7 @@ Portions of the test suite are linked to the OpenFAST repository through
 ``git submodule``. Specifically,
 
 - `r-test <https://github.com/openfast/r-test>`__
-- `pFUnit <http://pfunit.sourceforge.net>`__
+- `pFUnit <http://github.com/openfast/pfunit>`__
 
 Be sure to clone the repo with the ``--recursive`` flag or execute
 ``git submodule update --init --recursive`` after cloning.

--- a/docs/source/testing/index.rst
+++ b/docs/source/testing/index.rst
@@ -30,9 +30,8 @@ for particular build environments. See the installation documentation at :numref
 for more details on configuring the CMake targets.
 
 While the unit tests must be built with CMake due to its external dependencies,
-the regression test may be executed without building with CMake. :numref:`regression_test`
-and :numref:`unit_test` have more information on regression testing and unit testing,
-respectively.
+the regression test may be executed without building with CMake. :numref:`unit_test` and :numref:`regression_test`
+have more information on unit testing and regression testing, respectively.
 
 Test specific documentation
 ---------------------------

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -7,7 +7,7 @@ The regression test executes a series of test cases which intend to fully descri
 OpenFAST and its module's capabilities. Each locally computed result is compared
 to a static set of baseline results. To account for system, hardware, and compiler
 differences, the regression test attempts to match the current machine and
-compiler type to the appropriate solution set from these combinations
+compiler type to the appropriate solution set from these combinations:
 
 - macOS with GNU compiler (default)
 - Red Hat Enterprise Linux with Intel compiler
@@ -153,8 +153,8 @@ all locally generated solutions are located in the corresponding glue-code or mo
 ``openfast/build/reg_tests``. The baseline solutions contained in ``openfast/reg_tests/r-test``
 are strictly read not modified by the automated process.
 
-Regression test from scratch
-----------------------------
+Regression test example
+-----------------------
 
 - Build OpenFAST and the test suite
 

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -4,7 +4,12 @@ Regression test
 ===============
 
 The regression test executes a series of test cases which intend to fully describe
-OpenFAST and its module's capabilities. Each locally computed result is compared
+OpenFAST and its module's capabilities.
+
+Jump to :ref:`regression_test_ctest`, :ref:`regression_test_example`, or :ref:`regression_test_windows`
+for instructions on running the regression tests locally.
+
+Each locally computed result is compared
 to a static set of baseline results. To account for system, hardware, and compiler
 differences, the regression test attempts to match the current machine and
 compiler type to the appropriate solution set from these combinations:
@@ -123,6 +128,8 @@ should be specified in the CMake configuration under the ``CTEST_OPENFAST_EXECUT
 flag. There is also a corresponding ``CTEST_[MODULE]_NAME`` flag for each module
 included in the regression test.
 
+.. _regression_test_ctest:
+
 Running the regression test with CTest
 --------------------------------------
 
@@ -152,6 +159,8 @@ The automated regression test writes new files only into the build directory. Sp
 all locally generated solutions are located in the corresponding glue-code or module within
 ``openfast/build/reg_tests``. The baseline solutions contained in ``openfast/reg_tests/r-test``
 are strictly read not modified by the automated process.
+
+.. _regression_test_example:
 
 Regression test example
 -----------------------

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -177,11 +177,11 @@ Regression test example
   # - BUILD_TESTING
   # - CTEST_OPENFAST_EXECUTABLE
   # - CTEST_[MODULE]_EXECUTABLE
-  cmake ..
+  cmake .. -DBUILD_TESTING=ON
   make install
   ctest
 
-- Build only the test suite
+- Build only the test suite if an openfast binary already exists
 
 .. code-block:: bash
 

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -163,7 +163,7 @@ Regression test from scratch
   git clone --recursive https://github.com/openfast/openfast.git
   # The default git branch is 'master'. If necessary, switch to your target branch:
   # git checkout dev
-  mkdir build && cd build
+  mkdir build install && cd build
   # Configure CMake with openfast/CMakeLists.txt
   # - BUILD_TESTING
   # - CTEST_OPENFAST_EXECUTABLE
@@ -179,7 +179,7 @@ Regression test from scratch
   git clone --recursive https://github.com/openfast/openfast.git
   # The default git branch is 'master'. If necessary, switch to your target branch:
   # git checkout dev
-  mkdir build && cd build
+  mkdir build install && cd build
   # Configure CMake with openfast/reg_tests/CMakeLists.txt
   # - BUILD_TESTING
   # - CTEST_OPENFAST_EXECUTABLE

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -137,14 +137,18 @@ When driven by CTest, the regression test can be executed by running various
 forms of the command ``ctest`` from the build directory. The basic commands are
 
 - ``ctest`` - Run the entire regression test
+- ``ctest -N`` - Disable actual execution of tests; this is helpful in formulating a particular ctest command
 - ``ctest -V`` - Run the entire regression test with verbose output
-- ``ctest -R [TestName]`` - Run a test by name
+- ``ctest -R [TestName]`` - Run a test by name where TestName is a regex to search
 - ``ctest -j [N]`` - Run all tests with N tests executing in parallel
-- ``ctest -N`` - List all of the tests available
 
 Each regression test case contains a series of labels associating all of the
 modules used. The labeling can be seen in the test instantiation in
-``reg_tests/CTestList.cmake`` and called directly with
+``reg_tests/CTestList.cmake`` or with the command
+
+- ``ctest --print-labels`` - Print all available test labels
+
+Labels can be called directoly with
 
 - ``ctest -L [Label]``
 
@@ -154,6 +158,7 @@ These flags can be compounded making useful variations of ``ctest`` such as
 - ``ctest -j 16 -L aerodyn14`` - Runs all cases that use AeroDyn14 in 16 concurrent processes
 - ``ctest -V -R 5MW_DLL_Potential_WTurb`` - Runs the case with name "5MW_DLL_Potential_WTurb"
 - ``ctest -N -L beamdyn`` - Lists all tests with the "beamdyn" label
+- ``ctest -N -R bd --print-labels`` - Lists the labels included in all tests matching the regex "bd"
 
 The automated regression test writes new files only into the build directory. Specifically,
 all locally generated solutions are located in the corresponding glue-code or module within

--- a/docs/source/testing/regression_test_windows.rst
+++ b/docs/source/testing/regression_test_windows.rst
@@ -1,6 +1,6 @@
 .. _regression_test_windows:
 
-Windows With Visual Studio Regression Test
+Windows with Visual Studio regression test
 ==========================================
 
 1) Clone the openfast repo and initialize the testing database


### PR DESCRIPTION
This pull request add one significant update and a few minor updates to the documentation.

**Significant update**
Instructions for building the documentation locally without cmake and make are now included. This specifically serves Windows users who do not use a unix-like environment like MinGW or CygWin.
See this updated documentation at: http://raf-openfast.readthedocs.io/en/latest/source/dev/build_doc.html

This update fixes issue #63.

**Minor updates**
- Formating
- Spelling
- Outdated links were updated
- A recently added CMake build flag is included
- CTest example commands are improved