### PR TITLE
Small AeroDyn Linearization Bug Fix

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -3881,7 +3881,7 @@ FUNCTION CheckBEMTInputPerturbations( p, m ) RESULT(ValidPerturb)
             do j=1,p%NumBlNds         
             
                   ! don't allow the input perturbations to change Vx or Vy so that Vx=0 or Vy=0:
-               if ( EqualRealNos( m%BEMT_u(indx)%Vx(j,k), 0.0_ReKi ) .or. EqualRealNos( m%BEMT_u(indx)%Vy(j,k), 0.0_ReKi ) ) then
+               if ( EqualRealNos( m%BEMT_u(indx)%Vx(j,k), 0.0_ReKi ) .and. EqualRealNos( m%BEMT_u(indx)%Vy(j,k), 0.0_ReKi ) ) then
                   ValidPerturb = .false.
                   return
                end if


### PR DESCRIPTION
Complete this sentence
**THIS PULL REQUEST IS READY TO MERGE**

**Feature or improvement description**
Fixed check on Vx and Vy when not using induction to match the implementation plan.  The ".or." should have been an ".and.". This fix will not change results, but will allow some cases that previously aborted to run.

**Related issue, if one exists**
None

**Impacted areas of the software**
AeroDyn

**Additional supporting information**
This bug fix resolved a problem reported to me via e-mail by @alvarogonzalezsalcedo.

**Automated test results**
None
