### PR TITLE
Fixes issue #16 regarding VTK output file naming convention

### DIFF
--- a/modules-local/nwtc-library/src/ModMesh.f90
+++ b/modules-local/nwtc-library/src/ModMesh.f90
@@ -277,7 +277,7 @@ END SUBROUTINE MeshWrVTKreference
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine writes mesh information in VTK format.
 !! see VTK file information format for XML, here: http://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf
-SUBROUTINE MeshWrVTK ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, ErrStat, ErrMsg, Sib )
+SUBROUTINE MeshWrVTK ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, ErrStat, ErrMsg, Twidth, Sib )
       
    REAL(SiKi),      INTENT(IN)           :: RefPoint(3)     !< reference location, normally (0,0,0)
    TYPE(MeshType),  INTENT(IN)           :: M               !< mesh to be written
@@ -286,6 +286,7 @@ SUBROUTINE MeshWrVTK ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, Err
    LOGICAL,         INTENT(IN)           :: OutputFieldData !< flag to determine if we want to output field data or just the absolute position of this mesh
    INTEGER(IntKi),  INTENT(OUT)          :: ErrStat         !< Indicates whether an error occurred (see NWTC_Library)
    CHARACTER(*),    INTENT(OUT)          :: ErrMsg          !< Error message associated with the ErrStat
+   INTEGER(IntKi),  INTENT(IN)           :: Twidth          !< Number of digits in the maximum write-out step (used to pad the VTK write-out in the filename with zeros)
 
    TYPE(MeshType),  INTENT(IN), OPTIONAL :: Sib             !< "functional" Sibling of M that contains translational displacement information (used to place forces at displaced positions) 
 
@@ -293,6 +294,7 @@ SUBROUTINE MeshWrVTK ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, Err
    INTEGER(IntKi)                        :: Un            ! fortran unit number
    INTEGER(IntKi)                        :: i,j           ! loop counters
    CHARACTER(1024)                       :: FileName
+   CHARACTER(Twidth)                     :: Tstr          ! string for current VTK write-out step (padded with zeros)
       
    INTEGER(IntKi)                        :: ErrStat2 
    CHARACTER(ErrMsgLen)                  :: ErrMsg2
@@ -317,9 +319,12 @@ SUBROUTINE MeshWrVTK ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, Err
    !.................................................................
    ! write the data that potentially changes each time step:
    !.................................................................
+
+   ! construct the string for the zero-padded VTK write-out step
+   write(Tstr, '(i' // trim(Num2LStr(Twidth)) //'.'// trim(Num2LStr(Twidth)) // ')') VTKcount
       
    ! PolyData (.vtp) - Serial vtkPolyData (unstructured) file
-   FileName = TRIM(FileRootName)//'.t'//TRIM(Num2LStr(VTKcount))//'.vtp'
+   FileName = TRIM(FileRootName)//'.'//Tstr//'.vtp'
       
    call WrVTK_header( trim(FileName), M%Nnodes, M%ElemTable(ELEMENT_LINE2)%nelem, 0, Un, ErrStat2, ErrMsg2 )    
       call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
@@ -513,13 +518,14 @@ END SUBROUTINE MeshWrVTKfields
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine writes line2 mesh surface information in VTK format.
 !! see VTK file information format for XML, here: http://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf
-SUBROUTINE MeshWrVTK_Ln2Surface ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, ErrStat, ErrMsg, NumSegments, Radius, verts, Sib )
+SUBROUTINE MeshWrVTK_Ln2Surface ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, ErrStat, ErrMsg, Twidth, NumSegments, Radius, verts, Sib )
       
    REAL(SiKi),      INTENT(IN)           :: RefPoint(3)     !< reference location, normally (0,0,0)
    TYPE(MeshType),  INTENT(IN)           :: M               !< mesh to be written
    CHARACTER(*),    INTENT(IN)           :: FileRootName    !< Name of the file to write the output in (excluding extension)
    INTEGER(IntKi),  INTENT(IN)           :: VTKcount        !< Indicates number for VTK output file (when 0, the routine will also write reference information)
    LOGICAL,         INTENT(IN)           :: OutputFieldData !< flag to determine if we want to output field data or just the absolute position of this mesh
+   INTEGER(IntKi),  INTENT(IN)           :: Twidth          !< Number of digits in the maximum write-out step (used to pad the VTK write-out in the filename with zeros)
    INTEGER(IntKi),  INTENT(IN), OPTIONAL :: NumSegments     !< Number of segments to split the circle into
    REAL(SiKi),      INTENT(IN), OPTIONAL :: Radius(:)       !< Radius of each node
    REAL(SiKi),      INTENT(IN), OPTIONAL :: verts(:,:,:)    !< X-Y verticies (2x{NumSegs}xNNodes) of points that define a shape around each node
@@ -536,6 +542,7 @@ SUBROUTINE MeshWrVTK_Ln2Surface ( RefPoint, M, FileRootName, VTKcount, OutputFie
    CHARACTER(1024)                       :: FileName
    REAL(SiKi)                            :: angle
    REAL(SiKi)                            :: xyz(3)
+   CHARACTER(Twidth)                     :: Tstr          ! string for current write-out step (padded with zeros)
 
    INTEGER(IntKi)                        :: firstPntEnd, firstPntStart, secondPntStart, secondPntEnd  ! node indices for forming rectangle 
    INTEGER(IntKi)                        :: NumSegments1
@@ -566,9 +573,12 @@ SUBROUTINE MeshWrVTK_Ln2Surface ( RefPoint, M, FileRootName, VTKcount, OutputFie
    !.................................................................
    ! write the data that potentially changes each time step:
    !.................................................................
+
+   ! construct the string for the zero-padded VTK write-out step
+   write(Tstr, '(i' // trim(Num2LStr(Twidth)) //'.'// trim(Num2LStr(Twidth)) // ')') VTKcount
       
    ! PolyData (.vtp) - Serial vtkPolyData (unstructured) file
-   FileName = TRIM(FileRootName)//'.t'//TRIM(Num2LStr(VTKcount))//'.vtp'
+   FileName = TRIM(FileRootName)//'.'//Tstr//'.vtp'
        
       ! Write a VTP mesh file (Polygonal VTK file) with positions and polygons (surfaces)
       ! (note alignment of WRITE statements to make sure spaces are lined up in XML file)
@@ -671,13 +681,14 @@ SUBROUTINE MeshWrVTK_Ln2Surface ( RefPoint, M, FileRootName, VTKcount, OutputFie
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine writes point mesh surfaces information in VTK format.
 !! see VTK file information format for XML, here: http://www.vtk.org/wp-content/uploads/2015/04/file-formats.pdf
-SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, ErrStat, ErrMsg, NumSegments, Radius, verts, Sib )
+SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputFieldData, ErrStat, ErrMsg, Twidth, NumSegments, Radius, verts, Sib )
       
    REAL(SiKi),      INTENT(IN)           :: RefPoint(3)     !< reference location, normally (0,0,0)
    TYPE(MeshType),  INTENT(IN)           :: M               !< mesh to be written
    CHARACTER(*),    INTENT(IN)           :: FileRootName    !< Name of the file to write the output in (excluding extension)
    INTEGER(IntKi),  INTENT(IN)           :: VTKcount        !< Indicates number for VTK output file (when 0, the routine will also write reference information)
    LOGICAL,         INTENT(IN)           :: OutputFieldData !< flag to determine if we want to output field data or just the absolute position of this mesh
+   INTEGER(IntKi),  INTENT(IN)           :: Twidth          !< Number of digits in the maximum write-out timestep (used to pad the VTK write-out in the filename with zeros)
    INTEGER(IntKi),  INTENT(IN), OPTIONAL :: NumSegments     !< Number of segments to split the circle into
    REAL(SiKi),      INTENT(IN), OPTIONAL :: Radius          !< Radius of each node
    REAL(SiKi),      INTENT(IN), OPTIONAL :: verts(:,:)      !< X-Y-Z verticies (3xn) of points that define a volume around each node
@@ -699,6 +710,7 @@ SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputF
    CHARACTER(1024)                       :: FileName
    REAL(SiKi)                            :: angle, r, ratio
    REAL(SiKi)                            :: xyz(3)
+   CHARACTER(Twidth)                     :: Tstr          ! string for current VTK write-out step (padded with zeros)
 
    INTEGER(IntKi)                        :: firstPntEnd, firstPntStart, secondPntStart, secondPntEnd  ! node indices for forming rectangle 
    
@@ -757,9 +769,12 @@ SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputF
    !.................................................................
    ! write the data that potentially changes each time step:
    !.................................................................
+
+   ! construct the string for the zero-padded VTK write-out step
+   write(Tstr, '(i' // trim(Num2LStr(Twidth)) //'.'// trim(Num2LStr(Twidth)) // ')') VTKcount
       
    ! PolyData (.vtp) - Serial vtkPolyData (unstructured) file
-   FileName = TRIM(FileRootName)//'.t'//TRIM(Num2LStr(VTKcount))//'.vtp'
+   FileName = TRIM(FileRootName)//'.'//Tstr//'.vtp'
       
       ! Write a VTP mesh file (Polygonal VTK file) with positions and polygons (surfaces)
       ! (note alignment of WRITE statements to make sure spaces are lined up in XML file)

--- a/modules-local/nwtc-library/src/SysGnuLinux.f90
+++ b/modules-local/nwtc-library/src/SysGnuLinux.f90
@@ -15,30 +15,21 @@
 ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
-!
-!**********************************************************************************************************************************
-! File last committed: $Date$
-! (File) Revision #: $Rev$
-! URL: $HeadURL$
 !**********************************************************************************************************************************
 MODULE SysSubs
 
-
    ! This module contains routines with system-specific logic and references, including all references to the console unit, CU.
    ! It also contains standard (but not system-specific) routines it uses.
-
-   ! SysGnuLinux.f90 is specifically for the GNU Fortran (gfortran) compiler on Linux. This should also work for gfortran on MAC.
-
-
+   ! SysGnuLinux.f90 is specifically for the GNU Fortran (gfortran) compiler on Linux and macOS.
    ! It contains the following routines:
-
    !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
+   !     FUNCTION    Is_NaN( DblNum )                                         ! Please use IEEE_IS_NAN() instead
+   !     FUNCTION    NWTC_ERF( x )
+   !     FUNCTION    NWTC_gamma( x )                                          ! Returns the gamma value of its argument.   
    !     SUBROUTINE  FlushOut ( Unit )
    !     SUBROUTINE  GET_CWD( DirName, Status )
-   !     FUNCTION    Is_NaN( DblNum )                                         ! Please use IEEE_IS_NAN() instead
-   !     FUNCTION    NWTC_Gamma( x )                                          ! Returns the gamma value of its argument.   
-   ! per MLB, this can be removed, but only if CU is OUTPUT_UNIT:
-   !     SUBROUTINE  OpenCon                                                  ! Actually, it can't be removed until we get Intel's FLUSH working. (mlb)
+   !     SUBROUTINE  MKDIR( new_directory_path )
+   !     SUBROUTINE  OpenCon
    !     SUBROUTINE  OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
    !     SUBROUTINE  ProgExit ( StatCode )
    !     SUBROUTINE  Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
@@ -49,11 +40,15 @@ MODULE SysSubs
    !     SUBROUTINE LoadDynamicLib( DLL, ErrStat, ErrMsg )
    !     SUBROUTINE FreeDynamicLib( DLL, ErrStat, ErrMsg )
 
+   USE NWTC_Base
 
+   IMPLICIT NONE
 
-   USE                             NWTC_Base
-
-   IMPLICIT                        NONE
+   INTERFACE NWTC_ERF ! Returns the ERF value of its argument
+      MODULE PROCEDURE NWTC_ERFR4
+      MODULE PROCEDURE NWTC_ERFR8
+      MODULE PROCEDURE NWTC_ERFR16
+   END INTERFACE
 
    INTERFACE NWTC_gamma ! Returns the gamma value of its argument
          ! note: gamma is part of the F08 standard, but may not be implemented everywhere...
@@ -61,58 +56,29 @@ MODULE SysSubs
       MODULE PROCEDURE NWTC_gammaR8
       MODULE PROCEDURE NWTC_gammaR16
    END INTERFACE
-   
-   INTERFACE NWTC_ERF ! Returns the ERF value of its argument
-      MODULE PROCEDURE NWTC_ERFR4
-      MODULE PROCEDURE NWTC_ERFR8
-      MODULE PROCEDURE NWTC_ERFR16
-   END INTERFACE
-   
-   
-
-!=======================================================================
-
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
    INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
-                                                                                    ! CU = 7 works on gfortran compiler version 4.6 and possibly 4.5. Fails on version 4.7 and 4.8 (see bugzilla bug report #445 for details)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
-
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
-
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
    CHARACTER(*),  PARAMETER      :: OS_Desc     = 'GNU Fortran for Linux'           ! Description of the language/OS
    CHARACTER( 1), PARAMETER      :: PathSep     = '/'                               ! The path separator.
    CHARACTER( 1), PARAMETER      :: SwChar      = '-'                               ! The switch character for command-line options.
    CHARACTER(11), PARAMETER      :: UnfForm     = 'UNFORMATTED'                     ! The string to specify unformatted I/O files.
 
-
 CONTAINS
 
 !=======================================================================
-   FUNCTION FileSize( Unit )
+FUNCTION FileSize( Unit )
 
-
-      ! This function calls the portability routine, FSTAT, to obtain the file size
-      ! in bytes corresponding to a file unit number or returns -1 on error.
-
-
-      ! Function declaration.
+   ! This function calls the portability routine, FSTAT, to obtain the file size
+   ! in bytes corresponding to a file unit number or returns -1 on error.
 
    INTEGER(B8Ki)                             :: FileSize                      ! The size of the file in bytes to be returned.
-
-
-      ! Argument declarations:
-
    INTEGER, INTENT(IN)                       :: Unit                          ! The I/O unit number of the pre-opened file.
-
-
-      ! Local declarations:
-
    INTEGER                                   :: StatArray(13)                 ! An array returned by FSTAT that includes the file size.
    INTEGER                                   :: Status                        ! The status returned by
-
-
 
    Status = FSTAT( INT( Unit, B4Ki ), StatArray )
 
@@ -122,207 +88,176 @@ CONTAINS
       FileSize = StatArray(8)
    END IF
 
+   RETURN
+END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+FUNCTION Is_NaN( DblNum )
+
+   ! This routine determines if a REAL(DbKi) variable holds a proper number.
+   ! BJJ: this routine is used in CRUNCH.
+   ! Note that IsNaN does not exist in earlier versions of gfortran (e.g., 4.2.1),
+   ! but does exist in version 4.4. It should be replaced with the standard
+   ! IEEE_IS_NAN when gfortran implements it.
+
+   REAL(DbKi), INTENT(IN)       :: DblNum
+   LOGICAL                      :: Is_Nan
+
+   Is_NaN = IsNaN( DblNum )
 
    RETURN
-   END FUNCTION FileSize ! ( Unit )
+END FUNCTION Is_NaN ! ( DblNum )
 !=======================================================================
-   SUBROUTINE FlushOut ( Unit )
+FUNCTION NWTC_ERFR4( x )
 
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
 
-      ! This subroutine flushes the buffer on the specified Unit.
-      ! It is especially useful when printing "running..." type messages.
+   REAL(SiKi), INTENT(IN)     :: x           ! input 
+   REAL(SiKi)                 :: NWTC_ERFR4  ! result
+   
+   NWTC_ERFR4 = ERF( x )
 
+END FUNCTION NWTC_ERFR4
+!=======================================================================
+FUNCTION NWTC_ERFR8( x )
 
-      ! Argument declarations:
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
 
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_ERFR8    ! result
+   
+   NWTC_ERFR8 = ERF( x )
+
+END FUNCTION NWTC_ERFR8
+!=======================================================================
+FUNCTION NWTC_ERFR16( x )
+
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_ERFR16   ! result
+   
+   NWTC_ERFR16 = ERF( x )
+
+END FUNCTION NWTC_ERFR16
+!=======================================================================
+FUNCTION NWTC_GammaR4( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(SiKi), INTENT(IN)     :: x             ! input 
+   REAL(SiKi)                 :: NWTC_GammaR4  ! result
+   
+   NWTC_GammaR4 = gamma( x )
+
+END FUNCTION NWTC_GammaR4
+!=======================================================================
+FUNCTION NWTC_GammaR8( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_GammaR8  ! result
+   
+   NWTC_GammaR8 = gamma( x )
+
+END FUNCTION NWTC_GammaR8
+!=======================================================================
+FUNCTION NWTC_GammaR16( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_GammaR16  ! result
+   
+   NWTC_GammaR16 = gamma( x )
+
+END FUNCTION NWTC_GammaR16
+!=======================================================================
+SUBROUTINE FlushOut ( Unit )
+
+   ! This subroutine flushes the buffer on the specified Unit.
+   ! It is especially useful when printing "running..." type messages.
+   
    INTEGER, INTENT(IN)          :: Unit                                         ! The unit number of the file being flushed.
 
-
-
-  ! CALL FLUSH ( Unit )
-
+   ! CALL FLUSH ( Unit )
 
    RETURN
-   END SUBROUTINE FlushOut ! ( Unit )
+END SUBROUTINE FlushOut ! ( Unit )
 !=======================================================================
 !bjj note: this subroutine is not tested for this compiler
-   SUBROUTINE Get_CWD ( DirName, Status )
+SUBROUTINE Get_CWD ( DirName, Status )
 
+   ! This routine retrieves the path of the current working directory.
 
-      ! This routine retrieves the path of the current working directory.
-
-
-   IMPLICIT                        NONE
-
-
-      ! Passed variables.
+   IMPLICIT NONE
 
    CHARACTER(*), INTENT(OUT)    :: DirName                                         ! A CHARACTER string containing the path of the current working directory.
    INTEGER,      INTENT(OUT)    :: Status                                          ! Status returned by the call to a portability routine.
 
-
    Status = GETCWD ( DirName )
 
    RETURN
-   END SUBROUTINE Get_CWD
+END SUBROUTINE Get_CWD
 !=======================================================================
-   FUNCTION Is_NaN( DblNum )
+SUBROUTINE MKDIR ( new_directory_path )
 
+   ! This routine creates a given directory if it does not exist.
 
-      ! This routine determines if a REAL(DbKi) variable holds a proper number.
-      ! BJJ: this routine is used in CRUNCH.
-      ! Note that IsNaN does not exist in earlier versions of gfortran (e.g., 4.2.1),
-      ! but does exist in version 4.4. It should be replaced with the standard
-      ! IEEE_IS_NAN when gfortran implements it.
+   implicit none
 
+   character(*), intent(in) :: new_directory_path
+   character(1024)          :: make_command
+   logical                  :: directory_exists
 
-      ! Argument declarations.
+   ! Check if the directory exists first
+   inquire( file=trim(new_directory_path), exist=directory_exists )
 
-   REAL(DbKi), INTENT(IN)       :: DblNum
+   if ( .NOT. directory_exists ) then
+      make_command = 'mkdir -p '//trim(new_directory_path)
+      call system( make_command )
+   endif
 
-
-      ! Function declaration.
-
-   LOGICAL                      :: Is_Nan
-
-
-
-   Is_NaN = IsNaN( DblNum )
-
-
-   RETURN
-   END FUNCTION Is_NaN ! ( DblNum )
+END SUBROUTINE MKDIR
 !=======================================================================
-   FUNCTION NWTC_ERFR4( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+SUBROUTINE OpenCon
 
-      REAL(SiKi), INTENT(IN)     :: x           ! input 
-      REAL(SiKi)                 :: NWTC_ERFR4  ! result
-      
-      
-      NWTC_ERFR4 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR4
-!=======================================================================
-   FUNCTION NWTC_ERFR8( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
-
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_ERFR8    ! result
-      
-      
-      NWTC_ERFR8 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR8
-!=======================================================================
-   FUNCTION NWTC_ERFR16( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
-
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_ERFR16   ! result
-      
-      
-      NWTC_ERFR16 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR16
-!=======================================================================
-   FUNCTION NWTC_GammaR4( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(SiKi), INTENT(IN)     :: x             ! input 
-      REAL(SiKi)                 :: NWTC_GammaR4  ! result
-      
-      
-      NWTC_GammaR4 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR4
-!=======================================================================
-   FUNCTION NWTC_GammaR8( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_GammaR8  ! result
-      
-      
-      NWTC_GammaR8 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR8
-!=======================================================================
-   FUNCTION NWTC_GammaR16( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_GammaR16  ! result
-      
-      
-      NWTC_GammaR16 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR16
-!=======================================================================
-   SUBROUTINE OpenCon
-
-
-      ! This routine opens the console for standard output.
-
+   ! This routine opens the console for standard output.
 
 !bjj: removed for use with CygWin; Because CU = 6 now, this statement is not necessary
 !   OPEN ( CU , FILE='/dev/stdout' , STATUS='OLD' )
 
    CALL FlushOut ( CU )
 
-
    RETURN
-   END SUBROUTINE OpenCon
+END SUBROUTINE OpenCon
 !=======================================================================
-   SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
+SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
 
-
-      ! This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
-      ! Data are stored in RecLen-byte records.
+   ! This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
+   ! Data are stored in RecLen-byte records.
 
    IMPLICIT                        NONE
 
-
-
-      ! Argument declarations.
-
    INTEGER, INTENT(IN)          :: Un                                           ! Logical unit for the input file.
-
    CHARACTER(*), INTENT(IN)     :: InFile                                       ! Name of the input file.
-
    INTEGER, INTENT(IN)          :: RecLen                                       ! Size of records in the input file, in bytes.
-
    LOGICAL, INTENT(OUT)         :: Error                                        ! Flag to indicate the open failed.
-
-
-      ! Local declarations.
-
    INTEGER                      :: IOS                                          ! I/O status of OPEN.
 
-
-
-      ! Open input file.  Make sure it worked.
+   ! Open input file.  Make sure it worked.
 
    ! The non-standard CONVERT keyword allows us to read UNIX binary files, whose bytes are in reverse order (i.e., stored in BIG ENDIAN format).
-
    ! NOTE: using RecLen in bytes requires using the /assume:byterecl compiler option!
-
    OPEN ( Un, FILE=TRIM( InFile ), STATUS='OLD', FORM='UNFORMATTED', ACCESS='DIRECT', RECL=RecLen, IOSTAT=IOS, &
-                   ACTION='READ'  )                                              ! Use this for UNIX systems.
-!                  ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
-
+                  ACTION='READ'  )                                              ! Use this for UNIX systems.
+   !            ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
 
    IF ( IOS /= 0 )  THEN
       Error = .TRUE.
@@ -330,167 +265,122 @@ CONTAINS
       Error = .FALSE.
    END IF
 
-
    RETURN
-   END SUBROUTINE OpenUnfInpBEFile
+END SUBROUTINE OpenUnfInpBEFile
 !=======================================================================
-   SUBROUTINE ProgExit ( StatCode )
+SUBROUTINE ProgExit ( StatCode )
 
-
-      ! This routine stops the program.  If the compiler supports the EXIT routine,
-      ! pass the program status to it.  Otherwise, do a STOP.
-
-
-      ! Argument declarations.
+   ! This routine stops the program.  If the compiler supports the EXIT routine,
+   ! pass the program status to it.  Otherwise, do a STOP.
 
    INTEGER, INTENT(IN)          :: StatCode                                      ! The status code to pass to the OS.
 
-
-
    CALL EXIT ( StatCode )
 
-!   IF ( StatCode == 0 ) THEN
-!      STOP 0
-!   ELSE
-!      IF ( StatCode < 0 ) THEN
-!         CALL WrScr( 'Invalid STOP code.' )
-!      END IF
-!
-!      STOP 1
-!   END IF
+   ! IF ( StatCode == 0 ) THEN
+   !    STOP 0
+   ! ELSE
+   !    IF ( StatCode < 0 ) THEN
+   !       CALL WrScr( 'Invalid STOP code.' )
+   !    END IF
+   !    STOP 1
+   ! END IF
 
-
-   END SUBROUTINE ProgExit ! ( StatCode )
+END SUBROUTINE ProgExit ! ( StatCode )
 !=======================================================================
-   SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
-         
-      ! routine that sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
-      ! values for not-a-number and infinity in sindle and double 
-      ! precision) F03 has standard intrinsic routines to do this,  
-      ! but Gnu has not yet implemented it. This code will fail if  
-      ! the compiler checks for floating-point-error, hence the  
-      ! compiler directive FPE_TRAP_ENABLED.
-   
-   
-      REAL(DbKi), INTENT(inout)           :: Inf_D          ! IEEE value for NaN (not-a-number) in double precision
-      REAL(DbKi), INTENT(inout)           :: NaN_D          ! IEEE value for Inf (infinity) in double precision
-
-      REAL(ReKi), INTENT(inout)           :: Inf            ! IEEE value for NaN (not-a-number)
-      REAL(ReKi), INTENT(inout)           :: NaN            ! IEEE value for Inf (infinity)
-   
-         ! local variables for getting values of NaN and Inf (not necessary when using ieee_arithmetic)
-      REAL(DbKi)                          :: Neg_D          ! a negative real(DbKi) number
-      REAL(ReKi)                          :: Neg            ! a negative real(ReKi) number
-   
+SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
       
-         ! if compiling with floating-point-exception traps, this will not work, so we've added a compiler directive.
-         !  note that anything that refers to NaN or Inf will be incorrect in that case.
-         
+   ! routine that sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
+   ! values for not-a-number and infinity in sindle and double 
+   ! precision) F03 has standard intrinsic routines to do this,  
+   ! but Gnu has not yet implemented it. This code will fail if  
+   ! the compiler checks for floating-point-error, hence the  
+   ! compiler directive FPE_TRAP_ENABLED.
+
+   REAL(DbKi), INTENT(inout)           :: Inf_D          ! IEEE value for NaN (not-a-number) in double precision
+   REAL(DbKi), INTENT(inout)           :: NaN_D          ! IEEE value for Inf (infinity) in double precision
+   REAL(ReKi), INTENT(inout)           :: Inf            ! IEEE value for NaN (not-a-number)
+   REAL(ReKi), INTENT(inout)           :: NaN            ! IEEE value for Inf (infinity)
+
+      ! local variables for getting values of NaN and Inf (not necessary when using ieee_arithmetic)
+   REAL(DbKi)                          :: Neg_D          ! a negative real(DbKi) number
+   REAL(ReKi)                          :: Neg            ! a negative real(ReKi) number
+
+   
+      ! if compiling with floating-point-exception traps, this will not work, so we've added a compiler directive.
+      !  note that anything that refers to NaN or Inf will be incorrect in that case.
+      
 #ifndef FPE_TRAP_ENABLED      
-         ! set variables to negative numbers to calculate NaNs (compilers may complain when taking sqrt of negative constants)
-      Neg_D = -1.0_DbKi
-      Neg   = -1.0_ReKi
+      ! set variables to negative numbers to calculate NaNs (compilers may complain when taking sqrt of negative constants)
+   Neg_D = -1.0_DbKi
+   Neg   = -1.0_ReKi
 
-      NaN_D = SQRT ( Neg_D )
-      NaN   = SQRT ( Neg )
+   NaN_D = SQRT ( Neg_D )
+   NaN   = SQRT ( Neg )
 
-         ! set variables to zero to calculate Infs (using division by zero)
-      Neg_D = 0.0_DbKi
-      Neg   = 0.0_ReKi
-      
-      Inf_D = 1.0_DbKi / Neg_D
-      Inf   = 1.0_ReKi / Neg
-#endif 
+      ! set variables to zero to calculate Infs (using division by zero)
+   Neg_D = 0.0_DbKi
+   Neg   = 0.0_ReKi
    
-   END SUBROUTINE Set_IEEE_Constants  
+   Inf_D = 1.0_DbKi / Neg_D
+   Inf   = 1.0_ReKi / Neg
+#endif 
 
+END SUBROUTINE Set_IEEE_Constants
 !=======================================================================
-   SUBROUTINE UsrAlarm
+SUBROUTINE UsrAlarm
 
-
-      ! This routine generates an alarm to warn the user that something went wrong.
-
-
+   ! This routine generates an alarm to warn the user that something went wrong.
 
    CALL WrNR ( CHAR( 7 ) )
 
-
    RETURN
-   END SUBROUTINE UsrAlarm
+END SUBROUTINE UsrAlarm
 !=======================================================================
-   SUBROUTINE WrNR ( Str )
+SUBROUTINE WrNR ( Str )
 
-
-      ! This routine writes out a string to the screen without following it with a new line.
-
-
-      ! Argument declarations.
+   ! This routine writes out a string to the screen without following it with a new line.
 
    CHARACTER(*), INTENT(IN)     :: Str                                          ! The string to write to the screen.
 
-
-
-!   WRITE (CU,'(1X,A)',ADVANCE='NO')  Str
    WRITE (CU,'(A)',ADVANCE='NO')  Str
 
-
    RETURN
-   END SUBROUTINE WrNR ! ( Str )
+END SUBROUTINE WrNR ! ( Str )
 !=======================================================================
-   SUBROUTINE WrOver ( Str )
+SUBROUTINE WrOver ( Str )
 
-
-      ! This routine writes out a string that overwrites the previous line.
-
-
-      ! Argument declarations.
+   ! This routine writes out a string that overwrites the previous line.
 
    CHARACTER(*), INTENT(IN)     :: Str                                          ! The string to write to the screen.
-
-
-      ! Local declarations.
    INTEGER(IntKi)               :: NChars                                       ! Number of characters to write
    CHARACTER(1), PARAMETER      :: CR = ACHAR( 13 )                             ! The carriage return character.
    CHARACTER(25)                :: Fmt = '(2A,   (" "))'                        ! The format specifier for the output.
 
-
-
-!   WRITE (Fmt(5:6),'(I2)')  ConRecL - LEN( Str )
-
    NChars = MaxWrScrLen - LEN( Str )
 
    IF ( NChars > 0 ) THEN
-
       ! bjj: note that this will produce an error if NChars > 999
       WRITE (Fmt(5:7),'(I3)')  NChars
-
       WRITE (CU,Fmt,ADVANCE='NO')  CR, Str
-
    ELSE
       ! bjj: note that this will almost certainly write more than MaxWrScrLen characters on a line
       WRITE (CU,'(2A)',ADVANCE='NO')  CR, Str
    END IF
 
-
    RETURN
-   END SUBROUTINE WrOver ! ( Str )
+END SUBROUTINE WrOver ! ( Str )
 !=======================================================================
-   SUBROUTINE WriteScr ( Str, Frm )
+SUBROUTINE WriteScr ( Str, Frm )
 
+   ! This routine writes out a string to the screen.
 
-      ! This routine writes out a string to the screen.
-
-
-   IMPLICIT                        NONE
-
-
-      ! Argument declarations.
+   IMPLICIT NONE
 
    CHARACTER(*), INTENT(IN)     :: Str                                         ! The input string to write to the screen.
    CHARACTER(*), INTENT(IN)     :: Frm                                         ! Format specifier for the output.
-
-   INTEGER                      :: ErrStat                                     ! Error status of write operation (so code doesn't crash)
-
+   INTEGER                      :: ErrStat                                     ! Error stat
+   ! This SUBROUTINE is used to dynamically load a DLL.us of write operation (so code doesn't crash)
 
    IF ( LEN_TRIM(Str)  < 1 ) THEN
       WRITE ( CU, '()', IOSTAT=ErrStat )
@@ -498,19 +388,14 @@ CONTAINS
       WRITE ( CU, Frm, IOSTAT=ErrStat ) TRIM(Str)
    END IF
 
-   IF ( ErrStat /= 0 ) &
-      print *, ' WriteScr produced an error. Please inform the programmer.'
+   IF ( ErrStat /= 0 ) THEN
+         print *, ' WriteScr produced an error. Please inform the programmer.'
+   ENDIF
 
-
-   END SUBROUTINE WriteScr ! ( Str )
+END SUBROUTINE WriteScr ! ( Str )
 !=======================================================================
-
-!==================================================================================================================================
 SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to dynamically load a DLL.
-
-      ! Passed Variables:
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
@@ -524,8 +409,6 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
    INTEGER(C_INT), PARAMETER :: RTLD_NOW=2             ! "If this value is specified, or the environment variable LD_BIND_NOW is set to a nonempty string, all undefined symbols in the library are resolved before dlopen() returns. If this cannot be done, an error is returned."
    INTEGER(C_INT), PARAMETER :: RTLD_GLOBAL=256        ! "The symbols defined by this library will be made available for symbol resolution of subsequently loaded libraries"
    INTEGER(C_INT), PARAMETER :: RTLD_LOCAL=0           ! "This is the converse of RTLD_GLOBAL, and the default if neither flag is specified. Symbols defined in this library are not made available to resolve references in subsequently loaded libraries."
-
-
 
    INTERFACE !linux API routines
       !bjj see http://linux.die.net/man/3/dlopen
@@ -542,12 +425,10 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
    ErrStat = ErrID_None
    ErrMsg = ''
 
-
-      ! Load the DLL and get the file address:
+   ! Load the DLL and get the file address:
 
    DLL%FileAddrX = dlOpen( TRIM(DLL%FileName)//C_NULL_CHAR, RTLD_LAZY )  !the "C_NULL_CHAR" converts the Fortran string to a C-type string (i.e., adds //CHAR(0) to the end)
 
@@ -555,35 +436,30 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
       ErrStat = ErrID_Fatal
       WRITE(ErrMsg,'(I2)') BITS_IN_ADDR
       ErrMsg  = 'The dynamic library '//TRIM(DLL%FileName)//' could not be loaded. Check that the file '// &
-                'exists in the specified location and that it is compiled for '//TRIM(ErrMsg)//'-bit applications.'
+               'exists in the specified location and that it is compiled for '//TRIM(ErrMsg)//'-bit applications.'
       RETURN
    END IF
 
-
-      ! Get the procedure address:
+   ! Get the procedure address:
 
    CALL LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 #else
 
    ErrStat = ErrID_Fatal
    ErrMsg = ' LoadDynamicLib: Not compiled with -DUSE_DLL_INTERFACE for '//TRIM(OS_Desc)
-      
+
 #endif
-   
+
    RETURN
 END SUBROUTINE LoadDynamicLib
-!==================================================================================================================================
+!=======================================================================
 SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to dynamically load a procedure from a DLL.
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to dynamically load a procedure from a DLL.
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! local variables
    INTEGER(IntKi)                            :: i
 
 #ifdef USE_DLL_INTERFACE           
@@ -604,13 +480,8 @@ SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
    ErrStat = ErrID_None
    ErrMsg = ''
-
-   !IF( .NOT. C_ASSOCIATED(DLL%FileAddrX) ) RETURN
-
-      ! Get the procedure addresses:
 
    do i=1,NWTC_MAX_DLL_PROC
       if ( len_trim( DLL%ProcName(i) ) > 0 ) then
@@ -625,31 +496,26 @@ SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
          
       end if
    end do
-      
+   
 #else
 
    ErrStat = ErrID_Fatal
    ErrMsg = ' LoadDynamicLibProc: Not compiled with -DUSE_DLL_INTERFACE for '//TRIM(OS_Desc)
-      
-#endif
    
+#endif
+
    RETURN
 END SUBROUTINE LoadDynamicLibProc
-!==================================================================================================================================
+!=======================================================================
 SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to free a dynamically loaded DLL (loaded in LoadDynamicLib).
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to free a dynamically loaded DLL (loaded in LoadDynamicLib).
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be freed.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! Local variable:
    INTEGER(C_INT)                            :: Success     ! Whether or not the call to dlClose was successful
    INTEGER(C_INT), PARAMETER                 :: TRUE  = 0
-
 
 #ifdef USE_DLL_INTERFACE           
 !bjj: note that this is not tested.
@@ -668,8 +534,7 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
-      ! Close the library:
+   ! Close the library:
 
    IF( .NOT. C_ASSOCIATED(DLL%FileAddrX) ) RETURN
    Success = dlClose( DLL%FileAddrX ) !The function dlclose() returns 0 on success, and nonzero on error.
@@ -688,12 +553,10 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
    ErrStat = ErrID_Fatal
    ErrMsg = ' FreeDynamicLib: Not compiled with -DUSE_DLL_INTERFACE for '//TRIM(OS_Desc)
-         
+      
 #endif
-   
+
    RETURN
 END SUBROUTINE FreeDynamicLib
-!==================================================================================================================================
-
-
+!=======================================================================
 END MODULE SysSubs

--- a/modules-local/nwtc-library/src/SysGnuWin.f90
+++ b/modules-local/nwtc-library/src/SysGnuWin.f90
@@ -207,6 +207,26 @@ SUBROUTINE Get_CWD ( DirName, Status )
    RETURN
 END SUBROUTINE Get_CWD
 !=======================================================================
+SUBROUTINE MKDIR ( new_directory_path )
+
+   ! This routine creates a given directory if it does not exist.
+
+   implicit none
+
+   character(*), intent(in) :: new_directory_path
+   character(1024)          :: make_command
+   logical                  :: directory_exists
+
+   ! Check if the directory exists first
+   inquire( file=trim(new_directory_path), exist=directory_exists )
+
+   if ( .NOT. directory_exists ) then
+      make_command = 'mkdir -p '//trim(new_directory_path)
+      call system( make_command )
+   endif
+
+END SUBROUTINE MKDIR
+!=======================================================================
 SUBROUTINE OpenCon
 
    ! This routine opens the console for standard output.

--- a/modules-local/nwtc-library/src/SysGnuWin.f90
+++ b/modules-local/nwtc-library/src/SysGnuWin.f90
@@ -15,32 +15,20 @@
 ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
-!
-!**********************************************************************************************************************************
-! File last committed: $Date$
-! (File) Revision #: $Rev$
-! URL: $HeadURL$
 !**********************************************************************************************************************************
 MODULE SysSubs
 
-
    ! This module contains routines with system-specific logic and references, including all references to the console unit, CU.
    ! It also contains standard (but not system-specific) routines it uses.
-
    ! SysGnu.f90 is specifically for the GNU Fortran (gfortran) compiler on Windows.
-
-
    ! It contains the following routines:
-
    !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
-   !     SUBROUTINE  FlushOut ( Unit )
-   !     FUNCTION    NWTC_ERF( x )
-   !     FUNCTION    NWTC_gamma( x )
-   !     SUBROUTINE  GET_CWD( DirName, Status )
    !     FUNCTION    Is_NaN( DblNum )                                         ! Please use IEEE_IS_NAN() instead
-   !     FUNCTION    NWTC_Gamma( x )                                          ! Returns the gamma value of its argument.   
-   ! per MLB, this can be removed, but only if CU is OUTPUT_UNIT:
-   !     SUBROUTINE  OpenCon                                                  ! Actually, it can't be removed until we get Intel's FLUSH working. (mlb)
+   !     FUNCTION    NWTC_ERF( x )
+   !     FUNCTION    NWTC_gamma( x )                                          ! Returns the gamma value of its argument.   
+   !     SUBROUTINE  FlushOut ( Unit )
+   !     SUBROUTINE  GET_CWD( DirName, Status )
+   !     SUBROUTINE  OpenCon
    !     SUBROUTINE  OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
    !     SUBROUTINE  ProgExit ( StatCode )
    !     SUBROUTINE  Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
@@ -50,37 +38,28 @@ MODULE SysSubs
    !     SUBROUTINE  WriteScr ( Str, Frm )
    !     SUBROUTINE LoadDynamicLib( DLL, ErrStat, ErrMsg )
    !     SUBROUTINE FreeDynamicLib( DLL, ErrStat, ErrMsg )
-
-
-
-   USE                             NWTC_Base
-
-   IMPLICIT                        NONE
-
-   INTERFACE NWTC_gamma ! Returns the gamma value of its argument
-      MODULE PROCEDURE NWTC_gammaR4
-      MODULE PROCEDURE NWTC_gammaR8
-      MODULE PROCEDURE NWTC_gammaR16
-   END INTERFACE
    
+   USE NWTC_Base
+
+   IMPLICIT NONE
+
    INTERFACE NWTC_ERF ! Returns the ERF value of its argument
       MODULE PROCEDURE NWTC_ERFR4
       MODULE PROCEDURE NWTC_ERFR8
       MODULE PROCEDURE NWTC_ERFR16
    END INTERFACE
-   
-   
 
-!=======================================================================
-
+   INTERFACE NWTC_gamma ! Returns the gamma value of its argument
+         ! note: gamma is part of the F08 standard, but may not be implemented everywhere...
+      MODULE PROCEDURE NWTC_gammaR4
+      MODULE PROCEDURE NWTC_gammaR8
+      MODULE PROCEDURE NWTC_gammaR16
+   END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
    INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
-                                                                                    ! CU = 7 works on gfortran compiler version 4.6 and possibly 4.5. Fails on version 4.7 and 4.8 (see bugzilla bug report #445 for details)
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
-
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
-
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
    CHARACTER(*),  PARAMETER      :: OS_Desc     = 'GNU Fortran for Windows'         ! Description of the language/OS
    CHARACTER( 1), PARAMETER      :: PathSep     = '\'                               ! The path separator.
@@ -89,30 +68,18 @@ MODULE SysSubs
 
 CONTAINS
 
+
+
 !=======================================================================
-   FUNCTION FileSize( Unit )
+FUNCTION FileSize( Unit )
 
-
-      ! This function calls the portability routine, FSTAT, to obtain the file size
-      ! in bytes corresponding to a file unit number or returns -1 on error.
-
-
-      ! Function declaration.
+   ! This function calls the portability routine, FSTAT, to obtain the file size
+   ! in bytes corresponding to a file unit number or returns -1 on error.
 
    INTEGER(B8Ki)                             :: FileSize                      ! The size of the file in bytes to be returned.
-
-
-      ! Argument declarations:
-
    INTEGER, INTENT(IN)                       :: Unit                          ! The I/O unit number of the pre-opened file.
-
-
-      ! Local declarations:
-
    INTEGER(4)                                :: StatArray(13)                 ! An array returned by FSTAT that includes the file size.
    INTEGER(4)                                :: Status                        ! The status returned by
-
-
 
    Status = FSTAT( INT( Unit, B4Ki ), StatArray )
 
@@ -122,208 +89,156 @@ CONTAINS
       FileSize = StatArray(8)
    END IF
 
+   RETURN
+END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+   FUNCTION Is_NaN( DblNum )
+
+   ! This routine determines if a REAL(DbKi) variable holds a proper number.
+   ! BJJ: this routine is used in CRUNCH.
+   ! Note that IsNaN does not exist in earlier versions of gfortran (e.g., 4.2.1),
+   ! but does exist in version 4.4. It should be replaced with the standard
+   ! IEEE_IS_NAN when gfortran implements it.
+
+   REAL(DbKi), INTENT(IN)       :: DblNum
+   LOGICAL                      :: Is_Nan
+
+   Is_NaN = IsNaN( DblNum )
 
    RETURN
-   END FUNCTION FileSize ! ( Unit )
+END FUNCTION Is_NaN ! ( DblNum )
 !=======================================================================
-   SUBROUTINE FlushOut ( Unit )
+FUNCTION NWTC_ERFR4( x )
 
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
 
-      ! This subroutine flushes the buffer on the specified Unit.
-      ! It is especially useful when printing "running..." type messages.
+   REAL(SiKi), INTENT(IN)     :: x           ! input 
+   REAL(SiKi)                 :: NWTC_ERFR4  ! result
+   
+   NWTC_ERFR4 = ERF( x )
 
+END FUNCTION NWTC_ERFR4
+!=======================================================================
+FUNCTION NWTC_ERFR8( x )
 
-      ! Argument declarations:
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
 
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_ERFR8    ! result
+   
+   NWTC_ERFR8 = ERF( x )
+
+END FUNCTION NWTC_ERFR8
+!=======================================================================
+FUNCTION NWTC_ERFR16( x )
+
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_ERFR16   ! result
+   
+   NWTC_ERFR16 = ERF( x )
+
+END FUNCTION NWTC_ERFR16
+!=======================================================================
+FUNCTION NWTC_GammaR4( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(SiKi), INTENT(IN)     :: x             ! input 
+   REAL(SiKi)                 :: NWTC_GammaR4  ! result
+   
+   NWTC_GammaR4 = gamma( x )
+
+END FUNCTION NWTC_GammaR4
+!=======================================================================
+FUNCTION NWTC_GammaR8( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_GammaR8  ! result
+   
+   NWTC_GammaR8 = gamma( x )
+
+END FUNCTION NWTC_GammaR8
+!=======================================================================
+FUNCTION NWTC_GammaR16( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_GammaR16  ! result
+   
+   NWTC_GammaR16 = gamma( x )
+
+END FUNCTION NWTC_GammaR16
+!=======================================================================
+SUBROUTINE FlushOut ( Unit )
+
+   ! This subroutine flushes the buffer on the specified Unit.
+   ! It is especially useful when printing "running..." type messages.
+   
    INTEGER, INTENT(IN)          :: Unit                                         ! The unit number of the file being flushed.
 
-
-
-  ! CALL FLUSH ( Unit )
-
+   ! CALL FLUSH ( Unit )
 
    RETURN
-   END SUBROUTINE FlushOut ! ( Unit )
+END SUBROUTINE FlushOut ! ( Unit )
 !=======================================================================
 !bjj note: this subroutine is not tested for this compiler
-   SUBROUTINE Get_CWD ( DirName, Status )
+SUBROUTINE Get_CWD ( DirName, Status )
 
+   ! This routine retrieves the path of the current working directory.
 
-      ! This routine retrieves the path of the current working directory.
-
-
-   IMPLICIT                        NONE
-
-
-      ! Passed variables.
+   IMPLICIT NONE
 
    CHARACTER(*), INTENT(OUT)    :: DirName                                         ! A CHARACTER string containing the path of the current working directory.
    INTEGER,      INTENT(OUT)    :: Status                                          ! Status returned by the call to a portability routine.
 
-
    Status = GETCWD ( DirName )
 
    RETURN
-   END SUBROUTINE Get_CWD
+END SUBROUTINE Get_CWD
 !=======================================================================
-   FUNCTION Is_NaN( DblNum )
+SUBROUTINE OpenCon
 
+   ! This routine opens the console for standard output.
 
-      ! This routine determines if a REAL(DbKi) variable holds a proper number.
-      ! BJJ: this routine is used in CRUNCH.
-      ! Note that IsNaN does not exist in earlier versions of gfortran (e.g., 4.2.1),
-      ! but does exist in version 4.4. It should be replaced with the standard
-      ! IEEE_IS_NAN when gfortran implements it.
-
-
-      ! Argument declarations.
-
-   REAL(DbKi), INTENT(IN)       :: DblNum
-
-
-      ! Function declaration.
-
-   LOGICAL                      :: Is_Nan
-
-
-
-   Is_NaN = IsNaN( DblNum )
-
-
-   RETURN
-   END FUNCTION Is_NaN ! ( DblNum )
-!=======================================================================
-   FUNCTION NWTC_ERFR4( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
-
-      REAL(SiKi), INTENT(IN)     :: x           ! input 
-      REAL(SiKi)                 :: NWTC_ERFR4  ! result
-      
-      
-      NWTC_ERFR4 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR4
-!=======================================================================
-   FUNCTION NWTC_ERFR8( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
-
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_ERFR8    ! result
-      
-      
-      NWTC_ERFR8 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR8
-!=======================================================================
-   FUNCTION NWTC_ERFR16( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
-
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_ERFR16   ! result
-      
-      
-      NWTC_ERFR16 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR16
-!=======================================================================
-   FUNCTION NWTC_GammaR4( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(SiKi), INTENT(IN)     :: x             ! input 
-      REAL(SiKi)                 :: NWTC_GammaR4  ! result
-      
-      
-      NWTC_GammaR4 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR4
-!=======================================================================
-   FUNCTION NWTC_GammaR8( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_GammaR8  ! result
-      
-      
-      NWTC_GammaR8 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR8
-!=======================================================================
-   FUNCTION NWTC_GammaR16( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_GammaR16  ! result
-      
-      
-      NWTC_GammaR16 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR16
-!=======================================================================
-   SUBROUTINE OpenCon
-
-
-      ! This routine opens the console for standard output.  It is not needed for gfortran on Windows.
-
-
-
-!mlb_20-Jun-2011   OPEN ( CU , FILE='CON' , STATUS='UNKNOWN' , RECL=ConRecL )
-!   OPEN ( CU , FILE='CONOUT$' , STATUS='UNKNOWN' , RECL=ConRecL )
+!bjj: removed for use with CygWin; Because CU = 6 now, this statement is not necessary
+!   OPEN ( CU , FILE='/dev/stdout' , STATUS='OLD' )
 
 !   CALL FlushOut ( CU )
 
-
    RETURN
-   END SUBROUTINE OpenCon
+END SUBROUTINE OpenCon
 !=======================================================================
-   SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
+SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
 
-
-      ! This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
-      ! Data are stored in RecLen-byte records.
+   ! This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
+   ! Data are stored in RecLen-byte records.
 
    IMPLICIT                        NONE
 
-
-
-      ! Argument declarations.
-
    INTEGER, INTENT(IN)          :: Un                                           ! Logical unit for the input file.
-
    CHARACTER(*), INTENT(IN)     :: InFile                                       ! Name of the input file.
-
    INTEGER, INTENT(IN)          :: RecLen                                       ! Size of records in the input file, in bytes.
-
    LOGICAL, INTENT(OUT)         :: Error                                        ! Flag to indicate the open failed.
-
-
-      ! Local declarations.
-
    INTEGER                      :: IOS                                          ! I/O status of OPEN.
 
-
-
-      ! Open input file.  Make sure it worked.
+   ! Open input file.  Make sure it worked.
 
    ! The non-standard CONVERT keyword allows us to read UNIX binary files, whose bytes are in reverse order (i.e., stored in BIG ENDIAN format).
-
    ! NOTE: using RecLen in bytes requires using the /assume:byterecl compiler option!
-
    OPEN ( Un, FILE=TRIM( InFile ), STATUS='OLD', FORM='UNFORMATTED', ACCESS='DIRECT', RECL=RecLen, IOSTAT=IOS, &
-                   ACTION='READ'  )                                              ! Use this for UNIX systems.
-!                  ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
-
+                  ACTION='READ'  )                                              ! Use this for UNIX systems.
+   !            ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
 
    IF ( IOS /= 0 )  THEN
       Error = .TRUE.
@@ -331,166 +246,121 @@ CONTAINS
       Error = .FALSE.
    END IF
 
-
    RETURN
-   END SUBROUTINE OpenUnfInpBEFile
+END SUBROUTINE OpenUnfInpBEFile
 !=======================================================================
-   SUBROUTINE ProgExit ( StatCode )
+SUBROUTINE ProgExit ( StatCode )
 
-
-      ! This routine stops the program.  If the compiler supports the EXIT routine,
-      ! pass the program status to it.  Otherwise, do a STOP.
-
-
-      ! Argument declarations.
+   ! This routine stops the program.  If the compiler supports the EXIT routine,
+   ! pass the program status to it.  Otherwise, do a STOP.
 
    INTEGER, INTENT(IN)          :: StatCode                                      ! The status code to pass to the OS.
 
-
-
    CALL EXIT ( StatCode )
 
-!   IF ( StatCode == 0 ) THEN
-!      STOP 0
-!   ELSE
-!      IF ( StatCode < 0 ) THEN
-!         CALL WrScr( 'Invalid STOP code.' )
-!      END IF
-!
-!      STOP 1
-!   END IF
+   ! IF ( StatCode == 0 ) THEN
+   !    STOP 0
+   ! ELSE
+   !    IF ( StatCode < 0 ) THEN
+   !       CALL WrScr( 'Invalid STOP code.' )
+   !    END IF
+   !    STOP 1
+   ! END IF
 
-
-   END SUBROUTINE ProgExit ! ( StatCode )
+END SUBROUTINE ProgExit ! ( StatCode )
 !=======================================================================
-   SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
-         
-      ! routine that sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
-      ! values for not-a-number and infinity in sindle and double 
-      ! precision) F03 has standard intrinsic routines to do this,  
-      ! but Gnu has not yet implemented it. This code will fail if  
-      ! the compiler checks for floating-point-error, hence the  
-      ! compiler directive FPE_TRAP_ENABLED.
-   
-   
-      REAL(DbKi), INTENT(inout)           :: Inf_D          ! IEEE value for NaN (not-a-number) in double precision
-      REAL(DbKi), INTENT(inout)           :: NaN_D          ! IEEE value for Inf (infinity) in double precision
-
-      REAL(ReKi), INTENT(inout)           :: Inf            ! IEEE value for NaN (not-a-number)
-      REAL(ReKi), INTENT(inout)           :: NaN            ! IEEE value for Inf (infinity)
-   
-         ! local variables for getting values of NaN and Inf (not necessary when using ieee_arithmetic)
-      REAL(DbKi)                          :: Neg_D          ! a negative real(DbKi) number
-      REAL(ReKi)                          :: Neg            ! a negative real(ReKi) number
-   
+SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
       
-         ! if compiling with floating-point-exception traps, this will not work, so we've added a compiler directive.
-         !  note that anything that refers to NaN or Inf will be incorrect in that case.
-         
+   ! routine that sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
+   ! values for not-a-number and infinity in sindle and double 
+   ! precision) F03 has standard intrinsic routines to do this,  
+   ! but Gnu has not yet implemented it. This code will fail if  
+   ! the compiler checks for floating-point-error, hence the  
+   ! compiler directive FPE_TRAP_ENABLED.
+
+   REAL(DbKi), INTENT(inout)           :: Inf_D          ! IEEE value for NaN (not-a-number) in double precision
+   REAL(DbKi), INTENT(inout)           :: NaN_D          ! IEEE value for Inf (infinity) in double precision
+   REAL(ReKi), INTENT(inout)           :: Inf            ! IEEE value for NaN (not-a-number)
+   REAL(ReKi), INTENT(inout)           :: NaN            ! IEEE value for Inf (infinity)
+
+      ! local variables for getting values of NaN and Inf (not necessary when using ieee_arithmetic)
+   REAL(DbKi)                          :: Neg_D          ! a negative real(DbKi) number
+   REAL(ReKi)                          :: Neg            ! a negative real(ReKi) number
+
+   
+      ! if compiling with floating-point-exception traps, this will not work, so we've added a compiler directive.
+      !  note that anything that refers to NaN or Inf will be incorrect in that case.
+      
 #ifndef FPE_TRAP_ENABLED      
-         ! set variables to negative numbers to calculate NaNs (compilers may complain when taking sqrt of negative constants)
-      Neg_D = -1.0_DbKi
-      Neg   = -1.0_ReKi
+      ! set variables to negative numbers to calculate NaNs (compilers may complain when taking sqrt of negative constants)
+   Neg_D = -1.0_DbKi
+   Neg   = -1.0_ReKi
 
-      NaN_D = SQRT ( Neg_D )
-      NaN   = SQRT ( Neg )
+   NaN_D = SQRT ( Neg_D )
+   NaN   = SQRT ( Neg )
 
-         ! set variables to zero to calculate Infs (using division by zero)
-      Neg_D = 0.0_DbKi
-      Neg   = 0.0_ReKi
-      
-      Inf_D = 1.0_DbKi / Neg_D
-      Inf   = 1.0_ReKi / Neg
-#endif 
+      ! set variables to zero to calculate Infs (using division by zero)
+   Neg_D = 0.0_DbKi
+   Neg   = 0.0_ReKi
    
-   END SUBROUTINE Set_IEEE_Constants  
+   Inf_D = 1.0_DbKi / Neg_D
+   Inf   = 1.0_ReKi / Neg
+#endif 
 
+END SUBROUTINE Set_IEEE_Constants
 !=======================================================================
-   SUBROUTINE UsrAlarm
+SUBROUTINE UsrAlarm
 
-
-      ! This routine generates an alarm to warn the user that something went wrong.
-
-
+   ! This routine generates an alarm to warn the user that something went wrong.
 
    CALL WrNR ( CHAR( 7 ) )
 
-
    RETURN
-   END SUBROUTINE UsrAlarm
+END SUBROUTINE UsrAlarm
 !=======================================================================
-   SUBROUTINE WrNR ( Str )
+SUBROUTINE WrNR ( Str )
 
-
-      ! This routine writes out a string to the screen without following it with a new line.
-
-
-      ! Argument declarations.
+   ! This routine writes out a string to the screen without following it with a new line.
 
    CHARACTER(*), INTENT(IN)     :: Str                                          ! The string to write to the screen.
-
-
 
    WRITE (CU,'(1X,A)',ADVANCE='NO')  Str
 
-
    RETURN
-   END SUBROUTINE WrNR ! ( Str )
+END SUBROUTINE WrNR ! ( Str )
 !=======================================================================
    SUBROUTINE WrOver ( Str )
 
-
-      ! This routine writes out a string that overwrites the previous line.
-
-
-      ! Argument declarations.
+   ! This routine writes out a string that overwrites the previous line.
 
    CHARACTER(*), INTENT(IN)     :: Str                                          ! The string to write to the screen.
-
-
-      ! Local declarations.
    INTEGER(IntKi)               :: NChars                                       ! Number of characters to write
    CHARACTER(1), PARAMETER      :: CR = ACHAR( 13 )                             ! The carriage return character.
    CHARACTER(25)                :: Fmt = '(2A,   (" "))'                        ! The format specifier for the output.
 
-
-
-!   WRITE (Fmt(5:6),'(I2)')  ConRecL - LEN( Str )
-
    NChars = MaxWrScrLen - LEN( Str )
 
    IF ( NChars > 0 ) THEN
-
       ! bjj: note that this will produce an error if NChars > 999
       WRITE (Fmt(5:7),'(I3)')  NChars
-
       WRITE (CU,Fmt,ADVANCE='NO')  CR, Str
-
    ELSE
       ! bjj: note that this will almost certainly write more than MaxWrScrLen characters on a line
       WRITE (CU,'(A)',ADVANCE='NO')  CR, Str
    END IF
 
-
    RETURN
-   END SUBROUTINE WrOver ! ( Str )
+END SUBROUTINE WrOver ! ( Str )
 !=======================================================================
-   SUBROUTINE WriteScr ( Str, Frm )
+SUBROUTINE WriteScr ( Str, Frm )
 
+   ! This routine writes out a string to the screen.
 
-      ! This routine writes out a string to the screen.
+   IMPLICIT NONE
 
-
-   IMPLICIT                        NONE
-
-
-      ! Argument declarations.
-
-   CHARACTER(*), INTENT(IN)     :: Str                                          ! The input string to write to the screen.
-   CHARACTER(*), INTENT(IN)     :: Frm                                          ! Format specifier for the output.
-
-   INTEGER                      :: ErrStat                                      ! Error status of write operation (so code doesn't crash)
-
+   CHARACTER(*), INTENT(IN)     :: Str                                         ! The input string to write to the screen.
+   CHARACTER(*), INTENT(IN)     :: Frm                                         ! Format specifier for the output.
+   INTEGER                      :: ErrStat                                     ! Error status of write operation (so code doesn't crash)
 
    IF ( LEN_TRIM(Str)  < 1 ) THEN
       WRITE ( CU, '()', IOSTAT=ErrStat )
@@ -498,18 +368,15 @@ CONTAINS
       WRITE ( CU, Frm, IOSTAT=ErrStat ) TRIM(Str)
    END IF
 
+   IF ( ErrStat /= 0 ) THEN
+         print *, ' WriteScr produced an error. Please inform the programmer.'
+   ENDIF
 
-   END SUBROUTINE WriteScr ! ( Str )
-
+END SUBROUTINE WriteScr ! ( Str )
 !=======================================================================
-
-
-!==================================================================================================================================
 SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to dynamically load a DLL.
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to dynamically load a DLL.
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
@@ -534,45 +401,34 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
    ErrStat = ErrID_None
    ErrMsg = ''
 
-
-      ! Load the DLL and get the file address:
-
+   ! Load the DLL and get the file address:
    DLL%FileAddr = LoadLibrary( TRIM(DLL%FileName)//C_NULL_CHAR )  !the "C_NULL_CHAR" converts the Fortran string to a C-type string (i.e., adds //CHAR(0) to the end)
    IF ( DLL%FileAddr == INT(0,C_INTPTR_T) ) THEN
       ErrStat = ErrID_Fatal
       WRITE(ErrMsg,'(I2)') BITS_IN_ADDR
       ErrMsg  = 'The dynamic library '//TRIM(DLL%FileName)//' could not be loaded. Check that the file '// &
-                'exists in the specified location and that it is compiled for '//TRIM(ErrMsg)//'-bit applications.'
+               'exists in the specified location and that it is compiled for '//TRIM(ErrMsg)//'-bit applications.'
       RETURN
    END IF
 
-
-      ! Get the procedure address:
-
+   ! Get the procedure address:
    CALL LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
-
 
    RETURN
 END SUBROUTINE LoadDynamicLib
-!==================================================================================================================================
+!=======================================================================
 SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to dynamically load a procedure in a DLL.
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to dynamically load a procedure in a DLL.
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-
-      ! local variables
    INTEGER(IntKi)                            :: i
-   
+
    INTERFACE  ! Definitions of Windows API routines
 
       !...........................
@@ -593,44 +449,33 @@ SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
-
    ErrStat = ErrID_None
    ErrMsg = ''
-   !IF ( DLL%FileAddr == INT(0,C_INTPTR_T) ) RETURN
 
-   
-      ! Get the procedure addresses:
-
+   ! Get the procedure addresses:
    do i=1,NWTC_MAX_DLL_PROC
       if ( len_trim( DLL%ProcName(i) ) > 0 ) then
-   
          DLL%ProcAddr(i) = GetProcAddress( DLL%FileAddr, TRIM(DLL%ProcName(i))//C_NULL_CHAR )  !the "C_NULL_CHAR" converts the Fortran string to a C-type string (i.e., adds //CHAR(0) to the end)
-
          IF(.NOT. C_ASSOCIATED(DLL%ProcAddr(i))) THEN
             ErrStat = ErrID_Fatal
             ErrMsg  = 'The procedure '//TRIM(DLL%ProcName(i))//' in file '//TRIM(DLL%FileName)//' could not be loaded.'
             RETURN
          END IF
-         
       end if
    end do
-         
 
    RETURN
 END SUBROUTINE LoadDynamicLibProc
-!==================================================================================================================================
+!=======================================================================
 SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to free a dynamically loaded DLL (loaded in LoadDynamicLib).
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to free a dynamically loaded DLL (loaded in LoadDynamicLib).
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be freed.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
 
-      ! Local variable:
+   ! Local variable:
    INTEGER(C_INT)                            :: Success     ! Whether or not the call to FreeLibrary was successful
    INTEGER(C_INT), PARAMETER                 :: FALSE  = 0
 
@@ -646,8 +491,7 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
-      ! Free the DLL:
+   ! Free the DLL:
    IF ( DLL%FileAddr == INT(0,C_INTPTR_T) ) RETURN
 
    Success = FreeLibrary( DLL%FileAddr ) !If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.
@@ -664,7 +508,5 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
    RETURN
 END SUBROUTINE FreeDynamicLib
-!==================================================================================================================================
-
-
+!=======================================================================
 END MODULE SysSubs

--- a/modules-local/nwtc-library/src/SysIFL.f90
+++ b/modules-local/nwtc-library/src/SysIFL.f90
@@ -22,7 +22,7 @@ MODULE SysSubs
    ! It also contains standard (but not system-specific) routines it uses.
    ! SysIFL.f90 is specifically for the Intel Fortran for Linux compiler.
    ! It contains the following routines:
-  !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
+   !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
    !     FUNCTION    Is_NaN( DblNum )                                         ! Please use IEEE_IS_NAN() instead
    !     FUNCTION    NWTC_ERF( x )
    !     FUNCTION    NWTC_gamma( x )                                          ! Returns the gamma value of its argument.   
@@ -75,9 +75,11 @@ FUNCTION FileSize( Unit )
    ! This function calls the portability routine, FSTAT, to obtain the file size
    ! in bytes corresponding to a file unit number or returns -1 on error.
 
+   USE IFPORT
+
    INTEGER(B8Ki)                             :: FileSize                      ! The size of the file in bytes to be returned.
    INTEGER, INTENT(IN)                       :: Unit                          ! The I/O unit number of the pre-opened file.
-   INTEGER                                   :: StatArray(13)                 ! An array returned by FSTAT that includes the file size.
+   INTEGER                                   :: StatArray(12)                 ! An array returned by FSTAT that includes the file size.
    INTEGER                                   :: Status                        ! The status returned by
 
    Status = FSTAT( INT( Unit, B4Ki ), StatArray )

--- a/modules-local/nwtc-library/src/SysIFL.f90
+++ b/modules-local/nwtc-library/src/SysIFL.f90
@@ -15,32 +15,21 @@
 ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
-!
-!**********************************************************************************************************************************
-! File last committed: $Date$
-! (File) Revision #: $Rev$
-! URL: $HeadURL$
 !**********************************************************************************************************************************
 MODULE SysSubs
 
-
    ! This module contains routines with system-specific logic and references, including all references to the console unit, CU.
    ! It also contains standard (but not system-specific) routines it uses.
-
    ! SysIFL.f90 is specifically for the Intel Fortran for Linux compiler.
-
-
    ! It contains the following routines:
-
-   !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
-   !     SUBROUTINE  FlushOut ( Unit )
-   !     FUNCTION    NWTC_ERF( x )
-   !     FUNCTION    NWTC_gamma( x )
-   !     SUBROUTINE  GET_CWD( DirName, Status )
+  !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
    !     FUNCTION    Is_NaN( DblNum )                                         ! Please use IEEE_IS_NAN() instead
-   !     FUNCTION    NWTC_Gamma( x )                                          ! Returns the gamma value of its argument.   
-   ! per MLB, this can be removed, but only if CU is OUTPUT_UNIT:
-   !     SUBROUTINE  OpenCon                                                  ! Actually, it can't be removed until we get Intel's FLUSH working. (mlb)
+   !     FUNCTION    NWTC_ERF( x )
+   !     FUNCTION    NWTC_gamma( x )                                          ! Returns the gamma value of its argument.   
+   !     SUBROUTINE  FlushOut ( Unit )
+   !     SUBROUTINE  GET_CWD( DirName, Status )
+   !     SUBROUTINE  MKDIR( new_directory_path )
+   !     SUBROUTINE  OpenCon
    !     SUBROUTINE  OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
    !     SUBROUTINE  ProgExit ( StatCode )
    !     SUBROUTINE  Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
@@ -50,71 +39,46 @@ MODULE SysSubs
    !     SUBROUTINE  WriteScr ( Str, Frm )
    !     SUBROUTINE LoadDynamicLib( DLL, ErrStat, ErrMsg )
    !     SUBROUTINE FreeDynamicLib( DLL, ErrStat, ErrMsg )
-
-
-
-   USE                             NWTC_Base
-
-   IMPLICIT                        NONE
-
-   INTERFACE NWTC_gamma ! Returns the gamma value of its argument
-      MODULE PROCEDURE NWTC_gammaR4
-      MODULE PROCEDURE NWTC_gammaR8
-      MODULE PROCEDURE NWTC_gammaR16
-   END INTERFACE
    
+   USE NWTC_Base
+
+   IMPLICIT NONE
+
    INTERFACE NWTC_ERF ! Returns the ERF value of its argument
       MODULE PROCEDURE NWTC_ERFR4
       MODULE PROCEDURE NWTC_ERFR8
       MODULE PROCEDURE NWTC_ERFR16
    END INTERFACE
-   
-   
 
-!=======================================================================
-
+   INTERFACE NWTC_gamma ! Returns the gamma value of its argument
+         ! note: gamma is part of the F08 standard, but may not be implemented everywhere...
+      MODULE PROCEDURE NWTC_gammaR4
+      MODULE PROCEDURE NWTC_gammaR8
+      MODULE PROCEDURE NWTC_gammaR16
+   END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
    INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
-
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
-
    CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
    CHARACTER(*),  PARAMETER      :: OS_Desc     = 'Intel Fortran for Linux'         ! Description of the language/OS
    CHARACTER( 1), PARAMETER      :: PathSep     = '/'                               ! The path separator.
    CHARACTER( 1), PARAMETER      :: SwChar      = '-'                               ! The switch character for command-line options.
-   CHARACTER(11), PARAMETER      :: UnfForm     = 'UNFORMATTED'                     ! The string to specify unformatted I/O files.
+   CHARACTER(11), PARAMETER      :: UnfForm     = 'UNFORMATTED'                     ! The string to specify unformatted I/O files.   
 
 CONTAINS
 
 !=======================================================================
-   FUNCTION FileSize( Unit )
+FUNCTION FileSize( Unit )
 
-
-      ! This function calls the portability routine, FSTAT, to obtain the file size
-      ! in bytes corresponding to a file unit number or returns -1 on error.
-
-
-   USE                             IFPORT
-
-
-      ! Function declaration.
+   ! This function calls the portability routine, FSTAT, to obtain the file size
+   ! in bytes corresponding to a file unit number or returns -1 on error.
 
    INTEGER(B8Ki)                             :: FileSize                      ! The size of the file in bytes to be returned.
-
-
-      ! Argument declarations:
-
    INTEGER, INTENT(IN)                       :: Unit                          ! The I/O unit number of the pre-opened file.
-
-
-      ! Local declarations:
-
-   INTEGER                                   :: StatArray(12)                 ! An array returned by FSTAT that includes the file size.
+   INTEGER                                   :: StatArray(13)                 ! An array returned by FSTAT that includes the file size.
    INTEGER                                   :: Status                        ! The status returned by
-
-
 
    Status = FSTAT( INT( Unit, B4Ki ), StatArray )
 
@@ -124,215 +88,180 @@ CONTAINS
       FileSize = StatArray(8)
    END IF
 
+   RETURN
+END FUNCTION FileSize ! ( Unit )
+!=======================================================================
+FUNCTION Is_NaN( DblNum )
+
+   ! This routine determines if a REAL(DbKi) variable holds a proper number.
+   ! BJJ: this routine is used in CRUNCH.
+   ! It should be replaced with IEEE_IS_NAN in new code, but remains here for
+   ! backwards compatibility.
+
+   USE, INTRINSIC :: ieee_arithmetic
+
+   REAL(DbKi), INTENT(IN)       :: DblNum
+   LOGICAL                      :: Is_Nan
+
+   Is_NaN = IEEE_IS_NAN( DblNum )
 
    RETURN
-   END FUNCTION FileSize ! ( Unit )
+END FUNCTION Is_NaN ! ( DblNum )
 !=======================================================================
-   SUBROUTINE FlushOut ( Unit )
+FUNCTION NWTC_ERFR4( x )
 
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
 
-      ! This subroutine flushes the buffer on the specified Unit.
-      ! It is especially useful when printing "running..." type messages.
+   REAL(SiKi), INTENT(IN)     :: x           ! input 
+   REAL(SiKi)                 :: NWTC_ERFR4  ! result
 
+   NWTC_ERFR4 = ERF( x )
 
-   USE                             IFPORT
+END FUNCTION NWTC_ERFR4
+!=======================================================================
+FUNCTION NWTC_ERFR8( x )
 
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
 
-      ! Argument declarations:
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_ERFR8    ! result
+
+   NWTC_ERFR8 = ERF( x )
+
+END FUNCTION NWTC_ERFR8
+!=======================================================================
+FUNCTION NWTC_ERFR16( x )
+
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_ERFR16   ! result
+
+   NWTC_ERFR16 = ERF( x )
+
+END FUNCTION NWTC_ERFR16
+!=======================================================================
+FUNCTION NWTC_GammaR4( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(SiKi), INTENT(IN)     :: x             ! input 
+   REAL(SiKi)                 :: NWTC_GammaR4  ! result
+   
+   NWTC_GammaR4 = gamma( x )
+
+END FUNCTION NWTC_GammaR4
+!=======================================================================
+FUNCTION NWTC_GammaR8( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_GammaR8  ! result
+   
+   NWTC_GammaR8 = gamma( x )
+
+END FUNCTION NWTC_GammaR8
+!=======================================================================
+FUNCTION NWTC_GammaR16( x )
+
+   ! Returns the gamma value of its argument. The result has a value equal  
+   ! to a processor-dependent approximation to the gamma function of x. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_GammaR16  ! result
+   
+   NWTC_GammaR16 = gamma( x )
+
+END FUNCTION NWTC_GammaR16
+!=======================================================================
+SUBROUTINE FlushOut ( Unit )
+
+   ! This subroutine flushes the buffer on the specified Unit.
+   ! It is especially useful when printing "running..." type messages.
+
+   USE IFPORT
 
    INTEGER, INTENT(IN)          :: Unit                                         ! The unit number of the file being flushed.
 
-
-
    CALL FLUSH ( INT(Unit, B4Ki) )
 
-
    RETURN
-   END SUBROUTINE FlushOut ! ( Unit )
+END SUBROUTINE FlushOut ! ( Unit )
 !=======================================================================
-   SUBROUTINE Get_CWD ( DirName, Status )
+SUBROUTINE Get_CWD ( DirName, Status )
 
-
-      ! This routine retrieves the path of the current working directory.
-
-
-   USE                             IFPORT, ONLY: GETCWD
+   USE IFPORT, ONLY: GETCWD
 
    IMPLICIT                        NONE
-
-
-      ! Passed variables.
 
    CHARACTER(*), INTENT(OUT)    :: DirName                                         ! A CHARACTER string containing the path of the current working directory.
    INTEGER,      INTENT(OUT)    :: Status                                          ! Status returned by the call to a portability routine.
 
-
    Status = GETCWD ( DirName )
 
    RETURN
-   END SUBROUTINE Get_CWD
+END SUBROUTINE Get_CWD
 !=======================================================================
-   FUNCTION Is_NaN( DblNum )
+SUBROUTINE MKDIR ( new_directory_path )
 
+   ! This routine creates a given directory if it does not exist.
 
-      ! This routine determines if a REAL(DbKi) variable holds a proper number.
-      ! BJJ: this routine is used in CRUNCH.
-      ! It should be replaced with IEEE_IS_NAN in new code, but remains here for
-      ! backwards compatibility.
+   implicit none
 
-  USE, INTRINSIC :: ieee_arithmetic
+   character(*), intent(in) :: new_directory_path
+   character(1024)          :: make_command
+   logical                  :: directory_exists
 
+   ! Check if the directory exists first
+   inquire( directory=trim(new_directory_path), exist=directory_exists )
 
-      ! Argument declarations.
+   if ( .NOT. directory_exists ) then
+      make_command = 'mkdir -p '//trim(new_directory_path)
+      call system( make_command )
+   endif
 
-   REAL(DbKi), INTENT(IN)       :: DblNum
-
-
-      ! Function declaration.
-
-   LOGICAL                      :: Is_Nan
-
-
-
-   Is_NaN = IEEE_IS_NAN( DblNum )
-
-
-   RETURN
-   END FUNCTION Is_NaN ! ( DblNum )
+END SUBROUTINE MKDIR
 !=======================================================================
-   FUNCTION NWTC_ERFR4( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+SUBROUTINE OpenCon
 
-      REAL(SiKi), INTENT(IN)     :: x           ! input 
-      REAL(SiKi)                 :: NWTC_ERFR4  ! result
-      
-      
-      NWTC_ERFR4 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR4
-!=======================================================================
-   FUNCTION NWTC_ERFR8( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+   ! This routine opens the console for standard output.
 
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_ERFR8    ! result
-      
-      
-      NWTC_ERFR8 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR8
-!=======================================================================
-   FUNCTION NWTC_ERFR16( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
-
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_ERFR16   ! result
-      
-      
-      NWTC_ERFR16 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR16
-!=======================================================================
-   FUNCTION NWTC_GammaR4( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(SiKi), INTENT(IN)     :: x             ! input 
-      REAL(SiKi)                 :: NWTC_GammaR4  ! result
-      
-      
-      NWTC_GammaR4 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR4
-!=======================================================================
-   FUNCTION NWTC_GammaR8( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_GammaR8  ! result
-      
-      
-      NWTC_GammaR8 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR8
-!=======================================================================
-   FUNCTION NWTC_GammaR16( x )
-   
-      ! Returns the gamma value of its argument. The result has a value equal  
-      ! to a processor-dependent approximation to the gamma function of x. 
-
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_GammaR16  ! result
-      
-      
-      NWTC_GammaR16 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR16
-!=======================================================================
-   SUBROUTINE OpenCon
-
-
-      ! This routine opens the console for standard output.
-
-
-   USE                             IFPORT
-
+   USE IFPORT
 
 !bjj: Because CU = 6 now, this statement is not necessary
 !   OPEN ( CU , FILE='/dev/stdout' , STATUS='UNKNOWN' , CARRIAGECONTROL='FORTRAN', RECL=ConRecL )
 
    CALL FlushOut ( CU )
 
-
    RETURN
-   END SUBROUTINE OpenCon
+END SUBROUTINE OpenCon
 !=======================================================================
-   SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
+SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
 
+   ! This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
+   ! Data are stored in RecLen-byte records.
 
-      ! This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
-      ! Data are stored in RecLen-byte records.
-
-   IMPLICIT                        NONE
-
-
-
-      ! Argument declarations.
+   IMPLICIT NONE
 
    INTEGER, INTENT(IN)          :: Un                                           ! Logical unit for the input file.
-
    CHARACTER(*), INTENT(IN)     :: InFile                                       ! Name of the input file.
-
    INTEGER, INTENT(IN)          :: RecLen                                       ! Size of records in the input file, in bytes.
-
    LOGICAL, INTENT(OUT)         :: Error                                        ! Flag to indicate the open failed.
-
-
-      ! Local declarations.
-
    INTEGER                      :: IOS                                          ! I/O status of OPEN.
 
-
-
-      ! Open input file.  Make sure it worked.
+   ! Open input file.  Make sure it worked.
 
    ! The non-standard CONVERT keyword allows us to read UNIX binary files, whose bytes are in reverse order (i.e., stored in BIG ENDIAN format).
-
    ! NOTE: using RecLen in bytes requires using the /assume:byterecl compiler option!
-
    OPEN ( Un, FILE=TRIM( InFile ), STATUS='OLD', FORM='UNFORMATTED', ACCESS='DIRECT', RECL=RecLen, IOSTAT=IOS, &
-                   ACTION='READ'  )                                              ! Use this for UNIX systems.
+                  ACTION='READ'  )                                              ! Use this for UNIX systems.
 !                  ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
-
 
    IF ( IOS /= 0 )  THEN
       Error = .TRUE.
@@ -340,131 +269,94 @@ CONTAINS
       Error = .FALSE.
    END IF
 
-
    RETURN
-   END SUBROUTINE OpenUnfInpBEFile
+END SUBROUTINE OpenUnfInpBEFile
 !=======================================================================
-   SUBROUTINE ProgExit ( StatCode )
+SUBROUTINE ProgExit ( StatCode )
 
-
-      ! This routine stops the program.  If the compiler supports the EXIT routine,
-      ! pass the program status to it.  Otherwise, do a STOP.
-
-
-      ! Argument declarations.
+   ! This routine stops the program.  If the compiler supports the EXIT routine,
+   ! pass the program status to it.  Otherwise, do a STOP.
 
    INTEGER, INTENT(IN)          :: StatCode                                      ! The status code to pass to the OS.
 
-
-
    CALL EXIT ( StatCode )
 
-!   IF ( StatCode == 0 ) THEN
-!      STOP 0
-!   ELSE
-!      IF ( StatCode < 0 ) THEN
-!         CALL WrScr( 'Invalid STOP code.' )
-!      END IF
-!
-!      STOP 1
-!   END IF
+   ! IF ( StatCode == 0 ) THEN
+   !    STOP 0
+   ! ELSE
+   !    IF ( StatCode < 0 ) THEN
+   !       CALL WrScr( 'Invalid STOP code.' )
+   !    END IF
+   !    STOP 1
+   ! END IF
 
-
-   END SUBROUTINE ProgExit ! ( StatCode )
+END SUBROUTINE ProgExit ! ( StatCode )
 !=======================================================================
-   SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
-   
-      ! routine that sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
-      ! values for not-a-number and infinity in sindle and double 
-      ! precision) This uses standard F03 intrinsic routines,  
-      ! however Gnu has not yet implemented it, so we've placed this
-      ! routine in the system-specific code.
-   
-   
-      USE, INTRINSIC :: ieee_arithmetic  ! use this for compilers that have implemented ieee_arithmetic from F03 standard (otherwise see logic in SysGnu*.f90)
-   
-      REAL(DbKi), INTENT(inout)           :: Inf_D          ! IEEE value for NaN (not-a-number) in double precision
-      REAL(DbKi), INTENT(inout)           :: NaN_D          ! IEEE value for Inf (infinity) in double precision
+SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
 
-      REAL(ReKi), INTENT(inout)           :: Inf            ! IEEE value for NaN (not-a-number)
-      REAL(ReKi), INTENT(inout)           :: NaN            ! IEEE value for Inf (infinity)
+   ! routine that sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
+   ! values for not-a-number and infinity in sindle and double 
+   ! precision) This uses standard F03 intrinsic routines,  
+   ! however Gnu has not yet implemented it, so we've placed this
+   ! routine in the system-specific code.
+
+   USE, INTRINSIC :: ieee_arithmetic  ! use this for compilers that have implemented ieee_arithmetic from F03 standard (otherwise see logic in SysGnu*.f90)
+
+   REAL(DbKi), INTENT(inout)           :: Inf_D          ! IEEE value for NaN (not-a-number) in double precision
+   REAL(DbKi), INTENT(inout)           :: NaN_D          ! IEEE value for Inf (infinity) in double precision
+
+   REAL(ReKi), INTENT(inout)           :: Inf            ! IEEE value for NaN (not-a-number)
+   REAL(ReKi), INTENT(inout)           :: NaN            ! IEEE value for Inf (infinity)
+
    
-      
-      NaN_D = ieee_value(0.0_DbKi, ieee_quiet_nan)
-      Inf_D = ieee_value(0.0_DbKi, ieee_positive_inf)
-   
-      NaN   = ieee_value(0.0_ReKi, ieee_quiet_nan)
-      Inf   = ieee_value(0.0_ReKi, ieee_positive_inf)   
-   
-   
-   END SUBROUTINE Set_IEEE_Constants  
+   NaN_D = ieee_value(0.0_DbKi, ieee_quiet_nan)
+   Inf_D = ieee_value(0.0_DbKi, ieee_positive_inf)
+
+   NaN   = ieee_value(0.0_ReKi, ieee_quiet_nan)
+   Inf   = ieee_value(0.0_ReKi, ieee_positive_inf)   
+
+END SUBROUTINE Set_IEEE_Constants  
 !=======================================================================
-   SUBROUTINE UsrAlarm
+SUBROUTINE UsrAlarm
 
-
-      ! This routine generates an alarm to warn the user that something went wrong.
-
-
+   ! This routine generates an alarm to warn the user that something went wrong.
 
    CALL WrNR ( CHAR( 7 ) )
 
-
    RETURN
-   END SUBROUTINE UsrAlarm
+END SUBROUTINE UsrAlarm
 !=======================================================================
-   SUBROUTINE WrNR ( Str )
+SUBROUTINE WrNR ( Str )
 
-
-      ! This routine writes out a string to the screen without following it with a new line.
-
-
-      ! Argument declarations.
+   ! This routine writes out a string to the screen without following it with a new line.
 
    CHARACTER(*), INTENT(IN)     :: Str                                          ! The string to write to the screen.
-
-
 
    WRITE (CU,'(1X,A)',ADVANCE='NO')  Str
 
-
    RETURN
-   END SUBROUTINE WrNR ! ( Str )
+END SUBROUTINE WrNR ! ( Str )
 !=======================================================================
-   SUBROUTINE WrOver ( Str )
+SUBROUTINE WrOver ( Str )
 
-
-      ! This routine writes out a string that overwrites the previous line
-
-
-      ! Argument declarations.
+   ! This routine writes out a string that overwrites the previous line
 
    CHARACTER(*), INTENT(IN)     :: Str                                          ! The string to write to the screen.
 
-
-
    WRITE (CU,'(''+'',A)')  Str
 
-
-
    RETURN
-   END SUBROUTINE WrOver ! ( Str )
+END SUBROUTINE WrOver ! ( Str )
 !=======================================================================
-   SUBROUTINE WriteScr ( Str, Frm )
+SUBROUTINE WriteScr ( Str, Frm )
 
+   ! This routine writes out a string to the screen.
 
-      ! This routine writes out a string to the screen.
-
-
-   IMPLICIT                        NONE
-
-
-      ! Argument declarations.
+   IMPLICIT NONE
 
    CHARACTER(*), INTENT(IN)     :: Str                                         ! The input string to write to the screen.
    CHARACTER(*), INTENT(IN)     :: Frm                                         ! Format specifier for the output.
-
    INTEGER                      :: ErrStat                                     ! Error status of write operation (so code doesn't crash)
-
 
    IF ( LEN_TRIM(Str)  < 1 ) THEN
       WRITE ( CU, '()', IOSTAT=ErrStat )
@@ -472,19 +364,15 @@ CONTAINS
       WRITE ( CU, Frm, IOSTAT=ErrStat ) TRIM(Str)
    END IF
 
-   IF ( ErrStat /= 0 ) &
+   IF ( ErrStat /= 0 ) THEN
       print *, ' WriteScr produced an error. Please inform the programmer.'
+   ENDIF
 
-
-   END SUBROUTINE WriteScr ! ( Str )
+END SUBROUTINE WriteScr ! ( Str )
 !=======================================================================
-
-!==================================================================================================================================
 SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to dynamically load a DLL.
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to dynamically load a DLL.
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
@@ -498,8 +386,6 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
    INTEGER(C_INT), PARAMETER :: RTLD_NOW=2             ! "If this value is specified, or the environment variable LD_BIND_NOW is set to a nonempty string, all undefined symbols in the library are resolved before dlopen() returns. If this cannot be done, an error is returned."
    INTEGER(C_INT), PARAMETER :: RTLD_GLOBAL=256        ! "The symbols defined by this library will be made available for symbol resolution of subsequently loaded libraries"
    INTEGER(C_INT), PARAMETER :: RTLD_LOCAL=0           ! "This is the converse of RTLD_GLOBAL, and the default if neither flag is specified. Symbols defined in this library are not made available to resolve references in subsequently loaded libraries."
-
-
 
    INTERFACE !linux API routines
       !bjj see http://linux.die.net/man/3/dlopen
@@ -516,12 +402,10 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
    ErrStat = ErrID_None
    ErrMsg = ''
 
-
-      ! Load the DLL and get the file address:
+   ! Load the DLL and get the file address:
 
    DLL%FileAddrX = dlOpen( TRIM(DLL%FileName)//C_NULL_CHAR, RTLD_LAZY )  !the "C_NULL_CHAR" converts the Fortran string to a C-type string (i.e., adds //CHAR(0) to the end)
 
@@ -533,8 +417,7 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
       RETURN
    END IF
 
-
-      ! Get the procedure address:
+   ! Get the procedure address:
 
    CALL LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 #else
@@ -546,18 +429,14 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
    
    RETURN
 END SUBROUTINE LoadDynamicLib
-!==================================================================================================================================
+!=======================================================================
 SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
-      ! This SUBROUTINE is used to dynamically load a procedure from a DLL.
-
-      ! Passed Variables:
+   ! This SUBROUTINE is used to dynamically load a procedure from a DLL.
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! local variables
    INTEGER(IntKi)                            :: i
 
 #ifdef USE_DLL_INTERFACE           
@@ -578,13 +457,8 @@ SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
    ErrStat = ErrID_None
    ErrMsg = ''
-
-   !IF( .NOT. C_ASSOCIATED(DLL%FileAddrX) ) RETURN
-
-      ! Get the procedure addresses:
 
    do i=1,NWTC_MAX_DLL_PROC
       if ( len_trim( DLL%ProcName(i) ) > 0 ) then
@@ -609,21 +483,16 @@ SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
    
    RETURN
 END SUBROUTINE LoadDynamicLibProc
-!==================================================================================================================================
+!=======================================================================
 SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
       ! This SUBROUTINE is used to free a dynamically loaded DLL (loaded in LoadDynamicLib).
 
-      ! Passed Variables:
-
-   TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be freed.
-   INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
-   CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! Local variable:
-   INTEGER(C_INT)                            :: Success     ! Whether or not the call to dlClose was successful
-   INTEGER(C_INT), PARAMETER                 :: TRUE  = 0
-
+      TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         ! The DLL to be freed.
+      INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     ! Error status of the operation
+      CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
+      INTEGER(C_INT)                            :: Success     ! Whether or not the call to dlClose was successful
+      INTEGER(C_INT), PARAMETER                 :: TRUE  = 0
 
 #ifdef USE_DLL_INTERFACE           
 !bjj: note that this is not tested.
@@ -642,8 +511,7 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
    END INTERFACE
 
-
-      ! Close the library:
+   ! Close the library:
 
    IF( .NOT. C_ASSOCIATED(DLL%FileAddrX) ) RETURN
    Success = dlClose( DLL%FileAddrX ) !The function dlclose() returns 0 on success, and nonzero on error.
@@ -660,14 +528,12 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
    
 #else
 
-   ErrStat = ErrID_Fatal
-   ErrMsg = ' FreeDynamicLib: Not compiled with -DUSE_DLL_INTERFACE for '//TRIM(OS_Desc)
+      ErrStat = ErrID_Fatal
+      ErrMsg = ' FreeDynamicLib: Not compiled with -DUSE_DLL_INTERFACE for '//TRIM(OS_Desc)
          
 #endif
    
-   RETURN
-END SUBROUTINE FreeDynamicLib
-!==================================================================================================================================
-
-
+      RETURN
+   END SUBROUTINE FreeDynamicLib
+!=======================================================================
 END MODULE SysSubs

--- a/modules-local/nwtc-library/src/SysIVF.f90
+++ b/modules-local/nwtc-library/src/SysIVF.f90
@@ -15,158 +15,99 @@
 ! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 ! See the License for the specific language governing permissions and
 ! limitations under the License.
-!
 !**********************************************************************************************************************************
-! File last committed: $Date$
-! (File) Revision #: $Rev$
-! URL: $HeadURL$
-!**********************************************************************************************************************************
-!> This module contains routines with system-specific logic and references, including all references to the console unit, CU.
-!! It also contains standard (but not system-specific) routines it uses.
-!! SysIVF.f90 is specifically for the Intel Visual Fortran for Windows compiler.   
 MODULE SysSubs
 
-   USE                             NWTC_Base
+   ! This module contains routines with system-specific logic and references, including all references to the console unit, CU.
+   ! It also contains standard (but not system-specific) routines it uses.
+   ! SysIVF.f90 is specifically for the Intel Visual Fortran for Windows compiler.   
+   ! It contains the following routines:
+   !     FUNCTION    FileSize( Unit )                                         ! Returns the size (in bytes) of an open file.
+   !     FUNCTION    Is_NaN( DblNum )                                         ! Please use IEEE_IS_NAN() instead
+   !     FUNCTION    NWTC_ERF( x )
+   !     FUNCTION    NWTC_gamma( x )                                          ! Returns the gamma value of its argument.   
+   !     SUBROUTINE  FlushOut ( Unit )
+   !     SUBROUTINE  GET_CWD( DirName, Status )
+   !     SUBROUTINE  MKDIR( new_directory_path )
+   !     SUBROUTINE  OpenCon
+   !     SUBROUTINE  OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
+   !     SUBROUTINE  ProgExit ( StatCode )
+   !     SUBROUTINE  Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
+   !     SUBROUTINE  UsrAlarm
+   !     SUBROUTINE  WrNR ( Str )
+   !     SUBROUTINE  WrOver ( Str )
+   !     SUBROUTINE  WriteScr ( Str, Frm )
+   !     SUBROUTINE LoadDynamicLib( DLL, ErrStat, ErrMsg )
+   !     SUBROUTINE FreeDynamicLib( DLL, ErrStat, ErrMsg )
 
-   IMPLICIT                        NONE
+   USE NWTC_Base
 
-      !> \copydoc syssubs::nwtc_gammar4
-   INTERFACE NWTC_gamma ! Returns the gamma value of its argument
-      MODULE PROCEDURE NWTC_gammaR4
-      MODULE PROCEDURE NWTC_gammaR8
-      MODULE PROCEDURE NWTC_gammaR16
-   END INTERFACE
+   IMPLICIT NONE
    
-      !> \copydoc syssubs::nwtc_erfr4
-   INTERFACE NWTC_ERF
+   INTERFACE NWTC_ERF ! Returns the ERF value of its argument
       MODULE PROCEDURE NWTC_ERFR4
       MODULE PROCEDURE NWTC_ERFR8
       MODULE PROCEDURE NWTC_ERFR16
    END INTERFACE   
 
-!=======================================================================
+   INTERFACE NWTC_gamma ! Returns the gamma value of its argument
+         ! note: gamma is part of the F08 standard, but may not be implemented everywhere...
+      MODULE PROCEDURE NWTC_gammaR4
+      MODULE PROCEDURE NWTC_gammaR8
+      MODULE PROCEDURE NWTC_gammaR16
+   END INTERFACE
 
-
-   INTEGER, PARAMETER            :: ConRecL     = 120                               !< The record length for console output.
-   INTEGER, PARAMETER            :: CU          = 7                                 !< The I/O unit for the console.  Unit 6 causes ADAMS to crash.
-   INTEGER, PARAMETER            :: MaxWrScrLen = 98                                !< The maximum number of characters allowed to be written to a line in WrScr
-
-   LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            !< A flag to tell the program that keyboard input is allowed in the environment.
-
-   CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         !< The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\\r is a line feed, CHAR(10)=\\n is a new line}]
-   CHARACTER(*),  PARAMETER      :: OS_Desc     = 'Intel Visual Fortran for Windows'!< Description of the language/OS
-   CHARACTER( 1), PARAMETER      :: PathSep     = '\'                               !< The path separator.
-   CHARACTER( 1), PARAMETER      :: SwChar      = '/'                               !< The switch character for command-line options.
-   CHARACTER(11), PARAMETER      :: UnfForm     = 'BINARY'                          !< The string to specify unformatted I/O files. (used in OpenUOutFile and OpenUInpFile [see TurbSim's .bin files])
+   INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
+   INTEGER, PARAMETER            :: CU          = 7                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
+   INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
+   LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
+   CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
+   CHARACTER(*),  PARAMETER      :: OS_Desc     = 'Intel Visual Fortran for Windows'! Description of the language/OS
+   CHARACTER( 1), PARAMETER      :: PathSep     = '\'                               ! The path separator.
+   CHARACTER( 1), PARAMETER      :: SwChar      = '/'                               ! The switch character for command-line options.
+   CHARACTER(11), PARAMETER      :: UnfForm     = 'BINARY'                          ! The string to specify unformatted I/O files. (used in OpenUOutFile and OpenUInpFile [see TurbSim's .bin files])
 
 CONTAINS
 
 !=======================================================================
-!> This function calls the portability routine, FSTAT, to obtain the file size
-!! in bytes corresponding to a file unit number or returns -1 on error.
-   FUNCTION FileSize( Unit )
+FUNCTION FileSize( Unit )
+   ! This function calls the portability routine, FSTAT, to obtain the file size
+   ! in bytes corresponding to a file unit number or returns -1 on error.
 
-   USE IFPORT
+USE IFPORT
 
+INTEGER(B8Ki)                             :: FileSize                      !< The size of the file in bytes to be returned.
+INTEGER, INTENT(IN)                       :: Unit                          !< The I/O unit number of the pre-opened file.
+INTEGER                                   :: StatArray(12)                 ! An array returned by FSTAT that includes the file size.
+INTEGER                                   :: Status                        ! The status returned by
 
-      ! Function declaration.
+Status = FSTAT( INT( Unit, B4Ki ), StatArray )
 
-   INTEGER(B8Ki)                             :: FileSize                      !< The size of the file in bytes to be returned.
+IF ( Status /= 0 ) THEN
+   FileSize = -1
+ELSE
+   FileSize = StatArray(8)
+END IF
 
-
-      ! Argument declarations:
-
-   INTEGER, INTENT(IN)                       :: Unit                          !< The I/O unit number of the pre-opened file.
-
-
-      ! Local declarations:
-
-   INTEGER                                   :: StatArray(12)                 ! An array returned by FSTAT that includes the file size.
-   INTEGER                                   :: Status                        ! The status returned by
-
-
-
-   Status = FSTAT( INT( Unit, B4Ki ), StatArray )
-
-   IF ( Status /= 0 ) THEN
-      FileSize = -1
-   ELSE
-      FileSize = StatArray(8)
-   END IF
-
-
-   RETURN
-   END FUNCTION FileSize ! ( Unit )
+RETURN
+END FUNCTION FileSize ! ( Unit )
 !=======================================================================
-!> This subroutine flushes the buffer on the specified Unit.
-!! It is especially useful when printing "running..." type messages.
-   SUBROUTINE FlushOut ( Unit )
+FUNCTION Is_NaN( DblNum )
 
+   ! This routine determines if a REAL(DbKi) variable holds a NaN (not-a-number) value.
+   ! BJJ: this routine is used in CRUNCH.
+   ! It should be replaced with IEEE_IS_NAN, but remains here for
+   ! backwards compatibility (some older compilers aren't yet current).
 
-   USE                             IFPORT
+USE, INTRINSIC :: ieee_arithmetic
 
+REAL(DbKi), INTENT(IN)       :: DblNum  !< scalar value in question
+LOGICAL                      :: Is_Nan
 
-      ! Argument declarations:
+Is_NaN = IEEE_IS_NAN( DblNum )
 
-   INTEGER, INTENT(IN)          :: Unit                                         !< The unit number of the file being flushed.
-
-
-
-   CALL FLUSH ( INT(Unit, B4Ki) )
-!bjj: ADAMS does not compile well with this, so I'll put it back to the subroutine form:
-!   FLUSH ( Unit )
-
-
-   RETURN
-   END SUBROUTINE FlushOut ! ( Unit )
-!=======================================================================
-!> This routine retrieves the path of the current working directory.
-   SUBROUTINE Get_CWD ( DirName, Status )
-
-
-   USE                             IFPORT, ONLY: GETCWD
-
-   IMPLICIT                        NONE
-
-
-      ! Passed variables.
-
-   CHARACTER(*), INTENT(OUT)    :: DirName                                         !< A CHARACTER string containing the path of the current working directory.
-   INTEGER,      INTENT(OUT)    :: Status                                          !< Status returned by the call to a portability routine.
-
-
-   Status = GETCWD ( DirName )
-
-   RETURN
-   END SUBROUTINE Get_CWD
-!=======================================================================
-!> This routine determines if a REAL(DbKi) variable holds a NaN (not-a-number) value.
-   FUNCTION Is_NaN( DblNum )
-
-
-      ! BJJ: this routine is used in CRUNCH.
-      ! It should be replaced with IEEE_IS_NAN, but remains here for
-      ! backwards compatibility (some older compilers aren't yet current).
-
-  USE, INTRINSIC :: ieee_arithmetic
-
-
-      ! Argument declarations.
-
-   REAL(DbKi), INTENT(IN)       :: DblNum  !< scalar value in question
-
-
-      ! Function declaration.
-
-   LOGICAL                      :: Is_Nan  ! 
-
-
-
-   Is_NaN = IEEE_IS_NAN( DblNum )
-
-
-   RETURN
-   END FUNCTION Is_NaN ! ( DblNum )
+RETURN
+END FUNCTION Is_NaN ! ( DblNum )
 !=======================================================================
 !> This function returns the ERF value of its argument. The result has a value equal  
 !! to the Gauss error function: 
@@ -174,41 +115,40 @@ CONTAINS
 !! \mathrm{erf}(x)=\frac{2}{\sqrt{\pi}}\int_0^x e^{-t^2}\,dt
 !! \f} \n
 !! Use NWTC_ERF (syssubs::nwtc_erf) instead of directly calling a specific routine in the generic interface.
-   FUNCTION NWTC_ERFR4( x )
-   
+FUNCTION NWTC_ERFR4( x )
 
-      REAL(SiKi), INTENT(IN)     :: x           !< input 
-      REAL(SiKi)                 :: NWTC_ERFR4  !< \f$\mathrm{erf}(x)\f$
-      
-      
-      NWTC_ERFR4 = ERF( x )
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+
+   REAL(SiKi), INTENT(IN)     :: x           !< input 
+   REAL(SiKi)                 :: NWTC_ERFR4  !< \f$\mathrm{erf}(x)\f$
    
-   END FUNCTION NWTC_ERFR4
+   NWTC_ERFR4 = ERF( x )
+
+END FUNCTION NWTC_ERFR4
 !=======================================================================
 !> \copydoc syssubs::nwtc_erfr4
-   FUNCTION NWTC_ERFR8( x )
+FUNCTION NWTC_ERFR8( x )
+
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_ERFR8    ! this function
    
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_ERFR8    ! this function
-      
-      
-      NWTC_ERFR8 = ERF( x )
-   
-   END FUNCTION NWTC_ERFR8
+   NWTC_ERFR8 = ERF( x )
+
+END FUNCTION NWTC_ERFR8
 !=======================================================================
 !> \copydoc syssubs::nwtc_erfr4
-   FUNCTION NWTC_ERFR16( x )
-   
-      ! Returns the ERF value of its argument. The result has a value equal  
-      ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+FUNCTION NWTC_ERFR16( x )
 
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_ERFR16   ! result
-      
-      
-      NWTC_ERFR16 = ERF( x )
+   ! Returns the ERF value of its argument. The result has a value equal  
+   ! to the error function: 2/pi * integral_from_0_to_x of e^(-t^2) dt. 
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_ERFR16   ! result
    
-   END FUNCTION NWTC_ERFR16
+   NWTC_ERFR16 = ERF( x )
+
+END FUNCTION NWTC_ERFR16
 !=======================================================================
 !> Returns the gamma value of its argument. The result has a value equal  
 !! to a processor-dependent approximation to the gamma function of x:
@@ -216,95 +156,115 @@ CONTAINS
 !! \mathrm{ \Gamma }(x) = \int_0^\infty t^{x-1}e^{-t}\,dt
 !! \f} \n
 !! Use NWTC_Gamma (syssubs::nwtc_gamma) instead of directly calling a specific routine in the generic interface.
-   FUNCTION NWTC_GammaR4( x )
-   
+FUNCTION NWTC_GammaR4( x )
+
 ! \mathrm{ \Gamma }(x) = \int_0^\infinity t^{x-1}e^{-t}\,dt
 
-      REAL(SiKi), INTENT(IN)     :: x             !< input 
-      REAL(SiKi)                 :: NWTC_GammaR4  !< \f$\mathrm{\Gamma}(x)\f$
-      
-      
-      NWTC_GammaR4 = gamma( x )
+   REAL(SiKi), INTENT(IN)     :: x             !< input 
+   REAL(SiKi)                 :: NWTC_GammaR4  !< \f$\mathrm{\Gamma}(x)\f$
    
-   END FUNCTION NWTC_GammaR4
-!=======================================================================
-!> \copydoc syssubs::nwtc_gammar4
-   FUNCTION NWTC_GammaR8( x )
+   NWTC_GammaR4 = gamma( x )
 
-      REAL(R8Ki), INTENT(IN)     :: x             ! input 
-      REAL(R8Ki)                 :: NWTC_GammaR8  ! result
-      
-      
-      NWTC_GammaR8 = gamma( x )
-   
-   END FUNCTION NWTC_GammaR8
+END FUNCTION NWTC_GammaR4
 !=======================================================================
 !> \copydoc syssubs::nwtc_gammar4
-   FUNCTION NWTC_GammaR16( x )
+FUNCTION NWTC_GammaR8( x )
+
+   REAL(R8Ki), INTENT(IN)     :: x             ! input 
+   REAL(R8Ki)                 :: NWTC_GammaR8  ! result
    
-      REAL(QuKi), INTENT(IN)     :: x             ! input 
-      REAL(QuKi)                 :: NWTC_GammaR16  ! result
-      
-      
-      NWTC_GammaR16 = gamma( x )
+   NWTC_GammaR8 = gamma( x )
+
+END FUNCTION NWTC_GammaR8
+!=======================================================================
+!> \copydoc syssubs::nwtc_gammar4
+FUNCTION NWTC_GammaR16( x )
+
+   REAL(QuKi), INTENT(IN)     :: x             ! input 
+   REAL(QuKi)                 :: NWTC_GammaR16  ! result
    
-   END FUNCTION NWTC_GammaR16
+   NWTC_GammaR16 = gamma( x )
+
+END FUNCTION NWTC_GammaR16
+!=======================================================================
+!> This subroutine flushes the buffer on the specified Unit.
+!! It is especially useful when printing "running..." type messages.
+SUBROUTINE FlushOut ( Unit )
+
+   USE IFPORT
+
+   INTEGER, INTENT(IN)          :: Unit                                         !< The unit number of the file being flushed.
+
+   CALL FLUSH ( INT(Unit, B4Ki) )
+
+   RETURN
+END SUBROUTINE FlushOut ! ( Unit )
+!=======================================================================
+!> This routine retrieves the path of the current working directory.
+SUBROUTINE Get_CWD ( DirName, Status )
+
+   USE IFPORT, ONLY: GETCWD
+
+   IMPLICIT NONE
+
+   CHARACTER(*), INTENT(OUT)    :: DirName                                         !< A CHARACTER string containing the path of the current working directory.
+   INTEGER,      INTENT(OUT)    :: Status                                          !< Status returned by the call to a portability routine.
+
+   Status = GETCWD ( DirName )
+
+   RETURN
+END SUBROUTINE Get_CWD
+!=======================================================================
+!> This routine creates a given directory if it does not already exist.
+SUBROUTINE MKDIR ( new_directory_path )
+
+   implicit none
+
+   character(*), intent(in) :: new_directory_path
+   character(1024)          :: make_command
+   logical                  :: directory_exists
+
+   ! Check if the directory exists first
+   inquire( directory=trim(new_directory_path), exist=directory_exists )
+
+   if ( .NOT. directory_exists ) then
+      make_command = 'mkdir '//trim(new_directory_path)
+      call system( make_command )
+   endif
+
+END SUBROUTINE MKDIR
 !=======================================================================
 !> This routine opens the console for standard output.
-   SUBROUTINE OpenCon()
+SUBROUTINE OpenCon()
 
-   USE                             IFPORT
-
-!bjj this can be used later:
-!   INTEGER                      :: OUTPUT_UNIT
-!
-!
-!   OPEN ( OUTPUT_UNIT , FILE='CON' , STATUS='UNKNOWN' , CARRIAGECONTROL='FORTRAN', RECL=ConRecL )
-!
-!   CALL FlushOut ( OUTPUT_UNIT )
-
+   USE IFPORT
 
    OPEN ( CU , FILE='CON' , STATUS='UNKNOWN' , CARRIAGECONTROL='FORTRAN', RECL=ConRecL )
 
    CALL FlushOut ( CU )
 
    RETURN
-   END SUBROUTINE OpenCon
+END SUBROUTINE OpenCon
 !=======================================================================
 !> This routine opens a binary input file with data stored in Big Endian format (created on a UNIX machine.)
 !! Data are stored in RecLen-byte records. (This routine is used for 
-   SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
+SUBROUTINE OpenUnfInpBEFile ( Un, InFile, RecLen, Error )
 
-   IMPLICIT                        NONE
-
-
-      ! Argument declarations.
+   IMPLICIT NONE
 
    INTEGER, INTENT(IN)          :: Un                                           !< Logical unit for the input file.
-
    CHARACTER(*), INTENT(IN)     :: InFile                                       !< Name of the input file.
-
    INTEGER, INTENT(IN)          :: RecLen                                       !< Size of records in the input file, in bytes.
-
    LOGICAL, INTENT(OUT)         :: Error                                        !< Flag to indicate the open failed (true indicates an error occurred).
-
-
-      ! Local declarations.
-
    INTEGER                      :: IOS                                          ! I/O status of OPEN.
 
-
-
-      ! Open input file.  Make sure it worked.
+   ! Open input file.  Make sure it worked.
 
    ! The non-standard CONVERT keyword allows us to read UNIX binary files, whose bytes are in reverse order (i.e., stored in BIG ENDIAN format).
-
    ! NOTE: using RecLen in bytes requires using the /assume:byterecl compiler option!
-
    OPEN ( Un, FILE=TRIM( InFile ), STATUS='OLD', FORM='UNFORMATTED', ACCESS='DIRECT', RECL=RecLen, IOSTAT=IOS, &
-                   ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
-!                  ACTION='READ'  )                                              ! Use this for UNIX systems.
-
+   !                  ACTION='READ'  )                                              ! Use this for UNIX systems.
+                  ACTION='READ', CONVERT='BIG_ENDIAN' )                         ! Use this for PC systems.
 
    IF ( IOS /= 0 )  THEN
       Error = .TRUE.
@@ -312,115 +272,86 @@ CONTAINS
       Error = .FALSE.
    END IF
 
-
    RETURN
-   END SUBROUTINE OpenUnfInpBEFile
+END SUBROUTINE OpenUnfInpBEFile
 !=======================================================================
 !> This routine stops the program immediately.  If the compiler supports the EXIT routine,
 !! pass the program status to it.  Otherwise, do a STOP.
-   SUBROUTINE ProgExit ( StatCode )
-
-      ! Argument declarations.
+SUBROUTINE ProgExit ( StatCode )
 
    INTEGER, INTENT(IN)          :: StatCode                                      ! The status code to pass to the OS.
 
-
-
    CALL EXIT ( StatCode )
-
-!   IF ( StatCode == 0 ) THEN
-!      STOP 0
-!   ELSE
-!      IF ( StatCode < 0 ) THEN
-!         CALL WrScr( 'Invalid STOP code.' )
-!      END IF
-!
-!      STOP 1
-!   END IF
-
-
-   END SUBROUTINE ProgExit ! ( StatCode )
+   
+   ! IF ( StatCode == 0 ) THEN
+   !    STOP 0
+   ! ELSE
+   !    IF ( StatCode < 0 ) THEN
+   !       CALL WrScr( 'Invalid STOP code.' )
+   !    END IF
+   !    STOP 1
+   ! END IF
+END SUBROUTINE ProgExit ! ( StatCode )
 !=======================================================================
 !> This routine sets the values of NaN_D, Inf_D, NaN, Inf (IEEE 
 !! values for not-a-number and infinity in sindle and double 
 !! precision) This uses standard F03 intrinsic routines,  
 !! however Gnu has not yet implemented it, so we've placed this
 !! routine in the system-specific code.
-   SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
-   
-      USE, INTRINSIC :: ieee_arithmetic  ! use this for compilers that have implemented ieee_arithmetic from F03 standard (otherwise see logic in SysGnu*.f90)
-   
-      REAL(DbKi), INTENT(inout)           :: Inf_D          !< IEEE value for NaN (not-a-number) in double precision
-      REAL(DbKi), INTENT(inout)           :: NaN_D          !< IEEE value for Inf (infinity) in double precision
+SUBROUTINE Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf )   
 
-      REAL(ReKi), INTENT(inout)           :: Inf            !< IEEE value for NaN (not-a-number)
-      REAL(ReKi), INTENT(inout)           :: NaN            !< IEEE value for Inf (infinity)
+   USE, INTRINSIC :: ieee_arithmetic  ! use this for compilers that have implemented ieee_arithmetic from F03 standard (otherwise see logic in SysGnu*.f90)
+
+   REAL(DbKi), INTENT(inout)           :: Inf_D          !< IEEE value for NaN (not-a-number) in double precision
+   REAL(DbKi), INTENT(inout)           :: NaN_D          !< IEEE value for Inf (infinity) in double precision
+
+   REAL(ReKi), INTENT(inout)           :: Inf            !< IEEE value for NaN (not-a-number)
+   REAL(ReKi), INTENT(inout)           :: NaN            !< IEEE value for Inf (infinity)
    
-      
-      NaN_D = ieee_value(0.0_DbKi, ieee_quiet_nan)
-      Inf_D = ieee_value(0.0_DbKi, ieee_positive_inf)
-   
-      NaN   = ieee_value(0.0_ReKi, ieee_quiet_nan)
-      Inf   = ieee_value(0.0_ReKi, ieee_positive_inf)   
-   
-   
-   END SUBROUTINE Set_IEEE_Constants  
+   NaN_D = ieee_value(0.0_DbKi, ieee_quiet_nan)
+   Inf_D = ieee_value(0.0_DbKi, ieee_positive_inf)
+
+   NaN   = ieee_value(0.0_ReKi, ieee_quiet_nan)
+   Inf   = ieee_value(0.0_ReKi, ieee_positive_inf)   
+
+END SUBROUTINE Set_IEEE_Constants  
 !=======================================================================
 !> This routine generates an alarm to warn the user that something went wrong.
-   SUBROUTINE UsrAlarm()
+SUBROUTINE UsrAlarm()
 
    CALL WrNR ( CHAR( 7 ) )
 
    RETURN
-   END SUBROUTINE UsrAlarm
+END SUBROUTINE UsrAlarm
 !=======================================================================
 !> This routine writes out a string to the screen without following it with a new line.
-   SUBROUTINE WrNR ( Str )
-
-      ! Argument declarations.
+SUBROUTINE WrNR ( Str )
 
    CHARACTER(*), INTENT(IN)     :: Str                                          !< The string to write to the screen.
-
-
 
    WRITE (CU,'(1X,A)',ADVANCE='NO')  Str
 
-
    RETURN
-   END SUBROUTINE WrNR ! ( Str )
+END SUBROUTINE WrNR ! ( Str )
 !=======================================================================
 !> This routine writes out a string that overwrites the previous line
-   SUBROUTINE WrOver ( Str )
-
-      ! Argument declarations.
+SUBROUTINE WrOver ( Str )
 
    CHARACTER(*), INTENT(IN)     :: Str                                          !< The string to write to the screen.
 
-
-
-!mlb Leave this as it was until FLUSH get fixed.
    WRITE (CU,'(''+'',A)')  Str
-!   WRITE (CU,'(A)',ADVANCE='NO')  CHAR( 13 )//' '//Str
-
-
 
    RETURN
-   END SUBROUTINE WrOver ! ( Str )
+END SUBROUTINE WrOver ! ( Str )
 !=======================================================================
 !> This routine writes out a string to the screen.
-   SUBROUTINE WriteScr ( Str, Frm )
+SUBROUTINE WriteScr ( Str, Frm )
 
-
-   IMPLICIT                        NONE
-
-
-      ! Argument declarations.
+   IMPLICIT NONE
 
    CHARACTER(*), INTENT(IN)     :: Str         !< The input string to write to the screen.
    CHARACTER(*), INTENT(IN)     :: Frm         !< Format specifier for the output.
-
    INTEGER                      :: ErrStat     ! Error status of write operation (so code doesn't crash)
-
 
    IF ( LEN_TRIM(Str)  < 1 ) THEN
       WRITE ( CU, '()', IOSTAT=ErrStat )
@@ -428,37 +359,23 @@ CONTAINS
       WRITE ( CU, Frm, IOSTAT=ErrStat ) TRIM(Str)
    END IF
 
-
-   END SUBROUTINE WriteScr ! ( Str )
-
+END SUBROUTINE WriteScr ! ( Str )
 !=======================================================================
-
-
-!==================================================================================================================================
 !> This subroutine is used to dynamically load a DLL, using operating-system API routines to do so.
 SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
 
-
-   USE               IFWINTY,  ONLY : HANDLE
-   USE               kernel32, ONLY : LoadLibrary
-
-      ! Passed Variables:
+   USE IFWINTY,  ONLY : HANDLE
+   USE kernel32, ONLY : LoadLibrary
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         !< The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     !< Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      !< Error message if ErrStat /= ErrID_None
-
-
-      ! local variables
    INTEGER(HANDLE)                           :: FileAddr    ! The address of file FileName.         (RETURN value from LoadLibrary in kernel32.f90)
-
 
    ErrStat = ErrID_None
    ErrMsg = ''
 
-
       ! Load the DLL and get the file address:
-
    FileAddr = LoadLibrary( TRIM(DLL%FileName)//C_NULL_CHAR )  !the "C_NULL_CHAR" converts the Fortran string to a C-type string (i.e., adds //CHAR(0) to the end)
    DLL%FileAddr = TRANSFER(FileAddr, DLL%FileAddr)             !convert INTEGER(HANDLE) to INTEGER(C_INTPTR_T) [used only for compatibility with gfortran]
 
@@ -466,44 +383,33 @@ SUBROUTINE LoadDynamicLib ( DLL, ErrStat, ErrMsg )
       ErrStat = ErrID_Fatal
       WRITE(ErrMsg,'(I2)') BITS_IN_ADDR
       ErrMsg  = 'The dynamic library '//TRIM(DLL%FileName)//' could not be loaded. Check that the file '// &
-                'exists in the specified location and that it is compiled for '//TRIM(ErrMsg)//'-bit applications.'
+               'exists in the specified location and that it is compiled for '//TRIM(ErrMsg)//'-bit applications.'
       RETURN
    END IF
 
-
       ! Get the procedure address:
-
    CALL LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
-
 
    RETURN
 END SUBROUTINE LoadDynamicLib
-!==================================================================================================================================
-! This subroutine is used to dynamically load a procedure in a DLL, using operating-system API routines to do so.
+!=======================================================================
 SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
 
+   ! This subroutine is used to dynamically load a procedure in a DLL, using operating-system API routines to do so.
 
-   USE               IFWINTY,  ONLY : LPVOID
-   USE               kernel32, ONLY : GetProcAddress
-
-      ! Passed Variables:
+   USE IFWINTY,  ONLY : LPVOID
+   USE kernel32, ONLY : GetProcAddress
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         !< The DLL to be loaded.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     !< Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      !< Error message if ErrStat /= ErrID_None
-
-
-      ! local variables
    INTEGER(LPVOID)                           :: ProcAddr    ! The address of procedure ProcName.    (RETURN value from GetProcAddress in kernel32.f90)
    INTEGER(IntKi)                            :: i
 
    ErrStat = ErrID_None
    ErrMsg = ''
-   !IF ( DLL%FileAddr == INT(0,C_INTPTR_T) ) RETURN
-
-   
+         
       ! Get the procedure addresses:
-
    do i=1,NWTC_MAX_DLL_PROC
       if ( len_trim( DLL%ProcName(i) ) > 0 ) then
    
@@ -518,36 +424,27 @@ SUBROUTINE LoadDynamicLibProc ( DLL, ErrStat, ErrMsg )
          
       end if
    end do
-         
 
    RETURN
 END SUBROUTINE LoadDynamicLibProc
-!==================================================================================================================================
-! This subroutine is used to free a dynamically loaded DLL (loaded in LoadDynamicLib (syssubs::loaddynamiclib)), using operating-system API routines to do so.
+!=======================================================================
 SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
+! This subroutine is used to free a dynamically loaded DLL (loaded in LoadDynamicLib (syssubs::loaddynamiclib)), using operating-system API routines to do so.
 
-   USE               IFWINTY,  ONLY : BOOL, HANDLE, FALSE !, LPVOID
-   USE               kernel32, ONLY : FreeLibrary
-
-
-      ! Passed Variables:
+   USE IFWINTY,  ONLY : BOOL, HANDLE, FALSE !, LPVOID
+   USE kernel32, ONLY : FreeLibrary
 
    TYPE (DLL_Type),           INTENT(INOUT)  :: DLL         !< The DLL to be freed.
    INTEGER(IntKi),            INTENT(  OUT)  :: ErrStat     !< Error status of the operation
    CHARACTER(*),              INTENT(  OUT)  :: ErrMsg      !< Error message if ErrStat /= ErrID_None
-
-      ! Local variable:
    INTEGER(HANDLE)                           :: FileAddr    ! The address of file FileName.  (RETURN value from LoadLibrary in kernel32.f90)
    INTEGER(BOOL)                             :: Success     ! Whether or not the call to FreeLibrary was successful
 
-
    IF ( DLL%FileAddr == INT(0,C_INTPTR_T) ) RETURN
-
    
    FileAddr = TRANSFER(DLL%FileAddr, FileAddr) !convert INTEGER(C_INTPTR_T) to INTEGER(HANDLE) [used only for compatibility with gfortran]
 
       ! Free the DLL:
-
    Success = FreeLibrary( FileAddr ) !If the function succeeds, the return value is nonzero. If the function fails, the return value is zero.
 
    IF ( Success == FALSE ) THEN !BJJ: note that this is the Windows BOOL type so FALSE isn't the same as the Fortran LOGICAL .FALSE.
@@ -562,6 +459,5 @@ SUBROUTINE FreeDynamicLib ( DLL, ErrStat, ErrMsg )
 
    RETURN
 END SUBROUTINE FreeDynamicLib
-!==================================================================================================================================
-
+!=======================================================================
 END MODULE SysSubs

--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -4910,12 +4910,16 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 
 
    logical                                 :: outputFields        ! flag to determine if we want to output the HD mesh fields
-   INTEGER(IntKi)                          :: NumBl, k
+   INTEGER(IntKi)                          :: NumBl, k, Twidth
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_AllMeshes'
+
+   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
+   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
+   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
    
-   
+
    NumBl = 0
    if (allocated(ED%Output)) then
       if (allocated(ED%Output(1)%BladeRootMotion)) then
@@ -4932,10 +4936,10 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
          !  ElastoDyn outputs (motions)
       DO K=1,NumBl        
          !%BladeLn2Mesh(K) used only when not BD (see below)
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeRootMotion(K), trim(p_FAST%OutFileRoot)//'.ED_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeRootMotion(K), trim(p_FAST%OutFileRoot)//'.ED_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
       END DO
       
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.ED_TowerLn2Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.ED_TowerLn2Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
 
 ! these will get output with their sibling input meshes
       !call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(p_FAST%OutFileRoot)//'.ED_HubPtMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
@@ -4944,10 +4948,10 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       
          !  ElastoDyn inputs (loads)
       ! %BladePtLoads used only when not BD (see below)
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%TowerPtLoads, trim(p_FAST%OutFileRoot)//'.ED_TowerPtLoads', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, ED%Output(1)%TowerLn2Mesh )     
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%HubPtLoad, trim(p_FAST%OutFileRoot)//'.ED_Hub', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, ED%Output(1)%HubPtMotion )
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%NacelleLoads, trim(p_FAST%OutFileRoot)//'.ED_Nacelle' ,y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, ED%Output(1)%NacelleMotion )     
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%PlatformPtMesh, trim(p_FAST%OutFileRoot)//'.ED_PlatformPtMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, ED%Output(1)%PlatformPtMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%TowerPtLoads, trim(p_FAST%OutFileRoot)//'.ED_TowerPtLoads', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%TowerLn2Mesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%HubPtLoad, trim(p_FAST%OutFileRoot)//'.ED_Hub', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%HubPtMotion )
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%NacelleLoads, trim(p_FAST%OutFileRoot)//'.ED_Nacelle' ,y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%NacelleMotion )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%PlatformPtMesh, trim(p_FAST%OutFileRoot)//'.ED_PlatformPtMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%PlatformPtMesh )     
    end if
    
    
@@ -4957,11 +4961,11 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       do K=1,NumBl        
             ! BeamDyn inputs
          !call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%RootMotion, trim(p_FAST%OutFileRoot)//'.BD_RootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
-         call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%HubMotion, trim(p_FAST%OutFileRoot)//'.BD_HubMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )    
+         call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%HubMotion, trim(p_FAST%OutFileRoot)//'.BD_HubMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )    
       end do
       if (allocated(MeshMapData%y_BD_BldMotion_4Loads)) then
          do K=1,NumBl 
-            call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%DistrLoad, trim(p_FAST%OutFileRoot)//'.BD_DistrLoad'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, MeshMapData%y_BD_BldMotion_4Loads(k) )
+            call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%DistrLoad, trim(p_FAST%OutFileRoot)//'.BD_DistrLoad'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MeshMapData%y_BD_BldMotion_4Loads(k) )
             ! skipping PointLoad
          end do
       elseif (p_FAST%BD_OutputSibling) then
@@ -4988,8 +4992,8 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
    ELSE if (allocated(ED%Input) .and. allocated(ED%Output)) then
       ! ElastoDyn
       DO K=1,NumBl        
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%BladePtLoads(K), trim(p_FAST%OutFileRoot)//'.ED_BladePtLoads'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, ED%Output(1)%BladeLn2Mesh(K) )
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%BladePtLoads(K), trim(p_FAST%OutFileRoot)//'.ED_BladePtLoads'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%BladeLn2Mesh(K) )
       END DO      
    END IF
             
@@ -4997,11 +5001,11 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
    if (allocated(SrvD%Input)) then
       IF ( SrvD%Input(1)%NTMD%Mesh%Committed ) THEN         
          !call MeshWrVTK(p_FAST%TurbinePos, SrvD%Input(1)%NTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_NTMD_Motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
-         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%NTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_NTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, SrvD%Input(1)%TTMD%Mesh )                
+         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%NTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_NTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SrvD%Input(1)%TTMD%Mesh )                
       END IF      
       IF ( SrvD%Input(1)%TTMD%Mesh%Committed ) THEN 
          !call MeshWrVTK(p_FAST%TurbinePos, SrvD%Input(1)%TTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_TTMD_Motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
-         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%TTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_TTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, SrvD%Input(1)%TTMD%Mesh )         
+         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%TTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_TTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SrvD%Input(1)%TTMD%Mesh )         
       END IF   
    end if
    
@@ -5012,16 +5016,16 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       if (allocated(AD%Input(1)%BladeRootMotion)) then      
       
          DO K=1,NumBl   
-            call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeRootMotion(K), trim(p_FAST%OutFileRoot)//'.AD_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
+            call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeRootMotion(K), trim(p_FAST%OutFileRoot)//'.AD_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
             !call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(p_FAST%OutFileRoot)//'.AD_BladeMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
          END DO            
-         call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%HubMotion, trim(p_FAST%OutFileRoot)//'.AD_HubMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
+         call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%HubMotion, trim(p_FAST%OutFileRoot)//'.AD_HubMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
          !call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%TowerMotion, trim(p_FAST%OutFileRoot)//'.AD_TowerMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
                
          DO K=1,NumBl   
-            call MeshWrVTK(p_FAST%TurbinePos, AD%y%BladeLoad(K), trim(p_FAST%OutFileRoot)//'.AD_Blade'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, AD%Input(1)%BladeMotion(k) )     
+            call MeshWrVTK(p_FAST%TurbinePos, AD%y%BladeLoad(K), trim(p_FAST%OutFileRoot)//'.AD_Blade'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, AD%Input(1)%BladeMotion(k) )     
          END DO            
-         call MeshWrVTK(p_FAST%TurbinePos, AD%y%TowerLoad, trim(p_FAST%OutFileRoot)//'.AD_Tower', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, AD%Input(1)%TowerMotion )     
+         call MeshWrVTK(p_FAST%TurbinePos, AD%y%TowerLoad, trim(p_FAST%OutFileRoot)//'.AD_Tower', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, AD%Input(1)%TowerMotion )     
          
       end if
       
@@ -5034,14 +5038,14 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       !call MeshWrVTK(p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
       
       if (p_FAST%CompSub == Module_NONE) then
-         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(p_FAST%OutFileRoot)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, HD%Input(1)%Mesh )
+         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(p_FAST%OutFileRoot)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
          outputFields = .false.
       else         
-         call MeshWrVTK(p_FAST%TurbinePos, HD%y%Mesh, trim(p_FAST%OutFileRoot)//'.HD_Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, HD%Input(1)%Mesh )
+         call MeshWrVTK(p_FAST%TurbinePos, HD%y%Mesh, trim(p_FAST%OutFileRoot)//'.HD_Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
          outputFields = p_FAST%VTK_fields
       end if
-      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%LumpedMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonLumped', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, HD%Input(1)%Morison%LumpedMesh )     
-      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, HD%Input(1)%Morison%DistribMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%LumpedMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonLumped', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Morison%LumpedMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Morison%DistribMesh )     
       
                   
    END IF
@@ -5049,39 +5053,39 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 ! SubDyn   
    IF ( p_FAST%CompSub == Module_SD .and. allocated(SD%Input)) THEN
       !call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%TPMesh, trim(p_FAST%OutFileRoot)//'.SD_TPMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
-      call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%LMesh, trim(p_FAST%OutFileRoot)//'.SD_LMesh_y2Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, SD%y%y2Mesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%LMesh, trim(p_FAST%OutFileRoot)//'.SD_LMesh_y2Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SD%y%y2Mesh )     
       
-      call MeshWrVTK(p_FAST%TurbinePos, SD%y%y1Mesh, trim(p_FAST%OutFileRoot)//'.SD_y1Mesh_TPMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, SD%Input(1)%TPMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, SD%y%y1Mesh, trim(p_FAST%OutFileRoot)//'.SD_y1Mesh_TPMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SD%Input(1)%TPMesh )     
       !call MeshWrVTK(p_FAST%TurbinePos, SD%y%y2Mesh, trim(p_FAST%OutFileRoot)//'.SD_y2Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
    ELSE IF ( p_FAST%CompSub == Module_ExtPtfm .and. allocated(ExtPtfm%Input)) THEN
-      call MeshWrVTK(p_FAST%TurbinePos, ExtPtfm%y%PtfmMesh, trim(p_FAST%OutFileRoot)//'.ExtPtfm', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, ExtPtfm%Input(1)%PtfmMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, ExtPtfm%y%PtfmMesh, trim(p_FAST%OutFileRoot)//'.ExtPtfm', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ExtPtfm%Input(1)%PtfmMesh )     
    END IF     
        
 ! MAP
    IF ( p_FAST%CompMooring == Module_MAP ) THEN
       if (allocated(MAPp%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, MAPp%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.MAP_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, MAPp%Input(1)%PtFairDisplacement )     
+         call MeshWrVTK(p_FAST%TurbinePos, MAPp%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.MAP_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MAPp%Input(1)%PtFairDisplacement )     
          !call MeshWrVTK(p_FAST%TurbinePos, MAPp%Input(1)%PtFairDisplacement, trim(p_FAST%OutFileRoot)//'.MAP_PtFair_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
       end if
       
 ! MoorDyn      
    ELSEIF ( p_FAST%CompMooring == Module_MD ) THEN
       if (allocated(MD%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, MD%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.MD_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, MD%Input(1)%PtFairleadDisplacement )     
+         call MeshWrVTK(p_FAST%TurbinePos, MD%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.MD_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MD%Input(1)%PtFairleadDisplacement )     
          !call MeshWrVTK(p_FAST%TurbinePos, MD%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'.MD_PtFair_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
       end if
       
 ! FEAMooring                   
    ELSEIF ( p_FAST%CompMooring == Module_FEAM ) THEN
       if (allocated(FEAM%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, FEAM%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.FEAM_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, FEAM%Input(1)%PtFairleadDisplacement )     
+         call MeshWrVTK(p_FAST%TurbinePos, FEAM%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.FEAM_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, FEAM%Input(1)%PtFairleadDisplacement )     
          !call MeshWrVTK(p_FAST%TurbinePos, FEAM%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'.FEAM_PtFair_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
       end if
       
 ! Orca      
    ELSEIF ( p_FAST%CompMooring == Module_Orca ) THEN
       if (allocated(Orca%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, Orca%y%PtfmMesh, trim(p_FAST%OutFileRoot)//'.Orca_PtfmMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Orca%Input(1)%PtfmMesh )     
+         call MeshWrVTK(p_FAST%TurbinePos, Orca%y%PtfmMesh, trim(p_FAST%OutFileRoot)//'.Orca_PtfmMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Orca%Input(1)%PtfmMesh )     
          !call MeshWrVTK(p_FAST%TurbinePos, Orca%Input(1)%PtfmMesh, trim(p_FAST%OutFileRoot)//'.Orca_PtfmMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
       end if
    END IF
@@ -5090,7 +5094,7 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 ! IceFloe      
    IF ( p_FAST%CompIce == Module_IceF ) THEN
       if (allocated(IceF%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, IceF%y%iceMesh, trim(p_FAST%OutFileRoot)//'.IceF_iceMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, IceF%Input(1)%iceMesh )     
+         call MeshWrVTK(p_FAST%TurbinePos, IceF%y%iceMesh, trim(p_FAST%OutFileRoot)//'.IceF_iceMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, IceF%Input(1)%iceMesh )     
          !call MeshWrVTK(p_FAST%TurbinePos, IceF%Input(1)%iceMesh, trim(p_FAST%OutFileRoot)//'.IceF_iceMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
       end if
       
@@ -5099,7 +5103,7 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       if (allocated(IceD%Input)) then
             
          DO k = 1,p_FAST%numIceLegs
-            call MeshWrVTK(p_FAST%TurbinePos, IceD%y(k)%PointMesh, trim(p_FAST%OutFileRoot)//'.IceD_PointMesh'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, IceD%Input(1,k)%PointMesh )     
+            call MeshWrVTK(p_FAST%TurbinePos, IceD%y(k)%PointMesh, trim(p_FAST%OutFileRoot)//'.IceD_PointMesh'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, IceD%Input(1,k)%PointMesh )     
             !call MeshWrVTK(p_FAST%TurbinePos, IceD%Input(1,k)%PointMesh, trim(p_FAST%OutFileRoot)//'.IceD_PointMesh_motion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
          END DO
       end if
@@ -5135,43 +5139,47 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
 
 
    logical                                 :: OutputFields
-   INTEGER(IntKi)                          :: NumBl, k
+   INTEGER(IntKi)                          :: NumBl, k, Twidth
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_BasicMeshes'
+
+   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
+   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
+   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
    
-   
+
    NumBl = SIZE(ED%Output(1)%BladeRootMotion)            
 
 ! Nacelle
    call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%NacelleMotion, trim(p_FAST%OutFileRoot)//'.ED_Nacelle', y_FAST%VTK_count, &
-                  p_FAST%VTK_fields, ErrStat2, ErrMsg2, Sib=ED%Input(1)%NacelleLoads )     
+                  p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Sib=ED%Input(1)%NacelleLoads )     
                
 ! Hub
    call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(p_FAST%OutFileRoot)//'.ED_Hub', y_FAST%VTK_count, &
-                  p_FAST%VTK_fields, ErrStat2, ErrMsg2, Sib=ED%Input(1)%HubPtLoad )     
+                  p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Sib=ED%Input(1)%HubPtLoad )     
    
 ! Blades
    IF ( p_FAST%CompAero == Module_AD ) THEN  ! These meshes may have airfoil data associated with nodes...
       DO K=1,NumBl   
          call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(p_FAST%OutFileRoot)//'.AD_Blade'//trim(num2lstr(k)), &
-                        y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Sib=AD%y%BladeLoad(K) )     
+                        y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Sib=AD%y%BladeLoad(K) )     
       END DO                  
    ELSE IF ( p_FAST%CompElast == Module_BD ) THEN
       DO K=1,NumBl                 
          call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(p_FAST%OutFileRoot)//'.BD_BldMotion'//trim(num2lstr(k)), &
-                        y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )         
+                        y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )         
       END DO  
    ELSE
       DO K=1,NumBl        
          call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), &
-                        y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
+                        y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
       END DO  
    END IF   
          
 ! Tower motions
    call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.ED_TowerLn2Mesh_motion', &
-                  y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
+                  y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
    
    
 ! Substructure   
@@ -5184,14 +5192,14 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
    IF ( p_FAST%CompHydro == Module_HD ) THEN 
       
       if (p_FAST%CompSub == Module_NONE) then
-         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(p_FAST%OutFileRoot)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, HD%Input(1)%Mesh )
+         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(p_FAST%OutFileRoot)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
          outputFields = .false.
       else         
          OutputFields = p_FAST%VTK_fields
       end if
       
       call MeshWrVTK(p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib', &
-                     y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Sib=HD%y%Morison%DistribMesh )           
+                     y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth, Sib=HD%y%Morison%DistribMesh )           
    END IF
    
    
@@ -5234,12 +5242,16 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
 
 
    logical, parameter                      :: OutputFields = .FALSE. ! due to confusion about what fields mean on a surface, we are going to just output the basic meshes if people ask for fields
-   INTEGER(IntKi)                          :: NumBl, k
+   INTEGER(IntKi)                          :: NumBl, k, Twidth
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_Surfaces'
+
+   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
+   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK_...()
+   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
    
-   
+
    NumBl = SIZE(ED%Output(1)%BladeRootMotion)            
 
 ! Ground (written at initialization)
@@ -5250,36 +5262,36 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
    
 ! Nacelle
    call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%NacelleMotion, trim(p_FAST%OutFileRoot)//'.NacelleSurface', &
-                                y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, verts = p_FAST%VTK_Surface%NacelleBox, Sib=ED%Input(1)%NacelleLoads )
+                                y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts = p_FAST%VTK_Surface%NacelleBox, Sib=ED%Input(1)%NacelleLoads )
    
    
 ! Hub
    call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(p_FAST%OutFileRoot)//'.HubSurface', &
-                                y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, &
+                                y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , &
                                 NumSegments=p_FAST%VTK_Surface%NumSectors, radius=p_FAST%VTK_Surface%HubRad, Sib=ED%Input(1)%HubPtLoad )
    
 ! Blades
    IF ( p_FAST%CompAero == Module_AD ) THEN  ! These meshes may have airfoil data associated with nodes...
       DO K=1,NumBl
          call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(p_FAST%OutFileRoot)//'.Blade'//trim(num2lstr(k))//'Surface', &
-                                    y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords &
+                                    y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords &
                                     ,Sib=AD%y%BladeLoad(k) )
       END DO                  
    ELSE IF ( p_FAST%CompElast == Module_BD ) THEN
       DO K=1,NumBl                 
          call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(p_FAST%OutFileRoot)//'.Blade'//trim(num2lstr(k))//'Surface', &
-                                    y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords )
+                                    y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords )
       END DO  
    ELSE
       DO K=1,NumBl        
          call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.Blade'//trim(num2lstr(k))//'Surface', &
-                                    y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords )
+                                    y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords )
       END DO  
    END IF   
          
 ! Tower motions
    call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.TowerSurface', &
-                              y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, p_FAST%VTK_Surface%NumSectors, p_FAST%VTK_Surface%TowerRad )
+                              y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth, p_FAST%VTK_Surface%NumSectors, p_FAST%VTK_Surface%TowerRad )
    
 ! Platform
 ! call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%PlatformPtMesh, trim(p_FAST%OutFileRoot)//'.PlatformSurface', y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Radius = p_FAST%VTK_Surface%GroundRad )
@@ -5300,7 +5312,7 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
       !end if
          
       call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.MorisonSurface', &
-                                 y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, p_FAST%VTK_Surface%NumSectors, &
+                                 y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth, p_FAST%VTK_Surface%NumSectors, &
                                  p_FAST%VTK_Surface%MorisonRad, Sib=HD%y%Morison%DistribMesh )
    END IF
    
@@ -5311,7 +5323,7 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
 !   ELSEIF ( p_FAST%CompMooring == Module_MD ) THEN
 !      call MeshWrVTK(p_FAST%TurbinePos, MD%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'.MD_PtFair_motion', y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2 )        
 !   ELSEIF ( p_FAST%CompMooring == Module_FEAM ) THEN
-!      call MeshWrVTK(p_FAST%TurbinePos, FEAM%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'FEAM_PtFair_motion', y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2 )        
+!      call MeshWrVTK(p_FAST%TurbinePos, FEAM%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'FEAM_PtFair_motion', y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2   )        
 !   END IF
          
    

--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -28,7 +28,7 @@ MODULE FAST_Subs
 
    USE FAST_Solver
    USE FAST_Linear
-   
+
    IMPLICIT NONE
 
 CONTAINS
@@ -184,8 +184,6 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
    y_FAST%UnGra = -1                                                    ! set the binary graphics output file unit to -1 to indicate it's not open
    
    p_FAST%WrVTK = VTK_Unknown                                           ! set this so that we can potentially output VTK information on initialization error
-!   p_FAST%VTK_Type = VTK_Unknown                                        ! set this so that we can potentially output VTK information on initialization error
-!   p_FAST%VTK_fields = .false.                                          ! set this so that we can potentially output VTK information on initialization error
    y_FAST%VTK_LastWaveIndx = 1                                          ! Start looking for wave data at the first index
    y_FAST%VTK_count = 0                                                 ! first VTK file has 0 as output      
    y_FAST%n_Out = 0                                                     ! set the number of ouptut channels to 0 to indicate there's nothing to write to the binary file
@@ -1135,7 +1133,6 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
    ! -------------------------------------------------------------------------
    ! Initialize data for VTK output
    ! -------------------------------------------------------------------------
-            
    if ( p_FAST%WrVTK > VTK_None ) then
       call SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_AD, InitInData_HD, InitOutData_HD, ED, BD, AD, HD, ErrStat2, ErrMsg2)      
          call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
@@ -1344,7 +1341,7 @@ end subroutine GetProgramMetadata
 !! displays the copyright notice, and displays some version information (including addressing scheme and precision).
 SUBROUTINE FAST_ProgStart(ThisProgVer)
    TYPE(ProgDesc), INTENT(IN) :: ThisProgVer     !< program name/date/version description
-   character(200) :: name, version, date
+   character(200) :: name, version
    character(200) :: git_commit, architecture, precision
    character(200) :: execution_date, execution_time, execution_zone
    
@@ -2837,11 +2834,7 @@ END DO
             end if            
          END IF
                   
-      END IF            
-      
-            
-      
-   !---------------------- END OF FILE -----------------------------------------
+      END IF
 
    call cleanup()
    RETURN
@@ -2854,6 +2847,30 @@ CONTAINS
    end subroutine cleanup
    !...............................................................................................................................
 END SUBROUTINE FAST_ReadPrimaryFile
+!----------------------------------------------------------------------------------------------------------------------------------
+!> This function builds the path for the vtk directory based on the output file root
+FUNCTION get_vtkdir_path( out_file_root )
+   CHARACTER(1024) :: get_vtkdir_path
+   CHARACTER(*), INTENT(IN) :: out_file_root
+   INTEGER(IntKi) :: last_separator_index
+   
+   ! get the directory of the primary input file (i.e. the case directory); PathSep comes from Sys*.f90
+   last_separator_index = index(trim(out_file_root), PathSep, back=.true.)
+   get_vtkdir_path = trim(out_file_root(1 : last_separator_index) // 'vtk')
+END FUNCTION
+!----------------------------------------------------------------------------------------------------------------------------------
+!> This function builds the path for the vtk root file name based on the output file root
+FUNCTION get_vtkroot_path( out_file_root )
+   CHARACTER(1024) :: get_vtkroot_path
+   CHARACTER(*), INTENT(IN) :: out_file_root
+   INTEGER(IntKi) :: last_separator_index
+   INTEGER(IntKi) :: path_length
+
+   path_length = len(trim(out_file_root))
+   last_separator_index = index(trim(out_file_root), PathSep, back=.true.)
+   get_vtkroot_path = trim( get_vtkdir_path(out_file_root) ) // PathSep &
+                      // out_file_root( last_separator_index + 1 : path_length)
+END FUNCTION
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This subroutine sets up some of the information needed for plotting VTK surfaces. It initializes only the data needed before 
 !! HD initialization. (HD needs some of this data so it can return the wave elevation data we want.)
@@ -2935,42 +2952,42 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_AD, InitInData_H
    INTEGER(IntKi),               INTENT(  OUT) :: ErrStat          !< Error status of the operation
    CHARACTER(*),                 INTENT(  OUT) :: ErrMsg           !< Error message if ErrStat /= ErrID_None
 
-      
    REAL(SiKi)                              :: RefPoint(3), RefLengths(2)               
    REAL(SiKi)                              :: x, y                
    REAL(SiKi)                              :: TwrDiam_top, TwrDiam_base, TwrRatio, TwrLength
    INTEGER(IntKi)                          :: topNode, baseNode
    INTEGER(IntKi)                          :: tipNode, rootNode, cylNode
    INTEGER(IntKi)                          :: NumBl, k
+   CHARACTER(1024)                         :: VTK_path
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMsg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'SetVTKParameters'
-   
-         
+
    ErrStat = ErrID_None
    ErrMsg  = ""
    
-   NumBl = SIZE(ED%Output(1)%BladeRootMotion,1) 
-   
-   p_FAST%VTK_Surface%NumSectors = 18   
-   p_FAST%VTK_Surface%HubRad     = InitOutData_ED%HubRad
+   ! create the VTK directory if it does not exist
+   call MKDIR( get_vtkdir_path(p_FAST%OutFileRoot) )
 
+   ! initialize the vtk data
+   p_FAST%VTK_Surface%NumSectors = 18
+   p_FAST%VTK_Surface%HubRad     = InitOutData_ED%HubRad
    ! NOTE: we set p_FAST%VTK_Surface%GroundRad in SetVTKParameters_B4HD
-   
-   
+
    ! write the ground or seabed reference polygon:
+   VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )
    RefPoint = p_FAST%TurbinePos
    if (p_FAST%CompHydro == MODULE_HD) then
       RefLengths = p_FAST%VTK_Surface%GroundRad*VTK_GroundFactor/2.0_SiKi
       
       RefPoint(3) = p_FAST%TurbinePos(3) - InitOutData_HD%WtrDpth      
-      call WrVTK_Ground ( RefPoint, RefLengths, trim(p_FAST%OutFileRoot)//'.SeabedSurface', ErrStat2, ErrMsg2 )   
+      call WrVTK_Ground ( RefPoint, RefLengths, trim(VTK_path) // '.SeabedSurface', ErrStat2, ErrMsg2 )   
       
       RefPoint(3) = p_FAST%TurbinePos(3) - InitOutData_HD%MSL2SWL    
-      call WrVTK_Ground ( RefPoint, RefLengths, trim(p_FAST%OutFileRoot)//'.StillWaterSurface', ErrStat2, ErrMsg2 )       
+      call WrVTK_Ground ( RefPoint, RefLengths, trim(VTK_path) // '.StillWaterSurface', ErrStat2, ErrMsg2 )       
    else
       RefLengths = p_FAST%VTK_Surface%GroundRad !array = scalar
-      call WrVTK_Ground ( RefPoint, RefLengths, trim(p_FAST%OutFileRoot)//'.GroundSurface', ErrStat2, ErrMsg2 )         
+      call WrVTK_Ground ( RefPoint, RefLengths, trim(VTK_path) // '.GroundSurface', ErrStat2, ErrMsg2 )         
    end if
    
    
@@ -3016,7 +3033,7 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_AD, InitInData_H
    !.......................
    ! blade surfaces
    !.......................
-         
+   NumBl = SIZE(ED%Output(1)%BladeRootMotion,1)
    allocate(p_FAST%VTK_Surface%BladeShape(NumBl),stat=ErrStat2)
    if (errStat2/=0) then
       call setErrStat(ErrID_Fatal,'Error allocating VTK_Surface%BladeShape.',ErrStat,ErrMsg,RoutineName)
@@ -3212,8 +3229,7 @@ SUBROUTINE WrVTK_Ground ( RefPoint, HalfLengths, FileRootName, ErrStat, ErrMsg )
         
    INTEGER(IntKi)                        :: ErrStat2 
    CHARACTER(ErrMsgLen)                  :: ErrMsg2
-   CHARACTER(*),PARAMETER                :: RoutineName = 'MeshWrVTK_PointSurface'
-
+   CHARACTER(*),PARAMETER                :: RoutineName = 'WrVTK_Ground'
    
    ErrStat = ErrID_None
    ErrMsg  = ""
@@ -3254,7 +3270,7 @@ SUBROUTINE WrVTK_Ground ( RefPoint, HalfLengths, FileRootName, ErrStat, ErrMsg )
             
       call WrVTK_footer( Un )       
                      
-   END SUBROUTINE WrVTK_Ground
+END SUBROUTINE WrVTK_Ground
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This subroutine sets up the information needed to initialize AeroDyn, then initializes AeroDyn
 SUBROUTINE AD_SetInitInput(InitInData_AD14, InitOutData_ED, y_ED, p_FAST, ErrStat, ErrMsg)
@@ -4911,6 +4927,7 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 
    logical                                 :: outputFields        ! flag to determine if we want to output the HD mesh fields
    INTEGER(IntKi)                          :: NumBl, k, Twidth
+   CHARACTER(1024)                         :: VTK_path
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_AllMeshes'
@@ -4919,13 +4936,14 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
    ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
    Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
    
-
    NumBl = 0
    if (allocated(ED%Output)) then
       if (allocated(ED%Output(1)%BladeRootMotion)) then
          NumBl = SIZE(ED%Output(1)%BladeRootMotion)      
       end if
    end if
+
+   VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )
    
    
 ! I'm first going to just put all of the meshes that get mapped together, then decide if we're going to print/plot them all
@@ -4936,10 +4954,10 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
          !  ElastoDyn outputs (motions)
       DO K=1,NumBl        
          !%BladeLn2Mesh(K) used only when not BD (see below)
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeRootMotion(K), trim(p_FAST%OutFileRoot)//'.ED_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeRootMotion(K), trim(VTK_path)//'.ED_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
       END DO
       
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.ED_TowerLn2Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(VTK_path)//'.ED_TowerLn2Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
 
 ! these will get output with their sibling input meshes
       !call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(p_FAST%OutFileRoot)//'.ED_HubPtMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
@@ -4948,10 +4966,10 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       
          !  ElastoDyn inputs (loads)
       ! %BladePtLoads used only when not BD (see below)
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%TowerPtLoads, trim(p_FAST%OutFileRoot)//'.ED_TowerPtLoads', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%TowerLn2Mesh )     
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%HubPtLoad, trim(p_FAST%OutFileRoot)//'.ED_Hub', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%HubPtMotion )
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%NacelleLoads, trim(p_FAST%OutFileRoot)//'.ED_Nacelle' ,y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%NacelleMotion )     
-      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%PlatformPtMesh, trim(p_FAST%OutFileRoot)//'.ED_PlatformPtMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%PlatformPtMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%TowerPtLoads, trim(VTK_path)//'.ED_TowerPtLoads', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%TowerLn2Mesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%HubPtLoad, trim(VTK_path)//'.ED_Hub', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%HubPtMotion )
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%NacelleLoads, trim(VTK_path)//'.ED_Nacelle' ,y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%NacelleMotion )     
+      call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%PlatformPtMesh, trim(VTK_path)//'.ED_PlatformPtMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%PlatformPtMesh )     
    end if
    
    
@@ -4961,30 +4979,29 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       do K=1,NumBl        
             ! BeamDyn inputs
          !call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%RootMotion, trim(p_FAST%OutFileRoot)//'.BD_RootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
-         call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%HubMotion, trim(p_FAST%OutFileRoot)//'.BD_HubMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )    
+         call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%HubMotion, trim(VTK_path)//'.BD_HubMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )    
       end do
       if (allocated(MeshMapData%y_BD_BldMotion_4Loads)) then
          do K=1,NumBl 
-            call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%DistrLoad, trim(p_FAST%OutFileRoot)//'.BD_DistrLoad'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MeshMapData%y_BD_BldMotion_4Loads(k) )
+            call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%DistrLoad, trim(VTK_path)//'.BD_DistrLoad'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MeshMapData%y_BD_BldMotion_4Loads(k) )
             ! skipping PointLoad
          end do
       elseif (p_FAST%BD_OutputSibling) then
          do K=1,NumBl
-            call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%DistrLoad, trim(p_FAST%OutFileRoot)//'.BD_Blade'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, BD%y(k)%BldMotion )
+            call MeshWrVTK(p_FAST%TurbinePos, BD%Input(1,k)%DistrLoad, trim(p_FAST%OutFileRoot)//'.BD_Blade'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, BD%y(k)%BldMotion )
             ! skipping PointLoad
          end do
       end if
       
-      
-      do K=1,NumBl        
+      do K=1,NumBl
             ! BeamDyn outputs
-         call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%ReactionForce, trim(p_FAST%OutFileRoot)//'.BD_ReactionForce_RootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, BD%Input(1,k)%RootMotion )
+         call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%ReactionForce, trim(p_FAST%OutFileRoot)//'.BD_ReactionForce_RootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, BD%Input(1,k)%RootMotion )
       end do  
       
       if (.not. p_FAST%BD_OutputSibling) then !otherwise this mesh has been put with the DistrLoad mesh
          do K=1,NumBl
                ! BeamDyn outputs
-         call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(p_FAST%OutFileRoot)//'.BD_BldMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
+         call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(p_FAST%OutFileRoot)//'.BD_BldMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
       end do  
       end if
       
@@ -4992,8 +5009,8 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
    ELSE if (allocated(ED%Input) .and. allocated(ED%Output)) then
       ! ElastoDyn
       DO K=1,NumBl        
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%BladePtLoads(K), trim(p_FAST%OutFileRoot)//'.ED_BladePtLoads'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%BladeLn2Mesh(K) )
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(VTK_path)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Input(1)%BladePtLoads(K), trim(VTK_path)//'.ED_BladePtLoads'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ED%Output(1)%BladeLn2Mesh(K) )
       END DO      
    END IF
             
@@ -5001,11 +5018,11 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
    if (allocated(SrvD%Input)) then
       IF ( SrvD%Input(1)%NTMD%Mesh%Committed ) THEN         
          !call MeshWrVTK(p_FAST%TurbinePos, SrvD%Input(1)%NTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_NTMD_Motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
-         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%NTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_NTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SrvD%Input(1)%TTMD%Mesh )                
+         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%NTMD%Mesh, trim(VTK_path)//'.SrvD_NTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SrvD%Input(1)%TTMD%Mesh )                
       END IF      
       IF ( SrvD%Input(1)%TTMD%Mesh%Committed ) THEN 
          !call MeshWrVTK(p_FAST%TurbinePos, SrvD%Input(1)%TTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_TTMD_Motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
-         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%TTMD%Mesh, trim(p_FAST%OutFileRoot)//'.SrvD_TTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SrvD%Input(1)%TTMD%Mesh )         
+         call MeshWrVTK(p_FAST%TurbinePos, SrvD%y%TTMD%Mesh, trim(VTK_path)//'.SrvD_TTMD', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SrvD%Input(1)%TTMD%Mesh )         
       END IF   
    end if
    
@@ -5016,16 +5033,16 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       if (allocated(AD%Input(1)%BladeRootMotion)) then      
       
          DO K=1,NumBl   
-            call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeRootMotion(K), trim(p_FAST%OutFileRoot)//'.AD_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
+            call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeRootMotion(K), trim(VTK_path)//'.AD_BladeRootMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
             !call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(p_FAST%OutFileRoot)//'.AD_BladeMotion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
          END DO            
-         call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%HubMotion, trim(p_FAST%OutFileRoot)//'.AD_HubMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
+         call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%HubMotion, trim(VTK_path)//'.AD_HubMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
          !call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%TowerMotion, trim(p_FAST%OutFileRoot)//'.AD_TowerMotion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
                
          DO K=1,NumBl   
-            call MeshWrVTK(p_FAST%TurbinePos, AD%y%BladeLoad(K), trim(p_FAST%OutFileRoot)//'.AD_Blade'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, AD%Input(1)%BladeMotion(k) )     
+            call MeshWrVTK(p_FAST%TurbinePos, AD%y%BladeLoad(K), trim(VTK_path)//'.AD_Blade'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, AD%Input(1)%BladeMotion(k) )     
          END DO            
-         call MeshWrVTK(p_FAST%TurbinePos, AD%y%TowerLoad, trim(p_FAST%OutFileRoot)//'.AD_Tower', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, AD%Input(1)%TowerMotion )     
+         call MeshWrVTK(p_FAST%TurbinePos, AD%y%TowerLoad, trim(VTK_path)//'.AD_Tower', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, AD%Input(1)%TowerMotion )     
          
       end if
       
@@ -5038,14 +5055,14 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       !call MeshWrVTK(p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
       
       if (p_FAST%CompSub == Module_NONE) then
-         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(p_FAST%OutFileRoot)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
+         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(VTK_path)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
          outputFields = .false.
       else         
-         call MeshWrVTK(p_FAST%TurbinePos, HD%y%Mesh, trim(p_FAST%OutFileRoot)//'.HD_Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
+         call MeshWrVTK(p_FAST%TurbinePos, HD%y%Mesh, trim(VTK_path)//'.HD_Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
          outputFields = p_FAST%VTK_fields
       end if
-      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%LumpedMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonLumped', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Morison%LumpedMesh )     
-      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Morison%DistribMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%LumpedMesh, trim(VTK_path)//'.HD_MorisonLumped', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Morison%LumpedMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, HD%y%Morison%DistribMesh, trim(VTK_path)//'.HD_MorisonDistrib', y_FAST%VTK_count, outputFields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Morison%DistribMesh )     
       
                   
    END IF
@@ -5053,39 +5070,39 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 ! SubDyn   
    IF ( p_FAST%CompSub == Module_SD .and. allocated(SD%Input)) THEN
       !call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%TPMesh, trim(p_FAST%OutFileRoot)//'.SD_TPMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )     
-      call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%LMesh, trim(p_FAST%OutFileRoot)//'.SD_LMesh_y2Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SD%y%y2Mesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%LMesh, trim(VTK_path)//'.SD_LMesh_y2Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SD%y%y2Mesh )     
       
-      call MeshWrVTK(p_FAST%TurbinePos, SD%y%y1Mesh, trim(p_FAST%OutFileRoot)//'.SD_y1Mesh_TPMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SD%Input(1)%TPMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, SD%y%y1Mesh, trim(VTK_path)//'.SD_y1Mesh_TPMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, SD%Input(1)%TPMesh )     
       !call MeshWrVTK(p_FAST%TurbinePos, SD%y%y2Mesh, trim(p_FAST%OutFileRoot)//'.SD_y2Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
    ELSE IF ( p_FAST%CompSub == Module_ExtPtfm .and. allocated(ExtPtfm%Input)) THEN
-      call MeshWrVTK(p_FAST%TurbinePos, ExtPtfm%y%PtfmMesh, trim(p_FAST%OutFileRoot)//'.ExtPtfm', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ExtPtfm%Input(1)%PtfmMesh )     
+      call MeshWrVTK(p_FAST%TurbinePos, ExtPtfm%y%PtfmMesh, trim(VTK_path)//'.ExtPtfm', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, ExtPtfm%Input(1)%PtfmMesh )     
    END IF     
        
 ! MAP
    IF ( p_FAST%CompMooring == Module_MAP ) THEN
       if (allocated(MAPp%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, MAPp%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.MAP_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MAPp%Input(1)%PtFairDisplacement )     
+         call MeshWrVTK(p_FAST%TurbinePos, MAPp%y%PtFairleadLoad, trim(VTK_path)//'.MAP_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MAPp%Input(1)%PtFairDisplacement )     
          !call MeshWrVTK(p_FAST%TurbinePos, MAPp%Input(1)%PtFairDisplacement, trim(p_FAST%OutFileRoot)//'.MAP_PtFair_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
       end if
       
 ! MoorDyn      
    ELSEIF ( p_FAST%CompMooring == Module_MD ) THEN
       if (allocated(MD%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, MD%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.MD_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MD%Input(1)%PtFairleadDisplacement )     
+         call MeshWrVTK(p_FAST%TurbinePos, MD%y%PtFairleadLoad, trim(VTK_path)//'.MD_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, MD%Input(1)%PtFairleadDisplacement )     
          !call MeshWrVTK(p_FAST%TurbinePos, MD%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'.MD_PtFair_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
       end if
       
 ! FEAMooring                   
    ELSEIF ( p_FAST%CompMooring == Module_FEAM ) THEN
       if (allocated(FEAM%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, FEAM%y%PtFairleadLoad, trim(p_FAST%OutFileRoot)//'.FEAM_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, FEAM%Input(1)%PtFairleadDisplacement )     
+         call MeshWrVTK(p_FAST%TurbinePos, FEAM%y%PtFairleadLoad, trim(VTK_path)//'.FEAM_PtFairlead', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, FEAM%Input(1)%PtFairleadDisplacement )     
          !call MeshWrVTK(p_FAST%TurbinePos, FEAM%Input(1)%PtFairleadDisplacement, trim(p_FAST%OutFileRoot)//'.FEAM_PtFair_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )        
       end if
       
 ! Orca      
    ELSEIF ( p_FAST%CompMooring == Module_Orca ) THEN
       if (allocated(Orca%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, Orca%y%PtfmMesh, trim(p_FAST%OutFileRoot)//'.Orca_PtfmMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Orca%Input(1)%PtfmMesh )     
+         call MeshWrVTK(p_FAST%TurbinePos, Orca%y%PtfmMesh, trim(VTK_path)//'.Orca_PtfmMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Orca%Input(1)%PtfmMesh )     
          !call MeshWrVTK(p_FAST%TurbinePos, Orca%Input(1)%PtfmMesh, trim(p_FAST%OutFileRoot)//'.Orca_PtfmMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
       end if
    END IF
@@ -5094,7 +5111,7 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 ! IceFloe      
    IF ( p_FAST%CompIce == Module_IceF ) THEN
       if (allocated(IceF%Input)) then
-         call MeshWrVTK(p_FAST%TurbinePos, IceF%y%iceMesh, trim(p_FAST%OutFileRoot)//'.IceF_iceMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, IceF%Input(1)%iceMesh )     
+         call MeshWrVTK(p_FAST%TurbinePos, IceF%y%iceMesh, trim(VTK_path)//'.IceF_iceMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, IceF%Input(1)%iceMesh )     
          !call MeshWrVTK(p_FAST%TurbinePos, IceF%Input(1)%iceMesh, trim(p_FAST%OutFileRoot)//'.IceF_iceMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
       end if
       
@@ -5103,7 +5120,7 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
       if (allocated(IceD%Input)) then
             
          DO k = 1,p_FAST%numIceLegs
-            call MeshWrVTK(p_FAST%TurbinePos, IceD%y(k)%PointMesh, trim(p_FAST%OutFileRoot)//'.IceD_PointMesh'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, IceD%Input(1,k)%PointMesh )     
+            call MeshWrVTK(p_FAST%TurbinePos, IceD%y(k)%PointMesh, trim(VTK_path)//'.IceD_PointMesh'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, IceD%Input(1,k)%PointMesh )     
             !call MeshWrVTK(p_FAST%TurbinePos, IceD%Input(1,k)%PointMesh, trim(p_FAST%OutFileRoot)//'.IceD_PointMesh_motion'//trim(num2lstr(k)), y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2 )
          END DO
       end if
@@ -5137,9 +5154,9 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
    TYPE(IceFloe_Data),       INTENT(IN   ) :: IceF                !< IceFloe data
    TYPE(IceDyn_Data),        INTENT(IN   ) :: IceD                !< All the IceDyn data used in time-step loop
 
-
    logical                                 :: OutputFields
    INTEGER(IntKi)                          :: NumBl, k, Twidth
+   CHARACTER(1024)                         :: VTK_path
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_BasicMeshes'
@@ -5151,34 +5168,36 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
 
    NumBl = SIZE(ED%Output(1)%BladeRootMotion)            
 
+   VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )
+
 ! Nacelle
-   call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%NacelleMotion, trim(p_FAST%OutFileRoot)//'.ED_Nacelle', y_FAST%VTK_count, &
+   call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%NacelleMotion, trim(VTK_path)//'.ED_Nacelle', y_FAST%VTK_count, &
                   p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Sib=ED%Input(1)%NacelleLoads )     
                
 ! Hub
-   call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(p_FAST%OutFileRoot)//'.ED_Hub', y_FAST%VTK_count, &
+   call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(VTK_path)//'.ED_Hub', y_FAST%VTK_count, &
                   p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Sib=ED%Input(1)%HubPtLoad )     
    
 ! Blades
    IF ( p_FAST%CompAero == Module_AD ) THEN  ! These meshes may have airfoil data associated with nodes...
       DO K=1,NumBl   
-         call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(p_FAST%OutFileRoot)//'.AD_Blade'//trim(num2lstr(k)), &
+         call MeshWrVTK(p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(VTK_path)//'.AD_Blade'//trim(num2lstr(k)), &
                         y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, Sib=AD%y%BladeLoad(K) )     
       END DO                  
    ELSE IF ( p_FAST%CompElast == Module_BD ) THEN
       DO K=1,NumBl                 
-         call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(p_FAST%OutFileRoot)//'.BD_BldMotion'//trim(num2lstr(k)), &
+         call MeshWrVTK(p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(VTK_path)//'.BD_BldMotion'//trim(num2lstr(k)), &
                         y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )         
       END DO  
    ELSE
       DO K=1,NumBl        
-         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), &
+         call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(VTK_path)//'.ED_BladeLn2Mesh_motion'//trim(num2lstr(k)), &
                         y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )
       END DO  
    END IF   
          
 ! Tower motions
-   call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.ED_TowerLn2Mesh_motion', &
+   call MeshWrVTK(p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(VTK_path)//'.ED_TowerLn2Mesh_motion', &
                   y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth )     
    
    
@@ -5192,13 +5211,13 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
    IF ( p_FAST%CompHydro == Module_HD ) THEN 
       
       if (p_FAST%CompSub == Module_NONE) then
-         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(p_FAST%OutFileRoot)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
+         call MeshWrVTK(p_FAST%TurbinePos, HD%y%AllHdroOrigin, trim(VTK_path)//'.HD_AllHdroOrigin', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, Twidth, HD%Input(1)%Mesh )
          outputFields = .false.
       else         
          OutputFields = p_FAST%VTK_fields
       end if
       
-      call MeshWrVTK(p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.HD_MorisonDistrib', &
+      call MeshWrVTK(p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(VTK_path)//'.HD_MorisonDistrib', &
                      y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth, Sib=HD%y%Morison%DistribMesh )           
    END IF
    
@@ -5243,6 +5262,7 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
 
    logical, parameter                      :: OutputFields = .FALSE. ! due to confusion about what fields mean on a surface, we are going to just output the basic meshes if people ask for fields
    INTEGER(IntKi)                          :: NumBl, k, Twidth
+   CHARACTER(1024)                         :: VTK_path
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_Surfaces'
@@ -5254,6 +5274,8 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
 
    NumBl = SIZE(ED%Output(1)%BladeRootMotion)            
 
+   VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )
+
 ! Ground (written at initialization)
    
 ! Wave elevation
@@ -5261,36 +5283,36 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
    
    
 ! Nacelle
-   call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%NacelleMotion, trim(p_FAST%OutFileRoot)//'.NacelleSurface', &
+   call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%NacelleMotion, trim(VTK_path)//'.NacelleSurface', &
                                 y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts = p_FAST%VTK_Surface%NacelleBox, Sib=ED%Input(1)%NacelleLoads )
    
    
 ! Hub
-   call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(p_FAST%OutFileRoot)//'.HubSurface', &
+   call MeshWrVTK_PointSurface (p_FAST%TurbinePos, ED%Output(1)%HubPtMotion, trim(VTK_path)//'.HubSurface', &
                                 y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , &
                                 NumSegments=p_FAST%VTK_Surface%NumSectors, radius=p_FAST%VTK_Surface%HubRad, Sib=ED%Input(1)%HubPtLoad )
    
 ! Blades
    IF ( p_FAST%CompAero == Module_AD ) THEN  ! These meshes may have airfoil data associated with nodes...
       DO K=1,NumBl
-         call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(p_FAST%OutFileRoot)//'.Blade'//trim(num2lstr(k))//'Surface', &
+         call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, AD%Input(1)%BladeMotion(K), trim(VTK_path)//'.Blade'//trim(num2lstr(k))//'Surface', &
                                     y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords &
                                     ,Sib=AD%y%BladeLoad(k) )
       END DO                  
    ELSE IF ( p_FAST%CompElast == Module_BD ) THEN
       DO K=1,NumBl                 
-         call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(p_FAST%OutFileRoot)//'.Blade'//trim(num2lstr(k))//'Surface', &
+         call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, BD%y(k)%BldMotion, trim(VTK_path)//'.Blade'//trim(num2lstr(k))//'Surface', &
                                     y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords )
       END DO  
    ELSE
       DO K=1,NumBl        
-         call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(p_FAST%OutFileRoot)//'.Blade'//trim(num2lstr(k))//'Surface', &
+         call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, ED%Output(1)%BladeLn2Mesh(K), trim(VTK_path)//'.Blade'//trim(num2lstr(k))//'Surface', &
                                     y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth , verts=p_FAST%VTK_Surface%BladeShape(K)%AirfoilCoords )
       END DO  
    END IF   
          
 ! Tower motions
-   call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(p_FAST%OutFileRoot)//'.TowerSurface', &
+   call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, ED%Output(1)%TowerLn2Mesh, trim(VTK_path)//'.TowerSurface', &
                               y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth, p_FAST%VTK_Surface%NumSectors, p_FAST%VTK_Surface%TowerRad )
    
 ! Platform
@@ -5311,7 +5333,7 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
       !   OutputFields = p_FAST%VTK_fields
       !end if
          
-      call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(p_FAST%OutFileRoot)//'.MorisonSurface', &
+      call MeshWrVTK_Ln2Surface (p_FAST%TurbinePos, HD%Input(1)%Morison%DistribMesh, trim(VTK_path)//'.MorisonSurface', &
                                  y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2, Twidth, p_FAST%VTK_Surface%NumSectors, &
                                  p_FAST%VTK_Surface%MorisonRad, Sib=HD%y%Morison%DistribMesh )
    END IF
@@ -5350,8 +5372,9 @@ SUBROUTINE WrVTK_WaveElev(t_global, p_FAST, y_FAST, HD)
    CHARACTER(1024)                       :: FileName
    INTEGER(IntKi)                        :: NumberOfPoints 
    INTEGER(IntKi), parameter             :: NumberOfLines = 0
-   INTEGER(IntKi)                        :: NumberOfPolys 
-        
+   INTEGER(IntKi)                        :: NumberOfPolys
+   INTEGER(IntKi)                        :: Twidth
+   CHARACTER(1024)                       :: VTK_path, Tstr = ''
    INTEGER(IntKi)                        :: ErrStat2 
    CHARACTER(ErrMsgLen)                  :: ErrMsg2
    CHARACTER(*),PARAMETER                :: RoutineName = 'WrVTK_WaveElev'
@@ -5365,9 +5388,18 @@ SUBROUTINE WrVTK_WaveElev(t_global, p_FAST, y_FAST, HD)
    !.................................................................
    ! write the data that potentially changes each time step:
    !.................................................................
+
+   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
+   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK_...()
+   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+
+   VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )
+
+   ! construct the string for the zero-padded VTK write-out step
+   write(Tstr(1 : Twidth), '(i' // trim(Num2LStr(Twidth)) //'.'// trim(Num2LStr(Twidth)) // ')') y_FAST%VTK_count
       
    ! PolyData (.vtp) - Serial vtkPolyData (unstructured) file
-   FileName = TRIM(p_FAST%OutFileRoot)//'.WaveSurface.t'//TRIM(Num2LStr(y_FAST%VTK_count))//'.vtp'
+   FileName = TRIM(VTK_path)//'.WaveSurface.'//TRIM(Tstr)//'.vtp'
       
    call WrVTK_header( FileName, NumberOfPoints, NumberOfLines, NumberOfPolys, Un, ErrStat2, ErrMsg2 )    
       if (ErrStat2 >= AbortErrLev) return
@@ -5494,36 +5526,25 @@ SUBROUTINE WriteInputMeshesToFile(u_ED, u_AD, u_SD, u_HD, u_MAP, u_BD, FileName,
    TYPE(MAP_InputType),       INTENT(IN)  :: u_MAP          !< MAP inputs
    TYPE(BD_InputType),        INTENT(IN)  :: u_BD(:)        !< BeamDyn inputs
    CHARACTER(*),              INTENT(IN)  :: FileName       !< Name of file to write this information to
-   
    INTEGER(IntKi)                         :: ErrStat        !< Error status of the operation
    CHARACTER(*)                           :: ErrMsg         !< Error message if ErrStat /= ErrID_None
-   
-   
-      !FileName = TRIM(p_FAST%OutFileRoot)//'.InputMeshes.bin'
-   
-      
+
    INTEGER(IntKi)           :: unOut
-   !!!INTEGER(IntKi)           :: unOut2
    INTEGER(IntKi)           :: K_local
    INTEGER(B4Ki), PARAMETER :: File_ID = 3
    INTEGER(B4Ki)            :: NumBl
-      
 
       ! Open the binary output file:
    unOut=-1      
    CALL GetNewUnit( unOut, ErrStat, ErrMsg )
    CALL OpenBOutFile ( unOut, TRIM(FileName), ErrStat, ErrMsg )
       IF (ErrStat /= ErrID_None) RETURN
-  
-   !!!   ! get unit for text output
-   !!!CALL GetNewUnit( unOut2, ErrStat, ErrMsg )
-            
+
    ! note that I'm not doing anything with the errors here, so it won't tell
    ! you there was a problem writing the data unless it was the last call.
-          
+
       ! Add a file identification number (in case we ever have to change this):
    WRITE( unOut, IOSTAT=ErrStat )   File_ID
-   
 
       ! Add how many blade meshes there are:
    NumBl =  SIZE(u_ED%BladePtLoads,1)   ! Note that NumBl is B4Ki 
@@ -5532,12 +5553,6 @@ SUBROUTINE WriteInputMeshesToFile(u_ED, u_AD, u_SD, u_HD, u_MAP, u_BD, FileName,
       ! Add all of the input meshes:
    DO K_local = 1,NumBl
       CALL MeshWrBin( unOut, u_ED%BladePtLoads(K_local), ErrStat, ErrMsg )
-      
-      !!!write(unOut2,'(A)') '_____________________________________________________________________________'
-      !!!write(unOut2,*)     'ElastoDyn blade ', k_local, ' mesh'
-      !!!write(unOut2,'(A)') '_____________________________________________________________________________'      
-      !!!CALL MeshPrintInfo(unOut2, u_ED%BladePtLoads(K_local))
-      !!!write(unOut2,'(A)') '_____________________________________________________________________________'
    END DO            
    CALL MeshWrBin( unOut, u_ED%TowerPtLoads,            ErrStat, ErrMsg )
    CALL MeshWrBin( unOut, u_ED%PlatformPtMesh,          ErrStat, ErrMsg )
@@ -5566,7 +5581,6 @@ SUBROUTINE WriteInputMeshesToFile(u_ED, u_AD, u_SD, u_HD, u_MAP, u_BD, FileName,
       
       ! Close the file
    CLOSE(unOut)
-   !!!CLOSE(unOut2)
          
 END SUBROUTINE WriteInputMeshesToFile   
 !----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This update is a dependency of #16: Issue with VTK output file naming convention.

The "t" prefix to the timestamps has been eliminated in MeshWrVTK(), MeshWrVTKfields(), and MeshWrVTK_Ln2Surface(), all of which are in ModMesh.f90.

Additionally, the subroutines in FAST_Subs.f90 that call the above subroutines [WrVTK_AllMeshes(), WrVTK_BasicMeshes(), and WrVTK_Surfaces()] pass the maximum number of VTK write-out steps to the above subroutines, so that the timestamps may be padded with the appropriate number of zeros, as discussed in the Issue thread. This approach certainly means that the "width" of the number is repeatedly calculated (at every write-out step), but it seems relatively cheap in the grand scheme of things, and avoids adding it onto one of the persistent derived types, like the parameters. However, this alternate approach may be preferable.