### PR TITLE
Zero padding of VTK names, and log10 of zero (see #250)

### DIFF
--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -5006,12 +5006,12 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_AllMeshes'
 
-   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
-   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
-   if (y_FAST%NOutSteps==0) then
-      Twidth = 1
+   ! Calculate the number of digits for the maximum number of output steps to be written.
+   ! This will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
+   if ( (p_FAST%n_VTKTime>0) .and. (p_FAST%n_TMax_m1+1>0) ) then
+      Twidth = CEILING( log10( real(p_FAST%n_TMax_m1+1, ReKi) / p_FAST%n_VTKTime ) ) + 1
    else
-       Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+      Twidth = 1
    endif
    
    NumBl = 0
@@ -5239,12 +5239,12 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_BasicMeshes'
 
-   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
-   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
-   if (y_FAST%NOutSteps==0) then
-      Twidth = 1
+   ! Calculate the number of digits for the maximum number of output steps to be written.
+   ! This will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
+   if ( (p_FAST%n_VTKTime>0) .and. (p_FAST%n_TMax_m1+1>0) ) then
+      Twidth = CEILING( log10( real(p_FAST%n_TMax_m1+1, ReKi) / p_FAST%n_VTKTime ) ) + 1
    else
-      Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+      Twidth = 1
    endif
    
    
@@ -5352,12 +5352,12 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_Surfaces'
 
-   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
-   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK_...()
-   if (y_FAST%NOutSteps==0) then
-      Twidth = 1
+   ! Calculate the number of digits for the maximum number of output steps to be written.
+   ! This will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
+   if ( (p_FAST%n_VTKTime>0) .and. (p_FAST%n_TMax_m1+1>0) ) then
+      Twidth = CEILING( log10( real(p_FAST%n_TMax_m1+1, ReKi) / p_FAST%n_VTKTime ) ) + 1
    else
-      Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+      Twidth = 1
    endif
    
    
@@ -5480,13 +5480,12 @@ SUBROUTINE WrVTK_WaveElev(t_global, p_FAST, y_FAST, HD)
    !.................................................................
    ! write the data that potentially changes each time step:
    !.................................................................
-
-   ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
-   ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK_...()
-   if (y_FAST%NOutSteps==0) then
-      Twidth = 1
+   ! Calculate the number of digits for the maximum number of output steps to be written.
+   ! This will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
+   if ( (p_FAST%n_VTKTime>0) .and. (p_FAST%n_TMax_m1+1>0) ) then
+      Twidth = CEILING( log10( real(p_FAST%n_TMax_m1+1, ReKi) / p_FAST%n_VTKTime ) ) + 1
    else
-      Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+      Twidth = 1
    endif
 
    VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )

--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -5008,7 +5008,11 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW, O
 
    ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
    ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
-   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   if (y_FAST%NOutSteps==0) then
+      Twidth = 1
+   else
+       Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   endif
    
    NumBl = 0
    if (allocated(ED%Output)) then
@@ -5237,7 +5241,11 @@ SUBROUTINE WrVTK_BasicMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD14, AD, IfW,
 
    ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
    ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK()
-   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   if (y_FAST%NOutSteps==0) then
+      Twidth = 1
+   else
+      Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   endif
    
    
    NumBl = 0
@@ -5346,7 +5354,11 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD14, A
 
    ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
    ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK_...()
-   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   if (y_FAST%NOutSteps==0) then
+      Twidth = 1
+   else
+      Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   endif
    
    
    NumBl = 0
@@ -5471,7 +5483,11 @@ SUBROUTINE WrVTK_WaveElev(t_global, p_FAST, y_FAST, HD)
 
    ! calculate the number of digits in 'y_FAST%NOutSteps' (Maximum number of output steps to be written)
    ! this will be used to pad the write-out step in the VTK filename with zeros in calls to MeshWrVTK_...()
-   Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   if (y_FAST%NOutSteps==0) then
+      Twidth = 1
+   else
+      Twidth = int(log10(real(y_FAST%NOutSteps))) + 1
+   endif
 
    VTK_path = get_vtkroot_path( p_FAST%OutFileRoot )
 


### PR DESCRIPTION
**THIS PULL REQUEST IS READY TO MERGE**

**Related issue, if one exists**

Fixes #250

**Impacted areas of the software**

`openfast-library`, file `FAST_Subs`
