### PR TITLE
Support a CMake-generated Visual Studio solution

### DIFF
--- a/cmake/FindMKL.cmake
+++ b/cmake/FindMKL.cmake
@@ -14,22 +14,22 @@
 # limitations under the License.
 #
 
-find_path(MKL_INCLUDE_DIRS
-  mkl.h
-  HINTS $ENV{MKLROOT}
-  PATH_SUFFIXES include)
+# find_path(MKL_INCLUDE_DIRS
+#   mkl.h
+#   HINTS $ENV{MKLROOT}
+#   PATH_SUFFIXES include)
 
 find_library(MKL_IFACE_LIB
-  NAMES mkl_intel_lp64 libmkl_intel_lp64.a
-  PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 $ENV{INTEL}/mkl/lib/intel64)
+  NAMES mkl_intel_lp64 libmkl_intel_lp64.a mkl_intel_lp64_dll.lib
+  PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 $ENV{INTEL}/mkl/lib/intel64 $ENV{INTEL}/mkl/lib/intel64_win)
 
 find_library(MKL_SEQ_LIB
-  NAMES mkl_sequential libmkl_sequential.a
-  PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 $ENV{INTEL}/mkl/lib/intel64)
+  NAMES mkl_sequential libmkl_sequential.a mkl_sequential.lib
+  PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 $ENV{INTEL}/mkl/lib/intel64 $ENV{INTEL}/mkl/lib/intel64_win)
 
 find_library(MKL_CORE_LIB
-  NAMES mkl_core libmkl_core.a
-  PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 $ENV{INTEL}/mkl/lib/intel64)
+  NAMES mkl_core libmkl_core.a mkl_core_dll.lib
+  PATHS $ENV{MKLROOT}/lib $ENV{MKLROOT}/lib/intel64 $ENV{INTEL}/mkl/lib/intel64 $ENV{INTEL}/mkl/lib/intel64_win)
 
 if (MKL_IFACE_LIB AND MKL_SEQ_LIB AND MKL_CORE_LIB)
   set(MKL_LIBRARIES ${MKL_IFACE_LIB} ${MKL_SEQ_LIB} ${MKL_CORE_LIB})
@@ -40,6 +40,6 @@ endif()
 
 include(FindPackageHandleStandardArgs)
 find_package_handle_standard_args(MKL DEFAULT_MSG
-  MKL_LIBRARIES MKL_INCLUDE_DIRS MKL_IFACE_LIB MKL_SEQ_LIB MKL_CORE_LIB)
+  MKL_LIBRARIES MKL_IFACE_LIB MKL_SEQ_LIB MKL_CORE_LIB) # MKL_INCLUDE_DIRS)
 mark_as_advanced(
   MKL_INCLUDE_DIRS MKL_LIBRARIES MKL_IFACE_LIB MKL_SEQ_LIB MKL_CORE_LIB)

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -58,9 +58,6 @@ macro(set_fast_fortran)
     endif()
   endif()
 
-  # Set the preprocessor for all source files by default
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp ")
-
   # Force all .mod files to be stored in a single directory
   set(CMAKE_Fortran_MODULE_DIRECTORY "${CMAKE_BINARY_DIR}/ftnmods"
     CACHE STRING "Set the Fortran Modules directory" FORCE)
@@ -89,7 +86,7 @@ macro(set_fast_gfortran)
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DDOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -fdefault-real-8")
   endif (DOUBLE_PRECISION)
 
   # debug flags
@@ -118,7 +115,7 @@ macro(set_fast_intel_fortran_posix)
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DDOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double_size 128")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -r8 -double_size 128")
   endif (DOUBLE_PRECISION)
 endmacro(set_fast_intel_fortran_posix)
 
@@ -130,7 +127,7 @@ macro(set_fast_intel_fortran_windows)
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DDOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /real_size:64 /double_size:128")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /fpp /real_size:64 /double_size:128")
   endif (DOUBLE_PRECISION)
 
   # Turn off specific warnings

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -13,5 +13,6 @@ The developer team is moving towards a CMake-only approach that well supports Wi
    install_cmake_linux.rst
    install_spack.rst
    install_cmake_cygwin.rst
+   install_cmake_windows.rst
    install_vs_windows.rst
 

--- a/docs/source/install/install_cmake_windows.rst
+++ b/docs/source/install/install_cmake_windows.rst
@@ -1,14 +1,14 @@
-.. _install_cmake_linux:
+.. _install_cmake_windows:
 
-Building OpenFAST with CMake on Linux and Mac
-=============================================
+Building OpenFAST with CMake on Windows
+=======================================
 
 We describe here how to install OpenFAST (or any of its modules) using the `CMake <https://cmake.org>`_ 
-build system on Linux or Mac OS systems. Separate CMake documentation is 
-provided for Windows users at :numref:`install_cmake_windows` and Cygwin users at :numref:`install_cmake_cygwin`.
-Also, some template build scripts are available in ``openfast/share``.
+build system on Windows systems. Separate CMake documentation is 
+provided for Cygwin users at :numref:`install_cmake_cygwin` and Linux/Mac users at :numref:`install_cmake_linux`.
+A standalone Visual Studio solution also exists at `openfast/vs-build` and documentation is at :numref:`install_vs_windows`.
 
-Required software for building OpenFAST 
+Required software for building OpenFAST
 ---------------------------------------
 
 In order to build OpenFAST using CMake, one needs the following minimum set of packages installed:
@@ -17,7 +17,7 @@ In order to build OpenFAST using CMake, one needs the following minimum set of p
 
 - C/C++ compiler
 
-- GNU Make (version 3.81 or later)
+- Visual Studio
 
 - CMake (version 2.8.12 or later)
 
@@ -39,37 +39,35 @@ If one has the appropriate third party libraries, CMake, and git installed, obta
 
 .. code-block:: bash
 
-    # obtain the source code; e.g., from the command line using git:
+    # Obtain the source code; e.g., from the command line using git:
     git clone https://github.com/OpenFAST/OpenFAST.git
 
-    # go to the OpenFAST directory
+    # Go to the OpenFAST directory
     cd OpenFAST
 
-    # create a directory called `build`
+    # Create a directory called `build`
     mkdir build 
 
-    # go to the build directory
+    # Go to the build directory
     cd build
 
-    # execute CMake with the default options, which will create a series of Makefiles
-    cmake ../ 
+    # Execute CMake with the default options and a specific Visual Studio version
+    # and build architecture. For a list of available CMake generators, run
+    # `cmake .. -G`
+    cmake .. -G "Visual Studio 14 2015 Win64"
 
-    # execute a make command (with no target provided, equivalent to `make all`
-    make 
+    # Open the generated Visual Studio solution
+    start OpenFAST.sln
 
-This will build the OpenFAST suite in the ``build`` directory, which can be deleted for a clean build.
+Visual Studio will open a solution containing all of the OpenFAST projects, and you
+can then build any module library, module driver, or glue code. Note that any time 
+CMake is rerun, the Visual Studio solution will be regenerated causing the Visual Studio
+GUI to lag momentarily while it reloads the data.
 
-There are many  ``Makefile`` targets (besides ``all``), which can be listed via ``help``:
-
-.. code-block:: bash
-
-    # list available make targets
-    make help
-
-    # make a specific target, e.g.
-    make beamdyn_driver
-
-
+**The CMake-generated Visual Studio build is currently damaged.** Some modules are compiled
+before their associated registry type files are seen by Visual Studio so an initial build
+will fail. However, a simple work around is to run the build command in Visual Studio
+multiple times until it succeeds.
 
 Current CMake options
 ~~~~~~~~~~~~~~~~~~~~~
@@ -97,17 +95,3 @@ CMake options can be configured through command line, e.g.
     # to compile OpenFAST in single precision
     cmake .. -DDOUBLE_PRECISION:BOOL=OFF
  
-
-Parallel build
-~~~~~~~~~~~~~~
-
-GNU Make has a parellel build option with the ``-jobs`` or ``-j`` flag, and the OpenFAST
-CMake configuration handles setting up the dependencies for Make so the build can be 
-parallelized. However, it is important to note that the only parallel portion
-of the build process is in compiling the modules. Due to some interdependency between
-modules, the max parallel level is around 12. The remaining portion of the build,
-mainly compiling the OpenFAST library itself, takes a considerable amount of time
-and cannot be parallelized.
-
-An example parallel build command is ``make -j 8``.
-

--- a/docs/source/install/install_vs_windows.rst
+++ b/docs/source/install/install_vs_windows.rst
@@ -3,6 +3,10 @@
 Building OpenFAST on Windows with Visual Studio
 ===============================================
 
+These instructions are specifically for the standalone Visual Studio project at `openfast/vs-build`.
+Separate CMake documentation is provided for Windows users at :numref:`install_cmake_windows` and 
+Cygwin users at :numref:`install_cmake_cygwin`.
+
 Prerequisites
 ------------------------
 

--- a/modules-ext/map/CMakeLists.txt
+++ b/modules-ext/map/CMakeLists.txt
@@ -14,7 +14,9 @@
 # limitations under the License.
 #
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAP_DLL_EXPORTS -DCMINPACK_NO_DLL  -DNDEBUG -D_WINDOWS -D_USRDLL")
+if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAP_DLL_EXPORTS -DCMINPACK_NO_DLL  -DNDEBUG -D_WINDOWS -D_USRDLL")
+endif()
 
 generate_f90_types(src/MAP_Registry.txt MAP_Types.f90 -ccode)
 

--- a/modules-ext/map/CMakeLists.txt
+++ b/modules-ext/map/CMakeLists.txt
@@ -14,6 +14,8 @@
 # limitations under the License.
 #
 
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -DMAP_DLL_EXPORTS -DCMINPACK_NO_DLL  -DNDEBUG -D_WINDOWS -D_USRDLL")
+
 generate_f90_types(src/MAP_Registry.txt MAP_Types.f90 -ccode)
 
 file(GLOB MAP_CLIB_SOURCES src/*.c src/*.cc src/*/*.c src/*/*.cc)

--- a/modules-local/openfast-registry/CMakeLists.txt
+++ b/modules-local/openfast-registry/CMakeLists.txt
@@ -1,5 +1,20 @@
+#
+# Copyright 2016 National Renewable Energy Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
 
-add_executable(openfast_registry
+set(REGISTRY_SOURCES
   src/data.c
   src/gen_c_types.c
   src/gen_module_files.c
@@ -9,4 +24,12 @@ add_executable(openfast_registry
   src/registry.c
   src/sym.c
   src/symtab_gen.c
-  src/type.c)
+  src/type.c
+  )
+
+add_executable(openfast_registry ${REGISTRY_SOURCES})
+
+set_target_properties(openfast_registry PROPERTIES
+  RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/modules-local/openfast-registry
+  RUNTIME_OUTPUT_DIRECTORY_RELEASE ${CMAKE_BINARY_DIR}/modules-local/openfast-registry
+)

--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -42,7 +42,7 @@ set(CTEST_BEAMDYN_EXECUTABLE "${CMAKE_BINARY_DIR}/modules-local/beamdyn/beamdyn_
 
 # Set the python executable configuration option and default
 if(NOT EXISTS ${PYTHON_EXECUTABLE})
-  find_program(PYTHON_EXECUTABLE NAMES python3 python)
+  find_program(PYTHON_EXECUTABLE NAMES python3 python py)
   if(NOT EXISTS ${PYTHON_EXECUTABLE})
     message(FATAL_ERROR "CMake cannot find a Python interpreter in your path. Python is required to run OpenFAST tests." )
   endif()

--- a/reg_tests/lib/openfastDrivers.py
+++ b/reg_tests/lib/openfastDrivers.py
@@ -51,6 +51,6 @@ def runOpenfastCase(inputFile, executable, verbose=False):
     return _runGenericCase(inputFile, executable, verbose)
 
 def runBeamdynDriverCase(inputFile, executable, verbose=False):
-    caseDirectory = os.path.sep.join(inputFile.split("/")[:-1])
+    caseDirectory = os.path.sep.join(inputFile.split(os.path.sep)[:-1])
     os.chdir(caseDirectory)
     return _runGenericCase(inputFile, executable, verbose)

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -23,6 +23,14 @@ project(OpenFAST_UnitTest Fortran)
 
 include(CTest)
 
+# Set the python executable configuration option and default
+if(NOT EXISTS ${PYTHON_EXECUTABLE})
+  find_program(PYTHON_EXECUTABLE NAMES python3 python py)
+  if(NOT EXISTS ${PYTHON_EXECUTABLE})
+    message(FATAL_ERROR "CMake cannot find a Python interpreter in your path. Python is required to run OpenFAST tests." )
+  endif()
+endif()
+
 ### pfunit
 include(ExternalProject)
 set(ExternalProjectCMakeArgs
@@ -32,8 +40,6 @@ set(ExternalProjectCMakeArgs
 set(PFUNIT_INSTALL ${PROJECT_BINARY_DIR}/pfunit)
 
 ExternalProject_Add(pfunit
-  # DOWNLOAD_COMMAND git submodule update
-  DOWNLOAD_DIR ${PROJECT_SOURCE_DIR}
   SOURCE_DIR ${PROJECT_SOURCE_DIR}/pfunit
   BINARY_DIR ${PROJECT_BINARY_DIR}/pfunit-build
   STAMP_DIR ${PROJECT_BINARY_DIR}/pfunit-stamp
@@ -64,7 +70,7 @@ function(build_utest module testlist)
     set(test_dependency pfunit ${source_modulesdirectory}/${module}/tests/${test}.F90)
     add_custom_command(
       OUTPUT ${build_testdirectory}/${test}.F90
-      COMMAND python ${pfunit_directory}/bin/pFUnitParser.py ${source_modulesdirectory}/${module}/tests/${test}.F90 ${build_testdirectory}/${test}.F90
+      COMMAND ${PYTHON_EXECUTABLE} ${pfunit_directory}/bin/pFUnitParser.py ${source_modulesdirectory}/${module}/tests/${test}.F90 ${build_testdirectory}/${test}.F90 
       DEPENDS ${test_dependency}
     )
     set(test_sources ${test_sources} ${build_testdirectory}/${test}.F90)


### PR DESCRIPTION
This pull request updates the CMake configuration to better support the CMake-generated Visual Studio solution. Specifically included are:
- An update to the FindMKL function to support Windows Visual Fortran installations
- An explicit declaration for the output location of the registry executable
- A bug fix regarding a fortran preprocessor flag
- Minor improvements for cross platform compatibility
- Documentation reflecting these updates

The Visual Studio solution does not build the first time without error. As a workaround, the user must issue the build command in Visual Studio multiple times with the error count dropping each time. Eventually (after two or three builds), all libraries and executables will build without error.