### PR TITLE
Fixes #254 - Updates the testing documentation for Windows with instructions to copy r-test folder

### DIFF
--- a/docs/source/testing/regression_test_windows.rst
+++ b/docs/source/testing/regression_test_windows.rst
@@ -68,16 +68,23 @@ Windows with Visual Studio regression test
 
        iii) Close your Visual Studio and then Repeat Steps (a) through (c)
 
-    d) You should now see the file ``openfast_x64.exe`` in your ``openfast\build\bin`` folder
+    d) You should now see the file ``openfast_x64_Double.exe`` in your ``openfast\build\bin`` folder.
 
 
-4) Execute the OpenFAST regression Tests
+4) Prepare regression tests
+
+    a) Create a subdirectory called ``reg_tests`` in your ``openfast\build`` folder.
+
+    b) Copy the contents of ``openfast/reg_tests/r-test`` to ``openfast/build/reg_tests``.
+
+
+5) Execute the OpenFAST regression Tests
 
     a) Open a command prompt which is configured for Python [ like Anaconda3 ]
  
     b) Change your working directory to ``openfast\reg_tests``
 
-    c) Type: ``python manualRegressionTest.py ..\build\bin\openfast_x64.exe Windows Intel 1e-5``
+    c) Type: ``python manualRegressionTest.py ..\build\bin\openfast_x64_Double.exe Windows Intel 1e-5`` 
          You should see this: ``executing AWT_YFix_WSt``
 
     d) The tests will continue to execute one-by-one until you finally see something like this:

--- a/docs/source/testing/regression_test_windows.rst
+++ b/docs/source/testing/regression_test_windows.rst
@@ -75,7 +75,7 @@ Windows with Visual Studio regression test
 
     a) Create a subdirectory called ``reg_tests`` in your ``openfast\build`` folder.
 
-    b) Copy the contents of ``openfast/reg_tests/r-test`` to ``openfast/build/reg_tests``.
+    b) Copy the contents of ``openfast\reg_tests\r-test`` to ``openfast\build\reg_tests``.
 
 
 5) Execute the OpenFAST regression Tests


### PR DESCRIPTION
**THIS PULL REQUEST IS READY TO MERGE**

**Feature or improvement description**
In section 5.2.3. of the documentation ("Windows with Visual Studio regression test") an instruction is missing, that one needs to copy the contents of `openfast/reg_tests/r-test` into `openfast/build/reg_tests` to be able to run the regression test with the python script `manualRegressionTest.py`. This issue is fixed with this pull request by updating the file `\docs\source\testing\regression_test_windows.rst`.

Additionally, with the Visual Studio solution currently provided for compiling OpenFAST, the compiled executable will be named `openfast_x64_Double.exe`, when choosing Release_Double and x64. This pull request also updates section 5.2.3. of the documentation according to this fact..

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/254


