### PR TITLE
fixed a bug with computing member_eta.

### DIFF
--- a/modules-local/beamdyn/src/BeamDyn.f90
+++ b/modules-local/beamdyn/src/BeamDyn.f90
@@ -3247,7 +3247,7 @@ SUBROUTINE BD_MemberEta(member_total, QPtW, Jac, member_eta, total_length)
    ENDDO
 
    ! ratio of member's length to the total beam length
-   member_eta = member_eta/total_length
+   member_eta = member_length/total_length
 
 END SUBROUTINE BD_MemberEta
 


### PR DESCRIPTION
fixed a minor bug with computing member_eta used to determine relative position of quadrature points in multi-element beams. Interestingly, it didn't change any test results.