### PR TITLE
TurbSim bug fix for user-specified time-series input files

### DIFF
--- a/modules-local/inflowwind/src/InflowWind_Subs.f90
+++ b/modules-local/inflowwind/src/InflowWind_Subs.f90
@@ -1961,7 +1961,7 @@ SUBROUTINE CalculateOutput( Time, InputData, p, x, xd, z, OtherStates, y, m, Fil
          CASE (FDext_WindNumber)
             
             CALL IfW_4Dext_CalcOutput(Time, PositionXYZprime, p%FDext, y%VelocityUVW,  m%FDext, TmpErrStat, TmpErrMsg) 
-            DiskVel = 0.0_ReKi ! this is only for AD15, which we frankly don't care about in 4Dext wind
+            DiskVel = 0.0_ReKi ! this is only for AD14, which we frankly don't care about in 4Dext wind
                         
             CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
             IF ( ErrStat >= AbortErrLev ) RETURN

--- a/modules-local/turbsim/src/TSsubs.f90
+++ b/modules-local/turbsim/src/TSsubs.f90
@@ -1104,8 +1104,13 @@ SUBROUTINE CalcTargetPSD(p, S, U, ErrStat, ErrMsg)
                iPoint = p%usr%RefPtID
             END IF
        !bjj: make sure size(ssvs,1) = p%grid%NumFreq <= p%usr%nFreq = size(p%usr%S,1)
-            CALL Spec_TimeSer_Extrap ( p, p%grid%Z(iPoint), U(iPoint), SSVS )            
-            SSVS(1:p%usr%nFreq,:) = p%usr%S(:,iPointUsr,:)                         
+            ! initialize SSVS with extrapolated values if there are non-specified components or frequencies 
+            ! i.e., fill the gaps where wind component or frequencies exceed what was specified in the time-series data with some numerical model
+            ! (use zeros for known spectral values that will get overwritten later)
+            CALL Spec_TimeSer_Extrap ( p, p%grid%Z(iPoint), U(iPoint), SSVS )
+            
+            ! overwrite the frequencies and wind components that were computed from measurements in the time-series file
+            SSVS(1:p%usr%nFreq,1:p%usr%nComp) = p%usr%S(1:p%usr%nFreq,iPointUsr,1:p%usr%nComp)
                         
             S(:,iPoint,:) = SSVS*HalfDelF
          END DO

--- a/modules-local/turbsim/src/VelocitySpectra.f90
+++ b/modules-local/turbsim/src/VelocitySpectra.f90
@@ -631,11 +631,15 @@ SUBROUTINE Spec_TimeSer ( p, Ht, Ucmp, LastIndex, Spec )
 
 !bjj: fix me!!! (make use of nComp and height )                             
 
+      ! initialize Spec with extrapolated values on non-specified components or frequencies
+      ! i.e., fill the gaps where wind component or frequencies exceed what was specified in the time-series data with some numerical model
+      ! (or use zeros for known spectral values that will get overwritten later)
    CALL Spec_TimeSer_Extrap ( p, Ht, Ucmp, Spec )
 
 
    InCoord(2) = Ht
    
+      ! overwrite Spec at the frequencies and wind components by interpolating from known points
    DO I=1,p%usr%nFreq !p%grid%NumFreq ! note that this assumes TMax = AnalysisTime (i.e., we have the same delta frequencies)
       
       InCoord(1) = p%grid%Freq(i)      
@@ -680,6 +684,8 @@ SUBROUTINE Spec_TimeSer_Extrap ( p, Ht, Ucmp, Spec )
             
          END SELECT          
                                  
+   ELSE
+      Spec = 0.0_ReKi ! whole matrix is zero
    END IF
 
 END SUBROUTINE Spec_TimeSer_Extrap
@@ -695,7 +701,7 @@ SUBROUTINE UserSpec_Interp2D( InCoord, p_usr, LastIndex, OutSpec )
    REAL(ReKi),                     INTENT(IN   ) :: InCoord(2)                                   !< Arranged as (Freq, Ht)
    TYPE(UserTSSpec_ParameterType), INTENT(IN   ) :: p_usr                                        !<
    INTEGER(IntKi),                 INTENT(INOUT) :: LastIndex(2)                                 !< Index for the last (Freq, Ht) used
-   REAL(ReKi),                     INTENT(  OUT) :: OutSpec(3)                                   !< The interpolated resulting PSD from each component of p%usr%S(:,:,1-3)
+   REAL(ReKi),                     INTENT(INOUT) :: OutSpec(3)                                   !< The interpolated resulting PSD from each component of p%usr%S(:,:,1-3)
 
 
       ! Local variables

--- a/vs-build/TurbSim/TurbSim.vfproj
+++ b/vs-build/TurbSim/TurbSim.vfproj
@@ -1,7 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <VisualStudioProject ProjectCreator="Intel Fortran" Keyword="Console Application" Version="11.0" ProjectIdGuid="{9B76F7F4-E04F-4CAE-A34C-27F6FE973710}">
 	<Platforms>
-		<Platform Name="Win32"/></Platforms>
+		<Platform Name="Win32"/>
+		<Platform Name="x64"/></Platforms>
 	<Configurations>
 		<Configuration Name="Debug|Win32" OutputDirectory="..\..\build\bin" TargetName="$(ProjectName)_$(PlatformName)_$(ConfigurationName)">
 				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" PreprocessorDefinitions="NO_MESHMAPPING;GIT_INCLUDE_FILE='$(ProjectDir)\..\gitVersionInfo.h'" StandardWarnings="standardWarningsF03" DisableSpecificDiagnostics="5268" WarnDeclarations="true" WarnInterfaces="true" Traceback="true" RuntimeLibrary="rtMultiThreadedDebug" UseMkl="mklSequential"/>
@@ -15,9 +16,29 @@
 				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
 		<Configuration Name="Release|Win32" OutputDirectory="..\..\build\bin" TargetName="$(ProjectName)_$(PlatformName)">
 				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" PreprocessorDefinitions="NO_MESHMAPPING;GIT_INCLUDE_FILE='$(ProjectDir)\..\gitVersionInfo.h'" StandardWarnings="standardWarningsF03" DisableSpecificDiagnostics="5268" UseMkl="mklSequential"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" SubSystem="subSystemConsole"/>
+				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateManifest="false" SubSystem="subSystemConsole"/>
 				<Tool Name="VFResourceCompilerTool"/>
 				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
+				<Tool Name="VFCustomBuildTool"/>
+				<Tool Name="VFPreLinkEventTool"/>
+				<Tool Name="VFPreBuildEventTool" CommandLine="..\CreateGitVersion.bat"/>
+				<Tool Name="VFPostBuildEventTool"/>
+				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
+		<Configuration Name="Debug|x64" OutputDirectory="..\..\build\bin"  TargetName="$(ProjectName)_$(PlatformName)_$(ConfigurationName)">
+				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" PreprocessorDefinitions="NO_MESHMAPPING;GIT_INCLUDE_FILE='$(ProjectDir)\..\gitVersionInfo.h'" StandardWarnings="standardWarningsF03" DisableSpecificDiagnostics="5268" WarnDeclarations="true" WarnInterfaces="true" Traceback="true" RuntimeLibrary="rtMultiThreadedDebug" UseMkl="mklSequential"/>
+				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateManifest="false" GenerateDebugInformation="true" SubSystem="subSystemConsole"/>
+				<Tool Name="VFResourceCompilerTool"/>
+				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
+				<Tool Name="VFCustomBuildTool"/>
+				<Tool Name="VFPreLinkEventTool"/>
+				<Tool Name="VFPreBuildEventTool" CommandLine="..\CreateGitVersion.bat"/>
+				<Tool Name="VFPostBuildEventTool"/>
+				<Tool Name="VFManifestTool" SuppressStartupBanner="true"/></Configuration>
+		<Configuration Name="Release|x64" OutputDirectory="..\..\build\bin"  TargetName="$(ProjectName)_$(PlatformName)">
+				<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" Preprocess="preprocessYes" PreprocessorDefinitions="NO_MESHMAPPING;GIT_INCLUDE_FILE='$(ProjectDir)\..\gitVersionInfo.h'" StandardWarnings="standardWarningsF03" DisableSpecificDiagnostics="5268" UseMkl="mklSequential"/>
+				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateManifest="false" SubSystem="subSystemConsole"/>
+				<Tool Name="VFResourceCompilerTool"/>
+				<Tool Name="VFMidlTool" SuppressStartupBanner="true" TargetEnvironment="midlTargetAMD64"/>
 				<Tool Name="VFCustomBuildTool"/>
 				<Tool Name="VFPreLinkEventTool"/>
 				<Tool Name="VFPreBuildEventTool" CommandLine="..\CreateGitVersion.bat"/>


### PR DESCRIPTION
This affects cases where the number of components specified in the time-series input file is less than 3. In these cases, some parts of the velocity spectra were uninitialized or initialized improperly, giving random results.

Also changed some options for the Visual Studio TurbSim build and fixed a comment in InflowWind.