### PR TITLE
Sync the git versions for windows and linux builds

### DIFF
--- a/vs-build/CreateGitVersion.bat
+++ b/vs-build/CreateGitVersion.bat
@@ -3,7 +3,7 @@ SET IncludeFile=..\gitVersionInfo.h
 
 <NUL SET /p IncludeTxt=#define GIT_VERSION_INFO '> %IncludeFile%
 FOR /f %%a IN ('git describe --abbrev^=8 --always --tags --dirty') DO <NUL SET /p IncludeTxt=%%a>> %IncludeFile%
-git describe > NUL
-IF %ERRORLEVEL%==0 (ECHO '>> %IncludeFile%) else (ECHO Unversioned from $Format:%h$' >> %IncludeFile%)
+git describe --abbrev^=8 --always --tags --dirty > NUL
+IF %ERRORLEVEL%==0 ( ECHO '>> %IncludeFile% ) else ( ECHO Unversioned from $Format:%H$ '>> %IncludeFile% )
 
 EXIT /B 0


### PR DESCRIPTION

**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Makes the version numbers consistent between cmake and visual studio builds. I found this improvement in @bjonkman's fork at this commit https://github.com/bjonkman/openfast/commit/797c692e4b169843e5da1bffed11e895adfae6a8. This is currently a bug since the `dirty` version will not currently be detected.
@bjonkman do approve until your `vs-simulink` branch is merged?

**Related issue, if one exists**
None

**Impacted areas of the software**
Version number for all modules

**Additional supporting information**
None

**Test results, if applicable**
None