### PR TITLE
Fix InflowWind index for invalid channels + typo in HydroDyn echo file

### DIFF
--- a/modules-local/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules-local/hydrodyn/src/HydroDyn_Input.f90
@@ -974,7 +974,7 @@ SUBROUTINE HydroDynInput_GetInput( InitInp, ErrStat, ErrMsg )
 
         ! SumQTF     -- Full        Sum-Frequency forces computed with full QTFs from WAMIT file: {0: No        Sum-frequency forces, [10, 11, or 12]: WAMIT file to use}
 
-   CALL ReadVar ( UnIn, FileName, InitInp%WAMIT2%SumQTF, 'DiffQTF', 'Full Sum-Frequency forces computed with full QTFs from WAMIT file: {0: No Sum-frequency forces, [10, 11, or 12]: WAMIT file to use}', ErrStat2, ErrMsg2, UnEchoLocal )
+   CALL ReadVar ( UnIn, FileName, InitInp%WAMIT2%SumQTF, 'SumQTF', 'Full Sum-Frequency forces computed with full QTFs from WAMIT file: {0: No Sum-frequency forces, [10, 11, or 12]: WAMIT file to use}', ErrStat2, ErrMsg2, UnEchoLocal )
 
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'HydroDynInput_GetInput' )
       IF (ErrStat >= AbortErrLev) THEN

--- a/modules-local/inflowwind/src/InflowWind_Subs.f90
+++ b/modules-local/inflowwind/src/InflowWind_Subs.f90
@@ -1384,9 +1384,11 @@ SUBROUTINE InflowWind_SetParameters( InitInp, InputFileData, p, m, ErrStat, ErrM
    end if
    
       ! Allocate array for AllOuts
-   CALL AllocAry( m%AllOuts, MaxOutPts, 'AllOuts', TmpErrStat, TmpErrMsg )
-   CALL SetErrStat(TmpErrStat,TmpErrMsg,ErrStat,ErrMsg,RoutineName)
-   IF ( ErrStat>= AbortErrLev ) RETURN
+   ALLOCATE( m%AllOuts(0:MaxOutPts), Stat=TmpErrStat )
+   IF (TmpErrStat/=0) THEN
+      CALL SetErrStat(ErrID_Fatal,"Error allocating memory for m%AllOuts.",ErrStat,ErrMsg,RoutineName)
+      RETURN
+   END IF
    m%AllOuts = 0.0_ReKi
    
 


### PR DESCRIPTION
**THIS PULL REQUEST IS READY TO MERGE**

**Feature or improvement description**

This fixes a small typo in the HydroDyn variable description for `SumQTF`, and fixes a larger issue where InflowWind could produce a segmentation fault due to an incorrect index if a user requested an invalid output channel.

**Impacted areas of the software**

* This will impact InflowWind only when its input file requests output for an invalid channel.
* This will fix the name of the variable listed in the HydroDyn echo file and in the error message written to the screen if it cannot read the `SumQTF` line.


**Automated test results**

This should not affect any of the test results.