### PR TITLE
Setting last value of WaveDirArr (Closes #236)

### DIFF
--- a/modules-local/hydrodyn/src/Waves.f90
+++ b/modules-local/hydrodyn/src/Waves.f90
@@ -1641,6 +1641,10 @@ SUBROUTINE VariousWaves_Init ( InitInp, InitOut, ErrStat, ErrMsg )
 
             ENDDO
          ENDDO
+         ! Filling last value since it is not reached by the loop above
+         CALL RANDOM_NUMBER(WvSpreadThetaIdx)
+         LastInd  = MINLOC( WvSpreadThetaIdx, DIM=1 )
+         InitOut%WaveDirArr(K)   =  WvTheta( LastInd )
 
             ! Perform a quick sanity check.  We should have assigned all wave frequencies a direction, so K should be
             ! K = NStepWave2 (K is incrimented afterwards).


### PR DESCRIPTION
**THIS PULL REQUEST IS READY TO MERGE**

**Feature or improvement description**

Fixes #236

**Related issue, if one exists**

See #236

**Impacted areas of the software**

Impacts HydroDyn but impact is minor since only the last value of the array (i.e the last frequency) had an erroneous wave direction in. 

