### PR TITLE
Bug fix in allocating tower elevation array

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 # mac configuration
 before_install:
     # first uninstall a conflicting package
-    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
+    # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
 
     # install required packages
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ env:
 # mac configuration
 before_install:
     # first uninstall a conflicting package
-    # - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
+#    - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask uninstall oclint; fi
 
     # install required packages
     - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi

--- a/modules-local/aerodyn/src/AeroDyn.f90
+++ b/modules-local/aerodyn/src/AeroDyn.f90
@@ -231,14 +231,14 @@ subroutine AD_SetInitOut(p, InputFileData, InitOut, errStat, errMsg)
    end do
 
    !Tower data
-   ALLOCATE(InitOut%TwrElev(p%NumTwrNds), STAT = ErrStat2)
-   IF (ErrStat2 /= 0) THEN
-      CALL SetErrStat(ErrID_Fatal,"Error allocating memory for TwrElev.", ErrStat, ErrMsg, RoutineName)
-      RETURN
-   END IF
-   InitOut%TwrElev(:) = InputFileData%TwrElev(:)
-   
    IF ( p%NumTwrNds > 0 ) THEN
+      ALLOCATE(InitOut%TwrElev(p%NumTwrNds), STAT = ErrStat2)
+      IF (ErrStat2 /= 0) THEN
+         CALL SetErrStat(ErrID_Fatal,"Error allocating memory for TwrElev.", ErrStat, ErrMsg, RoutineName)
+         RETURN
+      END IF
+      InitOut%TwrElev(:) = InputFileData%TwrElev(:)
+
       ALLOCATE(InitOut%TwrDiam(p%NumTwrNds), STAT = ErrStat2)
       IF (ErrStat2 /= 0) THEN
          CALL SetErrStat(ErrID_Fatal,"Error allocating memory for TwrDiam.", ErrStat, ErrMsg, RoutineName)


### PR DESCRIPTION
This pull request moves an array allocation into an if-statement which determines whether the array should be allocated.

The problem arises when `NumTwrNds` is not 0 in the input but this block at [AeroDyn.f90L928](https://github.com/OpenFAST/openfast/blob/dev/modules-local/aerodyn/src/AeroDyn.f90#L928) executes:
```
   if (p%TwrPotent == TwrPotent_none .and. .not. p%TwrShadow .and. .not. p%TwrAero) then
      p%NumTwrNds     = 0
```
This causes `InitOut%TwrElev` to be allocated to an array of length 0 while `InputFileData%TwrElev` is nonzero so this line at [AeroDyn.f90L239](https://github.com/OpenFAST/openfast/blob/dev/modules-local/aerodyn/src/AeroDyn.f90#L239) is a seg fault:
```
InitOut%TwrElev(:) = InputFileData%TwrElev(:)
```

All regression tests pass since none test this particular case.