### PR TITLE
Fix a stack overflow issue in Cygwin

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -95,6 +95,13 @@ macro(set_fast_gfortran)
   if(CMAKE_BUILD_TYPE MATCHES Debug)
     set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -fcheck=all -pedantic -fbacktrace" )
   endif()
+
+  if(CYGWIN)
+    # increase the default 2MB stack size to 16 MB
+    MATH(EXPR stack_size "16 * 1024 * 1024")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS},--stack,${stack_size}")
+  endif()
+
 endmacro(set_fast_gfortran)
 
 #


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
For Cygwin only, add CMake commands to increase the default 2MB stack size to 16 MB.

**Related issue, if one exists**
#144 

**Impacted areas of the software**
Cygwin cmake

**Additional supporting information**
None

**Test results, if applicable**
There are the aerodyn15 tests excluding all 5MW tests because those take a long time to run.
```
rmudafor@rmudafor-w10vm ~/openfast/build
$ ctest -j4 -L aerodyn15 -E 5MW
Test project /home/rmudafor/openfast/build
      Start 14: SWRT_YFree_VS_EDG01
      Start  7: AOC_YFree_WTurb
      Start 15: SWRT_YFree_VS_EDC01
      Start 10: UAE_Upwind_Rigid_WRamp_PwrCurve
 1/11 Test #10: UAE_Upwind_Rigid_WRamp_PwrCurve ...   Passed  140.28 sec
      Start 13: WP_VSP_WTurb
 2/11 Test  #7: AOC_YFree_WTurb ...................   Passed  302.96 sec
      Start  5: AWT_WSt_StartUpShutDown
 3/11 Test #15: SWRT_YFree_VS_EDC01 ...............   Passed  306.32 sec
      Start  8: AOC_YFix_WSt
 4/11 Test #13: WP_VSP_WTurb ......................   Passed  186.16 sec
      Start  3: AWT_YFree_WSt
 5/11 Test  #8: AOC_YFix_WSt ......................   Passed   87.56 sec
      Start  2: AWT_WSt_StartUp_HighSpShutDown
 6/11 Test  #5: AWT_WSt_StartUpShutDown ...........   Passed  107.43 sec
      Start 12: WP_VSP_ECD
 7/11 Test  #3: AWT_YFree_WSt .....................   Passed   85.91 sec
      Start 17: WP_Stationary_Linear
 8/11 Test #17: WP_Stationary_Linear ..............   Passed    8.20 sec
 9/11 Test #14: SWRT_YFree_VS_EDG01 ...............   Passed  452.68 sec
10/11 Test  #2: AWT_WSt_StartUp_HighSpShutDown ....   Passed   60.98 sec
11/11 Test #12: WP_VSP_ECD ........................   Passed   51.82 sec
```