### PR TITLE
Change BD output mesh to be at trapezoidal quadrature points

### DIFF
--- a/modules-local/beamdyn/src/Registry_BeamDyn.txt
+++ b/modules-local/beamdyn/src/Registry_BeamDyn.txt
@@ -12,6 +12,10 @@ include Registry_NWTC_Library.txt
 param   BeamDyn/BD   -           IntKi    BD_STATIC_ANALYSIS   -  1  -  "Constant for static analysis" -
 param   ^            -           IntKi    BD_DYNAMIC_ANALYSIS  -  2  -  "Constant for dynamic analysis" -
 
+param   ^            -           IntKi    BD_MESH_FE           -  1  -  "Constant for creating y%BldMotion at the FE (GLL) nodes" -
+param   ^            -           IntKi    BD_MESH_QP           -  2  -  "Constant for creating y%BldMotion at the quadrature nodes" -
+param   ^            -           IntKi    BD_MESH_STATIONS     -  3  -  "Constant for creating y%BldMotion at the blade property input stations" -
+
 
 # ..... Initialization data
 # .......................................................................................................
@@ -194,6 +198,7 @@ typedef   ^        ParameterType ReKi           pitchC           -         - -  
 typedef   ^        ParameterType ReKi           torqM           {2}{2}     - -  "Pitch actuator matrix: (I-hA)^-1" - 
 typedef   ^        ParameterType qpParam        qp               -         - -  "Quadrature point info that does not change during simulation" -
 typedef   ^        ParameterType IntKi          qp_indx_offset   -         - -  "Offset for computing index of the quadrature arrays (gauss skips the first [end-point] node)" -
+typedef   ^        ParameterType IntKi          BldMotionNodeLoc -         - -  "switch to determine where the nodes on the blade motion mesh should be located 1=FE (GLL) nodes; 2=quadrature nodes; 3=blade input stations"
 # .... arrays for optimization ........................................................................................................
 typedef   ^        ParameterType    R8Ki        QPtw_Shp_Shp_Jac       {:}{:}{:}{:}  - - "optimization variable: QPtw_Shp_Shp_Jac(idx_qp,i,j,nelem) = p%Shp(i,idx_qp)*p%Shp(j,idx_qp)*p%QPtWeight(idx_qp)*p%Jacobian(idx_qp,nelem)" -
 typedef   ^        ParameterType    ^           QPtw_Shp_ShpDer        {:}{:}{:}     - - "optimization variable: QPtw_Shp_ShpDer(idx_qp,i,j) = p%Shp(i,idx_qp)*p%ShpDer(j,idx_qp)*p%QPtWeight(idx_qp)" -
@@ -302,6 +307,7 @@ typedef   ^        MiscVarType    ^            MassM        {:}{:}{:}{:}  - - "M
 typedef   ^        MiscVarType    ^            DampG        {:}{:}{:}{:}  - - "Damping Matrix" -
 typedef   ^        MiscVarType    ^            RHS          {:}{:}        - - "Right-hand-side vector" -
 typedef   ^        MiscVarType    ^            BldInternalForceFE   {:}{:}  - - "Force/Moment array for internal force calculations at FE" -
+typedef   ^        MiscVarType    ^            BldInternalForceQP   {:}{:}  - - "Force/Moment array for internal force calculations at QP" -
 typedef   ^        MiscVarType    ^            Solution     {:}{:}        - - "Result from LAPACK solve (X from A*X = B solve)" -
 # arrays for lapack routines                 
 typedef   ^        MiscVarType    ^            LP_StifK     {:}{:}        - - "Stiffness Matrix" -

--- a/modules-local/openfast-library/src/FAST_Registry.txt
+++ b/modules-local/openfast-library/src/FAST_Registry.txt
@@ -82,6 +82,7 @@ typedef	^	FAST_ParameterType	IntKi	NumCrctn	-	-	-	"Number of correction iteratio
 typedef	^	FAST_ParameterType	IntKi	KMax	-	-	-	"Maximum number of input-output-solve iterations (KMax >= 1)"	-
 typedef	^	FAST_ParameterType	IntKi	numIceLegs	-	-	-	"number of suport-structure legs in contact with ice (IceDyn coupling)"	-
 typedef	^	FAST_ParameterType	IntKi	nBeams	-	-	-	"number of BeamDyn instances"	-
+typedef	^	FAST_ParameterType	LOGICAL	BD_OutputSibling	-	-	-	"flag to determine if BD input is sibling of output mesh"	-
 typedef	^	FAST_ParameterType	LOGICAL	ModuleInitialized	{NumModules}	-	-	"An array determining if the module has been initialized"	-
 # Data for Jacobians:
 typedef	^	FAST_ParameterType	DbKi	DT_Ujac	-	-	-	"Time between when we need to re-calculate these Jacobians"	s

--- a/modules-local/openfast-library/src/FAST_Solver.f90
+++ b/modules-local/openfast-library/src/FAST_Solver.f90
@@ -86,6 +86,16 @@ SUBROUTINE BD_InputSolve( p_FAST, BD, y_AD, u_AD, MeshMapData, ErrStat, ErrMsg )
       
       IF ( p_FAST%CompAero == Module_AD ) THEN
          
+         if (p_FAST%BD_OutputSibling) then
+            
+            DO K = 1,p_FAST%nBeams ! Loop through all blades
+                                    
+               CALL Transfer_Line2_to_Line2( y_AD%BladeLoad(k), BD%Input(1,k)%DistrLoad, MeshMapData%AD_L_2_BDED_B(k), ErrStat2, ErrMsg2, u_AD%BladeMotion(k), BD%y(k)%BldMotion )
+                  CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+               
+            END DO
+            
+         else
          DO K = 1,p_FAST%nBeams ! Loop through all blades
             
             ! need to transfer the BD output blade motions to nodes on a sibling of the BD blade motion mesh:
@@ -96,6 +106,8 @@ SUBROUTINE BD_InputSolve( p_FAST, BD, y_AD, u_AD, MeshMapData, ErrStat, ErrMsg )
                CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
                
          END DO
+         end if
+         
                   
       ELSE
 
@@ -3914,14 +3926,14 @@ SUBROUTINE InitModuleMappings(p_FAST, ED, BD, AD14, AD, HD, SD, ExtPtfm, SrvD, M
       
          ! Blade root meshes
       ALLOCATE( MeshMapData%ED_P_2_AD_P_R(NumBl), STAT=ErrStat2 )
-         IF ( ErrStat2 /= 0 ) THEN
-            CALL SetErrStat( ErrID_Fatal, 'Error allocating MeshMapData%ED_P_2_AD_P_R.', ErrStat, ErrMsg, RoutineName )
-            RETURN
-         END IF      
-         
+      IF ( ErrStat2 /= 0 ) THEN
+         CALL SetErrStat( ErrID_Fatal, 'Error allocating MeshMapData%ED_P_2_AD_P_R.', ErrStat, ErrMsg, RoutineName )
+         RETURN
+      END IF      
+      
       DO K=1,NumBl         
          CALL MeshMapCreate( ED%Output(1)%BladeRootMotion(K), AD%Input(1)%BladeRootMotion(K), MeshMapData%ED_P_2_AD_P_R(K), ErrStat2, ErrMsg2 )
-            CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':ED_P_2_AD_P_R('//TRIM(Num2LStr(K))//')' )
+         CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':ED_P_2_AD_P_R('//TRIM(Num2LStr(K))//')' )
       END DO
       
       
@@ -3932,11 +3944,11 @@ SUBROUTINE InitModuleMappings(p_FAST, ED, BD, AD14, AD, HD, SD, ExtPtfm, SrvD, M
       
       ! Blade meshes: (allocate two mapping data structures to number of blades, then allocate data inside the structures)                  
       ALLOCATE( MeshMapData%BDED_L_2_AD_L_B(NumBl), MeshMapData%AD_L_2_BDED_B(NumBl), STAT=ErrStat2 )
-         IF ( ErrStat2 /= 0 ) THEN
-            CALL SetErrStat( ErrID_Fatal, 'Error allocating MeshMapData%BDED_L_2_AD_L_B and MeshMapData%AD_L_2_BDED_B.', &
-                            ErrStat, ErrMsg, RoutineName )
-            RETURN
-         END IF
+      IF ( ErrStat2 /= 0 ) THEN
+         CALL SetErrStat( ErrID_Fatal, 'Error allocating MeshMapData%BDED_L_2_AD_L_B and MeshMapData%AD_L_2_BDED_B.', &
+                          ErrStat, ErrMsg, RoutineName )
+         RETURN
+      END IF
          
       IF ( p_FAST%CompElast == Module_ED ) then
          
@@ -3957,55 +3969,59 @@ SUBROUTINE InitModuleMappings(p_FAST, ED, BD, AD14, AD, HD, SD, ExtPtfm, SrvD, M
                CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':AD_L_2_BDED_B('//TRIM(Num2LStr(K))//')' )
          END DO
          
-         ! Blade meshes for load transfer: (allocate meshes at BD input locations for motions transferred from BD output locations)                  
-         ALLOCATE( MeshMapData%BD_L_2_BD_L(NumBl), MeshMapData%y_BD_BldMotion_4Loads(NumBl), STAT=ErrStat2 )
-            IF ( ErrStat2 /= 0 ) THEN
-               CALL SetErrStat( ErrID_Fatal, 'Error allocating MeshMapData%BD_L_2_BD_L and MeshMapData%y_BD_BldMotion_4Loads.', &
-                               ErrStat, ErrMsg, RoutineName )
-               RETURN
-            END IF
-         
-         DO K=1,NumBl         
+!-------------------------
+!  BeamDyn <-> BeamDyn
+!-------------------------
+         if (.not. p_FAST%BD_OutputSibling) then
+
+            ! Blade meshes for load transfer: (allocate meshes at BD input locations for motions transferred from BD output locations)                  
+            ALLOCATE( MeshMapData%BD_L_2_BD_L(NumBl), MeshMapData%y_BD_BldMotion_4Loads(NumBl), STAT=ErrStat2 )
+                  IF ( ErrStat2 /= 0 ) THEN
+                     CALL SetErrStat( ErrID_Fatal, &
+                                    'Error allocating MeshMapData%BD_L_2_BD_L and MeshMapData%y_BD_BldMotion_4Loads.', &
+                                    ErrStat, ErrMsg, RoutineName )
+                     RETURN
+                  END IF
+            
+            DO K=1,NumBl         
                ! create the new mesh:
-            CALL MeshCopy ( SrcMesh  = BD%Input(1,k)%DistrLoad &
-                          , DestMesh = MeshMapData%y_BD_BldMotion_4Loads(k) &
-                          , CtrlCode = MESH_SIBLING     &
-                          , IOS      = COMPONENT_OUTPUT &
-                          , TranslationDisp = .TRUE.    &
-                          , Orientation     = .TRUE.    &
-                          , RotationVel     = .TRUE.    &
-                          , TranslationVel  = .TRUE.    &
-                          , RotationAcc     = .TRUE.    &
-                          , TranslationAcc  = .TRUE.    &
-                          , ErrStat  = ErrStat2         &
-                          , ErrMess  = ErrMsg2          ) 
+               CALL MeshCopy ( SrcMesh  = BD%Input(1,k)%DistrLoad &
+                              , DestMesh = MeshMapData%y_BD_BldMotion_4Loads(k) &
+                              , CtrlCode = MESH_SIBLING     &
+                              , IOS      = COMPONENT_OUTPUT &
+                              , TranslationDisp = .TRUE.    &
+                              , Orientation     = .TRUE.    &
+                              , RotationVel     = .TRUE.    &
+                              , TranslationVel  = .TRUE.    &
+                              , RotationAcc     = .TRUE.    &
+                              , TranslationAcc  = .TRUE.    &
+                              , ErrStat  = ErrStat2         &
+                              , ErrMess  = ErrMsg2          ) 
                CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )         
                IF (ErrStat >= AbortErrLev) RETURN
-                                    
+                                       
                ! create the mapping:
-            CALL MeshMapCreate( BD%y(k)%BldMotion, MeshMapData%y_BD_BldMotion_4Loads(k), MeshMapData%BD_L_2_BD_L(K), ErrStat2, ErrMsg2 )
+               CALL MeshMapCreate( BD%y(k)%BldMotion, MeshMapData%y_BD_BldMotion_4Loads(k), MeshMapData%BD_L_2_BD_L(K), ErrStat2, ErrMsg2 )
                CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':BD_L_2_BD_L('//TRIM(Num2LStr(K))//')' )         
-         END DO
+            END DO
          
-      END IF
-      
-         
+         end if !.not. p_FAST%BD_OutputSibling
+        
+      END IF ! CompElast
+          
       ! Tower mesh:
       IF ( AD%Input(1)%TowerMotion%Committed ) THEN
          CALL MeshMapCreate( ED%Output(1)%TowerLn2Mesh, AD%Input(1)%TowerMotion, MeshMapData%ED_L_2_AD_L_T, ErrStat2, ErrMsg2 )
             CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':ED_L_2_AD_L_T' )
-            
+                  
          IF ( AD%y%TowerLoad%Committed ) THEN            
             CALL MeshMapCreate( AD%y%TowerLoad, ED%Input(1)%TowerPtLoads,  MeshMapData%AD_L_2_ED_P_T, ErrStat2, ErrMsg2 )
-               CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':AD_L_2_ED_P_T' )
+            CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName//':AD_L_2_ED_P_T' )
          END IF         
       END IF
-      
-      
-   END IF
-   
-      
-      
+
+   END IF ! p_FAST%CompAero == Module_AD
+
    IF ( p_FAST%CompHydro == Module_HD ) THEN ! HydroDyn-{ElastoDyn or SubDyn}
          
          


### PR DESCRIPTION
This pull request changes the output of blade motion mesh from BeamDyn to be defined on quadrature points. This is similar functionality to @ashesh2512's pull request #120 which was closed without merge. However, this pull request takes the relevant updates directly from Envision Energy's pull request in https://github.com/rafmudaf/openfast/pull/6.

This work connects to issue #80.

Only the BeamDyn related OpenFAST regression test fails, as expected. The baseline solutions are being updated at https://github.com/openFAST/r-test/tree/rafaelmudafort/quadrature_point_output.

```
mbp@~/Desktop/openfast/build [feature/output_at_quadrature_points]$ ctest -j 30
Test project /Users/rmudafor/Desktop/openfast/build
      Start  1: AWT_YFix_WSt
      Start  2: AWT_WSt_StartUp_HighSpShutDown
      Start  3: AWT_YFree_WSt
      Start  4: AWT_YFree_WTurb
      Start  5: AWT_WSt_StartUpShutDown
      Start  6: AOC_WSt
      Start  7: AOC_YFree_WTurb
      Start  8: AOC_YFix_WSt
      Start  9: UAE_Dnwind_YRamp_WSt
      Start 10: UAE_Upwind_Rigid_WRamp_PwrCurve
      Start 11: WP_VSP_WTurb_PitchFail
      Start 12: WP_VSP_ECD
      Start 13: WP_VSP_WTurb
      Start 14: WP_Stationary_Linear
      Start 15: SWRT_YFree_VS_EDG01
      Start 16: SWRT_YFree_VS_EDC01
      Start 17: SWRT_YFree_VS_WTurb
      Start 18: 5MW_Land_DLL_WTurb
      Start 19: 5MW_OC3Mnpl_DLL_WTurb_WavesIrr
      Start 20: 5MW_OC3Trpd_DLL_WSt_WavesReg
      Start 21: 5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth
      Start 22: 5MW_ITIBarge_DLL_WTurb_WavesIrr
      Start 23: 5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti
      Start 24: 5MW_OC3Spar_DLL_WTurb_WavesIrr
      Start 25: 5MW_OC4Semi_WSt_WavesWN
      Start 26: 5MW_Land_BD_DLL_WTurb
      Start 27: bd_5MW_dynamic
      Start 28: bd_curved_beam
      Start 29: bd_isotropic_rollup
      Start 30: bd_static_cantilever_beam
 1/32 Test #29: bd_isotropic_rollup ......................   Passed    1.11 sec
      Start 31: bd_static_twisted_with_k1
 2/32 Test #30: bd_static_cantilever_beam ................   Passed    1.19 sec
      Start 32: beamdyn_utest
 3/32 Test #28: bd_curved_beam ...........................   Passed    1.21 sec
 4/32 Test #32: beamdyn_utest ............................   Passed    0.06 sec
 5/32 Test #31: bd_static_twisted_with_k1 ................   Passed    0.64 sec
 6/32 Test #14: WP_Stationary_Linear .....................   Passed    4.86 sec
 7/32 Test  #1: AWT_YFix_WSt .............................   Passed   78.67 sec
 8/32 Test  #6: AOC_WSt ..................................   Passed  109.90 sec
 9/32 Test #27: bd_5MW_dynamic ...........................   Passed  120.88 sec
10/32 Test #11: WP_VSP_WTurb_PitchFail ...................   Passed  127.96 sec
11/32 Test #12: WP_VSP_ECD ...............................   Passed  134.12 sec
12/32 Test  #2: AWT_WSt_StartUp_HighSpShutDown ...........   Passed  138.10 sec
13/32 Test  #3: AWT_YFree_WSt ............................   Passed  156.03 sec
14/32 Test  #8: AOC_YFix_WSt .............................   Passed  163.42 sec
15/32 Test  #5: AWT_WSt_StartUpShutDown ..................   Passed  189.92 sec
16/32 Test #22: 5MW_ITIBarge_DLL_WTurb_WavesIrr ..........   Passed  217.57 sec
17/32 Test #10: UAE_Upwind_Rigid_WRamp_PwrCurve ..........   Passed  237.06 sec
18/32 Test #13: WP_VSP_WTurb .............................   Passed  287.48 sec
19/32 Test #24: 5MW_OC3Spar_DLL_WTurb_WavesIrr ...........   Passed  327.47 sec
20/32 Test  #9: UAE_Dnwind_YRamp_WSt .....................   Passed  328.72 sec
21/32 Test #23: 5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti ....   Passed  336.93 sec
22/32 Test  #4: AWT_YFree_WTurb ..........................   Passed  371.96 sec
23/32 Test  #7: AOC_YFree_WTurb ..........................   Passed  392.17 sec
24/32 Test #16: SWRT_YFree_VS_EDC01 ......................   Passed  392.02 sec
25/32 Test #18: 5MW_Land_DLL_WTurb .......................   Passed  400.47 sec
26/32 Test #15: SWRT_YFree_VS_EDG01 ......................   Passed  506.91 sec
27/32 Test #25: 5MW_OC4Semi_WSt_WavesWN ..................   Passed  517.16 sec
28/32 Test #19: 5MW_OC3Mnpl_DLL_WTurb_WavesIrr ...........   Passed  640.04 sec
29/32 Test #26: 5MW_Land_BD_DLL_WTurb ....................***Failed  707.80 sec
30/32 Test #17: SWRT_YFree_VS_WTurb ......................   Passed  735.35 sec
31/32 Test #20: 5MW_OC3Trpd_DLL_WSt_WavesReg .............   Passed  1289.52 sec
32/32 Test #21: 5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth ...   Passed  2191.79 sec

97% tests passed, 1 tests failed out of 32

Label Time Summary:
aerodyn14    = 1970.13 sec*proc (7 tests)
aerodyn15    = 9013.29 sec*proc (19 tests)
beamdyn      = 832.84 sec*proc (6 tests)
dynamic      = 120.88 sec*proc (1 test)
elastodyn    = 10275.62 sec*proc (25 tests)
hydrodyn     = 5520.49 sec*proc (7 tests)
map          = 881.97 sec*proc (3 tests)
moordyn      = 517.16 sec*proc (1 test)
openfast     = 10983.42 sec*proc (26 tests)
servodyn     = 10978.56 sec*proc (25 tests)
static       =   4.16 sec*proc (4 tests)
subdyn       = 4121.35 sec*proc (3 tests)

Total Test time (real) = 2192.03 sec

The following tests FAILED:
	 26 - 5MW_Land_BD_DLL_WTurb (Failed)
Errors while running CTest
```