### PR TITLE
[BugFix] BeamDyn damping coefficients

### DIFF
--- a/modules-local/beamdyn/src/BeamDyn.f90
+++ b/modules-local/beamdyn/src/BeamDyn.f90
@@ -2328,7 +2328,10 @@ SUBROUTINE BD_StifAtDeformedQP( nelem, p, m )
 
    INTEGER(IntKi)                :: idx_qp         !< index counter for quadrature point
    INTEGER(IntKi)                :: temp_id2       !< Index to last node of previous element
+   INTEGER(IntKi)                :: i,j            !< generic counters
    REAL(BDKi)                    :: tempR6(6,6)
+   REAL(BDKi)                    :: tempBeta6(6,6)
+
 
    ! see Bauchau 2011 Flexible Multibody Dynamics p 692-693, section 17.7.2
 
@@ -2340,12 +2343,24 @@ SUBROUTINE BD_StifAtDeformedQP( nelem, p, m )
 
          ! Setup the temporary matrix for modifying the stiffness matrix. RR0 is changing with time.
       tempR6 = 0.0_BDKi
+      tempBeta6 = 0.0_BDKi
       tempR6(1:3,1:3) = m%qp%RR0(:,:,idx_qp,nelem)       ! upper left   -- translation
       tempR6(4:6,4:6) = m%qp%RR0(:,:,idx_qp,nelem)       ! lower right  -- rotation
-!NOTE: Bauchau has the lower right corner multiplied by H
+         !NOTE: Bauchau has the lower right corner multiplied by H
+
+         ! Move damping ratio from material frame to the calculation reference frame
+         !     This is the following:
+         !        tempBEta6=matmul(tempR6,matmul(diag(p%beta),transpose(tempR6)))
+      do j=1,6
+         do i=1,6
+               ! diagonal of p%beta * TRANSPOSE(tempR6)
+            tempBeta6(i,j) = p%beta(i)*tempR6(j,i)
+         enddo
+      enddo
+      tempBeta6 = matmul(tempR6,tempBeta6)
 
 
-         !> Modify the Mass matrix as
+         !> Modify the Mass matrix so it is in the calculation reference frame
          !! \f$ \begin{bmatrix}
          !!        \left(\underline{\underline{R}} \underline{\underline{R}}_0\right)      &  0             \\
          !!                      0  &  \left(\underline{\underline{R}} \underline{\underline{R}}_0\right)
@@ -2356,6 +2371,9 @@ SUBROUTINE BD_StifAtDeformedQP( nelem, p, m )
          !!                      0  &  \left(\underline{\underline{R}} \underline{\underline{R}}_0\right)^T
          !!     \end{bmatrix} \f$
       m%qp%Stif(:,:,idx_qp,nelem) = MATMUL(tempR6,MATMUL(p%Stif0_QP(1:6,1:6,temp_id2+idx_qp),TRANSPOSE(tempR6)))
+
+         ! Now apply the damping
+      m%qp%betaC(:,:,idx_qp,nelem) = matmul(tempBeta6,m%qp%Stif(:,:,idx_qp,nelem))
    ENDDO
 
 END SUBROUTINE BD_StifAtDeformedQP
@@ -2803,15 +2821,6 @@ SUBROUTINE BD_DissipativeForce( nelem, p, m,fact )
 
    INTEGER(IntKi)              :: idx_qp      !< index of current quadrature point
    
-   DO idx_qp=1,p%nqp
-      !m%qp%betaC(:,:,idx_qp,nelem) = MATMUL( diag(p%beta(i)), temp_b,m%qp%Stif(:,:,idx_qp,nelem))
-      DO j=1,6
-         DO i=1,6
-            m%qp%betaC(i,j,idx_qp,nelem) = p%beta(i)*m%qp%Stif(i,j,idx_qp,nelem)
-         END DO
-      END DO
-   END DO
-
    
    IF (.NOT. fact) then ! skip all but Fc and Fd terms
    


### PR DESCRIPTION
The damping coefficients were in the in incorrect reference frame.  This PR corrects this.

@ashesh2512, can you verify this produces the same results as the linearization results from yesterday?

My apologies for not fully testing this (it has been verified in the Envision-Energy code base and cherry-picked for this PR).