### PR TITLE
Minor bug fixes

### DIFF
--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -1619,7 +1619,8 @@ SUBROUTINE SetOutParamLin( p, ErrStat, ErrMsg )
    call AllocAry(p%OutParamLinIndx, 2, p%NumOuts, 'OutParamLinIndx', ErrStat2, ErrMsg2)
    call setErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
    if (ErrStat >= AbortErrLev) return
-      
+   
+   p%OutParamLinIndx = 0
    do i = 1,p%NumOuts
       if (p%OutParam(i)%SignM /= 0 ) then
          

--- a/modules/servodyn/src/ServoDyn.f90
+++ b/modules/servodyn/src/ServoDyn.f90
@@ -835,20 +835,20 @@ SUBROUTINE SrvD_UpdateStates( t, n, Inputs, InputTimes, p, x, xd, z, OtherState,
    !...............................................................................................................................  
       
       ! Torque control
-   CALL Torque_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat2, ErrMsg2 )      
+   CALL Torque_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       
       
       ! Pitch control:
-   CALL Pitch_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat, ErrMsg )
+   CALL Pitch_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       
       ! Yaw control: 
-   CALL Yaw_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat, ErrMsg )
+   CALL Yaw_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
    
       ! Tip brake control:    
-   CALL TipBrake_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat, ErrMsg )
+   CALL TipBrake_UpdateStates( t_next, u_interp, p, x, xd, z, OtherState, m, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
    
    !...............................................................................................................................   

--- a/modules/turbsim/src/Profiles.f90
+++ b/modules/turbsim/src/Profiles.f90
@@ -393,7 +393,7 @@ SUBROUTINE getDirectionProfile( p, Ht, DirectionProfile, VAngleProfile, ErrStat,
                ! Calculate the wind direction at this height
 
             IF ( Ht(J) <= p%met%USR_Z(1) ) THEN
-               DirectionProfile(IZ) = p%met%USR_WindDir(1)
+               DirectionProfile(J) = p%met%USR_WindDir(1)
             ELSEIF ( Ht(J) >= p%met%USR_Z(p%met%NumUSRz) ) THEN
                DirectionProfile(J) = p%met%USR_WindDir(p%met%NumUSRz)
             ELSE


### PR DESCRIPTION
Complete this sentence
**THIS PULL REQUEST __ [IS] __ READY TO MERGE**

**Feature or improvement description**

There are three fixes in this pull request:
1. In **TurbSim**, if the user-defined wind profiles were being used, and there were grid points below the lowest point specified in the user-defined profile, there could be an index out of bounds error and/or incorrectly specified wind direction.

2. In **InflowWind**, if the user was running the code through the Simulink interface, using the Lidar module, and performing a linearization analysis, a variable would be uninitialized, and could result in an index out of bounds.

3. In **ServoDyn**, some errors could be unreported.

**Related issue, if one exists**

None

**Impacted areas of the software**

- TurbSim user-defined wind profiles
- InflowWind linearization with the lidar module
