### PR TITLE
Reverse the testing order of the assertion

### DIFF
--- a/modules-local/beamdyn/tests/test_BD_InputGlobalLocal.F90
+++ b/modules-local/beamdyn/tests/test_BD_InputGlobalLocal.F90
@@ -80,23 +80,23 @@ subroutine test_BD_InputGlobalLocal()
     call BD_InputGlobalLocal(parametertype, inputtype)
     
     ! test the values
-    @assertEqual(inputtype%RootMotion%TranslationDisp(:,1), vectorAfterRotation, tolerance, testname)
-    @assertEqual(inputtype%RootMotion%TranslationVel(:,1) , vectorAfterRotation, tolerance, testname)
-    @assertEqual(inputtype%RootMotion%RotationVel(:,1)    , vectorAfterRotation, tolerance, testname)
-    @assertEqual(inputtype%RootMotion%TranslationAcc(:,1) , vectorAfterRotation, tolerance, testname)
-    @assertEqual(inputtype%RootMotion%RotationAcc(:,1)    , vectorAfterRotation, tolerance, testname)
+    @assertEqual(vectorAfterRotation, inputtype%RootMotion%TranslationDisp(:,1), tolerance, testname)
+    @assertEqual(vectorAfterRotation, inputtype%RootMotion%TranslationVel(:,1), tolerance, testname)
+    @assertEqual(vectorAfterRotation, inputtype%RootMotion%RotationVel(:,1), tolerance, testname)
+    @assertEqual(vectorAfterRotation, inputtype%RootMotion%TranslationAcc(:,1), tolerance, testname)
+    @assertEqual(vectorAfterRotation, inputtype%RootMotion%RotationAcc(:,1), tolerance, testname)
     
     do i = 1, parametertype%node_total
-       @assertEqual(inputtype%PointLoad%Force(1:3,i) , vectorAfterRotation, tolerance, testname)
-       @assertEqual(inputtype%PointLoad%Moment(1:3,i), vectorAfterRotation, tolerance, testname)
+       @assertEqual(vectorAfterRotation, inputtype%PointLoad%Force(1:3,i), tolerance, testname)
+       @assertEqual(vectorAfterRotation, inputtype%PointLoad%Moment(1:3,i), tolerance, testname)
     end do
     
     inputtype%DistrLoad%Nnodes = totalnodes
     do i = 1, inputtype%DistrLoad%Nnodes
-       @assertEqual(inputtype%DistrLoad%Force(1:3,i) , vectorAfterRotation, tolerance, testname)
-       @assertEqual(inputtype%DistrLoad%Moment(1:3,i), vectorAfterRotation, tolerance, testname)
+       @assertEqual(vectorAfterRotation, inputtype%DistrLoad%Force(1:3,i), tolerance, testname)
+       @assertEqual(vectorAfterRotation, inputtype%DistrLoad%Moment(1:3,i), tolerance, testname)
     end do
     
-    @assertEqual(inputtype%RootMotion%Orientation(:,:,1), transpose(parametertype%GlbRot), tolerance, testname)
+    @assertEqual(transpose(parametertype%GlbRot), inputtype%RootMotion%Orientation(:,:,1), tolerance, testname)
     
 end subroutine


### PR DESCRIPTION
The “truth” solution should be the first argument so that pfunit error messages have correct values for the “received” and “expected” fields. This fixes #153 .