### PR TITLE
BD bug fix: damping coefficients read in wrong order

### DIFF
--- a/modules-local/beamdyn/src/BeamDyn_IO.f90
+++ b/modules-local/beamdyn/src/BeamDyn_IO.f90
@@ -908,7 +908,6 @@ SUBROUTINE BD_ReadBladeFile(BldFile,BladeInputFileData,UnEc,ErrStat,ErrMsg)
    INTEGER(IntKi)             :: j
 
    REAL(BDKi)                 :: temp66(6,6)
-   REAL(BDKi)                 :: temp6(6)
 
    ErrStat = ErrID_None
    ErrMsg  = ""
@@ -960,21 +959,13 @@ SUBROUTINE BD_ReadBladeFile(BldFile,BladeInputFileData,UnEc,ErrStat,ErrMsg)
    CALL ReadCom(UnIn,BldFile,'units',ErrStat2,ErrMsg2,UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
-   CALL ReadAry(UnIn,BldFile,temp6,6,'damping coefficient','damping coefficient',ErrStat2,ErrMsg2,UnEc)
+   CALL ReadAry(UnIn,BldFile,BladeInputFileData%beta,6,'damping coefficient','damping coefficient',ErrStat2,ErrMsg2,UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
       if (ErrStat >= AbortErrLev) then
          call cleanup()
          return
       end if
-
-      ! Change to BD coordinates
-   BladeInputFileData%beta(1) = temp6(3)
-   BladeInputFileData%beta(2) = temp6(1)
-   BladeInputFileData%beta(3) = temp6(2)
-   BladeInputFileData%beta(4) = temp6(6)
-   BladeInputFileData%beta(5) = temp6(4)
-   BladeInputFileData%beta(6) = temp6(5)
 
 
 !  -------------- DISTRIBUTED PROPERTIES--------------------------------------------


### PR DESCRIPTION
The damping coefficients were read in the old BeamDyn Z-X-Y coordinate system instead of the IEC (X-Y-Z) system it now uses.

All of the OpenFAST regression tests with BeamDyn use the value 1.0e-3 for all 6 damping coefficients, so this will not be noticed in any current tests.