### PR TITLE
Docs: improve the developer documentation

### DIFF
--- a/docs/source/dev/dev_phil.rst
+++ b/docs/source/dev/dev_phil.rst
@@ -1,28 +1,48 @@
 .. _dev_philosophy:
 
-OpenFAST-development philosophy
-================================
+OpenFAST Development Philosophy
+===============================
 
-**Under construction**
+OpenFAST is intended to be a self sustaining community developed software. A couple of tenets of
+this goal are that the code should be reasonably straightforward to comprehend and manageable to
+improve. With that in mind, we expect that new capabilities will include adequate testing and documentation.
 
-OpenFAST and its underlying modules are mostly written in Fortran (adhering to the 2003 standard), but modules can be written in C/C++. 
-OpenFAST was created with the goal of being a community model with developers and users from research laboratories, academia, and industry. 
-
-**Our goal as developers is to ensure that OpenFAST is sustainable software that is well tested and well documented.**
-To that end, we are continually improving the documentation and test coverage for existing code, and we expect that new capabilities will include adequate testing and documentation.
-
-Moving forward, we have the following guidance for developers:
+We have the following guidance for developers:
 
 - When fixing a bug, first introduce a unit test that exposes the bug, fix the bug, and submit a Pull Request.  
-  See :numref:`testing` and :numref:`github_workflow`.
+  See :numref:`testing` and :numref:`github_workflow` for information on testing and the GitHub workflow.
 
 - When adding a new feature, create appropriate automated unit and regression tests as described in :numref:`testing`.  
   The objective is to create a GitHub pull request that provides adequate verification and validation such that the NREL OpenFAST developer team
   can merge the pull request with confidence that the new feature is "correct" and supports our goal of self-sustaining software.
   See :numref:`pull_requests` for detailed information on submitting a pull request.
   
-- If a code modification affects regression-test results in an expected manner, work with the NREL OpenFAST developer team to upgrade the regression-test suite via a ``New Issue`` on the `github.com <https://github.com/openfast/openfast/issues>`_ repository.
-   
-- While OpenFAST developer documentation is being enhanced here, developers are encouraged to consult the legacy FAST v8 `Programmer's Handbook <https://nwtc.nrel.gov/system/files/ProgrammingHandbook_Mod20130717.pdf>`_.
+- If a code modification affects regression test results in an expected manner, work with the NREL OpenFAST developer team to upgrade the 
+  regression test suite via a GitHub issue or pull request at the `openfast/r-test <https://github.com/openfast/r-test>`_ repository.
 
+Versioning
+----------
+OpenFAST follows `semantic versioning <https://semver.org>`_. In summary, this means that with a version number as MAJOR.MINOR.PATCH,
+the components will be incremented as follows:
 
+- MAJOR version when introducing incompatible API changes,
+- MINOR version when adding functionality in a backwards-compatible manner, and
+- PATCH version when making backwards-compatible bug fixes.
+
+Additional labels for pre-release and build metadata are available as extensions to the MAJOR.MINOR.PATCH format.
+
+For example, ``OpenFAST-v1.0.0-123-gabcd1234-dirty`` describes OpenFAST as:
+
+-	v1.0.0 is the MAJOR.MINOR.PATCH numbering system and corresponds to a tagged commit made by NREL on GitHub
+-	123-g is the number of additional commits after the most recent tag for a build [the ``-g`` is for ``git``]
+- abcd1234 is the first 8 characters of the current commit hash
+- dirty denotes that local changes have been made but not committed
+
+Code Style
+----------
+OpenFAST and its underlying modules are mostly written in Fortran adhering to the 2003 standard, but modules can be written in C or C++.
+Indentation is typically three spaces and no tabs.
+
+Generally, code should be written such that it is straightforward to read. Syntactic sugar or brevity should not
+detract from readability. The exception to this is in situations where performance dictates a poorly readable 
+code. Here, comment blocks should be used to describe what is not readily apparent in the code.

--- a/docs/source/dev/doxy_doc.rst
+++ b/docs/source/dev/doxy_doc.rst
@@ -1,7 +1,7 @@
 Doxygen API documentation
 =========================
 
-If the Doxygen documentation is avaiable, it can be found at the following locations
+If the Doxygen documentation is available, it can be found at the following locations
 
   * `Main Page <../../../doxygen/html/index.html>`_
   * `Index of Classes <../../../doxygen/html/classes.html>`_

--- a/docs/source/dev/github_workflow.rst
+++ b/docs/source/dev/github_workflow.rst
@@ -31,15 +31,17 @@ and never `force push <https://git-scm.com/docs/git-push#git-push---force>`__.
 
 In OpenFAST development, the typical workflow follows this procedure
 
-1. Fork OpenFAST/OpenFAST on GitHub
+1. Fork the OpenFAST/OpenFAST repository on GitHub
 
 2. Clone your new fork: ``git clone https://github.com/youruser/OpenFAST``
-  
-3. Create a feature branch for active development: ``git branch feature/a_great_feature``
-  
-4. Add new development on feature/a_great_feature: ``git push/pull``
 
-5. Update your feature branch with OpenFAST/dev: ``git pull https://github.com/OpenFAST/OpenFAST dev; git push``
+3. Add OpenFAST/OpenFAST as a remote: ``git remote add upstream https://github.com/OpenFAST/OpenFAST``
+  
+4. Create a feature branch for active development: ``git branch feature/a_great_feature`` or ``git checkout -b feature/a_great_feature``
+  
+5. Add new development on feature/a_great_feature: ``git add a_file.f90 && git commit -m "A message" && git push``
+
+5. Update your feature branch with OpenFAST/dev: ``git pull upstream dev && git push``
 
 6. Create a GitHub pull request to merge ``youruser/OpenFAST/feature/a_great_feature`` into ``OpenFAST/OpenFAST/dev``
   
@@ -63,8 +65,4 @@ New pull requests should contain
   
 - Updated unit tests, if applicable
 - Updated documentation in applicable sections ready for compilation and deployment to `readthedocs <http://openfast.readthedocs.io>`__.
-- A review request from a specific member of the NREL OpenFAST team
-
-
-
     

--- a/docs/source/dev/index.rst
+++ b/docs/source/dev/index.rst
@@ -3,12 +3,64 @@
 Developer Documentation
 =======================
 
-**Under construction.**
+**Our goal as developers is to ensure that OpenFAST is a sustainable open source software that is well tested and well documented.**
+To that end, we continually work to improve the documentation and test coverage along with feature additions and improvements.
+This section of the documentation outlines the processes and procedures we have established for external developers
+to work with the NREL OpenFAST team on code development.
 
-This section of OpenFAST documentation is directed at developers, e.g., those who will be adding new modules, improving existing modules, fixing bugs, etc.  The OpenFAST software repository is on `github.com <https://github.com/openfast/openfast>`_, and we ask that developers make contributions through "pull requests" as described in :numref:`github_workflow`.  
-OpenFAST documentation is posted on `readthedocs.com <http://openfast.readthedocs.io/>`_; that documentation is generated automatically from both the ``master`` and ``dev`` branches on `github.com <https://github.com/openfast/openfast>`_ whenever new material is committed.  
-However, documentation can be generated on a local machine as described in :numref:`build_doc`.  Note that on the `readthedocs.com <http://openfast.readthedocs.io/>`_ site, one can build a PDF of the documentation (click on lower left corner for options).
+Getting in touch
+----------------
+Please use `GitHub Issues <https://github.com/openfast/openfast/issues>`_ to:
 
+- ask usage or development questions
+- report bugs
+- suggest code enhancements
+
+For other questions regarding OpenFAST, please contact `Mike Sprague <mailto:michael.a.sprague@nrel.gov>`_.
+
+Contributing to OpenFAST
+------------------------
+If you'd like to help with general OpenFAST development or work on a particular feature, then first install OpenFAST
+following the :doc:`installation instructions <../install/index>` for your machine. Next, verify that your installation is 
+valid by running the test suite following the :doc:`testing instructions <../testing/index>`.
+
+After a successful and validated build, we encourage reading through the :doc:`OpenFAST development philosophy <dev_phil>` to
+understand the general workflow for individual and coordinated development. Finally, be sure to review the :doc:`GitHub workflow <github_workflow>`
+to avoid any merge or code conflicts.
+
+Coordination
+------------
+With development happening in parallel between NREL, industry partners, and universities, duplicated effort is likely without
+proper communication. In that regard, the NREL OpenFAST team maintains the GitHub
+`Issues <https://github.com/openfast/openfast/issues>`_ and `Pull Request <https://github.com/openfast/openfast/pulls>`_ pages.
+Any suggested bug fixes, improvements, or new features should be documented there.
+
+Issues and work assignment
+~~~~~~~~~~~~~~~~~~~~~~~~~~
+Issues should be opened with proper documentation and data to fully describe the problem or feature gap. It is here that
+communication and coordination should happen regarding ongoing work for new development, and developers should make clear
+any intention to complete a task.
+
+Pull requests and reviews
+~~~~~~~~~~~~~~~~~~~~~~~~~
+When a code modification is ready for review, a pull request should be submitted along with all appropriate documentation and tests
+as described in the :doc:`GitHub workflow <github_workflow>`. An NREL OpenFAST team member will assign a reviewer and work with the 
+developer to have the code merged into the main repository.
+
+Documentation
+-------------
+OpenFAST documentation is hosted on `readthedocs <http://openfast.readthedocs.io/>`_. It
+is automatically generated from both the ``master`` and ``dev`` branches whenever new commits are added.
+The documentation can also be generated locally as described in :doc:`build docs <build_doc>` while in development.
+
+Note that a PDF of the documentation can be retrieved from `readthedocs <http://openfast.readthedocs.io/>`_ by clicking the arrow on the 
+lower left corner of the page next to ``v:master`` or ``v:dev``.
+
+While OpenFAST developer documentation is being enhanced here, developers are encouraged to
+consult the legacy FAST v8 `Programmer's Handbook <https://nwtc.nrel.gov/system/files/ProgrammingHandbook_Mod20130717.pdf>`_.
+
+Section Map
+-----------
 .. toctree::
    :maxdepth: 1
 

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -148,7 +148,7 @@ modules used. The labeling can be seen in the test instantiation in
 
 - ``ctest --print-labels`` - Print all available test labels
 
-Labels can be called directoly with
+Labels can be called directly with
 
 - ``ctest -L [Label]``
 

--- a/docs/source/user/aerodyn/input.rst
+++ b/docs/source/user/aerodyn/input.rst
@@ -35,7 +35,7 @@ AeroDyn driver input file is given in
 :numref:`ad_appendix`.
 
 Set the ``Echo`` flag in this file to TRUE if you wish to have the
-``AeroDyn_Driver`` executeable echo the contents of the driver input file (useful
+``AeroDyn_Driver`` executable echo the contents of the driver input file (useful
 for debugging errors in the driver file). The echo file has the naming
 convention of *OutFileRoot.ech*, where ``OutFileRoot`` is
 specified in the I/O SETTINGS section of the driver input file below.

--- a/docs/source/user/beamdyn/running_bd.rst
+++ b/docs/source/user/beamdyn/running_bd.rst
@@ -33,7 +33,7 @@ main executable file, ``BeamDyn_Driver.exe``, which is used to execute
 the stand-alone BeamDyn program. The ``CertTest`` folder contains a
 collection of sample BeamDyn input files and driver input files that can
 be used as templates for the user’s own models. This document may be
-found in the ``Docs`` folder. The ``Compling`` folder contains files
+found in the ``Docs`` folder. The ``Compiling`` folder contains files
 for compiling the stand-alone ``BeamDyn_v1.00.00.exe`` file with either
 Visual Studio or gFortran. The Fortran source code is located in the
 ``Source`` folder.

--- a/docs/source/user/beamdyn/theory.rst
+++ b/docs/source/user/beamdyn/theory.rst
@@ -324,7 +324,7 @@ References :cite:`Patera:1984,Ronquist:1987,Sprague:2003,Sprague:2004`.
    :width: 47%
    :align: center
 
-   Representative :math:`p+1` Lagrangian-interpolant shape functions in the element natural coordinates for a eigth-order LSFEs, where nodes are located at the Gauss-Lobatto-Legendre points.
+   Representative :math:`p+1` Lagrangian-interpolant shape functions in the element natural coordinates for a eighth-order LSFEs, where nodes are located at the Gauss-Lobatto-Legendre points.
 
 
 

--- a/docs/source/user/cppapi/index.rst
+++ b/docs/source/user/cppapi/index.rst
@@ -16,7 +16,7 @@ A sample glue-code `FAST_Prog.cpp <https://github.com/OpenFAST/openfast/blob/dev
 .. literalinclude:: files/cDriver.i
    :language: yaml
 
-Command line invovation
+Command line invocation
 -----------------------
 
 .. code-block:: bash

--- a/docs/source/user/index.rst
+++ b/docs/source/user/index.rst
@@ -3,7 +3,7 @@
 User Documentation
 ==================
 
-This section contains documentation for the OpenFAST module-coupling environment and its underylying modules.
+This section contains documentation for the OpenFAST module-coupling environment and its underlying modules.
 Documentation covers usage of models, underlying theory, and in some cases module verification.   
 
 We are in the process of transitioning legacy FAST v8 documentation, which can be found at https://nwtc.nrel.gov/.   Details on the transition from FAST v8 to OpenFAST may be found in :numref:`fast_to_openfast`


### PR DESCRIPTION
This pull request improves the developer documentation and fixes a few spelling errors.

The built documentation can be previewed on [my fork](https://raf-openfast.readthedocs.io/en/latest/source/dev/index.html) of the docs.