### PR TITLE
Fix out-of-bounds array error in C++ API

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -288,12 +288,16 @@ void fast::OpenFAST::step() {
    nt_global = nt_global + 1;
   
   if ( (((nt_global - ntStart) % nEveryCheckPoint) == 0 )  && (nt_global != ntStart) ) {
+    // Use default FAST naming convention for checkpoint file
+    // <RootName>.<nt_global>
+    char dummyCheckPointRoot[INTERFACE_STRING_LENGTH] = " ";
+    // Ensure that we have a null character
+    dummyCheckPointRoot[1] = 0;
+
     if (nTurbinesProc > 0) backupVelocityDataFile(nt_global, velNodeDataFile);
-      
-    //sprintf(CheckpointFileRoot, "../../CertTest/Test18.%d", nt_global);
+
     for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
-      CheckpointFileRoot[iTurb] = " "; // if blank, it will use FAST convention <RootName>.nt_global
-      FAST_CreateCheckpoint(&iTurb, CheckpointFileRoot[iTurb].data(), &ErrStat, ErrMsg);
+      FAST_CreateCheckpoint(&iTurb, dummyCheckPointRoot, &ErrStat, ErrMsg);
       checkError(ErrStat, ErrMsg);
     }
     if(scStatus) {


### PR DESCRIPTION
This OOB error was reported in Nalu-Wind nightly testing by LLVM/Clang
address sanitizer:
https://my.cdash.org/testDetails.php?test=45554439&build=1613318

==17307==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x60300080c398 at pc 0x000000496f7f bp 0x7ffd323df520 sp 0x7ffd323decd0 READ of size 1025 at 0x60300080c398 thread T0
0x60300080c398 is located 0 bytes to the right of 24-byte region [0x60300080c380,0x60300080c398)

This issue was reported by Jon Rood. The fix implemented is similar to
the one discussed in #243.
