### PR TITLE
Minor bug fixes

### DIFF
--- a/modules/aerodyn/src/BEMT.f90
+++ b/modules/aerodyn/src/BEMT.f90
@@ -1746,7 +1746,7 @@ SUBROUTINE CheckLinearizationInput(p, u, z, m, OtherState, ErrStat, ErrMsg)
       do k = 1,p%numBlades            
          do j = 1,p%numBladeNodes
             if (.not. OtherState%ValidPhi(j,k)) then
-               call SetErrSTat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(k))//&
+               call SetErrSTat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(j))//&
                       ": Current operating point does not contain a valid value of phi.",ErrStat,ErrMsg,RoutineName)
                return
             end if
@@ -1762,7 +1762,7 @@ SUBROUTINE CheckLinearizationInput(p, u, z, m, OtherState, ErrStat, ErrMsg)
             do j = 1,p%numBladeNodes
             
                if ( VelocityIsZero( u%Vy(j,k)+m%TnInd_op(j,k)) .and. VelocityIsZero( u%Vx(j,k)+m%AxInd_op(j,k) ) ) then
-                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(k))//&
+                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(j))//&
                       ": residual is undefined because u%Vy + TnInd_op = u%Vx + AxInd_op = 0.",ErrStat,ErrMsg,RoutineName)
                   return
                end if
@@ -1776,15 +1776,15 @@ SUBROUTINE CheckLinearizationInput(p, u, z, m, OtherState, ErrStat, ErrMsg)
             do j = 1,p%numBladeNodes
             
                if ( EqualRealNos(z%phi(j,k), 0.0_ReKi) ) then
-                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(k))//&
+                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(j))//&
                        ": residual is discontinuous or undefined because z%phi = 0.",ErrStat,ErrMsg,RoutineName)
                   return
                else if ( VelocityIsZero(u%Vy(j,k)) ) then
-                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(k))//&
+                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(j))//&
                        ": residual is discontinuous or undefined because u%Vy = 0.",ErrStat,ErrMsg,RoutineName)
                   return
                else if ( VelocityIsZero(u%Vx(j,k)) ) then
-                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(k))//&
+                  call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(j))//&
                        ": residual is discontinuous or undefined because u%Vx = 0.",ErrStat,ErrMsg,RoutineName)
                   return
                end if
@@ -1802,7 +1802,7 @@ SUBROUTINE CheckLinearizationInput(p, u, z, m, OtherState, ErrStat, ErrMsg)
          do j = 1,p%numBladeNodes
             
             if ( EqualRealNos( u%Vy(j,k), 0.0_ReKi ) .and. EqualRealNos( u%Vx(j,k), 0.0_ReKi ) ) then
-               call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(k))//&
+               call SetErrStat(ErrID_Fatal,"Blade"//trim(num2lstr(k))//', node '//trim(num2lstr(j))//&
                     ": residual is undefined because u%Vy = u%Vx = 0.",ErrStat,ErrMsg,RoutineName)
                return
             end if

--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -11695,7 +11695,7 @@ SUBROUTINE ED_GetOP( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg, u_op,
          if (.not. EqualRealNos( u%BlPitchCom(1), u%BlPitchCom(k) ) ) then
             call SetErrStat(ErrID_Info,"Operating point of collective pitch extended input is invalid because "// &
                      "the commanded blade pitch angles are not the same for each blade.", ErrStat, ErrMsg, RoutineName)
-            return
+            exit
          end if      
       end do      
       

--- a/modules/hydrodyn/src/UserWaves.f90
+++ b/modules/hydrodyn/src/UserWaves.f90
@@ -940,8 +940,8 @@ CONTAINS
    FUNCTION ExtractFields(FU, s, n) result(OK)
       ! Arguments
       INTEGER, INTENT(IN)       :: FU       !< Unit name
-      CHARACTER(*), INTENT(OUT) :: s(n)     !< Fields
       INTEGER, INTENT(IN)       :: n        !< Number of fields
+      CHARACTER(*), INTENT(OUT) :: s(n)     !< Fields
       LOGICAL                   :: OK
       ! Local var
       CHARACTER(2048)           :: TextLine          !< One line of text read from the file

--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -480,6 +480,7 @@ SUBROUTINE FAST_Linearize_OP(t_global, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, AD1
    
    ErrStat = ErrID_None
    ErrMsg = ""
+   Un = -1
 
    
    LinRootName = TRIM(p_FAST%OutFileRoot)//'.'//trim(num2lstr(m_FAST%NextLinTimeIndx))
@@ -842,10 +843,13 @@ contains
       if (allocated(dYdz)) deallocate(dYdz)
       if (allocated(dZdz)) deallocate(dZdz)
       if (allocated(dZdu)) deallocate(dZdu)
-      if (allocated(ipiv)) deallocate(ipiv)     
+      if (allocated(ipiv)) deallocate(ipiv)
       
       if (allocated(dUdu)) deallocate(dUdu)
       if (allocated(dUdy)) deallocate(dUdy)
+      
+      if (Un > 0) close(Un)
+
    end subroutine cleanup
 END SUBROUTINE FAST_Linearize_OP   
 !----------------------------------------------------------------------------------------------------------------------------------
@@ -997,7 +1001,7 @@ END SUBROUTINE WrLinFile_txt_Head
 !> Routine that writes the A,B,C,D matrices from linearization to a text file. 
 SUBROUTINE WrLinFile_txt_End(Un, p_FAST, LinData)
 
-   INTEGER(IntKi),           INTENT(IN   ) :: Un                  !< unit number
+   INTEGER(IntKi),           INTENT(INOUT) :: Un                  !< unit number
    TYPE(FAST_ParameterType), INTENT(IN   ) :: p_FAST              !< parameters
    TYPE(FAST_LinType),       INTENT(IN   ) :: LinData             !< Linearization data for individual module or glue (coupled system)
    
@@ -1022,7 +1026,8 @@ SUBROUTINE WrLinFile_txt_End(Un, p_FAST, LinData)
    if (allocated(LinData%StateRel_x))    call WrPartialMatrix( LinData%StateRel_x,    Un, p_FAST%OutFmt, 'State_Rel_x' )
    if (allocated(LinData%StateRel_xdot)) call WrPartialMatrix( LinData%StateRel_xdot, Un, p_FAST%OutFmt, 'State_Rel_xdot' )
 
-   close(un)
+   close(Un)
+   Un = -1
    
 END SUBROUTINE WrLinFile_txt_End   
 !----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Complete this sentence
**THIS PULL REQUEST IS READY TO MERGE**

**Description**

This PR fixes a few minor issues in the code:
- The printed node number in AeroDyn error messages during linearization checks was actually the blade number.
- If an error occurred while a linearization output file was open, there is a possibility it may not have been explicitly closed.
- If the blade pitch command wasn't equal for all 3 blades, the linearization operating points for ElastoDyn (written to the linearization output files) may not have been set properly or may have generated a seg fault.
- In HydroDyn, an integer was defined after it was used to specify array size. This resulted in my compiler producing a warning that it was using an implicit definition for the variable.

**Related issue, if one exists**
None

**Automated test results**
This should not change any test results.
