### PR TITLE
Fix out-of-bounds memory access in C++ API

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -2,6 +2,7 @@
 #include <iostream>
 #include <fstream>
 #include <cmath>
+#include <algorithm>
 
 int fast::OpenFAST::AbortErrLev = ErrID_Fatal; // abort error level; compare with NWTC Library
 
@@ -39,6 +40,8 @@ inline bool fast::OpenFAST::checkFileExists(const std::string& name) {
 }
 
 void fast::OpenFAST::init() {
+  // Temporary buffer to pass filenames to OpenFAST fortran subroutines
+  char currentFileName[INTERFACE_STRING_LENGTH];
 
   allocateMemory();
 
@@ -49,7 +52,14 @@ void fast::OpenFAST::init() {
 
      for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
        /* note that this will set nt_global inside the FAST library */
-       FAST_OpFM_Restart(&iTurb, CheckpointFileRoot[iTurb].data(), &AbortErrLev, &dtFAST, &numBlades[iTurb], &numVelPtsBlade[iTurb], &ntStart, &cDriver_Input_from_FAST[iTurb], &cDriver_Output_to_FAST[iTurb], &cDriverSC_Input_from_FAST[iTurb], &cDriverSC_Output_to_FAST[iTurb], &ErrStat, ErrMsg);
+       std::copy(CheckpointFileRoot[iTurb].data(),
+                 CheckpointFileRoot[iTurb].data() + (CheckpointFileRoot[iTurb].size() + 1),
+                 currentFileName);
+       FAST_OpFM_Restart(
+           &iTurb, currentFileName, &AbortErrLev, &dtFAST, &numBlades[iTurb],
+           &numVelPtsBlade[iTurb], &ntStart, &cDriver_Input_from_FAST[iTurb],
+           &cDriver_Output_to_FAST[iTurb], &cDriverSC_Input_from_FAST[iTurb],
+           &cDriverSC_Output_to_FAST[iTurb], &ErrStat, ErrMsg);
        checkError(ErrStat, ErrMsg);
        nt_global = ntStart;
 
@@ -72,9 +82,19 @@ void fast::OpenFAST::init() {
       // this calls the Init() routines of each module
 
      for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
-       FAST_OpFM_Init(&iTurb, &tMax, FASTInputFileName[iTurb].data(), &TurbID[iTurb], &numScOutputs, &numScInputs, &numForcePtsBlade[iTurb], &numForcePtsTwr[iTurb], TurbineBasePos[iTurb].data(), &AbortErrLev, &dtFAST, &numBlades[iTurb], &numVelPtsBlade[iTurb], &cDriver_Input_from_FAST[iTurb], &cDriver_Output_to_FAST[iTurb], &cDriverSC_Input_from_FAST[iTurb], &cDriverSC_Output_to_FAST[iTurb], &ErrStat, ErrMsg);
+       std::copy(FASTInputFileName[iTurb].data(),
+                 FASTInputFileName[iTurb].data() + (FASTInputFileName[iTurb].size() + 1),
+                 currentFileName);
+       FAST_OpFM_Init(&iTurb, &tMax, currentFileName, &TurbID[iTurb],
+                      &numScOutputs, &numScInputs, &numForcePtsBlade[iTurb],
+                      &numForcePtsTwr[iTurb], TurbineBasePos[iTurb].data(),
+                      &AbortErrLev, &dtFAST, &numBlades[iTurb],
+                      &numVelPtsBlade[iTurb], &cDriver_Input_from_FAST[iTurb],
+                      &cDriver_Output_to_FAST[iTurb],
+                      &cDriverSC_Input_from_FAST[iTurb],
+                      &cDriverSC_Output_to_FAST[iTurb], &ErrStat, ErrMsg);
        checkError(ErrStat, ErrMsg);
-       
+
        timeZero = true;
 
        numVelPtsTwr[iTurb] = cDriver_Output_to_FAST[iTurb].u_Len - numBlades[iTurb]*numVelPtsBlade[iTurb] - 1;
@@ -102,9 +122,19 @@ void fast::OpenFAST::init() {
     case fast::restartDriverInitFAST:
 
      for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
-       FAST_OpFM_Init(&iTurb, &tMax, FASTInputFileName[iTurb].data(), &TurbID[iTurb], &numScOutputs, &numScInputs, &numForcePtsBlade[iTurb], &numForcePtsTwr[iTurb], TurbineBasePos[iTurb].data(), &AbortErrLev, &dtFAST, &numBlades[iTurb], &numVelPtsBlade[iTurb], &cDriver_Input_from_FAST[iTurb], &cDriver_Output_to_FAST[iTurb], &cDriverSC_Input_from_FAST[iTurb], &cDriverSC_Output_to_FAST[iTurb], &ErrStat, ErrMsg);
+       std::copy(FASTInputFileName[iTurb].data(),
+                 FASTInputFileName[iTurb].data() + (FASTInputFileName[iTurb].size() + 1),
+                 currentFileName);
+       FAST_OpFM_Init(&iTurb, &tMax, currentFileName, &TurbID[iTurb],
+                      &numScOutputs, &numScInputs, &numForcePtsBlade[iTurb],
+                      &numForcePtsTwr[iTurb], TurbineBasePos[iTurb].data(),
+                      &AbortErrLev, &dtFAST, &numBlades[iTurb],
+                      &numVelPtsBlade[iTurb], &cDriver_Input_from_FAST[iTurb],
+                      &cDriver_Output_to_FAST[iTurb],
+                      &cDriverSC_Input_from_FAST[iTurb],
+                      &cDriverSC_Output_to_FAST[iTurb], &ErrStat, ErrMsg);
        checkError(ErrStat, ErrMsg);
-       
+
        timeZero = true;
 
        numVelPtsTwr[iTurb] = cDriver_Output_to_FAST[iTurb].u_Len - numBlades[iTurb]*numVelPtsBlade[iTurb] - 1;


### PR DESCRIPTION
This commit attempts to address the heap-buffer-overflow error
reported in Nalu-Wind nightly tests using LLVM address sanitizer. For
details see:

https://my.cdash.org/testDetails.php?test=45418647&build=1609666
