### PR TITLE
Wrap python exe in quotes when passing to system

### DIFF
--- a/reg_tests/manualRegressionTest.py
+++ b/reg_tests/manualRegressionTest.py
@@ -72,7 +72,7 @@ prefix, passString, failString = "executing", "PASS", "FAIL"
 longestName = max(casenames, key=len)
 for case in casenames:
     print(strFormat(prefix).format(prefix), strFormat(longestName+" ").format(case), end="", flush=True)
-    command = "{} executeOpenfastRegressionCase.py {} {} {} {} {} {} {} {} {}".format(pythonCommand, case, openfast_executable, sourceDirectory, buildDirectory, tolerance, machine, compiler, plotFlag, noExecFlag)
+    command = "\"{}\" executeOpenfastRegressionCase.py {} {} {} {} {} {} {} {} {}".format(pythonCommand, case, openfast_executable, sourceDirectory, buildDirectory, tolerance, machine, compiler, plotFlag, noExecFlag)
     returnCode = subprocess.call(command, stdout=outstd, shell=True)
     resultString = passString if returnCode == 0 else failString
     results.append((case, resultString))


### PR DESCRIPTION
When the path to the python interpreter contains spaces, the command created to run the OpenFAST case fails. Wrapping it in quotes will include the spaces correctly. This fixes issue #215.