### PR TITLE
AD14: Restructure loop to fix optimization bug

### DIFF
--- a/modules/aerodyn14/src/AeroSubs.f90
+++ b/modules/aerodyn14/src/AeroSubs.f90
@@ -4693,13 +4693,8 @@ DO i = P%DynInflow%MaxInflo+1, maxInfl
    RHScos(i) = 0.
    RHSsin(i) = 0.
  ! First, calculate {rhs} = V[L]^-1*{alpha}
-   DO k = 1, maxInfl
-!   DO 260 k = MaxInflo+1, maxInfl
-      RHScos(i) = RHScos(i) + m%DynInflow%xLcos(i,k) * m%DynInflow%old_Alph(k)
-   END DO !k
-   DO k = P%DynInflow%MaxInflo+1, maxInfl
-      RHSsin(i) = RHSsin(i) + m%DynInflow%xLsin(i,k) * m%DynInflow%old_Beta(k)
-   END DO !k
+   RHScos(i) = sum(m%DynInflow%xLcos(i,1:maxInfl) * m%DynInflow%old_Alph(1:maxInfl))
+   RHSsin(i) = sum(m%DynInflow%xLsin(i,P%DynInflow%MaxInflo+1:maxInfl) * m%DynInflow%old_Beta(P%DynInflow%MaxInflo+1:maxInfl))
  ! Second, calculate {rhs} = 0.5*{tau} - [V]{rhs}
  !                         = 0.5*{tau} - [V][L]^-1*{alpha}
  !  USE "VPARAM" for m>0


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
When compiling with gfortran version 8+ on macOS and `-O3` compiler optimization level, AeroDyn 14 seg faults. This seems to be an issue with the compiler as the faulty loop shouldn't be compiled since it has a read and write to a location in memory within the same iteration loop. In any case, this change removes the read-write operation in the same line by replacing the loops with a more explicit summation.

**Related issue, if one exists**
#347 

**Impacted areas of the software**
AeroDyn 14

**Additional supporting information**
None

**Test results, if applicable**
As seen below, 4 tests did fail in the regression test suite. However, this is due to running with the newer `gfortran` compiler rather than `gfortran-7` which was used to generate the baselines. These test cases show that the bug is fixed, and the error plots for the failing tests are consistent with what we expect when changing the compiler.

```
89% tests passed, 4 tests failed out of 37

Label Time Summary:
aerodyn14    = 664.15 sec*proc (7 tests)
aerodyn15    = 4426.03 sec*proc (19 tests)
beamdyn      = 504.81 sec*proc (11 tests)
dynamic      =  55.60 sec*proc (3 tests)
elastodyn    = 4709.51 sec*proc (25 tests)
hydrodyn     = 3373.92 sec*proc (7 tests)
linear       =  67.51 sec*proc (4 tests)
map          = 208.08 sec*proc (3 tests)
moordyn      = 176.10 sec*proc (1 test)
openfast     = 5156.39 sec*proc (29 tests)
servodyn     = 5151.77 sec*proc (26 tests)
static       =   2.33 sec*proc (4 tests)
subdyn       = 2989.74 sec*proc (3 tests)

Total Test time (real) = 2104.37 sec

The following tests FAILED:
	  9 - UAE_Dnwind_YRamp_WSt (Failed)
	 16 - SWRT_YFree_VS_WTurb (Failed)
	 19 - 5MW_OC3Trpd_DLL_WSt_WavesReg (Failed)
	 20 - 5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth (Failed)
```
