### PR TITLE
Fixed undefined behaviour in VariousWaves_Init.

### DIFF
--- a/modules-local/hydrodyn/src/Waves.f90
+++ b/modules-local/hydrodyn/src/Waves.f90
@@ -1642,6 +1642,8 @@ SUBROUTINE VariousWaves_Init ( InitInp, InitOut, ErrStat, ErrMsg )
             ENDDO
          ENDDO
 
+         InitOut%WaveDirArr(InitOut%NStepWave2) = 0.0_ReKi
+
             ! Perform a quick sanity check.  We should have assigned all wave frequencies a direction, so K should be
             ! K = NStepWave2 (K is incrimented afterwards).
          IF ( K /= (InitOut%NStepWave2 ) )    CALL SetErrStat(ErrID_Fatal,  &


### PR DESCRIPTION
InitOut%WaveDirArr(InitOut%NStepWave2) is not set in case of
multi-directional waves. This leads to undefined behaviour (read of
uninitialized value).

Set this value to 0 as workaround (this generates defined behaviour).
The correct fix is unclear: maybe InitOut%WaveDirArr(0) should be set
to 0 and the index K starting from 1 then???