### PR TITLE
Fixes Runtime error in BeamDyn unit test, test_BD_GravityForce() #133

### DIFF
--- a/modules-local/beamdyn/tests/test_tools.F90
+++ b/modules-local/beamdyn/tests/test_tools.F90
@@ -122,7 +122,7 @@ contains
         call AllocAry(p%Jacobian, p%nqp, p%nodes_per_elem, 'Jacobian', ErrStat, ErrMsg)
 
         ! construct arrays
-        p%qp%mmm = getMassMatrix()
+        p%qp%mmm = 1.0
         
         do j=1, p%elem_total
             do i=1, p%nqp


### PR DESCRIPTION
This fixes #133 by altering the quadrature-point mass vector (`p%qp%mmm`) initialization in the function `simpleParameterType()`. All ones for the mass were chosen so as to correspond to the condition in the `bd_static_cantilever_beam` regression test.