### PR TITLE
HydroDyn: check for valid file unit before attempting to close

### DIFF
--- a/modules-local/hydrodyn/src/HydroDyn.f90
+++ b/modules-local/hydrodyn/src/HydroDyn.f90
@@ -1282,17 +1282,15 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
       IF(ALLOCATED( Waves_InitOut%WaveElevC0 ))  DEALLOCATE( Waves_InitOut%WaveElevC0 )
       !IF(ALLOCATED( InitLocal%WAMIT%WaveElevC0 ))  DEALLOCATE( InitLocal%WAMIT%WaveElevC0)
       
-         
-      
          ! Close the summary file
-         
-      CALL HDOut_CloseSum( InitLocal%UnSum, ErrStat2, ErrMsg2 )
-         CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-         IF ( ErrStat >= AbortErrLev ) THEN
-            CALL CleanUp()
-            RETURN
-         END IF
-    
+      IF ( InitLocal%UnSum > 0 ) THEN
+         CALL HDOut_CloseSum( InitLocal%UnSum, ErrStat2, ErrMsg2 )
+            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+            IF ( ErrStat >= AbortErrLev ) THEN
+               CALL CleanUp()
+               RETURN
+            END IF
+      END IF
       
       ! Define system output initializations (set up mesh) here:
       

--- a/modules-local/hydrodyn/src/HydroDyn.f90
+++ b/modules-local/hydrodyn/src/HydroDyn.f90
@@ -1283,7 +1283,7 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
       !IF(ALLOCATED( InitLocal%WAMIT%WaveElevC0 ))  DEALLOCATE( InitLocal%WAMIT%WaveElevC0)
       
          ! Close the summary file
-      IF ( InitLocal%UnSum > 0 ) THEN
+      IF ( InitLocal%HDSum ) THEN
          CALL HDOut_CloseSum( InitLocal%UnSum, ErrStat2, ErrMsg2 )
             CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
             IF ( ErrStat >= AbortErrLev ) THEN


### PR DESCRIPTION
Turning off `Hdsum` in HydroDyn leads to a seg fault since HydroDyn tries to close a file which is not opened to begin with. This pull request checks for a valid file unit before attempting to close the HydroDyn summary file.

This was reported at https://wind.nrel.gov/forum/wind/viewtopic.php?f=4&t=1111&start=15.