### PR TITLE
Add a “version” module to remove git dependency

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,12 +22,6 @@ include(${CMAKE_SOURCE_DIR}/cmake/OpenfastFortranOptions.cmake)
 
 set(CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
-# Get the git info into the executable
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake/")
-include(GetGitRevisionDescription)
-git_describe(GIT_DESCRIBE)
-add_definitions(-DGIT_VERSION_INFO="${GIT_DESCRIBE}")
-
 # CMake Configuration variables
 if (NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE "Release" CACHE STRING
@@ -98,6 +92,7 @@ set(OPENFAST_MODULES_LOCAL
   supercontroller
   turbsim
   openfast-library
+  version
   )
 
 ########################################################################

--- a/modules-local/aerodyn/CMakeLists.txt
+++ b/modules-local/aerodyn/CMakeLists.txt
@@ -23,6 +23,7 @@ generate_f90_types(src/UnsteadyAero_Registry.txt UnsteadyAero_Types.f90)
 generate_f90_types(src/AeroDyn_Driver_Registry.txt
   AeroDyn_Driver_Types.f90 -noextrap)
 
+# AeroDyn lib
 set(AD_LIBS_SOURCES
   src/AeroDyn.f90
   src/AeroDyn_IO.f90
@@ -45,6 +46,7 @@ set(AD_LIBS_SOURCES
 add_library(aerodynlib ${AD_LIBS_SOURCES})
 target_link_libraries(aerodynlib nwtclibs)
 
+# AeroDyn driver
 set(AD_DRIVER_SOURCES
   src/AeroDyn_Driver.f90
   src/AeroDyn_Driver_Subs.f90
@@ -53,7 +55,7 @@ set(AD_DRIVER_SOURCES
   AeroDyn_Driver_Types.f90)
 
 add_executable(aerodyn_driver ${AD_DRIVER_SOURCES})
-target_link_libraries(aerodyn_driver aerodynlib nwtclibs ${CMAKE_DL_LIBS})
+target_link_libraries(aerodyn_driver aerodynlib nwtclibs versioninfolib ${CMAKE_DL_LIBS})
 
 install(TARGETS aerodyn_driver aerodynlib
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"

--- a/modules-local/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules-local/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -22,7 +22,8 @@ module AeroDyn_Driver_Subs
    
    use AeroDyn_Driver_Types   
    use AeroDyn
-    
+   use VersionInfo
+
    implicit none   
    
    TYPE(ProgDesc), PARAMETER   :: version   = ProgDesc( 'AeroDyn_driver', '', '' )  ! The version number of this program.

--- a/modules-local/aerodyn/src/UnsteadyAero_Driver.f90
+++ b/modules-local/aerodyn/src/UnsteadyAero_Driver.f90
@@ -32,7 +32,8 @@ program UnsteadyAero_Driver
    use UnsteadyAero_Types
    use UnsteadyAero
    use UA_Dvr_Subs
-   
+   USE VersionInfo
+
    implicit none
 
    

--- a/modules-local/beamdyn/CMakeLists.txt
+++ b/modules-local/beamdyn/CMakeLists.txt
@@ -39,7 +39,7 @@ set(BD_DRIVER_SOURCES
   src/Driver_Beam_Subs.f90)
 
 add_executable(beamdyn_driver ${BD_DRIVER_SOURCES})
-target_link_libraries(beamdyn_driver beamdynlib nwtclibs ${CMAKE_DL_LIBS})
+target_link_libraries(beamdyn_driver beamdynlib nwtclibs versioninfolib ${CMAKE_DL_LIBS})
 
 install(TARGETS beamdyn_driver
   RUNTIME DESTINATION bin

--- a/modules-local/beamdyn/src/Driver_Beam.f90
+++ b/modules-local/beamdyn/src/Driver_Beam.f90
@@ -21,6 +21,7 @@
 PROGRAM BeamDyn_Driver_Program
 
    USE BeamDyn_driver_subs  ! all other modules inherited through this one
+   USE VersionInfo
 
    IMPLICIT NONE
 

--- a/modules-local/hydrodyn/CMakeLists.txt
+++ b/modules-local/hydrodyn/CMakeLists.txt
@@ -59,7 +59,7 @@ add_library(hydrodynlib ${HYDRODYN_SOURCES})
 target_link_libraries(hydrodynlib nwtclibs)
 
 add_executable(hydrodyn_driver src/HydroDyn_DriverCode.f90)
-target_link_libraries(hydrodyn_driver hydrodynlib nwtclibs)
+target_link_libraries(hydrodyn_driver hydrodynlib nwtclibs versioninfolib)
 
 #add_executable(ss_radiation
 #  src/SS_Radiation_DriverCode.f90)

--- a/modules-local/hydrodyn/src/HydroDyn_DriverCode.f90
+++ b/modules-local/hydrodyn/src/HydroDyn_DriverCode.f90
@@ -27,6 +27,7 @@ PROGRAM HydroDynDriver
    USE HydroDyn_Types
    USE HydroDyn_Output
    USE ModMesh_Types
+   USE VersionInfo
    
    IMPLICIT NONE
    

--- a/modules-local/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules-local/hydrodyn/src/HydroDyn_Input.f90
@@ -974,7 +974,7 @@ SUBROUTINE HydroDynInput_GetInput( InitInp, ErrStat, ErrMsg )
 
         ! SumQTF     -- Full        Sum-Frequency forces computed with full QTFs from WAMIT file: {0: No        Sum-frequency forces, [10, 11, or 12]: WAMIT file to use}
 
-   CALL ReadVar ( UnIn, FileName, InitInp%WAMIT2%SumQTF, 'DiffQTF', 'Full Sum-Frequency forces computed with full QTFs from WAMIT file: {0: No Sum-frequency forces, [10, 11, or 12]: WAMIT file to use}', ErrStat2, ErrMsg2, UnEchoLocal )
+   CALL ReadVar ( UnIn, FileName, InitInp%WAMIT2%SumQTF, 'SumQTF', 'Full Sum-Frequency forces computed with full QTFs from WAMIT file: {0: No Sum-frequency forces, [10, 11, or 12]: WAMIT file to use}', ErrStat2, ErrMsg2, UnEchoLocal )
 
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'HydroDynInput_GetInput' )
       IF (ErrStat >= AbortErrLev) THEN

--- a/modules-local/inflowwind/src/InflowWind_Subs.f90
+++ b/modules-local/inflowwind/src/InflowWind_Subs.f90
@@ -1384,9 +1384,11 @@ SUBROUTINE InflowWind_SetParameters( InitInp, InputFileData, p, m, ErrStat, ErrM
    end if
    
       ! Allocate array for AllOuts
-   CALL AllocAry( m%AllOuts, MaxOutPts, 'AllOuts', TmpErrStat, TmpErrMsg )
-   CALL SetErrStat(TmpErrStat,TmpErrMsg,ErrStat,ErrMsg,RoutineName)
-   IF ( ErrStat>= AbortErrLev ) RETURN
+   ALLOCATE( m%AllOuts(0:MaxOutPts), Stat=TmpErrStat )
+   IF (TmpErrStat/=0) THEN
+      CALL SetErrStat(ErrID_Fatal,"Error allocating memory for m%AllOuts.",ErrStat,ErrMsg,RoutineName)
+      RETURN
+   END IF
    m%AllOuts = 0.0_ReKi
    
 

--- a/modules-local/nwtc-library/src/NWTC_IO.f90
+++ b/modules-local/nwtc-library/src/NWTC_IO.f90
@@ -4456,56 +4456,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE ProgWarn 
-   
-!=======================================================================
-!> This routine outputs the git hash associate with the current codebase.
-   FUNCTION QueryGitVersion()
-   
-      ! Passed variables.
-   
-   !INTEGER(IntKi),     INTENT(OUT)     :: ErrStat                              ! Error status 
-   !CHARACTER(*),       INTENT(OUT)     :: ErrMsg                               ! Error message 
-      
-      ! Function declaration.
 
-   CHARACTER(200)                      :: QueryGitVersion                      ! This function.
-      
-      ! Local variables.
-
-   INTEGER(IntKi)                      :: UnIn                                 ! Unit number for reading file                                        
-   INTEGER(IntKi)                      :: ErrStat2                             ! Temporary Error status 
-   CHARACTER(ErrMsgLen)                :: ErrMsg2                              ! Temporary Error message 
-   
-   !ErrStat = ErrID_None 
-   !ErrMsg  = '' 
-   
-   QueryGitVersion = 'unversioned' 
-   
-   ! VS build method for obtaining the git version info.
-   ! This requires setting:
-   !  1) GIT_INCLUDE_FILE = '$(ProjectDir)\..\gitVersionInfo.h' preprocessor option on this file or the project containing this file.
-   !  2) Creating a prebuild event on the project file producing the resulting binary (i.e., FAST.exe) with the following command: ..\CreateGitVersion.bat
-   !  3) The bat file, CreateGitVersion.bat, located in the vs-build folder of the openfast repository, which contains the git command used to obtain the git info
-   !         @ECHO off
-   !         SET IncludeFile=..\gitVersionInfo.h
-   !         
-   !         <NUL SET /p IncludeTxt=#define GIT_VERSION_INFO '> %IncludeFile%
-   !         FOR /f %%a IN ('git describe --abbrev^=7 --always --tags --dirty') DO <NUL SET /p IncludeTxt=%%a>> %IncludeFile%
-   !         ECHO '>> %IncludeFile%
-   !         EXIT /B 0
-   !     This creates the gitVersionInfo.h file in the vs-build folder
-   
-#ifdef GIT_INCLUDE_FILE
-#include GIT_INCLUDE_FILE
-#endif
-
-#ifdef GIT_VERSION_INFO
-QueryGitVersion = GIT_VERSION_INFO
-#endif
-
-   RETURN
-   END FUNCTION QueryGitVersion
-   
 !=======================================================================
 !> \copydoc nwtc_io::int2lstr
    FUNCTION R2LStr4 ( Num )

--- a/modules-local/openfast-library/CMakeLists.txt
+++ b/modules-local/openfast-library/CMakeLists.txt
@@ -49,12 +49,10 @@ add_library(openfast_postlib
   src/FAST_Subs.f90
   src/FAST_Solver.f90
   )
-target_link_libraries(openfast_postlib openfast_prelib scfastlib foamfastlib)
+target_link_libraries(openfast_postlib openfast_prelib scfastlib foamfastlib versioninfolib)
 
-add_library(openfastlib
-  src/FAST_Library.f90)
-target_link_libraries(openfastlib
-  openfast_postlib openfast_prelib scfastlib foamfastlib)
+add_library(openfastlib src/FAST_Library.f90)
+target_link_libraries(openfastlib openfast_postlib openfast_prelib scfastlib foamfastlib)
 
 install(TARGETS openfastlib openfast_prelib openfast_postlib
   EXPORT ${CMAKE_PROJECT_NAME}Libraries

--- a/modules-local/openfast-library/src/FAST_Subs.f90
+++ b/modules-local/openfast-library/src/FAST_Subs.f90
@@ -23,6 +23,7 @@ MODULE FAST_Subs
 
    USE FAST_Solver
    USE FAST_Linear
+   USE VersionInfo
 
    IMPLICIT NONE
 

--- a/modules-local/subdyn/CMakeLists.txt
+++ b/modules-local/subdyn/CMakeLists.txt
@@ -32,7 +32,7 @@ set(SUBDYN_DRIVER_SOURCES
   src/SubDyn_Driver.f90)
 
 add_executable(subdyn_driver ${SUBDYN_DRIVER_SOURCES})
-target_link_libraries(subdyn_driver subdynlib nwtclibs)
+target_link_libraries(subdyn_driver subdynlib nwtclibs versioninfolib)
 
 install(TARGETS subdynlib subdyn_driver
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"

--- a/modules-local/subdyn/src/SubDyn_Driver.f90
+++ b/modules-local/subdyn/src/SubDyn_Driver.f90
@@ -25,6 +25,7 @@ PROGRAM TestSubDyn
    USE SubDyn
    USE SubDyn_Types
    USE SubDyn_Output
+   USE VersionInfo
 
    IMPLICIT NONE
 

--- a/modules-local/turbsim/src/TurbSim.f90
+++ b/modules-local/turbsim/src/TurbSim.f90
@@ -57,7 +57,7 @@ USE TSsubs
 USE TS_FileIO
 USE TS_Profiles
 use TS_CohStructures
-
+use VersionInfo
 
 IMPLICIT                   NONE
 

--- a/modules-local/version/CMakeLists.txt
+++ b/modules-local/version/CMakeLists.txt
@@ -14,20 +14,14 @@
 # limitations under the License.
 #
 
-set(MODULE_SOURCES
-  src/BlankModVKM.f90
-  src/CohStructures.f90
-  src/Profiles.f90
-  src/RandNum.f90
-  src/Root_Searching.f90
-  src/TS_FileIO.f90
-  src/TSsubs.f90
-  src/TurbSim.f90
-  src/TurbSim_Types.f90
-  src/VelocitySpectra.f90
-  )
+include(GetGitRevisionDescription)
+git_describe(GIT_DESCRIBE)
+add_definitions(-DGIT_VERSION_INFO="${GIT_DESCRIBE}")
 
-add_executable(turbsim ${MODULE_SOURCES})
-target_link_libraries(turbsim nwtclibs versioninfolib)
+add_library(versioninfolib src/VersionInfo.f90)
 
-install(TARGETS turbsim RUNTIME DESTINATION bin)
+install(TARGETS versioninfolib
+  EXPORT "${CMAKE_PROJECT_NAME}Libraries"
+  RUNTIME DESTINATION bin
+  LIBRARY DESTINATION lib
+  ARCHIVE DESTINATION lib)

--- a/modules-local/version/src/VersionInfo.f90
+++ b/modules-local/version/src/VersionInfo.f90
@@ -1,0 +1,43 @@
+!**********************************************************************************************************************************
+! LICENSING
+! Copyright (C) 2015-2016  National Renewable Energy Laboratory
+! Copyright (C) 2016-2017  Envision Energy USA, LTD
+!
+!    This file is part of the NWTC Subroutine Library.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+!
+!**********************************************************************************************************************************
+MODULE VersionInfo
+
+   implicit none
+
+contains
+
+FUNCTION QueryGitVersion()
+
+   CHARACTER(200) :: QueryGitVersion
+   QueryGitVersion = 'unversioned'
+
+#ifdef GIT_INCLUDE_FILE
+#include GIT_INCLUDE_FILE
+#endif
+
+#ifdef GIT_VERSION_INFO
+   QueryGitVersion = GIT_VERSION_INFO
+#endif
+
+   RETURN
+END FUNCTION QueryGitVersion
+
+END MODULE

--- a/vs-build/AeroDyn/AeroDyn_Driver.vfproj
+++ b/vs-build/AeroDyn/AeroDyn_Driver.vfproj
@@ -306,5 +306,6 @@
 			<FileConfiguration Name="Release_Double|x64">
 				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat UA" Description="Running Registry for UnsteadyAero" Outputs="..\..\build\types-files\UnsteadyAero_Types.f90"/></FileConfiguration></File>
 		<File RelativePath="..\..\build\types-files\UnsteadyAero_Types.f90"/></Filter>
-		<File RelativePath="..\..\modules-local\AeroDyn\src\UnsteadyAero.f90"/></Filter></Filter></Files>
+		<File RelativePath="..\..\modules-local\AeroDyn\src\UnsteadyAero.f90"/></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/vs-build/BeamDyn/BeamDyn.vfproj
+++ b/vs-build/BeamDyn/BeamDyn.vfproj
@@ -289,5 +289,6 @@
 			<FileConfiguration Name="Release_Double|x64">
 				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
 			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter></Filter></Files>
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/vs-build/FASTlib/FASTlib.vfproj
+++ b/vs-build/FASTlib/FASTlib.vfproj
@@ -1423,5 +1423,6 @@
 			<FileConfiguration Name="Release_Matlab|Win32">
 				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat SuperController" Description="Running Registry for SuperController" Outputs="..\..\build\types-files\SuperController_Types.f90"/></FileConfiguration></File>
 		<File RelativePath="..\..\build\types-files\SuperController_Types.f90"/></Filter>
-		<File RelativePath="..\..\modules-local\supercontroller\src\SuperController.f90"/></Filter></Filter></Files>
+		<File RelativePath="..\..\modules-local\supercontroller\src\SuperController.f90"/></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/vs-build/HydroDyn/HydroDynDriver.vfproj
+++ b/vs-build/HydroDyn/HydroDynDriver.vfproj
@@ -242,5 +242,6 @@
 			<FileConfiguration Name="Debug|x64">
 				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
 			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter></Filter></Files>
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/vs-build/SubDyn/SubDyn.vfproj
+++ b/vs-build/SubDyn/SubDyn.vfproj
@@ -178,5 +178,6 @@
 		<File RelativePath="..\..\modules-local\subdyn\src\SD_FEM.f90"/>
 		<File RelativePath="..\..\modules-local\subdyn\src\SubDyn.f90"/>
 		<File RelativePath="..\..\modules-local\subdyn\src\SubDyn_Driver.f90"/>
-		<File RelativePath="..\..\modules-local\subdyn\src\SubDyn_Output.f90"/></Filter></Filter></Files>
+		<File RelativePath="..\..\modules-local\subdyn\src\SubDyn_Output.f90"/></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/vs-build/TurbSim/TurbSim.vfproj
+++ b/vs-build/TurbSim/TurbSim.vfproj
@@ -75,5 +75,6 @@
 		<File RelativePath="..\..\modules-local\turbsim\src\TSsubs.f90"/>
 		<File RelativePath="..\..\modules-local\turbsim\src\TurbSim.f90"/>
 		<File RelativePath="..\..\modules-local\turbsim\src\TurbSim_Types.f90"/>
-		<File RelativePath="..\..\modules-local\turbsim\src\VelocitySpectra.f90"/></Filter></Filter></Files>
+		<File RelativePath="..\..\modules-local\turbsim\src\VelocitySpectra.f90"/></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>

--- a/vs-build/UnsteadyAero/UnsteadyAero.vfproj
+++ b/vs-build/UnsteadyAero/UnsteadyAero.vfproj
@@ -321,5 +321,6 @@
 				<Tool Name="VFFortranCompilerTool" DisableSpecificDiagnostics="5268" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
 		<File RelativePath="..\..\modules-local\aerodyn\src\UA_Dvr_subs.f90"/>
 		<File RelativePath="..\..\modules-local\aerodyn\src\UnsteadyAero.f90"/>
-		<File RelativePath="..\..\modules-local\aerodyn\src\UnsteadyAero_Driver.f90"/></Filter></Filter></Files>
+		<File RelativePath="..\..\modules-local\aerodyn\src\UnsteadyAero_Driver.f90"/></Filter>
+		<File RelativePath="..\..\modules-local\version\src\VersionInfo.f90"/></Filter></Files>
 	<Globals/></VisualStudioProject>


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
This pull request changes the versioning system as it was initially implemented in CMake. This does not affect the build for Windows with Visual Studio.

The existing implementation inserts the git hash (AKA the version) into the source code through a compiler flag and preprocessor directive in NWTC_IO. Therefore, anytime the git status changes the compile command also changes so everything has to be recompiled.

This pull request improves the build system
1. Moving the git status checking to a standalone module
2. Moving the compiler flag from the main CMakeLists to the new module CMakeLists

These changes mean that the compile command for the other modules does not change with the git commit and only the lightweight Version module needs to be recompiled. The driver programs which use this module are relinked during compile time.

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/267

**Impacted areas of the software**
The build system through CMake

**Additional supporting information**
This is important when dealing with multiple branches as the git status changes frequently. Also, it will enable improved performance in the automated testing.

**Test results, if applicable**
Only the existing TravisCI tests are necessary.