### PR TITLE
Adding safety on number of lines and number of fields per line when WaveMode=6 (Should Fix #118)

### DIFF
--- a/modules-local/hydrodyn/src/HydroDyn_DriverCode.f90
+++ b/modules-local/hydrodyn/src/HydroDyn_DriverCode.f90
@@ -127,6 +127,9 @@ PROGRAM HydroDynDriver
    CHARACTER(200)                   :: git_commit    ! String containing the current git commit hash
 
    TYPE(ProgDesc), PARAMETER        :: version   = ProgDesc( 'HydroDyn Driver', '', '' )  ! The version number of this program.
+
+   ! Variables Init
+   Time = -99999
    
    !...............................................................................................................................
    ! Routines called in initialization


### PR DESCRIPTION
**THIS PULL REQUEST IS READY TO MERGE**

**Feature or improvement description**

Input files are now checked for sufficient number of lines, and each line is checked to see if enough columns are provided. Explicit error messages with recommendations are provided.
The format is still rather flexible. One line of comment is required at the beginning of the file. 
The file should then contain `n x m` values space, or comma separated, with `n>=WaveTMax/WaveDt` and `m>=NNodes` (the number of internal HydroDyn Nodes. If we want strict equality, it's a bit more work. 

**Related issue, if one exists**

See #118
 
**Impacted areas of the software**

HydroDyn with `WaveMod=6`

**Automated test results**

None, but the safety checks can be tried by removing some data in the input file (either a line or a single field), and HydroDyn should now mention where the data is missing in the file. 