### PR TITLE
Add a cmake flag for c-based shared libraries

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -80,6 +80,7 @@ endmacro(set_fast_fortran)
 macro(set_fast_gfortran)
   if(NOT WIN32)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpic ")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
   endif(NOT WIN32)
 
   # Fix free-form compilation for OpenFAST


### PR DESCRIPTION
Without this flag, OpenFAST does not link properly to `libmapcpp` when using gfortran on peregrine.