### PR TITLE
Bug fix for reported external buoyancy

### DIFF
--- a/modules-local/hydrodyn/src/Morison.f90
+++ b/modules-local/hydrodyn/src/Morison.f90
@@ -1194,23 +1194,27 @@ SUBROUTINE WriteSummaryFile( UnSum, MSL2SWL, WtrDpth, numNodes, nodes, numElemen
       
       
          ! Attach the external distributed buoyancy loads to the distributed mesh so they can be transferred to the WRP
-         
+      
+         ! Because of wave stretching and user-supplied waves, we may have loads above the still water line (SWL) which will be used
+         ! in the hydrodynamics for conditions where the wave height is > SWL.  So we now need to check that the vertical position
+         ! is <= SWL for this summary file calculation.
+      
       DO J = 1, outDistribMesh%Nnodes
-         
-         DO I=1,6
+         if ( outDistribMesh%Position(3,J) <= MSL2SWL ) then
+            DO I=1,6
             
-            IF (I < 4 ) THEN           
+               IF (I < 4 ) THEN
                
-               outDistribMesh%Force(I   ,J) = D_F_B(I,J) 
+                  outDistribMesh%Force(I   ,J) = D_F_B(I,J)
             
-            ELSE
+               ELSE
                
-               outDistribMesh%Moment(I-3,J) = D_F_B(I,J)
+                  outDistribMesh%Moment(I-3,J) = D_F_B(I,J)
                
-            END IF
+               END IF
             
-         END DO  ! DO I
-         
+            END DO  ! DO I
+         end if              ! <= MSL2SWL check
       END DO ! DO J
       
  
@@ -1226,23 +1230,27 @@ SUBROUTINE WriteSummaryFile( UnSum, MSL2SWL, WtrDpth, numNodes, nodes, numElemen
       
       
          ! Transfer the loads from the lumped mesh to the (0,0,0) point mesh
-         
+
+         ! Because of wave stretching and user-supplied waves, we may have loads above the still water line (SWL) which will be used
+         ! in the hydrodynamics for conditions where the wave height is > SWL.  So we now need to check that the vertical position
+         ! is <= SWL for this summary file calculation.
+
       DO J = 1, outLumpedMesh%Nnodes
-          
-         DO I=1,6
+         if ( outLumpedMesh%Position(3,J) <= MSL2SWL ) then 
+            DO I=1,6
             
-            IF (I < 4 ) THEN           
+               IF (I < 4 ) THEN           
                
-               outLumpedMesh%Force(I   ,J) = L_F_B(I,J) 
+                  outLumpedMesh%Force(I   ,J) = L_F_B(I,J)
             
-            ELSE
+               ELSE
                
-               outLumpedMesh%Moment(I-3,J) = L_F_B(I,J)
+                  outLumpedMesh%Moment(I-3,J) = L_F_B(I,J)
                
-            END IF
+               END IF
             
-         END DO  ! DO I
-         
+            END DO  ! DO I
+         end if              ! <= MSL2SWL check
       END DO ! DO J
       
          ! Remap for the lumped to WRP mesh transfer       
@@ -1272,9 +1280,9 @@ SUBROUTINE WriteSummaryFile( UnSum, MSL2SWL, WtrDpth, numNodes, nodes, numElemen
          
          DO I=1,6
             
-            IF (I < 4 ) THEN           
+            IF (I < 4 ) THEN
                
-               outDistribMesh%Force(I,J   ) = D_F_BF(I,J) 
+               outDistribMesh%Force(I,J   ) = D_F_BF(I,J)
                
             ELSE
                
@@ -1296,9 +1304,9 @@ SUBROUTINE WriteSummaryFile( UnSum, MSL2SWL, WtrDpth, numNodes, nodes, numElemen
          
          DO I=1,6
             
-            IF (I < 4 ) THEN           
+            IF (I < 4 ) THEN
                
-               outLumpedMesh%Force(I,J) = L_F_BF(I,J) 
+               outLumpedMesh%Force(I,J) = L_F_BF(I,J)
             
             ELSE
                


### PR DESCRIPTION
Corrects reported external buoyancy in the HydroDyn summary file, issue [#202](https://github.com/OpenFAST/openfast/issues/202).

For a previous spar example HD reported:

Volume Calculations(m^3)
------------------------
  Structure Volume     :    1.36265E+04
  Submerged Volume     :    1.30854E+04
  Marine Growth Volume :    0.00000E+00
  Ballasted Volume     :    0.00000E+00


External Buoyancy loads summed about ( 0.0, 0.0, 0.0 )
---------------------------------------------
BuoyFzi     = 1.369697E+08          


After this bug fix, the code now correctly reports:

External Buoyancy loads summed about ( 0.0, 0.0, 0.0 )
---------------------------------------------
BuoyFzi     = 1.315310E+08          