### PR TITLE
Bug fix in compiling DWM Driver with intel

### DIFF
--- a/modules-local/aerodyn14/src/DWM_driver_wind_farm.f90
+++ b/modules-local/aerodyn14/src/DWM_driver_wind_farm.f90
@@ -3,7 +3,7 @@ PROGRAM DWM_driver_wind_farm
    USE DWM_driver_wind_farm_sub
    USE read_wind_farm_parameter_data, ONLY: NumWT, DWM_exe_name
    USE DWM_init_data, ONLY:InputFile
-#ifdef _WIN32
+#ifdef __INTEL_COMPILER
    USE IFPORT
 #endif
    

--- a/modules-local/aerodyn14/src/DWM_driver_wind_farm_sub.f90
+++ b/modules-local/aerodyn14/src/DWM_driver_wind_farm_sub.f90
@@ -838,9 +838,8 @@ SUBROUTINE rename_FAST_output(SimulationOrder_index)
 !............................................................................
 ! This routine is called to rename the fast output
 !............................................................................
-#ifdef _WIN32
+#ifdef __INTEL_COMPILER
     USE IFPORT
-    USE DFLIB
 #endif
     USE wind_farm_geometry_data,         ONLY: turbine_sort
     USE DWM_init_data,                   ONLY: OutFileRoot


### PR DESCRIPTION
This pull request fixes a bug introduced in #146 where the DWM driver does not compiler with ifort on linux or Mac. The regression test caught this error, but the continuous integration system did not. However, #203 is intending to include an intel compiled branch in the continuous integration system so this will be caught immediately in the future.