### PR TITLE
Fix single precision build bugs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -58,10 +58,10 @@ matrix:
 
 script:
     # beamdyn unit tests
-    - ctest -R beamdyn_utest
+    - if [[ "$DOUBLE_PRECISION" == "ON" ]]; then ctest -R beamdyn_utest; fi
 
     # beamdyn regression tests
-    - ctest -R bd_
+    - if [[ "$DOUBLE_PRECISION" == "ON" ]]; then ctest -R bd_; fi
 
     # subset of openfast regression tests
     # do not run

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -83,12 +83,12 @@ macro(set_fast_gfortran)
   endif(NOT WIN32)
 
   # Fix free-form compilation for OpenFAST
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -cpp")
 
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DDOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -cpp -fdefault-real-8")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
   endif (DOUBLE_PRECISION)
 
   # debug flags
@@ -113,11 +113,11 @@ endmacro(set_fast_intel_fortran)
 # arch
 #
 macro(set_fast_intel_fortran_posix)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpic ")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpic -fpp")
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DDOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpp -r8 -double_size 128")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double_size 128")
   endif (DOUBLE_PRECISION)
 
   # debug flags
@@ -131,16 +131,16 @@ endmacro(set_fast_intel_fortran_posix)
 # windows arch
 #
 macro(set_fast_intel_fortran_windows)
-  # Deal with Double/Single precision
-  if (DOUBLE_PRECISION)
-    add_definitions(-DDOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /fpp /real_size:64 /double_size:128")
-  endif (DOUBLE_PRECISION)
-
   # Turn off specific warnings
   # - 5199: too many continuation lines
   # - 5268: 132 column limit
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /Qdiag-disable:5199,5268")
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /Qdiag-disable:5199,5268 /fpp")
+
+  # Deal with Double/Single precision
+  if (DOUBLE_PRECISION)
+    add_definitions(-DDOUBLE_PRECISION)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /real_size:64 /double_size:128")
+  endif (DOUBLE_PRECISION)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)

--- a/modules-local/beamdyn/src/BeamDyn.f90
+++ b/modules-local/beamdyn/src/BeamDyn.f90
@@ -3673,6 +3673,9 @@ SUBROUTINE BD_FD_Stat( x, gravity, p, m, ErrStat, ErrMsg )
     CHARACTER(ErrMsgLen)                           :: ErrMsg2  ! Temporary Error message
     CHARACTER(*), PARAMETER                        :: RoutineName = 'BD_FD_Stat'
 
+    ErrStat = ErrID_None
+    ErrMsg  = ""
+
     ! zero out the local matrices.
     m%RHS_m    = 0.0_BDKi
     m%RHS_p    = 0.0_BDKi
@@ -4816,6 +4819,9 @@ SUBROUTINE BD_FD_GA2( x, OtherState, p, m, ErrStat, ErrMsg )
     INTEGER(IntKi)                                 :: ErrStat2 ! Temporary Error status
     CHARACTER(ErrMsgLen)                           :: ErrMsg2  ! Temporary Error message
     CHARACTER(*), PARAMETER                        :: RoutineName = 'BD_FD_GA2'
+
+    ErrStat = ErrID_None
+    ErrMsg  = ""
 
     ! zero out the local matrices. Not sure where these should be initailzed
     m%RHS_m    = 0.0_BDKi

--- a/modules-local/beamdyn/src/Registry_BeamDyn.txt
+++ b/modules-local/beamdyn/src/Registry_BeamDyn.txt
@@ -221,8 +221,8 @@ typedef   ^        ParameterType IntKi          qp_indx_offset   -         - -  
 typedef   ^        ParameterType IntKi          BldMotionNodeLoc -         - -  "switch to determine where the nodes on the blade motion mesh should be located 1=FE (GLL) nodes; 2=quadrature nodes; 3=blade input stations"
 typedef   ^        ParameterType Logical        tngt_stf_fd      -         - -  "Flag to compute tangent stifness matrix via finite difference" - 
 typedef   ^        ParameterType Logical        tngt_stf_comp    -         - -  "Flag to compare finite differenced and analytical tangent stifness" - 
-typedef   ^        ParameterType ReKi           tngt_stf_pert    -         - -  "Perturbation size for computing finite differenced tangent stiffness" - 
-typedef   ^        ParameterType ReKi           tngt_stf_difftol -         - -  "When comparing tangent stiffness matrix, stop simulation if error greater than this" -
+typedef   ^        ParameterType R8Ki           tngt_stf_pert    -         - -  "Perturbation size for computing finite differenced tangent stiffness" - 
+typedef   ^        ParameterType R8Ki           tngt_stf_difftol -         - -  "When comparing tangent stiffness matrix, stop simulation if error greater than this" -
 # .... arrays for optimization ........................................................................................................
 typedef   ^        ParameterType    R8Ki        QPtw_Shp_Shp_Jac       {:}{:}{:}{:}  - - "optimization variable: QPtw_Shp_Shp_Jac(idx_qp,i,j,nelem) = p%Shp(i,idx_qp)*p%Shp(j,idx_qp)*p%QPtWeight(idx_qp)*p%Jacobian(idx_qp,nelem)" -
 typedef   ^        ParameterType    ^           QPtw_Shp_ShpDer        {:}{:}{:}     - - "optimization variable: QPtw_Shp_ShpDer(idx_qp,i,j) = p%Shp(i,idx_qp)*p%ShpDer(j,idx_qp)*p%QPtWeight(idx_qp)" -

--- a/modules-local/beamdyn/tests/test_BD_CheckRotMat.F90
+++ b/modules-local/beamdyn/tests/test_BD_CheckRotMat.F90
@@ -36,8 +36,8 @@ subroutine test_BD_CheckRotMat()
     ! --------------------------------------------------------------------------    
     testname = "known invalid rotation matrix: halve the angle of the diagonal elements:"
     ! this should produce a fatal error (ErrStat = 4)
-    testR(:,2) = (/ testR(1,2),  cos(Pi/2), testR(3,2) /)
-    testR(:,3) = (/ testR(1,2), testR(2,2),  cos(Pi/2) /)
+    testR(:,2) = (/ testR(1,2), cos(real(Pi/2, BDKi)),            testR(3,2) /)
+    testR(:,3) = (/ testR(1,2),            testR(2,2), cos(real(Pi/2, BDKi)) /)
     call BD_CheckRotMat(testR, ErrStat, ErrMsg)    
     @assertEqual(4, ErrStat, testname)
 

--- a/modules-local/beamdyn/tests/test_BD_CrvExtractCrv.F90
+++ b/modules-local/beamdyn/tests/test_BD_CrvExtractCrv.F90
@@ -39,7 +39,7 @@ subroutine test_BD_CrvExtractCrv()
     r = RonXAxis(angle)
     call BD_CrvExtractCrv(r, test_wmparams, ErrStat, ErrMsg)
     
-    @assertEqual(0.0, ErrStat, tolerance, testname)
+    @assertEqual(0.0_BDKi, ErrStat, tolerance, testname)
     @assertEqual(baseline_wmparams, test_wmparams, tolerance, testname)
     
     
@@ -53,7 +53,7 @@ subroutine test_BD_CrvExtractCrv()
     r = RonXAxis(angle)
     call BD_CrvExtractCrv(r, test_wmparams, ErrStat, ErrMsg)
     
-    @assertEqual(0.0, ErrStat, tolerance, testname)
+    @assertEqual(0.0_BDKi, ErrStat, tolerance, testname)
     @assertEqual(baseline_wmparams, test_wmparams, tolerance, testname)
     
     
@@ -67,7 +67,7 @@ subroutine test_BD_CrvExtractCrv()
     r = RonXAxis(angle)
     call BD_CrvExtractCrv(r, test_wmparams, ErrStat, ErrMsg)
     
-    @assertEqual(0.0, ErrStat, tolerance, testname)
+    @assertEqual(0.0_BDKi, ErrStat, tolerance, testname)
     @assertEqual(baseline_wmparams, test_wmparams, tolerance, testname)
         
 end subroutine test_BD_CrvExtractCrv

--- a/modules-local/beamdyn/tests/test_BD_InputGlobalLocal.F90
+++ b/modules-local/beamdyn/tests/test_BD_InputGlobalLocal.F90
@@ -44,7 +44,7 @@ subroutine test_BD_InputGlobalLocal()
     
     ! build the parameter type
     parametertype%node_total = totalnodes
-    parametertype%GlbRot = calcRotationMatrix(Pi, rotationaxis)
+    parametertype%GlbRot = calcRotationMatrix(real(Pi, BDKi), rotationaxis)
     
     ! build the inputs    
     call AllocAry(inputtype%RootMotion%TranslationDisp, 3, 1, 'TranslationDisp', ErrStat, ErrMsg)
@@ -80,21 +80,21 @@ subroutine test_BD_InputGlobalLocal()
     call BD_InputGlobalLocal(parametertype, inputtype)
     
     ! test the values
-    @assertEqual(vectorAfterRotation, inputtype%RootMotion%TranslationDisp(:,1), tolerance, testname)
-    @assertEqual(vectorAfterRotation, inputtype%RootMotion%TranslationVel(:,1), tolerance, testname)
-    @assertEqual(vectorAfterRotation, inputtype%RootMotion%RotationVel(:,1), tolerance, testname)
-    @assertEqual(vectorAfterRotation, inputtype%RootMotion%TranslationAcc(:,1), tolerance, testname)
-    @assertEqual(vectorAfterRotation, inputtype%RootMotion%RotationAcc(:,1), tolerance, testname)
+    @assertEqual(vectorAfterRotation, real(inputtype%RootMotion%TranslationDisp(:,1), BDKi), tolerance, testname)
+    @assertEqual(vectorAfterRotation, real(inputtype%RootMotion%TranslationVel(:,1), BDKi), tolerance, testname)
+    @assertEqual(vectorAfterRotation, real(inputtype%RootMotion%RotationVel(:,1), BDKi), tolerance, testname)
+    @assertEqual(vectorAfterRotation, real(inputtype%RootMotion%TranslationAcc(:,1), BDKi), tolerance, testname)
+    @assertEqual(vectorAfterRotation, real(inputtype%RootMotion%RotationAcc(:,1), BDKi), tolerance, testname)
     
     do i = 1, parametertype%node_total
-       @assertEqual(vectorAfterRotation, inputtype%PointLoad%Force(1:3,i), tolerance, testname)
-       @assertEqual(vectorAfterRotation, inputtype%PointLoad%Moment(1:3,i), tolerance, testname)
+       @assertEqual(vectorAfterRotation, real(inputtype%PointLoad%Force(1:3,i), BDKi), tolerance, testname)
+       @assertEqual(vectorAfterRotation, real(inputtype%PointLoad%Moment(1:3,i), BDKi), tolerance, testname)
     end do
     
     inputtype%DistrLoad%Nnodes = totalnodes
     do i = 1, inputtype%DistrLoad%Nnodes
-       @assertEqual(vectorAfterRotation, inputtype%DistrLoad%Force(1:3,i), tolerance, testname)
-       @assertEqual(vectorAfterRotation, inputtype%DistrLoad%Moment(1:3,i), tolerance, testname)
+       @assertEqual(vectorAfterRotation, real(inputtype%DistrLoad%Force(1:3,i), BDKi), tolerance, testname)
+       @assertEqual(vectorAfterRotation, real(inputtype%DistrLoad%Moment(1:3,i), BDKi), tolerance, testname)
     end do
     
     @assertEqual(transpose(parametertype%GlbRot), inputtype%RootMotion%Orientation(:,:,1), tolerance, testname)

--- a/modules-local/beamdyn/tests/test_tools.F90
+++ b/modules-local/beamdyn/tests/test_tools.F90
@@ -51,9 +51,9 @@ contains
         
         real(BDKi) :: angle, r(3,3), RonXAxis(3,3)
         
-        r(1,:) = (/  1.0,         0.0,         0.0 /)
-        r(2,:) = (/  0.0,  cos(angle), -sin(angle) /)
-        r(3,:) = (/  0.0,  sin(angle),  cos(angle) /)
+        r(1,:) = (/  1.0_BDKi,    0.0_BDKi,    0.0_BDKi /)
+        r(2,:) = (/  0.0_BDKi,  cos(angle), -sin(angle) /)
+        r(3,:) = (/  0.0_BDKi,  sin(angle),  cos(angle) /)
         RonXAxis = r
     end function  
         


### PR DESCRIPTION
This pull request improves on #168 regarding single precision build bugs introduced in #155. There are also improvements to the BeamDyn unit tests allowing them to build properly. This pull request **does not** address the question of tolerance in single precision for any of the tests.