### PR TITLE
Fix #143: Use the official pfunit repo

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -3,4 +3,4 @@
 	url = https://github.com/openfast/r-test.git
 [submodule "unit_tests/pfunit"]
 	path = unit_tests/pfunit
-	url = https://github.com/openfast/pfunit.git
+	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git


### PR DESCRIPTION
pFUnit has moved from sourceforge to github leaving behind the reliability issues that caused us OpenFAST to host its own mirror of the repository. This pull request deprecates the OpenFAST mirror and links to the official pFUnit repository at https://github.com/Goddard-Fortran-Ecosystem/pFUnit.