### PR TITLE
Cleanup of SubDyn module

### DIFF
--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -922,9 +922,11 @@ SUBROUTINE LumpForces(Area1,Area2,crat,L,rho, g, DirCos, F)
    REAL(ReKi), INTENT( OUT) :: F(12)            !< Lumped forces
    !LOCALS
    REAL(ReKi)                         :: TempCoeff,a0,a1,a2  !coefficients of the gravity quadratically distributed force
-   
+   print*,'Error: the function lumpforces is not ready to use'
+   STOP
+
    !Calculate quadratic polynomial coefficients
-   a0 = a1
+   a0 = -99999 ! TODO: this is wrong
    a2 = ( (Area1+A2) - (Area1*crat+Area2/crat) )/L**2. ! *x**2
    a1 = (Area2-Area1)/L -a2*L                          ! *x
    

--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -110,7 +110,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    ErrMsg  = ""
    
    ! number of nodes per element
-   IF( ( Init%FEMMod .GE. 0 ) .and. (Init%FEMMod .LE. 3) ) THEN
+   IF( ( Init%FEMMod >= 0 ) .and. (Init%FEMMod <= 3) ) THEN
       NNE = 2 
    ELSE
       CALL Fatal('FEMMod '//TRIM(Num2LStr(Init%FEMMod))//' not implemented.')
@@ -127,7 +127,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    !bjj: replaced with max value instead of NNE: Init%MembersCol = Init%MembersCol + (NNE - 2) 
    
    ! check the number of interior modes
-   IF ( p%Nmodes .GT. 6*(Init%NNode - Init%NInterf - p%NReact) ) THEN
+   IF ( p%Nmodes > 6*(Init%NNode - Init%NInterf - p%NReact) ) THEN
       CALL Fatal(' NModes must be less than or equal to '//TRIM(Num2LStr( 6*(Init%NNode - Init%NInterf - p%NReact) )))
       RETURN
    ENDIF
@@ -279,7 +279,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
     kprop = Init%NPropSets
     Init%MemberNodes = 0
 
-    IF (Init%NDiv .GT. 1) THEN
+    IF (Init%NDiv > 1) THEN
        DO I = 1, p%NMembers !the first p%NMembers rows of p%Elems contain the element information
           ! create new node
           Node1 = TempMembers(I, 2)

--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -19,11 +19,10 @@
 MODULE SD_FEM
   USE NWTC_Library
   USE SubDyn_Types
-  
   IMPLICIT NONE
-  
-   INTEGER,         PARAMETER  :: LAKi            = R8Ki                  ! Define the kind to be used for LAPACK routines for getting eigenvalues/vectors. Apparently there is a problem with SGGEV's eigenvectors
-  
+
+  INTEGER,          PARAMETER  :: LAKi            = R8Ki                  ! Define the kind to be used for LAPACK routines for getting eigenvalues/vectors. Apparently there is a problem with SGGEV's eigenvectors
+ 
   INTEGER(IntKi),   PARAMETER  :: MaxMemjnt       = 10                    ! Maximum number of members at one joint
   INTEGER(IntKi),   PARAMETER  :: MaxOutChs       = 2000                  ! Max number of Output Channels to be read in
   INTEGER(IntKi),   PARAMETER  :: TPdofL          = 6                     ! 6 degrees of freedom (length of u subarray [UTP])
@@ -40,50 +39,37 @@ MODULE SD_FEM
   INTEGER(IntKi),   PARAMETER  :: CMassCol        = 5                     ! Number of columns in Concentrated Mass (CMJointID,JMass,JMXX,JMYY,JMZZ)
   
   INTEGER(IntKi),   PARAMETER  :: SDMaxInpCols    = MAX(JointsCol,ReactCol,InterfCol,MembersCol,PropSetsCol,XPropSetsCol,COSMsCol,CMassCol)
-    CONTAINS
-    
-SUBROUTINE NodeCon(Init,p, ErrStat, ErrMsg)
-  
-!This Subroutine maps nodes to elements
-! allocate for NodesConnE and NodesConnN                                                                               
-  USE qsort_c_module
-  IMPLICIT NONE
 
-  TYPE(SD_InitType),              INTENT( INOUT )  ::Init   
-  TYPE(SD_ParameterType),         INTENT( IN    )  ::p  
-  INTEGER(IntKi),                 INTENT(   OUT )  :: ErrStat     ! Error status of the operation
-  CHARACTER(*),                   INTENT(   OUT )  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-   
-  !local variable
+CONTAINS
+    
+!> Maps nodes to elements 
+!! allocate NodesConnE and NodesConnN                                                                               
+SUBROUTINE NodeCon(Init,p, ErrStat, ErrMsg)
+  USE qsort_c_module ,only: QsortC
+  TYPE(SD_InitType),              INTENT( INOUT ) :: Init
+  TYPE(SD_ParameterType),         INTENT( IN    ) :: p
+  INTEGER(IntKi),                 INTENT(   OUT ) :: ErrStat     ! Error status of the operation
+  CHARACTER(*),                   INTENT(   OUT ) :: ErrMsg      ! Error message if ErrStat /= ErrID_None
+  ! Local variables
   INTEGER(IntKi) :: SortA(MaxMemJnt,1)  !To sort nodes and elements
   INTEGER(IntKi) :: I,J,K  !counter
   
-  ! bjj: shouldn't there be a check that there AREN'T actually more members at one joint than MaxMemJnt?
-  ALLOCATE(Init%NodesConnE(Init%NNode, MaxMemJnt+1), STAT=ErrStat)                !the row index is the number of the real node, i.e. ID, 1st col has number of elements attached to node, and 2nd col has element numbers (up to 10)                                    
-  IF ( ErrStat /= 0 )  THEN                                                                                                
-      ErrMsg = ' Error allocating NodesConnE matrix'                                                    
-      ErrStat = ErrID_Fatal                                                                                                         
-      RETURN                                                                                                              
-  ENDIF                                                                                                                  
+  ! The row index is the number of the real node, i.e. ID, 1st col has number of elements attached to node, and 2nd col has element numbers (up to 10)                                    
+  CALL AllocAry(Init%NodesConnE, Init%NNode, MaxMemJnt+1,'NodesConnE', ErrStat, ErrMsg); if (ErrStat/=0) return;
+  CALL AllocAry(Init%NodesConnN, Init%NNode, MaxMemJnt+2,'NodesConnN', ErrStat, ErrMsg); if (ErrStat/=0) return;
   Init%NodesConnE = 0                                                                                                    
-                                                                                                                          
-  ALLOCATE(Init%NodesConnN(Init%NNode, MaxMemJnt+2), STAT=ErrStat)                                                    
-  IF ( ErrStat /= 0 )  THEN                                                                                                
-      ErrMsg = ' Error allocating NodesConnN matrix'                                                    
-      ErrStat = ErrID_Fatal                                                                                                         
-      RETURN                                                                                                              
-  ENDIF                                                                                                                  
   Init%NodesConnN = 0                                                                                                    
                                                                                                                           
-!   ! find the node connectivity, nodes/elements that connect to a common node                                             
-   
+   ! find the node connectivity, nodes/elements that connect to a common node                                             
    DO I = 1, Init%NNode                                                                                                   
       Init%NodesConnN(I, 1) = NINT( Init%Nodes(I, 1) )      !This should not be needed, could remove the extra 1st column like for the other array                                                                      
-                                                                                                                          
       k = 0                                                                                                               
       DO J = 1, Init%NElem                          !This should be vectorized                                                                      
          IF ( ( NINT(Init%Nodes(I, 1))==p%Elems(J, 2)) .OR. (NINT(Init%Nodes(I, 1))==p%Elems(J, 3) ) ) THEN   !If i-th nodeID matches 1st node or 2nd of j-th element                                                                   
             k = k + 1                                                                                                     
+            if (k > MaxMemJnt+1) then 
+               CALL SetErrStat(ErrID_Fatal, 'Maximum number of members reached on node'//trim(Num2LStr(NINT(Init%Nodes(I,1)))), ErrStat, ErrMsg, 'NodeCon');
+            endif
             Init%NodesConnE(I, k + 1) = p%Elems(J, 1)                                                                  
             Init%NodesConnN(I, k + 1) = p%Elems(J, 3)                                                                  
             IF ( NINT(Init%Nodes(I, 1))==p%Elems(J, 3) ) Init%NodesConnN(I, k + 1) = p%Elems(J, 2)     !If nodeID matches 2nd node of element                                                                
@@ -103,14 +89,12 @@ SUBROUTINE NodeCon(Init,p, ErrStat, ErrMsg)
 END SUBROUTINE NodeCon
 
 !----------------------------------------------------------------------------
-!----------------------------------------------------------------------------
 SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
-
    TYPE(SD_InitType),            INTENT(INOUT)  ::Init
    TYPE(SD_ParameterType),       INTENT(INOUT)  ::p
    INTEGER(IntKi),               INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),                 INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-      ! local variable
+   ! local variable
    INTEGER                       :: I, J, n, Node, Node1, Node2, Prop, Prop1, Prop2   
    INTEGER                       :: OldJointIndex(Init%NJoints)
    INTEGER                       :: NNE      ! number of nodes per element
@@ -122,21 +106,16 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    LOGICAL                       :: found, CreateNewProp
    INTEGER(IntKi)                :: ErrStat2
    CHARACTER(1024)               :: ErrMsg2
-   
-   
    ErrStat = ErrID_None
    ErrMsg  = ""
-   
-   !~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    
    ! number of nodes per element
    IF( ( Init%FEMMod .GE. 0 ) .and. (Init%FEMMod .LE. 3) ) THEN
       NNE = 2 
    ELSE
-      CALL SetErrStat(ErrID_Fatal, 'FEMMod '//TRIM(Num2LStr(Init%FEMMod))//' not implemented.',ErrStat,ErrMsg,'SD_Discrt')
+      CALL Abort('FEMMod '//TRIM(Num2LStr(Init%FEMMod))//' not implemented.')
       RETURN
    ENDIF
-   
    
    Init%NNode = Init%NJoints + ( Init%NDiv - 1 )*p%NMembers    ! Calculate total number of nodes according to divisions 
    Init%NElem = p%NMembers*Init%NDiv                           ! Total number of element   
@@ -149,7 +128,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    
    ! check the number of interior modes
    IF ( p%Nmodes .GT. 6*(Init%NNode - Init%NInterf - p%NReact) ) THEN
-      CALL SetErrStat(ErrID_Fatal, ' NModes must be less than or equal to '//TRIM(Num2LStr( 6*(Init%NNode - Init%NInterf - p%NReact) )),ErrStat,ErrMsg,'SD_Discrt')
+      CALL Abort(' NModes must be less than or equal to '//TRIM(Num2LStr( 6*(Init%NNode - Init%NInterf - p%NReact) )))
       RETURN
    ENDIF
    
@@ -163,7 +142,6 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    CALL AllocAry(TempMembers,     p%NMembers,    MembersCol, 'TempMembers',     ErrStat2, ErrMsg2); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'SD_Discrt') 
    CALL AllocAry(TempProps,       MaxNProp,      PropSetsCol,'TempProps',       ErrStat2, ErrMsg2); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'SD_Discrt') 
    CALL AllocAry(TempReacts,      p%NReact,      ReactCol,   'TempReacts',      ErrStat2, ErrMsg2); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'SD_Discrt')
-   
 
    IF ( ErrStat >= AbortErrLev ) THEN
       CALL CleanUp_Discrt()
@@ -186,12 +164,10 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
       p%Elems(I,     1) = I                     ! element/member number (not MemberID)
 !bjj: TODO: JMJ wants check that YoungE, ShearG, and MatDens are equal in the two properties because we aren't going to interpolate them. This should be less confusing for users.                                                
       
-      
-         ! loop through the JointIDs for this member and find the corresponding indices into the Joints array
+      ! loop through the JointIDs for this member and find the corresponding indices into the Joints array
       DO n = 2,3  ! Members column for JointIDs for nodes 1 and 2
          Node = Init%Members(I, n)  ! n=2 or 3
-      
-            ! ...... search for index of joint whose JointID matches Node ......
+         ! ...... search for index of joint whose JointID matches Node ......
          J = 1
          found = .false.      
          DO WHILE ( .NOT. found .AND. J <= Init%NJoints )
@@ -201,29 +177,19 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
             END IF
             J = J + 1
          END DO 
-         
          IF ( .NOT. found) THEN
-            CALL SetErrStat(ErrID_Fatal,' Member '//TRIM(Num2LStr(I))//' has JointID'//TRIM(Num2LStr(n-1))//' = '//& 
-                                   TRIM(Num2LStr(Node))//' which is not in the node list !', ErrStat,ErrMsg,'SD_Discrt');
-            CALL CleanUp_Discrt()
+            CALL Abort(' Member '//TRIM(Num2LStr(I))//' has JointID'//TRIM(Num2LStr(n-1))//' = '// TRIM(Num2LStr(Node))//' which is not in the node list !')
             RETURN
          END IF
-         
       END DO ! loop through nodes/joints
       
-      
-         ! loop through the PropSetIDs for this member and find the corresponding indices into the Joints array
-      
+      ! loop through the PropSetIDs for this member and find the corresponding indices into the Joints array
       ! we're setting these two values:   
-      !p%Elems(I, 4) = property set for node 1 (note this sets the YoungE, ShearG, and MatDens columns for the ENTIRE element)   
-      !p%Elems(I, 5) = property set for node 2 (note this should be used only for the XsecD and XsecT properties in the element [for a linear distribution from node 1 to node 2 of D and T])
-         
+      ! p%Elems(I, 4) = property set for node 1 (note this sets the YoungE, ShearG, and MatDens columns for the ENTIRE element)   
+      ! p%Elems(I, 5) = property set for node 2 (note this should be used only for the XsecD and XsecT properties in the element [for a linear distribution from node 1 to node 2 of D and T])
       DO n=4,5 ! Member column for MPropSetID1 and MPropSetID2
-      
-                                                            
          Prop = Init%Members(I, n)  ! n=4 or 5
-      
-            ! ...... search for index of property set whose PropSetID matches Prop ......
+         ! ...... search for index of property set whose PropSetID matches Prop ......
          J = 1
          found = .false.      
          DO WHILE ( .NOT. found .AND. J <= Init%NPropSets )
@@ -233,16 +199,11 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
             END IF
             J = J + 1
          END DO
-      
          IF ( .NOT. found) THEN
-            CALL SetErrStat(ErrID_Fatal,' Member '//TRIM(Num2LStr(I))//' has PropSetID'//TRIM(Num2LStr(n-3))//' = '//& 
-                                   TRIM(Num2LStr(Prop))//' which is not in the Member X-Section Property data!', ErrStat,ErrMsg,'SD_Discrt');
-            CALL CleanUp_Discrt()
+            CALL Abort(' Member '//TRIM(Num2LStr(I))//' has PropSetID'//TRIM(Num2LStr(n-3))//' = '//TRIM(Num2LStr(Prop))//' which is not in the Member X-Section Property data!')
             RETURN
          END IF
-
       END DO ! loop through property ids         
-   
    END DO ! loop through members
    
    ! Initialize TempMembers
@@ -252,18 +213,14 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    TempProps = 0
    TempProps(1:Init%NPropSets, :) = Init%PropSets   
    
-   
    ! Initialize boundary constraint vector
    ! Change the node number
-   
-   
-    !Allocate array that will be p%Reacts renumbered and ordered so that ID does not play a role, just ordinal position number will count -RRD
+   ! Allocate array that will be p%Reacts renumbered and ordered so that ID does not play a role, just ordinal position number will count -RRD
    Init%BCs = 0
-   TempReacts=0 !INitialize -RRD
+   TempReacts=0
    DO I = 1, p%NReact
       Node1 = p%Reacts(I, 1);  !NODE ID
       TempReacts(I,2:ReactCol)=p%Reacts(I, 2:ReactCol)  !Assign all the appropriate fixity to the new Reacts array -RRD
-      
       found = .false.
       DO J = 1, Init%NJoints
          IF ( Node1 == NINT(Init%Joints(J, 1)) ) THEN
@@ -273,25 +230,19 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
             EXIT  !Exit J loop if node found -RRD
          ENDIF
       ENDDO
-      
       IF (.not. found) THEN
-         CALL SetErrStat(ErrID_Fatal,' React has node not in the node list !', ErrStat,ErrMsg,'SD_Discrt');
-         CALL CleanUp_Discrt()
+         CALL Abort(' React has node not in the node list !')
          RETURN
       ENDIF
-      
-      
       DO J = 1, 6
          Init%BCs( (I-1)*6+J, 1) = (Node2-1)*6+J;
          Init%BCs( (I-1)*6+J, 2) = p%Reacts(I, J+1);
       ENDDO
-      
    ENDDO
    p%Reacts=TempReacts   !UPDATED REACTS
       
    ! Initialize interface constraint vector
    ! Change the node number
-
    Init%IntFc = 0
    DO I = 1, Init%NInterf
       Node1 = Init%Interf(I, 1);
@@ -302,13 +253,10 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
             found = .true.
          ENDIF
       ENDDO
-      
       IF (.not. found) THEN
-         CALL SetErrStat(ErrID_Fatal,' Interf has node not in the node list !', ErrStat,ErrMsg,'SD_Discrt');
-         CALL CleanUp_Discrt()
+         CALL Abort(' Interf has node not in the node list !')
          RETURN
       ENDIF
-      
       DO J = 1, 6
          Init%IntFc( (I-1)*6+J, 1) = (Node2-1)*6+J;
          Init%IntFc( (I-1)*6+J, 2) = Init%Interf(I, J+1);
@@ -325,160 +273,151 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
       ENDDO
    ENDDO
 
-! discretize structure according to NDiv 
+    ! discretize structure according to NDiv 
+    knode = Init%NJoints
+    kelem = 0
+    kprop = Init%NPropSets
+    Init%MemberNodes = 0
 
-knode = Init%NJoints
-kelem = 0
-kprop = Init%NPropSets
-Init%MemberNodes = 0
+    IF (Init%NDiv .GT. 1) THEN
+       DO I = 1, p%NMembers !the first p%NMembers rows of p%Elems contain the element information
+          ! create new node
+          Node1 = TempMembers(I, 2)
+          Node2 = TempMembers(I, 3)
+          
+          IF ( Node1==Node2 ) THEN
+             CALL Abort(' Same starting and ending node in the member.')
+             RETURN
+          ENDIF
+          
+          Prop1 = TempMembers(I, 4)
+          Prop2 = TempMembers(I, 5)
+          
+          Init%MemberNodes(I,           1) = Node1
+          Init%MemberNodes(I, Init%NDiv+1) = Node2
+          
+          IF  ( ( .not. EqualRealNos(TempProps(Prop1, 2),TempProps(Prop2, 2) ) ) &
+           .OR. ( .not. EqualRealNos(TempProps(Prop1, 3),TempProps(Prop2, 3) ) ) &
+           .OR. ( .not. EqualRealNos(TempProps(Prop1, 4),TempProps(Prop2, 4) ) ) )  THEN
+          
+             CALL Abort(' Material E,G and rho in a member must be the same')
+             RETURN
+          ENDIF
 
+          x1 = Init%Nodes(Node1, 2)
+          y1 = Init%Nodes(Node1, 3)
+          z1 = Init%Nodes(Node1, 4)
 
-IF (Init%NDiv .GT. 1) THEN
-   DO I = 1, p%NMembers !the first p%NMembers rows of p%Elems contain the element information
-      ! create new node
-      Node1 = TempMembers(I, 2)
-      Node2 = TempMembers(I, 3)
-      
-      IF ( Node1==Node2 ) THEN
-         CALL SetErrStat(ErrID_Fatal,' Same starting and ending node in the member.', ErrStat,ErrMsg,'SD_Discrt');
-         CALL CleanUp_Discrt()
-         RETURN
-      ENDIF
-    
-      
-      
-      Prop1 = TempMembers(I, 4)
-      Prop2 = TempMembers(I, 5)
-      
-      Init%MemberNodes(I,           1) = Node1
-      Init%MemberNodes(I, Init%NDiv+1) = Node2
-      
-      IF  ( ( .not. EqualRealNos(TempProps(Prop1, 2),TempProps(Prop2, 2) ) ) &
-       .OR. ( .not. EqualRealNos(TempProps(Prop1, 3),TempProps(Prop2, 3) ) ) &
-       .OR. ( .not. EqualRealNos(TempProps(Prop1, 4),TempProps(Prop2, 4) ) ) )  THEN
-      
-         CALL SetErrStat(ErrID_Fatal,' Material E,G and rho in a member must be the same', ErrStat,ErrMsg,'SD_Discrt');
-         CALL CleanUp_Discrt()
-         RETURN
-      ENDIF
+          x2 = Init%Nodes(Node2, 2)
+          y2 = Init%Nodes(Node2, 3)
+          z2 = Init%Nodes(Node2, 4)
+          
+          dx = ( x2 - x1 )/Init%NDiv
+          dy = ( y2 - y1 )/Init%NDiv
+          dz = ( z2 - z1 )/Init%NDiv
+          
+          d1 = TempProps(Prop1, 5)
+          t1 = TempProps(Prop1, 6)
 
-      x1 = Init%Nodes(Node1, 2)
-      y1 = Init%Nodes(Node1, 3)
-      z1 = Init%Nodes(Node1, 4)
+          d2 = TempProps(Prop2, 5)
+          t2 = TempProps(Prop2, 6)
+          
+          dd = ( d2 - d1 )/Init%NDiv
+          dt = ( t2 - t1 )/Init%NDiv
+          
+             ! If both dd and dt are 0, no interpolation is needed, and we can use the same property set for new nodes/elements. otherwise we'll have to create new properties for each new node
+          CreateNewProp = .NOT. ( EqualRealNos( dd , 0.0_ReKi ) .AND.  EqualRealNos( dt , 0.0_ReKi ) )  
+          
+          ! node connect to Node1
+          knode = knode + 1
+          Init%MemberNodes(I, 2) = knode
+          CALL SetNewNode(knode, x1+dx, y1+dy, z1+dz, Init)
+          
+          
+          IF ( CreateNewProp ) THEN   
+               ! create a new property set 
+               ! k, E, G, rho, d, t, Init
+               kprop = kprop + 1
+               CALL SetNewProp(kprop, TempProps(Prop1, 2), TempProps(Prop1, 3), TempProps(Prop1, 4), d1+dd, t1+dt, TempProps)           
+               kelem = kelem + 1
+               CALL SetNewElem(kelem, Node1, knode, Prop1, kprop, p)  
+               nprop = kprop              
+          ELSE
+               kelem = kelem + 1
+               CALL SetNewElem(kelem, Node1, knode, Prop1, Prop1, p)                
+               nprop = Prop1 
+          ENDIF
+          
+          ! interior nodes
+          DO J = 2, (Init%NDiv-1)
+             knode = knode + 1
+             Init%MemberNodes(I, J+1) = knode
 
-      x2 = Init%Nodes(Node2, 2)
-      y2 = Init%Nodes(Node2, 3)
-      z2 = Init%Nodes(Node2, 4)
-      
-      dx = ( x2 - x1 )/Init%NDiv
-      dy = ( y2 - y1 )/Init%NDiv
-      dz = ( z2 - z1 )/Init%NDiv
-      
-      d1 = TempProps(Prop1, 5)
-      t1 = TempProps(Prop1, 6)
+             CALL SetNewNode(knode, x1 + J*dx, y1 + J*dy, z1 + J*dz, Init)
+             
+             IF ( CreateNewProp ) THEN   
+                  ! create a new property set 
+                  ! k, E, G, rho, d, t, Init
+                  
+                  kprop = kprop + 1
+                  CALL SetNewProp(kprop, TempProps(Prop1, 2), TempProps(Prop1, 3),&
+                                  Init%PropSets(Prop1, 4), d1 + J*dd, t1 + J*dt, &
+                                  TempProps)           
+                  kelem = kelem + 1
+                  CALL SetNewElem(kelem, knode-1, knode, nprop, kprop, p)
+                  nprop = kprop                
+             ELSE
+                  kelem = kelem + 1
+                  CALL SetNewElem(kelem, knode-1, knode, nprop, nprop, p)         
+                   
+             ENDIF
+          ENDDO
+          
+          ! the element connect to Node2
+          kelem = kelem + 1
+          CALL SetNewElem(kelem, knode, Node2, nprop, Prop2, p)                
 
-      d2 = TempProps(Prop2, 5)
-      t2 = TempProps(Prop2, 6)
-      
-      dd = ( d2 - d1 )/Init%NDiv
-      dt = ( t2 - t1 )/Init%NDiv
-      
-         ! If both dd and dt are 0, no interpolation is needed, and we can use the same property set for new nodes/elements. otherwise we'll have to create new properties for each new node
-      CreateNewProp = .NOT. ( EqualRealNos( dd , 0.0_ReKi ) .AND. &
-                              EqualRealNos( dt , 0.0_ReKi ) )  
-      
-      ! node connect to Node1
-      knode = knode + 1
-      Init%MemberNodes(I, 2) = knode
-      CALL GetNewNode(knode, x1+dx, y1+dy, z1+dz, Init)
-      
-      
-      IF ( CreateNewProp ) THEN   
-           ! create a new property set 
-           ! k, E, G, rho, d, t, Init
-           
-           kprop = kprop + 1
-           CALL GetNewProp(kprop, TempProps(Prop1, 2), TempProps(Prop1, 3),&
-                           TempProps(Prop1, 4), d1+dd, t1+dt, TempProps)           
-           kelem = kelem + 1
-           CALL GetNewElem(kelem, Node1, knode, Prop1, kprop, p)  
-           nprop = kprop              
-      ELSE
-           kelem = kelem + 1
-           CALL GetNewElem(kelem, Node1, knode, Prop1, Prop1, p)                
-           nprop = Prop1 
-      ENDIF
-      
-      ! interior nodes
-      
-      DO J = 2, (Init%NDiv-1)
-         knode = knode + 1
-         Init%MemberNodes(I, J+1) = knode
+       ENDDO ! loop over all members
 
-         CALL GetNewNode(knode, x1 + J*dx, y1 + J*dy, z1 + J*dz, Init)
-         
-         IF ( CreateNewProp ) THEN   
-              ! create a new property set 
-              ! k, E, G, rho, d, t, Init
-              
-              kprop = kprop + 1
-              CALL GetNewProp(kprop, TempProps(Prop1, 2), TempProps(Prop1, 3),&
-                              Init%PropSets(Prop1, 4), d1 + J*dd, t1 + J*dt, &
-                              TempProps)           
-              kelem = kelem + 1
-              CALL GetNewElem(kelem, knode-1, knode, nprop, kprop, p)
-              nprop = kprop                
-         ELSE
-              kelem = kelem + 1
-              CALL GetNewElem(kelem, knode-1, knode, nprop, nprop, p)         
-               
-         ENDIF
-      ENDDO
-      
-      ! the element connect to Node2
-      kelem = kelem + 1
-      CALL GetNewElem(kelem, knode, Node2, nprop, Prop2, p)                
+    ELSE ! NDiv = 1
 
-   ENDDO ! loop over all members
+       Init%MemberNodes(1:p%NMembers, 1:2) = p%Elems(1:Init%NElem, 2:3)   
 
-ELSE ! NDiv = 1
+    ENDIF ! if NDiv is greater than 1
 
-   Init%MemberNodes(1:p%NMembers, 1:2) = p%Elems(1:Init%NElem, 2:3)   
+    ! set the props in Init
+    Init%NProp = kprop
+    CALL AllocAry(Init%Props, Init%NProp, PropSetsCol,  'Init%Props', ErrStat2, ErrMsg2); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'SD_Discrt')
+       IF (ErrStat >= AbortErrLev ) THEN
+          CALL SetErrStat(ErrStat2,ErrMsg2, ErrStat,ErrMsg,'SD_Discrt');
+          CALL CleanUp_Discrt()
+       RETURN
+    ENDIF
+    !Init%Props(1:kprop, 1:Init%PropSetsCol) = TempProps
+    Init%Props = TempProps(1:Init%NProp, :)  !!RRD fixed it on 1/23/14 to account for NDIV=1
 
-ENDIF ! if NDiv is greater than 1
+    CALL CleanUp_Discrt()
 
-! set the props in Init
-Init%NProp = kprop
-CALL AllocAry(Init%Props, Init%NProp, PropSetsCol,  'Init%Props', ErrStat2, ErrMsg2); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'SD_Discrt')
-   IF (ErrStat >= AbortErrLev ) THEN
-      CALL SetErrStat(ErrStat2,ErrMsg2, ErrStat,ErrMsg,'SD_Discrt');
-      CALL CleanUp_Discrt()
-   RETURN
-ENDIF
-!Init%Props(1:kprop, 1:Init%PropSetsCol) = TempProps
-Init%Props = TempProps(1:Init%NProp, :)  !!RRD fixed it on 1/23/14 to account for NDIV=1
-
-CALL CleanUp_Discrt()
-
-RETURN
 CONTAINS
-!................
-   SUBROUTINE CleanUp_Discrt()
-   
-! deallocate temp matrices
-IF (ALLOCATED(TempProps)) DEALLOCATE(TempProps)
-IF (ALLOCATED(TempMembers)) DEALLOCATE(TempMembers)
-IF (ALLOCATED(TempReacts)) DEALLOCATE(TempReacts)
+   SUBROUTINE Abort(ErrMsg_in)
+      CHARACTER(len=*), intent(in) :: ErrMsg_in
+      CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'SD_Discrt');
+      CALL CleanUp_Discrt()
+   END SUBROUTINE Abort
 
+   SUBROUTINE CleanUp_Discrt()
+      ! deallocate temp matrices
+      IF (ALLOCATED(TempProps))   DEALLOCATE(TempProps)
+      IF (ALLOCATED(TempMembers)) DEALLOCATE(TempMembers)
+      IF (ALLOCATED(TempReacts))  DEALLOCATE(TempReacts)
    END SUBROUTINE CleanUp_Discrt
 
 END SUBROUTINE SD_Discrt
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE GetNewNode(k, x, y, z, Init)
 
+!------------------------------------------------------------------------------------------------------
+!> Set properties of node k
+SUBROUTINE SetNewNode(k, x, y, z, Init)
    TYPE(SD_InitType),      INTENT(INOUT) :: Init
-   
    INTEGER,                INTENT(IN)    :: k
    REAL(ReKi),             INTENT(IN)    :: x, y, z
    
@@ -487,19 +426,17 @@ SUBROUTINE GetNewNode(k, x, y, z, Init)
    Init%Nodes(k, 3) = y
    Init%Nodes(k, 4) = z
 
+END SUBROUTINE SetNewNode
 
-END SUBROUTINE GetNewNode
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE GetNewElem(k, n1, n2, p1, p2, p)
-
+!> Set properties of element k
+SUBROUTINE SetNewElem(k, n1, n2, p1, p2, p)
    INTEGER,                INTENT(IN   )   :: k
    INTEGER,                INTENT(IN   )   :: n1
    INTEGER,                INTENT(IN   )   :: n2
    INTEGER,                INTENT(IN   )   :: p1
    INTEGER,                INTENT(IN   )   :: p2
    TYPE(SD_ParameterType), INTENT(INOUT)   :: p
-  
    
    p%Elems(k, 1) = k
    p%Elems(k, 2) = n1
@@ -507,12 +444,11 @@ SUBROUTINE GetNewElem(k, n1, n2, p1, p2, p)
    p%Elems(k, 4) = p1
    p%Elems(k, 5) = p2
 
-END SUBROUTINE GetNewElem
+END SUBROUTINE SetNewElem
+
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE GetNewProp(k, E, G, rho, d, t, TempProps)
-!RRD-modifying this routine: This routine intends to calculate new member properties in case NDIV>1 ; 1/23/14
-   
+!> Set material properties of element k
+SUBROUTINE SetNewProp(k, E, G, rho, d, t, TempProps)
    INTEGER   , INTENT(IN)   :: k
    REAL(ReKi), INTENT(IN)   :: E, G, rho, d, t
    REAL(ReKi), INTENT(INOUT):: TempProps(:, :)
@@ -524,22 +460,20 @@ SUBROUTINE GetNewProp(k, E, G, rho, d, t, TempProps)
    TempProps(k, 5) = d
    TempProps(k, 6) = t
 
-END SUBROUTINE GetNewProp
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
+END SUBROUTINE SetNewProp
 
-   TYPE(SD_InitType),            INTENT(INOUT)  ::Init
-   TYPE(SD_ParameterType),       INTENT(INOUT)  ::p
-   INTEGER(IntKi),               INTENT(  OUT)  :: ErrStat     ! Error status of the operation
-   CHARACTER(*),                 INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-   
+!------------------------------------------------------------------------------------------------------
+!> Assemble stiffness and mass matrix, and gravity force vector
+SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
+   TYPE(SD_InitType),            INTENT(INOUT) :: Init
+   TYPE(SD_ParameterType),       INTENT(INOUT) :: p
+   INTEGER(IntKi),               INTENT(  OUT) :: ErrStat     ! Error status of the operation
+   CHARACTER(*),                 INTENT(  OUT) :: ErrMsg      ! Error message if ErrStat /= ErrID_None
+   ! Local variables
    INTEGER                  :: I, J, K, Jn, Kn
-   
-   INTEGER                  :: NNE        ! number of nodes in one element
+   INTEGER, PARAMETER       :: NNE=2      ! number of nodes in one element, fixed to 2
    INTEGER                  :: N1, N2     ! starting node and ending node in the element
    INTEGER                  :: P1, P2     ! property set numbers for starting and ending nodes
-
    REAL(ReKi)               :: D1, D2, t1, t2, E, G, rho ! properties of a section
    REAL(ReKi)               :: x1, y1, z1, x2, y2, z2    ! coordinates of the nodes
    REAL(ReKi)               :: DirCos(3, 3)              ! direction cosine matrices
@@ -547,55 +481,46 @@ SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
    REAL(ReKi)               :: r1, r2, t, Iyy, Jzz, Ixx, A, kappa, nu, ratioSq, D_inner, D_outer
    LOGICAL                  :: shear
    REAL(ReKi), ALLOCATABLE  :: Ke(:,:), Me(:, :), FGe(:) ! element stiffness and mass matrices gravity force vector
-   INTEGER, ALLOCATABLE     :: nn(:)                     ! node number in element 
+   INTEGER, DIMENSION(NNE)  :: nn                        ! node number in element 
    INTEGER                  :: r
-   
-   
    INTEGER(IntKi)           :: ErrStat2
    CHARACTER(1024)          :: ErrMsg2
-
    
-      ! for current application
-   IF ( (Init%FEMMod .LE. 3) .and. (Init%FEMMod .GE. 0)) THEN
-      NNE = 2
-   ELSE
-      ErrStat = ErrID_Fatal
-      ErrMsg = 'Invalid FEMMod in AssembleKM'
-      RETURN
-   ENDIF                              
+   ! for current application
+   if    (Init%FEMMod == 2) THEN ! tapered Euler-Bernoulli
+       CALL Abort ('FEMMod = 2 is not implemented.')
+       return
+   elseif (Init%FEMMod == 4) THEN ! tapered Timoshenko
+       CALL Abort ('FEMMod = 2 is not implemented.')
+       return
+   elseif ((Init%FEMMod == 1) .or. (Init%FEMMod == 3)) THEN !
+      ! 1: uniform Euler-Bernouli,  3: uniform Timoshenko
+   else
+       CALL Abort('FEMMod is not valid. Please choose from 1, 2, 3, and 4. ')
+       return
+   endif
    
    ! total degrees of freedom of the system 
    Init%TDOF = 6*Init%NNode
    
-         ! Assemble system stiffness and mass matrices with gravity force vector
-   
    ALLOCATE( p%ElemProps(Init%NElem), STAT=ErrStat2)
-      IF (ErrStat2 /= 0) THEN
-         CALL SetErrStat ( ErrID_Fatal, 'Error allocating p%ElemProps', ErrStat, ErrMsg, 'AssembleKM' )
-         CALL CleanUp_AssembleKM()
-      RETURN
+   IF (ErrStat2 /= 0) THEN
+       CALL Abort('Error allocating p%ElemProps')
+       return
    ENDIF
 
-   CALL AllocAry( Ke,     NNE*6,         NNE*6 , 'Ke',      ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! element stiffness matrix
-   CALL AllocAry( Me,     NNE*6,         NNE*6 , 'Me',      ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! element mass matrix 
-   CALL AllocAry( FGe,    NNE*6,                 'FGe',     ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! element gravity force vector 
-   CALL AllocAry( nn,     NNE,                   'nn',      ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! node number in element array 
-   
-   CALL AllocAry( Init%K, Init%TDOF, Init%TDOF , 'Init%K',  ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! system stiffness matrix 
-   CALL AllocAry( Init%m, Init%TDOF, Init%TDOF , 'Init%M',  ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! system mass matrix 
-   CALL AllocAry( Init%FG,Init%TDOF,             'Init%FG', ErrStat2, ErrMsg2); CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )    ! system gravity force vector 
-    
-   IF (ErrStat >= AbortErrLev) THEN
-      CALL CleanUp_AssembleKM()
-      RETURN
-   ENDIF
-   
-   Init%K = 0.0_ReKi
-   Init%M = 0.0_ReKi
+   CALL AllocAry( Ke,     NNE*6,         NNE*6 , 'Ke',      ErrStat2, ErrMsg2); if(Failed()) return; ! element stiffness matrix
+   CALL AllocAry( Me,     NNE*6,         NNE*6 , 'Me',      ErrStat2, ErrMsg2); if(Failed()) return; ! element mass matrix 
+   CALL AllocAry( FGe,    NNE*6,                 'FGe',     ErrStat2, ErrMsg2); if(Failed()) return; ! element gravity force vector 
+   CALL AllocAry( Init%K, Init%TDOF, Init%TDOF , 'Init%K',  ErrStat2, ErrMsg2); if(Failed()) return; ! system stiffness matrix 
+   CALL AllocAry( Init%m, Init%TDOF, Init%TDOF , 'Init%M',  ErrStat2, ErrMsg2); if(Failed()) return; ! system mass matrix 
+   CALL AllocAry( Init%FG,Init%TDOF,             'Init%FG', ErrStat2, ErrMsg2); if(Failed()) return; ! system gravity force vector 
+   Init%K  = 0.0_ReKi
+   Init%M  = 0.0_ReKi
    Init%FG = 0.0_ReKi
 
    
-      ! loop over all elements
+   ! loop over all elements
    DO I = 1, Init%NElem
    
       DO J = 1, NNE
@@ -607,7 +532,6 @@ SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
       
       P1 = p%Elems(I, NNE + 2)
       P2 = p%Elems(I, NNE + 3)
-      
       
       E   = Init%Props(P1, 2)
       G   = Init%Props(P1, 3)
@@ -625,166 +549,119 @@ SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
       y2  = Init%Nodes(N2, 3)
       z2  = Init%Nodes(N2, 4)
 
-      CALL GetDirCos(X1, Y1, Z1, X2, Y2, Z2, DirCos, L, ErrStat2, ErrMsg2)
-         CALL SetErrStat ( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM' )
-         IF (ErrStat >= AbortErrLev) THEN
-            CALL CleanUp_AssembleKM()
-            RETURN
-         END IF
+      CALL GetDirCos(X1, Y1, Z1, X2, Y2, Z2, DirCos, L, ErrStat2, ErrMsg2); if(Failed()) return
+         
+      r1 = 0.25*(D1 + D2)
+      t  = 0.5*(t1+t2)
       
-         
-!BJJ: TODO: for efficiency, this if check should be OUTSIDE the DO loop. 
-      ! 1: uniform Euler-Bernouli
-      ! 3: uniform Timoshenko
-      IF ( (Init%FEMMod == 1).OR.(Init%FEMMod == 3)) THEN ! uniform element 
-         r1 = 0.25*(D1 + D2)
-         t  = 0.5*(t1+t2)
-         
-         IF ( EqualRealNos(t, 0.0_ReKi) ) THEN
-            r2 = 0
-         ELSE
-            r2 = r1 - t
-         ENDIF
-         
-         A = Pi_D*(r1*r1-r2*r2)
-         Ixx = 0.25*Pi_D*(r1**4-r2**4)
-         Iyy = Ixx
-         Jzz = 2.0*Ixx
-         
-         IF( Init%FEMMod == 1 ) THEN ! uniform Euler-Bernoulli
-            Shear = .false.
-            kappa = 0
-         ELSEIF( Init%FEMMod == 3 ) THEN ! uniform Timoshenko
-            Shear = .true.
-          ! kappa = 0.53            
-            
-               ! equation 13 (Steinboeck et al) in SubDyn Theory Manual 
-            nu = E / (2.0_ReKi*G) - 1.0_ReKi
-            D_outer = 2.0_ReKi * r1  ! average (outer) diameter
-            D_inner = D_outer - 2*t  ! remove 2x thickness to get inner diameter
-            ratioSq = ( D_inner / D_outer)**2
-            kappa =   ( 6.0 * (1.0 + nu) **2 * (1.0 + ratioSq)**2 ) &
-                    / ( ( 1.0 + ratioSq )**2 * ( 7.0 + 14.0*nu + 8.0*nu**2 ) + 4.0 * ratioSq * ( 5.0 + 10.0*nu + 4.0 *nu**2 ) )
-                        
-         ENDIF
-         
-         p%ElemProps(i)%Area = A
-         p%ElemProps(i)%Length = L
-         p%ElemProps(i)%Ixx = Ixx
-         p%ElemProps(i)%Iyy = Iyy
-         p%ElemProps(i)%Jzz = Jzz
-         p%ElemProps(i)%Shear = Shear
-         p%ElemProps(i)%kappa = kappa
-         p%ElemProps(i)%YoungE = E
-         p%ElemProps(i)%ShearG = G
-         p%ElemProps(i)%Rho = rho
-         p%ElemProps(i)%DirCos = DirCos
-         
-         
-         CALL ElemK(A, L, Ixx, Iyy, Jzz, Shear, kappa, E, G, DirCos, Ke)
-         CALL ElemM(A, L, Ixx, Iyy, Jzz, rho, DirCos, Me)
-         CALL ElemG(A, L, rho, DirCos, FGe, Init%g)
-         
-      ELSEIF  (Init%FEMMod == 2) THEN ! tapered Euler-Bernoulli
-         CALL SetErrStat ( ErrID_Fatal, 'FEMMod = 2 is not implemented.', ErrStat, ErrMsg, 'AssembleKM' )
-         CALL CleanUp_AssembleKM()
-         RETURN
-         
-      ELSEIF  (Init%FEMMod == 4) THEN ! tapered Timoshenko
-         CALL SetErrStat ( ErrID_Fatal, 'FEMMod = 4 is not implemented.', ErrStat, ErrMsg, 'AssembleKM' )
-         CALL CleanUp_AssembleKM()
-         RETURN
-         
+      IF ( EqualRealNos(t, 0.0_ReKi) ) THEN
+         r2 = 0
       ELSE
-         CALL SetErrStat ( ErrID_Fatal, 'FEMMod is not valid. Please choose from 1, 2, 3, and 4. ', ErrStat, ErrMsg, 'AssembleKM' )
-         CALL CleanUp_AssembleKM()
-         RETURN
-         
-      ENDIF  
-                                                                                                                                                               
-
+         r2 = r1 - t
+      ENDIF
+      
+      A = Pi_D*(r1*r1-r2*r2)
+      Ixx = 0.25*Pi_D*(r1**4-r2**4)
+      Iyy = Ixx
+      Jzz = 2.0*Ixx
+      
+      IF( Init%FEMMod == 1 ) THEN ! uniform Euler-Bernoulli
+         Shear = .false.
+         kappa = 0
+      ELSEIF( Init%FEMMod == 3 ) THEN ! uniform Timoshenko
+         Shear = .true.
+       ! kappa = 0.53            
+         ! equation 13 (Steinboeck et al) in SubDyn Theory Manual 
+         nu = E / (2.0_ReKi*G) - 1.0_ReKi
+         D_outer = 2.0_ReKi * r1  ! average (outer) diameter
+         D_inner = D_outer - 2*t  ! remove 2x thickness to get inner diameter
+         ratioSq = ( D_inner / D_outer)**2
+         kappa =   ( 6.0 * (1.0 + nu) **2 * (1.0 + ratioSq)**2 ) &
+                 / ( ( 1.0 + ratioSq )**2 * ( 7.0 + 14.0*nu + 8.0*nu**2 ) + 4.0 * ratioSq * ( 5.0 + 10.0*nu + 4.0 *nu**2 ) )
+      ENDIF
+      
+      p%ElemProps(i)%Area = A
+      p%ElemProps(i)%Length = L
+      p%ElemProps(i)%Ixx = Ixx
+      p%ElemProps(i)%Iyy = Iyy
+      p%ElemProps(i)%Jzz = Jzz
+      p%ElemProps(i)%Shear = Shear
+      p%ElemProps(i)%kappa = kappa
+      p%ElemProps(i)%YoungE = E
+      p%ElemProps(i)%ShearG = G
+      p%ElemProps(i)%Rho = rho
+      p%ElemProps(i)%DirCos = DirCos
+      
+      CALL ElemK(A, L, Ixx, Iyy, Jzz, Shear, kappa, E, G, DirCos, Ke)
+      CALL ElemM(A, L, Ixx, Iyy, Jzz, rho, DirCos, Me)
+      CALL ElemG(A, L, rho, DirCos, FGe, Init%g)
       
       ! assemble element matrices to global matrices
-         
       DO J = 1, NNE
          jn = nn(j)
-         
-         Init%FG( (jn*6-5):(jn*6) ) = Init%FG( (jn*6-5):(jn*6) ) &
-                                    + FGe( (J*6-5):(J*6) )
-         
+         Init%FG( (jn*6-5):(jn*6) ) = Init%FG( (jn*6-5):(jn*6) )  + FGe( (J*6-5):(J*6) )
          DO K = 1, NNE
             kn = nn(k)
-            
-            Init%K( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) = Init%K( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) &
-                                                  + Ke( (J*6-5):(J*6), (K*6-5):(K*6) )
-                  
-            Init%M( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) = Init%M( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) &
-                                                  + Me( (J*6-5):(J*6), (K*6-5):(K*6) )
-                     
-                     
+            Init%K( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) = Init%K( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) + Ke( (J*6-5):(J*6), (K*6-5):(K*6) )
+            Init%M( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) = Init%M( (jn*6-5):(jn*6), (kn*6-5):(kn*6) ) + Me( (J*6-5):(J*6), (K*6-5):(K*6) )
          ENDDO !K
-                     
       ENDDO !J
-                     
-                     
    ENDDO ! I end loop over elements
-               
       
-      ! add concentrated mass 
+   ! add concentrated mass 
    DO I = 1, Init%NCMass
       DO J = 1, 3
           r = ( NINT(Init%CMass(I, 1)) - 1 )*6 + J
           Init%M(r, r) = Init%M(r, r) + Init%CMass(I, 2)
-          
       ENDDO
       DO J = 4, 6
           r = ( NINT(Init%CMass(I, 1)) - 1 )*6 + J
           Init%M(r, r) = Init%M(r, r) + Init%CMass(I, J-1)
       ENDDO
+   ENDDO ! Loop on concentrated mass
 
-   ENDDO ! I concentrated mass
- 
-      ! add concentrated mass induced gravity force
+   ! add concentrated mass induced gravity force
    DO I = 1, Init%NCMass
-      
-      r = ( NINT(Init%CMass(I, 1)) - 1 )*6 + 3
-      Init%FG(r) = Init%FG(r) - Init%CMass(I, 2)*Init%g 
-
+       r = ( NINT(Init%CMass(I, 1)) - 1 )*6 + 3
+       Init%FG(r) = Init%FG(r) - Init%CMass(I, 2)*Init%g 
    ENDDO ! I concentrated mass induced gravity
    
    CALL CleanUp_AssembleKM()
-   RETURN
    
 CONTAINS
-!..............
+   LOGICAL FUNCTION Failed()
+        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AssembleKM') 
+        Failed =  ErrStat >= AbortErrLev
+        if (Failed) call Cleanup_AssembleKM()
+   END FUNCTION Failed
+   
+   SUBROUTINE Abort(ErrMsg_in)
+      character(len=*), intent(in) :: ErrMsg_in
+      CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'AssembleKM');
+      CALL CleanUp_AssembleKM()
+   END SUBROUTINE Abort
+
    SUBROUTINE CleanUp_AssembleKM()
-! deallocate temp matrices
-      IF (ALLOCATED(Ke)) DEALLOCATE(Ke)
-      IF (ALLOCATED(Me)) DEALLOCATE(Me)
-      IF (ALLOCATED(FGe)) DEALLOCATE(FGe)
-      IF (ALLOCATED(nn)) DEALLOCATE(nn)
+      IF(ALLOCATED(Ke )) DEALLOCATE(Ke )
+      IF(ALLOCATED(Me )) DEALLOCATE(Me )
+      IF(ALLOCATED(FGe)) DEALLOCATE(FGe)
    END SUBROUTINE CleanUp_AssembleKM
    
 END SUBROUTINE AssembleKM
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
 
+!------------------------------------------------------------------------------------------------------
+!> Computes directional cosine matrix DirCos
+!! rrd: This should be from local to global 
+!! bjj: note that this is the transpose of what is normally considered the Direction Cosine Matrix  
+!!      in the FAST framework. It seems to be used consistantly in the code (i.e., the transpose 
+!!      of this matrix is used later).
 SUBROUTINE GetDirCos(X1, Y1, Z1, X2, Y2, Z2, DirCos, L, ErrStat, ErrMsg)
-   !This should be from local to global -RRD
-   ! bjj: note that this is the transpose of what is normally considered the Direction Cosine Matrix  
-   !      in the FAST framework. It seems to be used consistantly in the code (i.e., the transpose 
-   !      of this matrix is used later).
-   
-   
    REAL(ReKi) ,      INTENT(IN   )  :: x1, y1, z1, x2, y2, z2  ! (x,y,z) positions of two nodes making up an element
    REAL(ReKi) ,      INTENT(  OUT)  :: DirCos(3, 3)            ! calculated direction cosine matrix
    REAL(ReKi) ,      INTENT(  OUT)  :: L                       ! length of element
-   
    INTEGER(IntKi),   INTENT(  OUT)  :: ErrStat                 ! Error status of the operation
    CHARACTER(*),     INTENT(  OUT)  :: ErrMsg                  ! Error message if ErrStat /= ErrID_None
-   
    REAL(ReKi)                       ::  Dx,Dy,Dz, Dxy          ! distances between nodes
-!real(reki) :: dxyz         
    ErrMsg  = ""
    ErrStat = ErrID_None
    
@@ -826,27 +703,24 @@ SUBROUTINE GetDirCos(X1, Y1, Z1, X2, Y2, Z2, DirCos, L, ErrStat, ErrMsg)
    ENDIF
 
 END SUBROUTINE GetDirCos
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
 
+!------------------------------------------------------------------------------------------------------
+!> Element stiffness matrix for classical beam elements
+!! shear is true  -- non-tapered Timoshenko beam 
+!! shear is false -- non-tapered Euler-Bernoulli beam 
 SUBROUTINE ElemK(A, L, Ixx, Iyy, Jzz, Shear, kappa, E, G, DirCos, K)
-   ! element stiffness matrix for classical beam elements
-   ! shear is true  -- non-tapered Timoshenko beam 
-   ! shear is false -- non-tapered Euler-Bernoulli beam 
-
-   REAL(ReKi), INTENT( IN)               :: A, L, Ixx, Iyy, Jzz, E, G, kappa
-   REAL(ReKi), INTENT( IN)               :: DirCos(3,3)
-   LOGICAL, INTENT( IN)                  :: Shear
-   
-   REAL(ReKi), INTENT(OUT)             :: K(12, 12)  !RRD:  Ke and Me  need to be modified if convention of dircos is not followed?
-         
+   REAL(ReKi), INTENT( IN) :: A, L, Ixx, Iyy, Jzz, E, G, kappa
+   REAL(ReKi), INTENT( IN) :: DirCos(3,3)
+   LOGICAL   , INTENT( IN) :: Shear
+   REAL(ReKi), INTENT(OUT) :: K(12, 12) 
+   ! Local variables
    REAL(ReKi)                            :: Ax, Ay, Kx, Ky
    REAL(ReKi)                            :: DC(12, 12)
    
    Ax = kappa*A
    Ay = kappa*A
    
-   K = 0
+   K(1:12,1:12) = 0
    
    IF (Shear) THEN
       Kx = 12.0*E*Iyy / (G*Ax*L*L)
@@ -904,33 +778,26 @@ SUBROUTINE ElemK(A, L, Ixx, Iyy, Jzz, Shear, kappa, E, G, DirCos, K)
    DC( 7: 9,  7: 9) = DirCos
    DC(10:12, 10:12) = DirCos
    
-   K = MATMUL( MATMUL(DC, K), TRANSPOSE(DC) )
+   K = MATMUL( MATMUL(DC, K), TRANSPOSE(DC) ) ! TODO: change me if DirCos convention is  transposed
    
-   !write(*, *) K - TRANSPOSE(K)
-
 END SUBROUTINE ElemK
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
 
+!------------------------------------------------------------------------------------------------------
+!> Element mass matrix for classical beam elements
 SUBROUTINE ElemM(A, L, Ixx, Iyy, Jzz, rho, DirCos, M)
-   ! element mass matrix for classical beam elements
+   REAL(ReKi), INTENT( IN) :: A, L, Ixx, Iyy, Jzz, rho
+   REAL(ReKi), INTENT( IN) :: DirCos(3,3)
+   REAL(ReKi), INTENT(OUT) :: M(12, 12)
 
-
-   REAL(ReKi), INTENT( IN)               :: A, L, Ixx, Iyy, Jzz, rho
-   REAL(ReKi), INTENT( IN)               :: DirCos(3,3)
-   
-   REAL(ReKi)             :: M(12, 12)
-         
-   REAL(ReKi)                            :: t, rx, ry, po
-   REAL(ReKi)                            :: DC(12, 12)
+   REAL(ReKi) :: t, rx, ry, po
+   REAL(ReKi) :: DC(12, 12)
    
    t = rho*A*L;
    rx = rho*Ixx;
    ry = rho*Iyy;
    po = rho*Jzz*L;   
 
-   M = 0
-   
+   M(1:12,1:12) = 0
       
    M( 9,  9) = t/3.0
    M( 7,  7) = 13.0*t/35.0 + 6.0*ry/(5.0*L)
@@ -980,68 +847,56 @@ SUBROUTINE ElemM(A, L, Ixx, Iyy, Jzz, rho, DirCos, M)
    DC( 7: 9,  7: 9) = DirCos
    DC(10:12, 10:12) = DirCos
    
-   M = MATMUL( MATMUL(DC, M), TRANSPOSE(DC) )
+   M = MATMUL( MATMUL(DC, M), TRANSPOSE(DC) ) ! TODO change me if direction cosine is transposed
 
 END SUBROUTINE ElemM
 
-
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-
+!> Apply constraint (Boundary conditions) on Mass and Stiffness matrices
 SUBROUTINE ApplyConstr(Init,p)
-
-
-   TYPE(SD_InitType), INTENT(INOUT)   :: Init
-   TYPE(SD_ParameterType), INTENT(IN)   :: p
+   TYPE(SD_InitType     ),INTENT(INOUT):: Init
+   TYPE(SD_ParameterType),INTENT(IN   ):: p
    
-   INTEGER                  :: I !, J, k
-   INTEGER                  :: row_n !bgn_j, end_j, 
+   INTEGER :: I !, J, k
+   INTEGER :: row_n !bgn_j, end_j,
    
    DO I = 1, p%NReact*6
       row_n = Init%BCs(I, 1)
-      
       IF (Init%BCs(I, 2) == 1) THEN
-         Init%K(row_n, :) = 0
-         Init%K(:, row_n) = 0
-         Init%K(row_n, row_n) = 1
-      
-         Init%M(row_n, :) = 0
-         Init%M(:, row_n) = 0
-         Init%M(row_n, row_n) = 0 !0.00001          !what is this???? I changed this to 0.  RRD 7/31
+         Init%K(row_n,:    )= 0
+         Init%K(:    ,row_n)= 0
+         Init%K(row_n,row_n)= 1
+
+         Init%M(row_n,:    )= 0
+         Init%M(:    ,row_n)= 0
+         Init%M(row_n,row_n)= 0
       ENDIF
-      
-   ENDDO ! I
-
-      
-
+   ENDDO ! I, loop on reaction nodes
 END SUBROUTINE ApplyConstr
+
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
+!> calculates the lumped forces and moments due to gravity on a given element:
+!! the element has two nodes, with the loads for both elements stored in array F. Indexing of F is:
+!!    Fx_n1=1,Fy_n1=2,Fz_n1=3,Mx_n1= 4,My_n1= 5,Mz_n1= 6,
+!!    Fx_n2=7,Fy_n2=8,Fz_n2=9,Mx_n2=10,My_n2=11,Mz_n2=12
 SUBROUTINE ElemG(A, L, rho, DirCos, F, g)
-! this routine calculates the lumped forces and moments due to gravity on a given element:
-! the element has two nodes, with the loads for both elements stored in array F. Indexing of F is:
-!  Fx_n1=1,Fy_n1=2,Fz_n1=3,Mx_n1= 4,My_n1= 5,Mz_n1= 6,
-!  Fx_n2=7,Fy_n2=8,Fz_n2=9,Mx_n2=10,My_n2=11,Mz_n2=12
-!------------------------------------------------------------------------------------------------------
-   REAL(ReKi), INTENT( OUT)           :: F(12)        ! returned loads. positions 1-6 are the loads for node 1; 7-12 are loads for node 2.
-   REAL(ReKi), INTENT( IN )           :: A            ! area
-   REAL(ReKi), INTENT( IN )           :: g            ! gravity
-   REAL(ReKi), INTENT( IN )           :: L            ! element length
-   REAL(ReKi), INTENT( IN )           :: rho           
-   REAL(ReKi), INTENT( IN )           :: DirCos(3, 3) ! direction cosine matrix (for determining distance between nodes 1 and 2)
-
-   REAL(ReKi)                         :: TempCoeff
-   REAL(ReKi)                         :: w            ! weight per unit length
-
+   REAL(ReKi), INTENT( IN )           :: A            !< area
+   REAL(ReKi), INTENT( IN )           :: L            !< element length
+   REAL(ReKi), INTENT( IN )           :: rho          !< density
+   REAL(ReKi), INTENT( IN )           :: DirCos(3, 3) !< direction cosine matrix (for determining distance between nodes 1 and 2)
+   REAL(ReKi), INTENT( IN )           :: g            !< gravity
+   REAL(ReKi), INTENT( OUT)           :: F(12)        !< returned loads. positions 1-6 are the loads for node 1; 7-12 are loads for node 2.
+   REAL(ReKi) :: TempCoeff
+   REAL(ReKi) :: w            ! weight per unit length
    
    F = 0             ! initialize whole array to zero, then set the non-zero portions
    w = rho*A*g       ! weight per unit length
    
-      ! lumped forces on both nodes (z component only):
+   ! lumped forces on both nodes (z component only):
    F(3) = -0.5*L*w 
    F(9) = F(3)
           
-      ! lumped moments on node 1 (x and y components only):
+   ! lumped moments on node 1 (x and y components only):
    ! bjj: note that RRD wants factor of 1/12 because of boundary conditions. Our MeshMapping routines use factor of 1/6 (assuming generic/different boundary  
    !      conditions), so we may have some inconsistent behavior. JMJ suggests using line2 elements for SubDyn's input/output meshes to improve the situation.
    TempCoeff = L*L*w/12.0_ReKi ! let's not calculate this twice  
@@ -1053,31 +908,25 @@ SUBROUTINE ElemG(A, L, rho, DirCos, F, g)
    F(11) = -F(5)
    !F(12) is 0 for g along z alone
    
-   
 END SUBROUTINE ElemG
 !------------------------------------------------------------------------------------------------------
+!> Calculates the lumped gravity forces at the nodes given the element geometry
+!! It assumes a linear variation of the dimensions from node 1 to node 2, thus the area may be quadratically varying if crat<>1
+!! bjj: note this routine is a work in progress, intended for future version of SubDyn. Compare with ElemG.
 SUBROUTINE LumpForces(Area1,Area2,crat,L,rho, g, DirCos, F)
-!bjj: note this routine is a work in progress, intended for future version of SubDyn. Compare with ElemG.
-
-         !This rountine calculates the lumped gravity forces at the nodes given the element geometry
-         !It assumes a linear variation of the dimensions from node 1 to node 2, thus the area may be quadratically varying if crat<>1
-   REAL(ReKi), INTENT( OUT)           :: F(12)
-   REAL(ReKi), INTENT( IN )           :: Area1,Area2,crat !X-sectional areas at node 1 and node 2, t2/t1 thickness ratio
-   REAL(ReKi), INTENT( IN )           :: g !gravity
-   REAL(ReKi), INTENT( IN )           :: L !Length of element
-   REAL(ReKi), INTENT( IN )           :: rho !density
-   REAL(ReKi), INTENT( IN )           :: DirCos(3, 3)
-
-    !LOCALS
+   REAL(ReKi), INTENT( IN ) :: Area1,Area2,crat !< X-sectional areas at node 1 and node 2, t2/t1 thickness ratio
+   REAL(ReKi), INTENT( IN ) :: g                !< gravity
+   REAL(ReKi), INTENT( IN ) :: L                !< Length of element
+   REAL(ReKi), INTENT( IN ) :: rho              !< density
+   REAL(ReKi), INTENT( IN ) :: DirCos(3, 3)     !< Direction cosine matrix
+   REAL(ReKi), INTENT( OUT) :: F(12)            !< Lumped forces
+   !LOCALS
    REAL(ReKi)                         :: TempCoeff,a0,a1,a2  !coefficients of the gravity quadratically distributed force
-
-   A1 = -99999  !bjj initialized this to avoid getting warning by Intel Analyzers; needs to be set differently
-   A2 = -99999  !bjj initialized this to avoid getting warning by Intel Analyzers; needs to be set differently
    
    !Calculate quadratic polynomial coefficients
-   a0=A1
-   a2=( (Area1+A2) - (Area1*crat+Area2/crat) )/L**2.  !*x**2
-   a1= (Area2-Area1)/L -a2*L                       !*x                   
+   a0 = a1
+   a2 = ( (Area1+A2) - (Area1*crat+Area2/crat) )/L**2. ! *x**2
+   a1 = (Area2-Area1)/L -a2*L                          ! *x
    
    !Now calculate the Lumped Forces
    F = 0
@@ -1092,14 +941,12 @@ SUBROUTINE LumpForces(Area1,Area2,crat,L,rho, g, DirCos, F)
    !F(5) = TempCoeff*( DirCos(1, 3)*DirCos(2, 2) - DirCos(1, 2)*DirCos(2, 3) ) 
    
    !RRD attempt at new dircos which keeps x in the X-Y plane
-         F(4) = -TempCoeff * SQRT(1-DirCos(3,3)**2) * DirCos(1,1) !bjj: compare with ElemG() and verify this lumping is consistent
-         F(5) = -TempCoeff * SQRT(1-DirCos(3,3)**2) * DirCos(2,1) !bjj: compare with ElemG() and verify this lumping is consistent
-    !RRD ends
+   F(4) = -TempCoeff * SQRT(1-DirCos(3,3)**2) * DirCos(1,1) !bjj: compare with ElemG() and verify this lumping is consistent
+   F(5) = -TempCoeff * SQRT(1-DirCos(3,3)**2) * DirCos(2,1) !bjj: compare with ElemG() and verify this lumping is consistent
+   !RRD ends
    F(10) = -F(4)
    F(11) = -F(5)
    !F(12) is 0 for g along z alone
-
-   
 END SUBROUTINE LumpForces
 
 END MODULE SD_FEM

--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -113,7 +113,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    IF( ( Init%FEMMod .GE. 0 ) .and. (Init%FEMMod .LE. 3) ) THEN
       NNE = 2 
    ELSE
-      CALL Abort('FEMMod '//TRIM(Num2LStr(Init%FEMMod))//' not implemented.')
+      CALL Fatal('FEMMod '//TRIM(Num2LStr(Init%FEMMod))//' not implemented.')
       RETURN
    ENDIF
    
@@ -128,7 +128,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
    
    ! check the number of interior modes
    IF ( p%Nmodes .GT. 6*(Init%NNode - Init%NInterf - p%NReact) ) THEN
-      CALL Abort(' NModes must be less than or equal to '//TRIM(Num2LStr( 6*(Init%NNode - Init%NInterf - p%NReact) )))
+      CALL Fatal(' NModes must be less than or equal to '//TRIM(Num2LStr( 6*(Init%NNode - Init%NInterf - p%NReact) )))
       RETURN
    ENDIF
    
@@ -178,7 +178,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
             J = J + 1
          END DO 
          IF ( .NOT. found) THEN
-            CALL Abort(' Member '//TRIM(Num2LStr(I))//' has JointID'//TRIM(Num2LStr(n-1))//' = '// TRIM(Num2LStr(Node))//' which is not in the node list !')
+            CALL Fatal(' Member '//TRIM(Num2LStr(I))//' has JointID'//TRIM(Num2LStr(n-1))//' = '// TRIM(Num2LStr(Node))//' which is not in the node list !')
             RETURN
          END IF
       END DO ! loop through nodes/joints
@@ -200,7 +200,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
             J = J + 1
          END DO
          IF ( .NOT. found) THEN
-            CALL Abort(' Member '//TRIM(Num2LStr(I))//' has PropSetID'//TRIM(Num2LStr(n-3))//' = '//TRIM(Num2LStr(Prop))//' which is not in the Member X-Section Property data!')
+            CALL Fatal(' Member '//TRIM(Num2LStr(I))//' has PropSetID'//TRIM(Num2LStr(n-3))//' = '//TRIM(Num2LStr(Prop))//' which is not in the Member X-Section Property data!')
             RETURN
          END IF
       END DO ! loop through property ids         
@@ -231,7 +231,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
          ENDIF
       ENDDO
       IF (.not. found) THEN
-         CALL Abort(' React has node not in the node list !')
+         CALL Fatal(' React has node not in the node list !')
          RETURN
       ENDIF
       DO J = 1, 6
@@ -254,7 +254,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
          ENDIF
       ENDDO
       IF (.not. found) THEN
-         CALL Abort(' Interf has node not in the node list !')
+         CALL Fatal(' Interf has node not in the node list !')
          RETURN
       ENDIF
       DO J = 1, 6
@@ -286,7 +286,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
           Node2 = TempMembers(I, 3)
           
           IF ( Node1==Node2 ) THEN
-             CALL Abort(' Same starting and ending node in the member.')
+             CALL Fatal(' Same starting and ending node in the member.')
              RETURN
           ENDIF
           
@@ -300,7 +300,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
            .OR. ( .not. EqualRealNos(TempProps(Prop1, 3),TempProps(Prop2, 3) ) ) &
            .OR. ( .not. EqualRealNos(TempProps(Prop1, 4),TempProps(Prop2, 4) ) ) )  THEN
           
-             CALL Abort(' Material E,G and rho in a member must be the same')
+             CALL Fatal(' Material E,G and rho in a member must be the same')
              RETURN
           ENDIF
 
@@ -399,11 +399,11 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
     CALL CleanUp_Discrt()
 
 CONTAINS
-   SUBROUTINE Abort(ErrMsg_in)
+   SUBROUTINE Fatal(ErrMsg_in)
       CHARACTER(len=*), intent(in) :: ErrMsg_in
       CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'SD_Discrt');
       CALL CleanUp_Discrt()
-   END SUBROUTINE Abort
+   END SUBROUTINE Fatal
 
    SUBROUTINE CleanUp_Discrt()
       ! deallocate temp matrices
@@ -488,15 +488,15 @@ SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
    
    ! for current application
    if    (Init%FEMMod == 2) THEN ! tapered Euler-Bernoulli
-       CALL Abort ('FEMMod = 2 is not implemented.')
+       CALL Fatal ('FEMMod = 2 is not implemented.')
        return
    elseif (Init%FEMMod == 4) THEN ! tapered Timoshenko
-       CALL Abort ('FEMMod = 2 is not implemented.')
+       CALL Fatal ('FEMMod = 2 is not implemented.')
        return
    elseif ((Init%FEMMod == 1) .or. (Init%FEMMod == 3)) THEN !
       ! 1: uniform Euler-Bernouli,  3: uniform Timoshenko
    else
-       CALL Abort('FEMMod is not valid. Please choose from 1, 2, 3, and 4. ')
+       CALL Fatal('FEMMod is not valid. Please choose from 1, 2, 3, and 4. ')
        return
    endif
    
@@ -505,7 +505,7 @@ SUBROUTINE AssembleKM(Init,p, ErrStat, ErrMsg)
    
    ALLOCATE( p%ElemProps(Init%NElem), STAT=ErrStat2)
    IF (ErrStat2 /= 0) THEN
-       CALL Abort('Error allocating p%ElemProps')
+       CALL Fatal('Error allocating p%ElemProps')
        return
    ENDIF
 
@@ -635,11 +635,11 @@ CONTAINS
         if (Failed) call Cleanup_AssembleKM()
    END FUNCTION Failed
    
-   SUBROUTINE Abort(ErrMsg_in)
+   SUBROUTINE Fatal(ErrMsg_in)
       character(len=*), intent(in) :: ErrMsg_in
       CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'AssembleKM');
       CALL CleanUp_AssembleKM()
-   END SUBROUTINE Abort
+   END SUBROUTINE Fatal
 
    SUBROUTINE CleanUp_AssembleKM()
       IF(ALLOCATED(Ke )) DEALLOCATE(Ke )

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -1070,7 +1070,7 @@ CONTAINS
 
    SUBROUTINE Abort(ErrMsg_in)
       character(len=*), intent(in) :: ErrMsg_in
-      CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'SD_Init');
+      CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'SD_Input');
       CALL CleanUp()
    END SUBROUTINE Abort
 
@@ -1516,22 +1516,23 @@ SUBROUTINE Craig_Bampton(Init, p, CBparams, ErrStat, ErrMsg)
    
       
    CALL AllocParameters(p, CBparams%DOFM, ErrStat2, ErrMsg2);                                  ; if (Failed()) return
-   CALL AllocAry( MRR,             p%DOFR, p%DOFR,        'matrix MRR',     ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( MLL,             p%DOFL, p%DOFL,        'matrix MLL',     ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( MRL,             p%DOFR, p%DOFL,        'matrix MRL',     ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( KRR,             p%DOFR, p%DOFR,        'matrix KRR',     ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( KLL,             p%DOFL, p%DOFL,        'matrix KLL',     ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( KRL,             p%DOFR, p%DOFL,        'matrix KRL',     ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( FGL,             p%DOFL,                'array FGL',      ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( FGR,             p%DOFR,                'array FGR',      ErrStat2, ErrMsg2 ); if (Failed()) return
+
+   CALL AllocAry( MRR,             p%DOFR, p%DOFR,        'matrix MRR',     ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( MLL,             p%DOFL, p%DOFL,        'matrix MLL',     ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( MRL,             p%DOFR, p%DOFL,        'matrix MRL',     ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( KRR,             p%DOFR, p%DOFR,        'matrix KRR',     ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( KLL,             p%DOFL, p%DOFL,        'matrix KLL',     ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( KRL,             p%DOFR, p%DOFL,        'matrix KRL',     ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( FGL,             p%DOFL,                'array FGL',      ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
+   CALL AllocAry( FGR,             p%DOFR,                'array FGR',      ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')  
       
-   CALL AllocAry( CBparams%MBB,    p%DOFR, p%DOFR,       'CBparams%MBB',    ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( CBparams%MBM,    p%DOFR, CBparams%DOFM,'CBparams%MBM',    ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( CBparams%KBB,    p%DOFR, p%DOFR,       'CBparams%KBB',    ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( CBparams%PhiL,   p%DOFL, p%DOFL,       'CBparams%PhiL',   ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( CBparams%PhiR,   p%DOFL, p%DOFR,       'CBparams%PhiR',   ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( CBparams%OmegaL, p%DOFL,               'CBparams%OmegaL', ErrStat2, ErrMsg2 ); if (Failed()) return
-   CALL AllocAry( CBparams%TI2,    p%DOFR, 6,            'CBparams%TI2',    ErrStat2, ErrMsg2 ); if (Failed()) return
+   CALL AllocAry( CBparams%MBB,    p%DOFR, p%DOFR,       'CBparams%MBB',    ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')
+   CALL AllocAry( CBparams%MBM,    p%DOFR, CBparams%DOFM,'CBparams%MBM',    ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')
+   CALL AllocAry( CBparams%KBB,    p%DOFR, p%DOFR,       'CBparams%KBB',    ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')
+   CALL AllocAry( CBparams%PhiL,   p%DOFL, p%DOFL,       'CBparams%PhiL',   ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')
+   CALL AllocAry( CBparams%PhiR,   p%DOFL, p%DOFR,       'CBparams%PhiR',   ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')
+   CALL AllocAry( CBparams%OmegaL, p%DOFL,               'CBparams%OmegaL', ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton')
+   CALL AllocAry( CBparams%TI2,    p%DOFR, 6,            'CBparams%TI2',    ErrStat2, ErrMsg2 ); if(Failed()) return
    
    ! Set the index arrays p%IDI, p%IDR, p%IDL, p%IDC, and p%IDY. 
    CALL SetIndexArrays(Init, p, ErrStat2, ErrMsg2) ; if(Failed()) return
@@ -1588,7 +1589,7 @@ SUBROUTINE Craig_Bampton(Init, p, CBparams, ErrStat, ErrMsg)
 contains
 
    logical function Failed()
-        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'SD_Init') 
+        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'Craig_Bampton') 
         Failed =  ErrStat >= AbortErrLev
         if (Failed) call CleanUpCB()
    end function Failed
@@ -1610,27 +1611,22 @@ contains
    end subroutine CleanUpCB
 
 END SUBROUTINE Craig_Bampton 
+
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
+!>
 SUBROUTINE BreakSysMtrx(Init, p, MRR, MLL, MRL, KRR, KLL, KRL, FGR, FGL   )
-   
    TYPE(SD_InitType),      INTENT(IN   )  :: Init         ! Input data for initialization routine
    TYPE(SD_ParameterType), INTENT(IN   )  :: p  
-   
    REAL(ReKi),             INTENT(  OUT)  :: MRR(p%DOFR, p%DOFR)
    REAL(ReKi),             INTENT(  OUT)  :: MLL(p%DOFL, p%DOFL) 
    REAL(ReKi),             INTENT(  OUT)  :: MRL(p%DOFR, p%DOFL)
    REAL(ReKi),             INTENT(  OUT)  :: KRR(p%DOFR, p%DOFR)
    REAL(ReKi),             INTENT(  OUT)  :: KLL(p%DOFL, p%DOFL)
    REAL(ReKi),             INTENT(  OUT)  :: KRL(p%DOFR, p%DOFL)
-                                    
    REAL(ReKi),             INTENT(  OUT)  :: FGR(p%DOFR)
    REAL(ReKi),             INTENT(  OUT)  :: FGL(p%DOFL)
-   
-   
-      ! local variables
+   ! local variables
    INTEGER(IntKi)          :: I, J, II, JJ
-               
    
    DO I = 1, p%DOFR   !Boundary DOFs
       II = p%IDR(I)
@@ -1662,61 +1658,48 @@ SUBROUTINE BreakSysMtrx(Init, p, MRR, MLL, MRL, KRR, KLL, KRL, FGR, FGL   )
    ENDDO
       
 END SUBROUTINE BreakSysMtrx
+
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
-                     MBB, MBM, KBB, PhiL, PhiR, OmegaL, ErrStat, ErrMsg,p)
-! This routine sets the following values, as documented in the SubDyn Theory Guide:
+!> Sets the CB values, as documented in the SubDyn Theory Guide:
 ! OmegaL (omega) and PhiL from Eq. 2
 ! p%PhiL_T and p%PhiLInvOmgL2 for static improvement (will be added to theory guide later?)
 ! PhiR from Eq. 3
 ! MBB, MBM, and KBB from Eq. 4.
 !................................
-
-   USE SubDyn_Types
+SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
+                     MBB, MBM, KBB, PhiL, PhiR, OmegaL, ErrStat, ErrMsg,p)
    TYPE(SD_InitType),      INTENT(IN)    :: Init
    TYPE(SD_ParameterType), INTENT(INOUT) :: p  
    INTEGER(IntKi),         INTENT(  in)  :: DOFM
-   
    REAL(ReKi),             INTENT(  IN)  :: MRR( p%DOFR, p%DOFR)
    REAL(ReKi),             INTENT(  IN)  :: MLL( p%DOFL, p%DOFL) 
    REAL(ReKi),             INTENT(  IN)  :: MRL( p%DOFR, p%DOFL)
    REAL(ReKi),             INTENT(  IN)  :: KRR( p%DOFR, p%DOFR)
    REAL(ReKi),             INTENT(INOUT) :: KLL( p%DOFL, p%DOFL)  ! on exit, it has been factored (otherwise not changed)
    REAL(ReKi),             INTENT(  IN)  :: KRL( p%DOFR, p%DOFL)
-   
-   
-   REAL(ReKi),             INTENT(INOUT)  :: MBB( p%DOFR, p%DOFR)
-   REAL(ReKi),             INTENT(INOUT)  :: MBM( p%DOFR,   DOFM)
-   REAL(ReKi),             INTENT(INOUT)  :: KBB( p%DOFR, p%DOFR)
-   REAL(ReKi),             INTENT(INOUT)  :: PhiR(p%DOFL, p%DOFR)   
-   
-   REAL(ReKi),             INTENT(INOUT)  :: PhiL(p%DOFL, p%DOFL)    !used to be PhiM(DOFL,DOFM), now it is more generic
-   REAL(ReKi),             INTENT(INOUT)  :: OmegaL(p%DOFL)   !used to be omegaM only   ! Eigenvalues
-
-   INTEGER(IntKi),         INTENT(  OUT)  :: ErrStat     ! Error status of the operation
-   CHARACTER(*),           INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
+   REAL(ReKi),             INTENT(INOUT) :: MBB( p%DOFR, p%DOFR)
+   REAL(ReKi),             INTENT(INOUT) :: MBM( p%DOFR,   DOFM)
+   REAL(ReKi),             INTENT(INOUT) :: KBB( p%DOFR, p%DOFR)
+   REAL(ReKi),             INTENT(INOUT) :: PhiR(p%DOFL, p%DOFR)   
+   REAL(ReKi),             INTENT(INOUT) :: PhiL(p%DOFL, p%DOFL)    !used to be PhiM(DOFL,DOFM), now it is more generic
+   REAL(ReKi),             INTENT(INOUT) :: OmegaL(p%DOFL)   !used to be omegaM only   ! Eigenvalues
+   INTEGER(IntKi),         INTENT(  OUT) :: ErrStat     ! Error status of the operation
+   CHARACTER(*),           INTENT(  OUT) :: ErrMsg      ! Error message if ErrStat /= ErrID_None
    ! LOCAL VARIABLES
    REAL(ReKi) , allocatable               :: Mu(:, :)          ! matrix for normalization Mu(p%DOFL, p%DOFL) [bjj: made allocatable to try to avoid stack issues]
    REAL(ReKi) , allocatable               :: Temp(:, :)        ! temp matrix for intermediate steps [bjj: made allocatable to try to avoid stack issues]
    REAL(ReKi) , allocatable               :: PhiR_T_MLL(:,:)   ! PhiR_T_MLL(p%DOFR,p%DOFL) = transpose of PhiR * MLL (temporary storage)
-   
-   
-   
    INTEGER                                :: I !, lwork !counter, and varibales for inversion routines
    INTEGER                                :: DOFvar !placeholder used to get both PhiL or PhiM into 1 process
    INTEGER                                :: ipiv(p%DOFL) !the integer vector ipvt of length min(m,n), containing the pivot indices. 
                                                        !Returned as: a one-dimensional array of (at least) length min(m,n), containing integers,
                                                        !where 1 <= less than or equal to ipvt(i) <= less than or equal to m.
-                                                       
    INTEGER(IntKi)                         :: ErrStat2                                                                    
    CHARACTER(ErrMsgLen)                   :: ErrMsg2
    CHARACTER(*), PARAMETER                :: RoutineName = 'CBMatrix'
                                                        
    ErrStat = ErrID_None 
    ErrMsg  = ''
-   
    
    CALL WrScr('   Calculating Internal Modal Eigenvectors')
         
@@ -1730,26 +1713,17 @@ SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
    ! Set OmegaL and PhiL from Eq. 2
    !....................................................
    IF ( DOFvar > 0 ) THEN ! Only time this wouldn't happen is if no modes retained and no static improvement...
-      CALL EigenSolve(KLL, MLL, p%DOFL, DOFvar, .False.,Init,p, PhiL(:,1:DOFvar), OmegaL(1:DOFvar),  ErrStat2, ErrMsg2)
-         CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-         IF ( ErrStat >= AbortErrLev ) RETURN
-         
-      CALL AllocAry( Temp,  p%DOFL, p%DOFL, 'Temp', ErrStat2, ErrMsg2)
-         CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-         
-      CALL AllocAry( MU,  p%DOFL, p%DOFL, 'Mu', ErrStat2, ErrMsg2)
-         CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-         IF (ErrStat >= AbortErrLev) RETURN
-         
-      ! normalize PhiL
+      CALL EigenSolve(KLL, MLL, p%DOFL, DOFvar, .False.,Init,p, PhiL(:,1:DOFvar), OmegaL(1:DOFvar),  ErrStat2, ErrMsg2); if(Failed()) return
+
+      ! --- Normalize PhiL
       ! bjj: break up this equation to avoid as many tenporary variables on the stack
-      !MU = MATMUL ( MATMUL( TRANSPOSE(PhiL), MLL ), PhiL )
+      ! MU = MATMUL ( MATMUL( TRANSPOSE(PhiL), MLL ), PhiL )
+      CALL AllocAry( Temp , p%DOFL , p%DOFL , 'Temp' , ErrStat2 , ErrMsg2); if(Failed()) return
+      CALL AllocAry( MU   , p%DOFL , p%DOFL , 'Mu'   , ErrStat2 , ErrMsg2); if(Failed()) return
       MU   = TRANSPOSE(PhiL)
       Temp = MATMUL( MU, MLL )
       MU   = MATMUL( Temp, PhiL )
-   
       DEALLOCATE(Temp)
-      
       ! PhiL = MATMUL( PhiL, MU2 )  !this is the nondimensionalization (MU2 is diagonal)   
       DO I = 1, DOFvar
          PhiL(:,I) = PhiL(:,I) / SQRT( MU(I, I) )
@@ -1758,7 +1732,6 @@ SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
          PhiL(:,I) = 0.0_ReKi
          OmegaL(I) = 0.0_ReKi
       END DO     
-   
       DEALLOCATE(MU)
       
       !....................................................
@@ -1766,7 +1739,6 @@ SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
       !....................................................
       IF (p%SttcSolve) THEN   
          p%PhiL_T=TRANSPOSE(PhiL) !transpose of PhiL for static improvement
-      
          DO I = 1, p%DOFL
             p%PhiLInvOmgL2(:,I) = PhiL(:,I)* (1./OmegaL(I)**2)
          ENDDO 
@@ -1781,21 +1753,15 @@ SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
    !....................................................   
    ! now factor KLL to compute PhiR: KLL*PhiR=-TRANSPOSE(KRL)
    ! ** note this must be done after EigenSolve() because it modifies KLL **
-   CALL LAPACK_getrf( p%DOFL, p%DOFL, KLL, ipiv, ErrStat2, ErrMsg2)
-      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-      IF ( ErrStat >= AbortErrLev ) RETURN
+   CALL LAPACK_getrf( p%DOFL, p%DOFL, KLL, ipiv, ErrStat2, ErrMsg2); if(Failed()) return
    
    PhiR = -1.0_ReKi * TRANSPOSE(KRL) !set "b" in Ax=b  (solve KLL * PhiR = - TRANSPOSE( KRL ) for PhiR)
-   CALL LAPACK_getrs( TRANS='N',N=p%DOFL,A=KLL,IPIV=ipiv, B=PhiR, ErrStat=ErrStat2, ErrMsg=ErrMsg2)
-      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-      IF ( ErrStat >= AbortErrLev ) RETURN
+   CALL LAPACK_getrs( TRANS='N',N=p%DOFL,A=KLL,IPIV=ipiv, B=PhiR, ErrStat=ErrStat2, ErrMsg=ErrMsg2); if(Failed()) return
    
    !....................................................
    ! Set MBB, MBM, and KBB from Eq. 4:
    !....................................................
-   CALL AllocAry( PhiR_T_MLL,  p%DOFR, p%DOFL, 'PhiR_T_MLL', ErrStat2, ErrMsg2)
-      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-      IF (ErrStat >= AbortErrLev) RETURN
+   CALL AllocAry( PhiR_T_MLL,  p%DOFR, p%DOFL, 'PhiR_T_MLL', ErrStat2, ErrMsg2); if(Failed()) return
       
    PhiR_T_MLL = TRANSPOSE(PhiR)
    PhiR_T_MLL = MATMUL(PhiR_T_MLL, MLL)
@@ -1814,13 +1780,24 @@ SUBROUTINE CBMatrix( MRR, MLL, MRL, KRR, KLL, KRL, DOFM, Init, &
    KBB = MATMUL(KRL, PhiR)   
    KBB = KBB + KRR
      
+CONTAINS
+
+   logical function Failed()
+        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'CBMatrix') 
+        Failed =  ErrStat >= AbortErrLev
+        if (Failed) call CleanUp()
+   end function Failed
    
+   subroutine CleanUp()
+      if (allocated(Mu        )) DEALLOCATE(Mu        )
+      if (allocated(Temp      )) DEALLOCATE(Temp      )
+      if (allocated(PhiR_T_MLL)) DEALLOCATE(PhiR_T_MLL)
+   end subroutine
 END SUBROUTINE CBMatrix
 
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
+!>
 SUBROUTINE TrnsfTI(Init, TI, DOFI, IDI, TI2, DOFR, IDR, ErrStat, ErrMsg)
-
    TYPE(SD_InitType),      INTENT(IN   )  :: Init         ! Input data for initialization routine
    INTEGER(IntKi),         INTENT(IN   )  :: DOFI         ! # of DOFS of interface nodes
    INTEGER(IntKi),         INTENT(IN   )  :: DOFR         ! # of DOFS of restrained nodes (restraints and interface)
@@ -1828,52 +1805,33 @@ SUBROUTINE TrnsfTI(Init, TI, DOFI, IDI, TI2, DOFR, IDR, ErrStat, ErrMsg)
    INTEGER(IntKi),         INTENT(IN   )  :: IDR(DOFR)
    REAL(ReKi),             INTENT(INOUT)  :: TI( DOFI,6)  ! matrix TI that relates the reduced matrix to the TP, 
    REAL(ReKi),             INTENT(INOUT)  :: TI2(DOFR,6)  ! matrix TI2 that relates to (0,0,0) the overall substructure mass
-   
    INTEGER(IntKi),         INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),           INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! local variables
+   ! local variables
    INTEGER                                :: I, di 
    INTEGER                                :: rmndr, n
-   REAL(ReKi)                             :: x, y, z, dx, dy, dz
+   REAL(ReKi)                             :: dx, dy, dz
    
    ErrStat = ErrID_None
    ErrMsg  = ""
       
-   TI = 0. !INitialize     
-   
+   TI(:,:) = 0. !Initialize     
    DO I = 1, DOFI
       di = IDI(I)
       rmndr = MOD(di, 6)
       n = CEILING(di/6.0)
       
-      x = Init%Nodes(n, 2)
-      y = Init%Nodes(n, 3)
-      z = Init%Nodes(n, 4)
-      
-      dx = x - Init%TP_RefPoint(1)
-      dy = y - Init%TP_RefPoint(2)
-      dz = z - Init%TP_RefPoint(3)
+      dx = Init%Nodes(n, 2) - Init%TP_RefPoint(1)
+      dy = Init%Nodes(n, 3) - Init%TP_RefPoint(2)
+      dz = Init%Nodes(n, 4) - Init%TP_RefPoint(3)
       
       SELECT CASE (rmndr)
-         CASE (1)
-            TI(I, 1:6) = (/1.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi,       dz,      -dy/)
-            
-         CASE (2)
-            TI(I, 1:6) = (/0.0_ReKi, 1.0_ReKi, 0.0_ReKi,      -dz, 0.0_ReKi,       dx/)
-            
-         CASE (3)
-            TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 1.0_ReKi,       dy,      -dx, 0.0_ReKi/)
-         
-         CASE (4)
-            TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi, 0.0_ReKi/)
-            
-         CASE (5)
-            TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi/)
-            
-         CASE (0)
-            TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi/)
-            
+         CASE (1); TI(I, 1:6) = (/1.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi,       dz,      -dy/)
+         CASE (2); TI(I, 1:6) = (/0.0_ReKi, 1.0_ReKi, 0.0_ReKi,      -dz, 0.0_ReKi,       dx/)
+         CASE (3); TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 1.0_ReKi,       dy,      -dx, 0.0_ReKi/)
+         CASE (4); TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi, 0.0_ReKi/)
+         CASE (5); TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi/)
+         CASE (0); TI(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi/)
          CASE DEFAULT
             ErrStat = ErrID_Fatal
             ErrMsg  = 'Error calculating transformation matrix TI '
@@ -1883,38 +1841,22 @@ SUBROUTINE TrnsfTI(Init, TI, DOFI, IDI, TI2, DOFR, IDR, ErrStat, ErrMsg)
    ENDDO
    
    !Augment with TI2
-   TI2 = 0. !INitialize 
+   TI2(:,:) = 0. !Initialize 
    DO I = 1, DOFR
       di = IDR(I)
       rmndr = MOD(di, 6)
       n = CEILING(di/6.0)
       
-      x = Init%Nodes(n, 2)
-      y = Init%Nodes(n, 3)
-      z = Init%Nodes(n, 4)
-      
-      dx = x 
-      dy = y 
-      dz = z 
+      dx = Init%Nodes(n, 2)
+      dy = Init%Nodes(n, 3) 
+      dz = Init%Nodes(n, 4) 
      SELECT CASE (rmndr)
-         CASE (1)
-            TI2(I, 1:6) = (/1.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi,       dz,      -dy/)
-            
-         CASE (2)
-            TI2(I, 1:6) = (/0.0_ReKi, 1.0_ReKi, 0.0_ReKi,      -dz, 0.0_ReKi,       dx/)
-            
-         CASE (3)
-            TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 1.0_ReKi,       dy,      -dx, 0.0_ReKi/)
-         
-         CASE (4)
-            TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi, 0.0_ReKi/)
-            
-         CASE (5)
-            TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi/)
-            
-         CASE (0)
-            TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi/)
-            
+         CASE (1); TI2(I, 1:6) = (/1.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi,       dz,      -dy/)
+         CASE (2); TI2(I, 1:6) = (/0.0_ReKi, 1.0_ReKi, 0.0_ReKi,      -dz, 0.0_ReKi,       dx/)
+         CASE (3); TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 1.0_ReKi,       dy,      -dx, 0.0_ReKi/)
+         CASE (4); TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi, 0.0_ReKi/)
+         CASE (5); TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi, 0.0_ReKi/)
+         CASE (0); TI2(I, 1:6) = (/0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 0.0_ReKi, 1.0_ReKi/)
          CASE DEFAULT
             ErrStat = ErrID_Fatal
             ErrMsg  = 'Error calculating transformation matrix TI2 '
@@ -1922,19 +1864,12 @@ SUBROUTINE TrnsfTI(Init, TI, DOFI, IDI, TI2, DOFR, IDR, ErrStat, ErrMsg)
          END SELECT 
    ENDDO
    
-   
-   
 END SUBROUTINE TrnsfTI
+
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
+!> Return eigenvalues, Omega, and eigenvectors, Phi, 
 SUBROUTINE EigenSolve(K, M, nDOF, NOmega, Reduced, Init,p, Phi, Omega, ErrStat, ErrMsg )
-! This routine returns eigenvalues, Omega, and eigenvectors, Phi, 
-
-   USE NWTC_Library
-   USE NWTC_ScaLAPACK
-
-   IMPLICIT NONE
-
+   USE NWTC_ScaLAPACK, only: ScaLAPACK_LASRT
    INTEGER,                INTENT(IN   )    :: nDOF                               ! Total degrees of freedom of the incoming system
    REAL(ReKi),             INTENT(IN   )    :: K(nDOF, nDOF)                      ! stiffness matrix 
    REAL(ReKi),             INTENT(IN   )    :: M(nDOF, nDOF)                      ! mass matrix 
@@ -1946,143 +1881,109 @@ SUBROUTINE EigenSolve(K, M, nDOF, NOmega, Reduced, Init,p, Phi, Omega, ErrStat, 
    REAL(ReKi),             INTENT(  OUT)    :: Omega(NOmega)                      ! RRD: Returned Eigenvalues
    INTEGER(IntKi),         INTENT(  OUT)    :: ErrStat                            ! Error status of the operation
    CHARACTER(*),           INTENT(  OUT)    :: ErrMsg                             ! Error message if ErrStat /= ErrID_None
-   
    ! LOCALS         
    REAL(LAKi), ALLOCATABLE                   :: Omega2(:)                         !RRD: Eigen-values new system
 ! note: SGGEV seems to have memory issues in certain cases. The eigenvalues seem to be okay, but the eigenvectors vary wildly with different compiling options.
 !       DGGEV seems to work better, so I'm making these variables LAKi (which is set to R8Ki for now)   - bjj 4/25/2014
    REAL(LAKi), ALLOCATABLE                   :: Kred(:,:), Mred(:,:) 
    REAL(LAKi), ALLOCATABLE                   :: WORK (:),  VL(:,:), VR(:,:), ALPHAR(:), ALPHAI(:), BETA(:) ! eigensolver variables
-   
    INTEGER                                   :: i  
    INTEGER                                   :: N, LWORK                          !variables for the eigensolver
    INTEGER,    ALLOCATABLE                   :: KEY(:)
-   
    INTEGER(IntKi)                            :: ErrStat2
    CHARACTER(ErrMsgLen)                      :: ErrMsg2
-                  
       
    ErrStat = ErrID_None
    ErrMsg  = ''
          
-    !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
+   !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
    IF (Reduced) THEN !bjj: i.e., We need to reduce; it's not reduced yet
       ! First I need to remove constrained nodes DOFs
       ! This is actually done when we are printing out the 'full' set of eigenvalues
-      CALL ReduceKMdofs(Kred,K,nDOF, Init,p, ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve') ! Allocate and initialize Kred        !
-      CALL ReduceKMdofs(Mred,M,nDOF, Init,p, ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve') ! Allocate and initialize Mred
+      CALL ReduceKMdofs(Kred,K,nDOF, Init,p, ErrStat2, ErrMsg2 ); if(Failed()) return
+      CALL ReduceKMdofs(Mred,M,nDOF, Init,p, ErrStat2, ErrMsg2 ); if(Failed()) return
       N=SIZE(Kred,1)    
    ELSE
-        ! This is actually done whe we are generating the CB-reduced set of eigenvalues, so the the variable 'Reduced' can be a bit confusing. GJH 8/1/13
+      ! This is actually done whe we are generating the CB-reduced set of eigenvalues, so the the variable 'Reduced' can be a bit confusing. GJH 8/1/13
       N=SIZE(K,1)
-      CALL AllocAry( Kred, n, n, 'Kred', ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
-      CALL AllocAry( Mred, n, n, 'Mred', ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
-        
+      CALL AllocAry( Kred, n, n, 'Kred', ErrStat2, ErrMsg2 ); if(Failed()) return
+      CALL AllocAry( Mred, n, n, 'Mred', ErrStat2, ErrMsg2 ); if(Failed()) return
       Kred=REAL( K, LAKi )
       Mred=REAL( M, LAKi )
    ENDIF
-    
-      ! Note:  NOmega must be <= N, which is the length of Omega2, Phi!
-      
-    IF ( NOmega > N ) THEN
-       CALL SetErrStat(ErrID_Fatal,"NOmega must be less than or equal to N",ErrStat,ErrMsg,'EigenSolve')
-       CALL CleanupEigen()
-       RETURN
-    END IF
+   ! Note:  NOmega must be <= N, which is the length of Omega2, Phi!
+   IF ( NOmega > N ) THEN
+      CALL SetErrStat(ErrID_Fatal,"NOmega must be less than or equal to N",ErrStat,ErrMsg,'EigenSolve')
+      CALL CleanupEigen()
+      RETURN
+   END IF
 
-      ! allocate working arrays and return arrays for the eigensolver
+   ! allocate working arrays and return arrays for the eigensolver
    LWORK=8*N + 16  !this is what the eigensolver wants  >> bjj: +16 because of MKL ?ggev documenation ( "lwork >= max(1, 8n+16) for real flavors"), though LAPACK documenation says 8n is fine
-   CALL AllocAry( Work,   lwork,     'Work',   ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve') !bjj: there seems to be a memory problem in *GGEV, so I'm making the WORK array larger to see if I can figure it out
+   !bjj: there seems to be a memory problem in *GGEV, so I'm making the WORK array larger to see if I can figure it out
+   CALL AllocAry( Work,   lwork,     'Work',   ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve') 
    CALL AllocAry( Omega2, n,         'Omega2', ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
    CALL AllocAry( ALPHAR, n,         'ALPHAR', ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
    CALL AllocAry( ALPHAI, n,         'ALPHAI', ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
    CALL AllocAry( BETA,   n,         'BETA',   ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
    CALL AllocAry( VR,     n,  n,     'VR',     ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
    CALL AllocAry( VL,     n,  n,     'VR',     ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
-   CALL AllocAry( KEY,    n,         'KEY',    ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
-   
-   IF ( ErrStat >= AbortErrLev ) THEN
-      CALL CleanupEigen()
-      RETURN
-   END IF
+   CALL AllocAry( KEY,    n,         'KEY',    ErrStat2, ErrMsg2 ); if(Failed()) return
     
-    CALL  LAPACK_ggev('N','V',N ,Kred, Mred, ALPHAR, ALPHAI, BETA, VL, VR, work, lwork, ErrStat2, ErrMsg2)
-      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
-      IF ( ErrStat >= AbortErrLev ) THEN
-         CALL CleanupEigen()
-         RETURN
-      END IF      
-!if (.not. reduced) call wrmatrix(REAL(VR,ReKi),77,'ES15.8e2')    
-           
- ! bjj: This comes from the LAPACK documentation:
- !   Note: the quotients ALPHAR(j)/BETA(j) and ALPHAI(j)/BETA(j) may easily over- or underflow, and BETA(j) may even be zero.
- !   Thus, the user should avoid naively computing the ratio alpha/beta.  However, ALPHAR and ALPHAI will be always less
- !   than and usually comparable with norm(A) in magnitude, and BETA always less than and usually comparable with norm(B).    
-      
+   CALL  LAPACK_ggev('N','V',N ,Kred, Mred, ALPHAR, ALPHAI, BETA, VL, VR, work, lwork, ErrStat2, ErrMsg2)
+   if(Failed()) return
+   !if (.not. reduced) call wrmatrix(REAL(VR,ReKi),77,'ES15.8e2')    
+   ! bjj: This comes from the LAPACK documentation:
+   !   Note: the quotients ALPHAR(j)/BETA(j) and ALPHAI(j)/BETA(j) may easily over- or underflow, and BETA(j) may even be zero.
+   !   Thus, the user should avoid naively computing the ratio alpha/beta.  However, ALPHAR and ALPHAI will be always less
+   !   than and usually comparable with norm(A) in magnitude, and BETA always less than and usually comparable with norm(B).    
    ! Omega2=ALPHAR/BETA  !Note this may not be correct if ALPHAI<>0 and/or BETA=0 TO INCLUDE ERROR CHECK, also they need to be sorted
    DO I=1,N !Initialize the key and calculate Omega2
       KEY(I)=I
-        
       IF ( EqualRealNos(Beta(I),0.0_LAKi) ) THEN
          Omega2(I) = HUGE(Omega2)  ! bjj: should this be an error?
       ELSE
          Omega2(I) = REAL( ALPHAR(I)/BETA(I), ReKi )
       END IF           
    ENDDO  
-   
-   CALL ScaLAPACK_LASRT('I',N,Omega2,key,ErrStat2,ErrMsg2)
-      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')
-      IF ( ErrStat >= AbortErrLev ) THEN
-         CALL CleanupEigen()
-         RETURN
-      END IF      
+   CALL ScaLAPACK_LASRT('I',N,Omega2,key,ErrStat2,ErrMsg2); if(Failed()) return
     
-    !we need to rearrange eigenvectors based on sorting of Omega2
-    !Now rearrange VR based on the new key, also I might have to scale the eigenvectors following generalized mass =idnetity criterion, also if i reduced the matrix I will need to re-expand the eigenvector
+   !we need to rearrange eigenvectors based on sorting of Omega2
+   !Now rearrange VR based on the new key, also I might have to scale the eigenvectors following generalized mass =idnetity criterion, also if i reduced the matrix I will need to re-expand the eigenvector
    ! ALLOCATE(normcoeff(N,N), STAT = ErrStat )
    ! result1 = matmul(Mred2,VR)
-    
    ! result2 = matmul(transpose(VR),result1)
    ! normcoeff=sqrt(result2)  !This should be a diagonal matrix which contains the normalization factors
-    
-    !normcoeff=sqrt(matmul(transpose(VR),matmul(Mred2,VR)))  !This should be a diagonal matrix which contains the normalization factors
-    
-    
-    VL=VR  !temporary storage for sorting VR
-    DO I=1,N 
-        !VR(:,I)=VL(:,KEY(I))/normcoeff(KEY(I),KEY(I))  !reordered and normalized
-        VR(:,I)=VL(:,KEY(I))  !just reordered as Huimin had a normalization outside of this one
-    ENDDO
- 
- !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
-    
-   !===============================================================================
-   !=====             Finish EigenSolve
-   !===============================================================================
+   !normcoeff=sqrt(matmul(transpose(VR),matmul(Mred2,VR)))  !This should be a diagonal matrix which contains the normalization factors
+   VL=VR  !temporary storage for sorting VR
+   DO I=1,N 
+      !VR(:,I)=VL(:,KEY(I))/normcoeff(KEY(I),KEY(I))  !reordered and normalized
+      VR(:,I)=VL(:,KEY(I))  !just reordered as Huimin had a normalization outside of this one
+   ENDDO
+   !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++!
 
-      ! Note:  NOmega must be <= N, which is the length of Omega2, Phi!
-   
+   ! --- Finish EigenSolve
+   ! Note:  NOmega must be <= N, which is the length of Omega2, Phi!
    Omega=SQRT( Omega2(1:NOmega) ) !Assign my new Omega and below my new Phi (eigenvectors) [eigenvalues are actually the square of omega]
-                  
-
    IF ( Reduced ) THEN ! this is called for the full system Eigenvalues:
-      !Need to expand eigenvectors for removed DOFs
-      CALL UnReduceVRdofs(VR(:,1:NOmega),Phi,N,NOmega, Init,p, ErrStat2, ErrMsg2 ) ! set Phi 
-         CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,'EigenSolve')   
+      !Need to expand eigenvectors for removed DOFs, setting Phi 
+      CALL UnReduceVRdofs(VR(:,1:NOmega),Phi,N,NOmega, Init,p, ErrStat2, ErrMsg2 ) ; if(Failed()) return
    ELSE ! IF (.NOT.(Reduced)) THEN !For the time being Phi gets updated only when CB eigensolver is requested. I need to fix it for the other case (full fem) and then get rid of the other eigensolver, this implies "unreducing" the VR
-         ! This is done as part of the CB-reduced eigensolve
+       ! This is done as part of the CB-reduced eigensolve
       Phi=REAL( VR(:,1:NOmega), ReKi )   ! eigenvectors
    ENDIF  
- 
    
    CALL CleanupEigen()
    RETURN
 
 CONTAINS
-!.........................
+   LOGICAL FUNCTION Failed()
+        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'EigenSolve') 
+        Failed =  ErrStat >= AbortErrLev
+        if (Failed) call CleanUpEigen()
+   END FUNCTION Failed
+
    SUBROUTINE CleanupEigen()
-      ! deallocate any local variables:
-      
       IF (ALLOCATED(Work)  ) DEALLOCATE(Work)
       IF (ALLOCATED(Omega2)) DEALLOCATE(Omega2)  !bjj: break in Debug_Doub
       IF (ALLOCATED(ALPHAR)) DEALLOCATE(ALPHAR)
@@ -2090,38 +1991,30 @@ CONTAINS
       IF (ALLOCATED(BETA)  ) DEALLOCATE(BETA)
       IF (ALLOCATED(VR)    ) DEALLOCATE(VR)
       IF (ALLOCATED(VL)    ) DEALLOCATE(VL)
-         
       IF (ALLOCATED(KEY)   ) DEALLOCATE(KEY)
       IF (ALLOCATED(Kred)  ) DEALLOCATE(Kred)
       IF (ALLOCATED(Mred)  ) DEALLOCATE(Mred)
-            
    END SUBROUTINE CleanupEigen
   
 END SUBROUTINE EigenSolve
+
 !------------------------------------------------------------------------------------------------------
+!> Calculate Kred from K after removing consstrained node DOFs from the full M and K matrices
+!!Note it works for constrained nodes, still to see how to make it work for interface nodes if needed
 SUBROUTINE ReduceKMdofs(Kred,K,TDOF, Init,p, ErrStat, ErrMsg )
-!This routine calculates Kred from K after removing consstrained node DOFs from the full M and K matrices
-!Note it works for constrained nodes, still to see how to make it work for interface nodes if needed
-!......................
-   IMPLICIT NONE
-   
    TYPE(SD_InitType),      INTENT(  in)  :: Init  
    TYPE(SD_ParameterType), INTENT(  in)  :: p  
-   
    INTEGER,                INTENT(IN   ) :: TDOF           ! Size of matrix K (total DOFs)                              
    REAL(ReKi),             INTENT(IN   ) :: K(TDOF, TDOF)  ! full matrix
    REAL(LAKi),ALLOCATABLE, INTENT(  OUT) :: Kred(:,:)      ! reduced matrix
    INTEGER(IntKi),         INTENT(  OUT) :: ErrStat        ! Error status of the operation
    CHARACTER(*),           INTENT(  OUT) :: ErrMsg         ! Error message if ErrStat /= ErrID_None
-   
    !locals
    INTEGER                               :: I, J           ! counters into full or reduced matrix
    INTEGER                               :: L              ! number of DOFs to eliminate 
-
    INTEGER, ALLOCATABLE                  :: idx(:)         ! vector to map reduced matrix to full matrix
    INTEGER                               :: NReactDOFs
    INTEGER                               :: DOF_reduced
-
    INTEGER                               :: ErrStat2
    CHARACTER(1024)                       :: ErrMsg2
    
@@ -2135,16 +2028,12 @@ SUBROUTINE ReduceKMdofs(Kred,K,TDOF, Init,p, ErrStat, ErrMsg )
       RETURN
    END IF
   
-   CALL AllocAry(idx,  TDOF, 'idx',  ErrStat2, ErrMsg2 )
-      CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat,ErrMsg,'ReduceKMdofs')
-      IF (ErrStat >= AbortErrLev) THEN
-         IF (ALLOCATED(idx)) DEALLOCATE(idx)
-         RETURN
-      END IF   
+   CALL AllocAry(idx,  TDOF, 'idx',  ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat,ErrMsg,'ReduceKMdofs')
+   IF (ErrStat >= AbortErrLev) THEN
+      RETURN
+   END IF   
    
-   !........
    ! Calculate how many rows/columns need to be eliminated:
-   !........
    DO I = 1, TDOF       
       idx(I) = I
    END DO
@@ -2153,64 +2042,48 @@ SUBROUTINE ReduceKMdofs(Kred,K,TDOF, Init,p, ErrStat, ErrMsg )
    DO I = 1, NReactDOFs  !Cycle on reaction DOFs      
       IF (Init%BCs(I, 2) == 1) THEN
          L=L+1 !number of DOFs to eliminate
-         
          idx( Init%BCs(I, 1) ) = 0 ! Eliminate this one
       END IF    
    END DO   
    
-   !........
    ! Allocate the output matrix and the index mapping array
-   !........   
    DOF_reduced = TDOF-L   
-   CALL AllocAry(Kred, DOF_reduced, DOF_reduced, 'Kred', ErrStat2, ErrMsg2 )
-      CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat,ErrMsg,'ReduceKMdofs')
-      IF (ErrStat >= AbortErrLev) THEN
-         IF (ALLOCATED(idx)) DEALLOCATE(idx)
-         RETURN
-      END IF
+   CALL AllocAry(Kred, DOF_reduced, DOF_reduced, 'Kred', ErrStat2, ErrMsg2 ); CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat,ErrMsg,'ReduceKMdofs')
+   IF (ErrStat >= AbortErrLev) THEN
+      CALL CleanUp()
+      RETURN
+   END IF
    
-   !........
    ! set the indices we want to keep (i.e., a mapping from reduced to full matrix)
-   !........
    J  = 1   
    DO I=1,TDOF
-      
       idx(J) = idx(I)      
       IF ( idx(J) /= 0 ) J = J + 1         
-                                
    END DO
-      
          
-   !........
    ! Remove rows and columns from every row/column in full matrix where Init%BC(:,2) == 1,
    ! using the mapping created above. (This is a symmetric matrix.)
-   !........   
    DO J = 1, DOF_reduced  !Cycle on reaction DOFs      
       DO I = 1, DOF_reduced  !Cycle on reaction DOFs      
          Kred(I,J) = REAL( K( idx(I), idx(J) ), LAKi )
       END DO
    END DO
-      
-   !........
    ! clean up local variables:
-   !........
-   
-   DEALLOCATE(idx)
-   
+   CALL CleanUp()
+CONTAINS
+   subroutine CleanUp()
+      IF (ALLOCATED(idx)) DEALLOCATE(idx)
+   end subroutine
 END SUBROUTINE ReduceKMdofs
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE UnReduceVRdofs(VRred,VR,rDOF,rModes, Init,p, ErrStat, ErrMsg )
-!This routine calculates augments VRred to VR for the constrained DOFs, somehow reversing what ReducedKM did for matrices
-!Note it works for constrained nodes, still to see how to make it work for interface nodes if needed
 
-   USE NWTC_Library
-   IMPLICIT NONE
-   
+!------------------------------------------------------------------------------------------------------
+!> Augments VRred to VR for the constrained DOFs, somehow reversing what ReducedKM did for matrices
+!Note it works for constrained nodes, still to see how to make it work for interface nodes if needed
+SUBROUTINE UnReduceVRdofs(VRred,VR,rDOF,rModes, Init,p, ErrStat, ErrMsg )
    TYPE(SD_InitType),      INTENT(in   ) :: Init  
    TYPE(SD_ParameterType), INTENT(in   ) :: p  
    INTEGER,                INTENT(IN   ) :: rDOF ,RModes  !retained DOFs after removing restrained DOFs and retained modes 
    REAL(LAKi),             INTENT(IN   ) :: VRred(rDOF, rModes)  !eigenvector matrix with restrained DOFs removed
-   
    REAL(ReKi),             INTENT(INOUT) :: VR(:,:) !eigenvalues including the previously removed DOFs
    INTEGER(IntKi),         INTENT(  OUT) :: ErrStat     ! Error status of the operation
    CHARACTER(*),           INTENT(  OUT) :: ErrMsg      ! Error message if ErrStat /= ErrID_None
@@ -2221,100 +2094,82 @@ SUBROUTINE UnReduceVRdofs(VRred,VR,rDOF,rModes, Init,p, ErrStat, ErrMsg )
    ErrStat = ErrID_None
    ErrMsg  = ''    
   
-  ALLOCATE(idx(p%NReact*6), STAT = ErrStat )  !it contains row/col index that was originally eliminated when applying restraints
-  idx=0 !initialize
-  L=0 !initialize
-  DO I = 1, p%NReact*6  !Cycle on reaction DOFs
-      IF (Init%BCs(I, 2) == 1) THEN
-          idx(I)=Init%BCs(I, 1) !row/col index that was originally eliminated when applying restraints
-          L=L+1 !number of DOFs to eliminate
-      ENDIF    
-  ENDDO
-  
+   ALLOCATE(idx(p%NReact*6), STAT = ErrStat )  !it contains row/col index that was originally eliminated when applying restraints
+   idx=0 !initialize
+   L=0 !initialize
+   DO I = 1, p%NReact*6  !Cycle on reaction DOFs
+       IF (Init%BCs(I, 2) == 1) THEN
+           idx(I)=Init%BCs(I, 1) !row/col index that was originally eliminated when applying restraints
+           L=L+1 !number of DOFs to eliminate
+       ENDIF    
+   ENDDO
 !  PRINT *, '    rDOF+L=',rDOF+L, 'SIZE(Phi2)=',SIZE(VR,1)
-  
 !  ALLOCATE(VR(rDOF+L,rModes), STAT = ErrStat )  !Restored eigenvectors with restrained node DOFs included
-  VR=0.!Initialize
-  
-  I2=1 !Initialize 
-  DO I=1,rDOF+L  !This loop inserts Vred in VR in all but the removed DOFs
+   VR=0.!Initialize
+
+   I2=1 !Initialize 
+   DO I=1,rDOF+L  !This loop inserts Vred in VR in all but the removed DOFs
       IF (ALL((idx-I).NE.0)) THEN
          VR(I,:)=REAL( VRred(I2,:), ReKi ) ! potentially change of precision
          I2=I2+1  !Note this counter gets updated only if we insert Vred rows into VR
       ENDIF   
-  ENDDO
-  
-  
+   ENDDO
 END SUBROUTINE UnReduceVRdofs
-!------------------------------------------------------------------------------------------------------
+
 !------------------------------------------------------------------------------------------------------
 SUBROUTINE CBApplyConstr(DOFI, DOFR, DOFM,  DOFL,  &
                          MBB , MBM , KBB , PHiR , FGR ,       &
                          MBBb, MBMb, KBBb, PHiRb, FGRb)
-
    INTEGER(IntKi),         INTENT(IN   )  :: DOFR, DOFI, DOFM, DOFL
-                                       
    REAL(ReKi),             INTENT(IN   )  ::  FGR(DOFR)
    REAL(ReKi),             INTENT(IN   )  ::  MBB(DOFR, DOFR)
    REAL(ReKi),             INTENT(IN   )  ::  MBM(DOFR, DOFM)
    REAL(ReKi),             INTENT(IN   )  ::  KBB(DOFR, DOFR)
    REAL(ReKi),             INTENT(IN   )  :: PhiR(DOFL, DOFR)   
-   
    REAL(ReKi),             INTENT(  OUT)  ::  MBBb(DOFI, DOFI)
    REAL(ReKi),             INTENT(  OUT)  ::  KBBb(DOFI, DOFI)
    REAL(ReKi),             INTENT(  OUT)  ::  MBMb(DOFI, DOFM)
    REAL(ReKi),             INTENT(  OUT)  ::  FGRb(DOFI)
    REAL(ReKi),             INTENT(  OUT)  :: PhiRb(DOFL, DOFI)   
-   
       
    MBBb  = MBB(DOFR-DOFI+1:DOFR, DOFR-DOFI+1:DOFR) 
    KBBb  = KBB(DOFR-DOFI+1:DOFR, DOFR-DOFI+1:DOFR)    
 IF (DOFM > 0) THEN   
    MBMb  = MBM(DOFR-DOFI+1:DOFR, :               )
 END IF
-
    FGRb  = FGR(DOFR-DOFI+1:DOFR )
    PhiRb = PhiR(              :, DOFR-DOFI+1:DOFR)
    
 END SUBROUTINE CBApplyConstr
-!------------------------------------------------------------------------------------------------------
+
 !------------------------------------------------------------------------------------------------------
 SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, PhiL, ErrStat, ErrMsg)
- 
    TYPE(SD_InitType),        INTENT(IN   )   :: Init         ! Input data for initialization routine
    TYPE(SD_ParameterType),   INTENT(INOUT)   :: p            ! Parameters
-   
    REAL(ReKi),               INTENT(IN   )   :: MBBb(  p%DOFI, p%DOFI)
    REAL(ReKi),               INTENT(IN   )   :: MBMb(  p%DOFI, p%Nmodes)
    REAL(ReKi),               INTENT(IN   )   :: KBBb(  p%DOFI, p%DOFI)
    REAL(ReKi),               INTENT(IN   )   :: PhiL ( p%DOFL, p%DOFL)   
    REAL(ReKi),               INTENT(IN   )   :: PhiRb( p%DOFL, p%DOFI)   
    REAL(ReKi),               INTENT(IN   )   :: OmegaL(p%DOFL)   
-                             
    REAL(ReKi),               INTENT(IN   )   :: FGRb(p%DOFI) 
    REAL(ReKi),               INTENT(IN   )   ::  FGL(p%DOFL)
-         
    INTEGER(IntKi),           INTENT(  OUT)   :: ErrStat     ! Error status of the operation
    CHARACTER(*),             INTENT(  OUT)   :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
    ! local variables
    REAL(ReKi)                                :: TI_transpose(TPdofL,p%DOFI) !bjj: added this so we don't have to take the transpose 5+ times
    INTEGER(IntKi)                            :: I
    integer(IntKi)                            :: n                          ! size of jacobian in AM2 calculation
    INTEGER(IntKi)                            :: ErrStat2
    CHARACTER(ErrMsgLen)                      :: ErrMsg2
-
    CHARACTER(*), PARAMETER                   :: RoutineName = 'SetParameters'
    
    ErrStat = ErrID_None 
    ErrMsg  = ''
-   
       
    TI_transpose =  TRANSPOSE(p%TI) 
-   
-   
 
-        ! Store FGL for later processes
+   ! Store FGL for later processes
    IF (p%SttcSolve) THEN     
        p%FGL = FGL  
    ENDIF     
@@ -2322,30 +2177,24 @@ SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, Ph
    ! block element of D2 matrix (D2_21, D2_42, & part of D2_62)
    p%PhiRb_TI = MATMUL(PhiRb, p%TI)
    
-   
    !...............................
    ! equation 46-47 (used to be 9):
    !...............................
-   
    p%MBB = MATMUL( MATMUL( TI_transpose, MBBb ), p%TI) != MBBt
    p%KBB = MATMUL( MATMUL( TI_transpose, KBBb ), p%TI) != KBBt
 
    !p%D1_15=-TI_transpose  !this is 6x6NIN
-   
    IF ( p%NModes > 0 ) THEN ! These values don't exist for DOFM=0; i.e., p%NModes == 0
          ! p%MBM = MATMUL( TRANSPOSE(p%TI), MBmb )    != MBMt
       CALL LAPACK_gemm( 'T', 'N', 1.0_ReKi, p%TI, MBmb, 0.0_ReKi, p%MBM, ErrStat2, ErrMsg2) != MBMt
          CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName//'p%MBM')
       
       p%MMB = TRANSPOSE( p%MBM )                          != MMBt
-   
       p%PhiM  = PhiL(:,1:p%Nmodes)
-      
       
       ! A_21, A_22 (these are diagonal matrices. bjj: I am storing them as arrays instead of full matrices)
       p%NOmegaM2      = -1.0_ReKi * OmegaL(1:p%Nmodes) * OmegaL(1:p%Nmodes)          ! OmegaM is a one-dimensional array
       p%N2OmegaMJDamp = -2.0_ReKi * OmegaL(1:p%Nmodes) * Init%JDampings(1:p%Nmodes)  ! Init%JDampings is also a one-dimensional array
-   
    
       ! B_23, B_24
       !p%PhiM_T =  TRANSPOSE( p%PhiM  )
@@ -2353,7 +2202,6 @@ SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, Ph
       ! FX
       ! p%FX = MATMUL( p%PhiM_T, FGL ) != MATMUL( TRANSPOSE(PhiM), FGL )
       p%FX = MATMUL( FGL, p%PhiM ) != MATMUL( TRANSPOSE(PhiM), FGL ) because FGL is 1-D
-         
    
       ! C1_11, C1_12  ( see eq 15 [multiply columns by diagonal matrix entries for diagonal multiply on the left])   
       DO I = 1, p%Nmodes ! if (p%NModes=p%qmL=DOFM == 0), this loop is skipped
@@ -2378,14 +2226,12 @@ SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, Ph
       p%FY =    MATMUL( p%MBM, p%FX ) &  
               - MATMUL( TI_transpose, ( FGRb + MATMUL( TRANSPOSE(PhiRb), FGL) ) ) 
       
-
       ! C2_21, C2_42
       ! C2_61, C2_62
       DO I = 1, p%Nmodes ! if (p%NModes=p%qmL=DOFM == 0), this loop is skipped
          p%C2_61(:, i) = p%PhiM(:, i)*p%NOmegaM2(i)
          p%C2_62(:, i) = p%PhiM(:, i)*p%N2OmegaMJDamp(i)
       ENDDO   
-            
       
       ! D2_53, D2_63, D2_64 
       p%D2_63 = MATMUL( p%PhiM, p%MMB )
@@ -2398,18 +2244,14 @@ SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, Ph
       ! F2_61
       p%F2_61 = MATMUL( p%D2_64, FGL )       
                               
-   
      !Now calculate a Jacobian used when AM2 is called and store in parameters    
       IF (p%IntMethod .EQ. 4) THEN       ! Allocate Jacobian if AM2 is requested & if there are states (p%qmL > 0)
          n=2*p%qmL
-         CALL AllocAry( p%AM2Jac, n, n, 'p%AM2InvJac', ErrStat2, ErrMsg2 ) ! This will be the Jacobian
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-         CALL AllocAry( p%AM2JacPiv, n, 'p%AM2JacPiv', ErrStat2, ErrMsg2 )                         
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)         
-            IF ( ErrStat >= AbortErrLev ) RETURN 
+         CALL AllocAry( p%AM2Jac, n, n, 'p%AM2InvJac', ErrStat2, ErrMsg2 ); if(Failed()) return
+         CALL AllocAry( p%AM2JacPiv, n, 'p%AM2JacPiv', ErrStat2, ErrMsg2 ); if(Failed()) return
          
-               ! First we calculate the Jacobian:
-               ! (note the Jacobian is first stored as p%AM2InvJac)
+         ! First we calculate the Jacobian:
+         ! (note the Jacobian is first stored as p%AM2InvJac)
          p%AM2Jac=0.
          DO i=1,p%qmL
             p%AM2Jac(i+p%qmL,i      )=p%SDdeltaT/2.*p%NOmegaM2(i)      !J21   
@@ -2421,14 +2263,10 @@ SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, Ph
             p%AM2Jac(I,p%qmL+I)=p%SDdeltaT/2.  !J12
             p%AM2Jac(p%qmL+I,p%qmL+I)=p%AM2Jac(p%qmL+I,p%qmL+I)-1  !J22 complete
          ENDDO
-               ! Now need to factor it:        
+         ! Now need to factor it:        
          !I think it could be improved and made more efficient if we can say the matrix is positive definite
-         CALL LAPACK_getrf( n, n, p%AM2Jac, p%AM2JacPiv, ErrStat2, ErrMsg2)
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-            IF ( ErrStat >= AbortErrLev ) RETURN
-                
+         CALL LAPACK_getrf( n, n, p%AM2Jac, p%AM2JacPiv, ErrStat2, ErrMsg2); if(Failed()) return
       END IF     
-      
       
    ELSE ! no retained modes, so 
       ! OmegaM, JDampings, PhiM, MBM, MMB, FX , x don't exist in this case
@@ -2443,30 +2281,27 @@ SUBROUTINE SetParameters(Init, p, MBBb, MBmb, KBBb, FGRb, PhiRb, OmegaL, FGL, Ph
       p%FY    = - MATMUL( TI_transpose, ( FGRb + MATMUL( TRANSPOSE(PhiRb), FGL) ) ) 
                   
    END IF
-      
-      
-   RETURN
+
+CONTAINS
+   LOGICAL FUNCTION Failed()
+        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'SetParameters') 
+        Failed =  ErrStat >= AbortErrLev
+   END FUNCTION Failed
    
 END SUBROUTINE SetParameters
+
 !------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
+
+!> Allocate parameter arrays, based on the dimensions already set in the parameter data type.
 SUBROUTINE AllocParameters(p, DOFM, ErrStat, ErrMsg)
-! This routine allocates parameter arrays, based on the dimensions already set in the parameter data type.
-!......................................................................................................
-
    TYPE(SD_ParameterType), INTENT(INOUT)        :: p           ! Parameters
-
    INTEGER(IntKi), INTENT(  in)                 :: DOFM    
-   
-   
    INTEGER(IntKi),               INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),                 INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! local variables
+   ! local variables
    INTEGER(IntKi)                               :: ErrStat2
    CHARACTER(ErrMsgLen)                         :: ErrMsg2
-   
-      ! initialize error handling:
+   ! initialize error handling:
    ErrStat = ErrID_None
    ErrMsg  = ""
       
@@ -2474,29 +2309,22 @@ SUBROUTINE AllocParameters(p, DOFM, ErrStat, ErrMsg)
    
    CALL AllocAry( p%KBB,           TPdofL, TPdofL, 'p%KBB',           ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
    CALL AllocAry( p%MBB,           TPdofL, TPdofL, 'p%MBB',           ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
-                                                                       
    CALL AllocAry( p%TI,            p%DOFI,  6,     'p%TI',            ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
-                                                                       
    CALL AllocAry( p%D1_14,         TPdofL, p%DOFL, 'p%D1_14',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
-   !CALL AllocAry( p%D1_15,         6,      p%DOFI, 'p%D1_15',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%FY,            TPdofL,         'p%FY',            ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%PhiRb_TI,      p%DOFL, TPdofL, 'p%PhiRb_TI',      ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    
 if (p%Nmodes > 0 ) THEN  
    CALL AllocAry( p%MBM,           TPdofL, DOFM,   'p%MBM',           ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
    CALL AllocAry( p%MMB,           DOFM,   TPdofL, 'p%MMB',           ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
-   
    CALL AllocAry( p%NOmegaM2,      DOFM,           'p%NOmegaM2',      ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
    CALL AllocAry( p%N2OmegaMJDamp, DOFM,           'p%N2OmegaMJDamp', ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
-   !CALL AllocAry( p%PhiM_T,        DOFM,   p%DOFL, 'p%PhiM_T',        ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')
    CALL AllocAry( p%FX,            DOFM,           'p%FX',            ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%C1_11,         TPdofL, DOFM,   'p%C1_11',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%C1_12,         TPdofL, DOFM,   'p%C1_12',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%PhiM,          p%DOFL, DOFM,   'p%PhiM',          ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%C2_61,         p%DOFL, DOFM,   'p%C2_61',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
    CALL AllocAry( p%C2_62,         p%DOFL, DOFM,   'p%C2_62',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters')        
-   
-   
    CALL AllocAry( p%D1_13,         TPdofL, TPdofL, 'p%D1_13',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters') ! is p%MBB when p%NModes == 0        
    CALL AllocAry( p%D2_63,         p%DOFL, TPdofL, 'p%D2_63',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters') ! is p%PhiRb_TI when p%NModes == 0       
    CALL AllocAry( p%D2_64,         p%DOFL, p%DOFL, 'p%D2_64',         ErrStat2, ErrMsg2 ); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocParameters') ! is zero when p%NModes == 0       
@@ -2516,92 +2344,68 @@ if ( p%SttcSolve ) THEN
 end if            
    
 END SUBROUTINE AllocParameters
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE AllocMiscVars(p, Misc, ErrStat, ErrMsg)
-! This routine allocates parameter arrays, based on the dimensions already set in the parameter data type.
-!......................................................................................................
 
+!------------------------------------------------------------------------------------------------------
+!> Allocate parameter arrays, based on the dimensions already set in the parameter data type.
+SUBROUTINE AllocMiscVars(p, Misc, ErrStat, ErrMsg)
    TYPE(SD_MiscVarType),    INTENT(INOUT)    :: Misc        ! Miscellaneous values, used to avoid local copies and/or multiple allocation/deallocation of same variables each call
    TYPE(SD_ParameterType),  INTENT(IN)       :: p           ! Parameters
-   
-   
    INTEGER(IntKi),          INTENT(  OUT)    :: ErrStat     ! Error status of the operation
    CHARACTER(*),            INTENT(  OUT)    :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! local variables
+   ! local variables
    INTEGER(IntKi)                            :: ErrStat2
    CHARACTER(ErrMsgLen)                      :: ErrMsg2
-   
-      ! initialize error handling:
+   ! initialize error handling:
    ErrStat = ErrID_None
    ErrMsg  = ""
       
    ! for readability, we're going to keep track of the max ErrStat through SetErrStat() and not return until the end of this routine.
-   
    CALL AllocAry( Misc%UFL,          p%DOFL,    'UFL',           ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
-   
    CALL AllocAry( Misc%UR_bar,       p%URbarL,  'UR_bar',        ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
    CALL AllocAry( Misc%UR_bar_dot,   p%URbarL,  'UR_bar_dot',    ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
    CALL AllocAry( Misc%UR_bar_dotdot,p%URbarL,  'UR_bar_dotdot', ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
-   
    CALL AllocAry( Misc%UL,           p%DOFL,    'UL',            ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
    CALL AllocAry( Misc%UL_dot,       p%DOFL,    'UL_dot',        ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
    CALL AllocAry( Misc%UL_dotdot,    p%DOFL,    'UL_dotdot',     ErrStat2, ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'AllocMiscVars')      
-      
    
 END SUBROUTINE AllocMiscVars
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE SetIndexArrays(Init, p, ErrStat, ErrMsg)
-! this routine sets the index arrays IDI, IDR, IDL, IDC, and IDY. 
-!.......................................................
 
-   USE qsort_c_module   
+!------------------------------------------------------------------------------------------------------
+!> Set the index arrays IDI, IDR, IDL, IDC, and IDY. 
+SUBROUTINE SetIndexArrays(Init, p, ErrStat, ErrMsg)
+   USE qsort_c_module, only: QsortC
 
    TYPE(SD_InitType),       INTENT(  IN)        :: Init        ! Input data for initialization routine
    TYPE(SD_ParameterType),  INTENT(INOUT)       :: p           ! Parameters   
-   
    INTEGER(IntKi),          INTENT(  OUT)       :: ErrStat     ! Error status of the operation
    CHARACTER(*),            INTENT(  OUT)       :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-
-      ! local variables
+   ! local variables
    INTEGER(IntKi)                               :: TempIDY(p%DOFC+p%DOFI+p%DOFL, 2)
    INTEGER(IntKi)                               :: IDT(Init%TDOF)
    INTEGER(IntKi)                               :: I, K  ! counters
-   
-   
-   ! initialize error handling:
    ErrStat = ErrID_None
    ErrMsg  = ""
          
-   !................................         
-   ! index IDI for interface DOFs
-   !................................         
+   ! Index IDI for interface DOFs
    p%IDI = Init%IntFc(1:p%DOFI, 1)  !RRD interface DOFs
     
-   !................................         
-   ! index IDC for constraint DOFs
-   !................................         
+   ! Index IDC for constraint DOFs
    p%IDC = Init%BCs(1:p%DOFC, 1) !Constraint DOFs 
    
-   !................................         
-   ! index IDR for IDR DOFs
-   !................................         
+   ! Index IDR for IDR DOFs
    p%IDR(       1:p%DOFC ) = p%IDC  ! Constraint DOFs again
    p%IDR(p%DOFC+1:p%DOFR)  = p%IDI  ! IDR contains DOFs ofboundaries, constraints first then interface
    
-   !................................         
-   ! index IDL for IDL DOFs
-   !................................         
-      ! first set the total DOFs:
+   ! --- Index IDL for IDL DOFs
+   ! first set the total DOFs:
    DO I = 1, Init%TDOF  !Total DOFs
       IDT(I) = I      
    ENDDO
-      ! remove DOFs on the boundaries:
+   ! remove DOFs on the boundaries:
    DO I = 1, p%DOFR  !Boundary DOFs (Interface + Constraints)
       IDT(p%IDR(I)) = 0   !Set 0 wherever DOFs belong to boundaries
    ENDDO
-   
-      ! That leaves the internal DOFs:
+   ! That leaves the internal DOFs:
    K = 0
    DO I = 1, Init%TDOF
       IF ( IDT(I) .NE. 0 ) THEN
@@ -2609,63 +2413,51 @@ SUBROUTINE SetIndexArrays(Init, p, ErrStat, ErrMsg)
          p%IDL(K) = IDT(I)   !Internal DOFs
       ENDIF
    ENDDO   
-   
    IF ( K /= p%DOFL ) THEN
       ErrStat = ErrID_Fatal
       ErrMsg = "SetIndexArrays: IDL or p%DOFL are the incorrect size."
       RETURN
    END IF
    
-   
-   !................................         
-   ! index IDY for all DOFs:
-   !................................         
-      ! set the second column of the temp array      
+   ! --- Index IDY for all DOFs:
+   ! set the second column of the temp array      
    DO I = 1, SIZE(TempIDY,1)
       TempIDY(I, 2) = I   ! this column will become the returned "key" (i.e., the original location in the array)
    ENDDO
-      ! set the first column of the temp array      
+   ! set the first column of the temp array      
    TempIDY(1:p%DOFI, 1) = p%IDI
    TempIDY(p%DOFI+1 : p%DOFI+p%DOFL, 1) = p%IDL
    TempIDY(p%DOFI+p%DOFL+1: p%DOFI+p%DOFL+p%DOFC, 1) = p%IDC
-      ! sort based on the first column
+   ! sort based on the first column
    CALL QsortC( TempIDY )
-      ! the second column is the key:
+   ! the second column is the key:
    p%IDY = TempIDY(:, 2)
-
    
 END SUBROUTINE SetIndexArrays
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
-SUBROUTINE Test_CB_Results(MBBt, MBMt, KBBt, OmegaM, DOFTP, DOFM, ErrStat, ErrMsg,Init,p)
 
+!------------------------------------------------------------------------------------------------------
+!>
+SUBROUTINE Test_CB_Results(MBBt, MBMt, KBBt, OmegaM, DOFTP, DOFM, ErrStat, ErrMsg,Init,p)
    TYPE(SD_InitType),      INTENT(  in)                :: Init         ! Input data for initialization routine
    TYPE(SD_ParameterType), INTENT(inout)                :: p           ! Parameters
-   
    INTEGER(IntKi)                                     :: DOFTP, DOFM
-
    REAL(ReKi)                                         :: MBBt(DOFTP, DOFTP)
    REAL(ReKi)                                         :: MBmt(DOFTP, DOFM)
    REAL(ReKi)                                         :: KBBt(DOFTP, DOFTP)
    REAL(ReKi)                                         :: OmegaM(DOFM)
    INTEGER(IntKi),               INTENT(  OUT)  :: ErrStat     ! Error status of the operation
    CHARACTER(*),                 INTENT(  OUT)  :: ErrMsg      ! Error message if ErrStat /= ErrID_None
-! local variables
-
+   ! local variables
    INTEGER(IntKi) :: DOFT, NM, i
    REAL(ReKi), Allocatable     :: OmegaCB(:), PhiCB(:, :)
-   
    REAL(ReKi), Allocatable     :: K(:, :)
    REAL(ReKi), Allocatable     :: M(:, :)
-   
    Character(1024)             :: rootname
-   
    ErrStat = ErrID_None
    ErrMsg  = ''
    
    DOFT = DOFTP + DOFM
    NM = DOFT - 3
-   
    Allocate( OmegaCB(NM), K(DOFT, DOFT), M(DOFT, DOFT), PhiCB(DOFT, NM) )
    K = 0.0
    M = 0.0
@@ -2675,91 +2467,70 @@ SUBROUTINE Test_CB_Results(MBBt, MBMt, KBBt, OmegaM, DOFTP, DOFM, ErrStat, ErrMs
    M(1:DOFTP, 1:DOFTP) = MBBt
    M(1:DOFTP, (DOFTP+1):DOFT ) = MBMt
    M((DOFTP+1):DOFT, 1:DOFTP ) = transpose(mbmt)
-   
 
    DO i = 1, DOFM
       K(DOFTP+i, DOFTP+i) = OmegaM(i)*OmegaM(i)
       M(DOFTP+i, DOFTP+i) = 1.0
    ENDDO
-   
       
    K(1:DOFTP, 1:DOFTP) = KBBt
 
-      ! temporary rootname
-   rootname = 'C:\test_assemble_C-B'
-
+   ! temporary rootname
+   rootname = './test_assemble_C-B_out'
    
    CALL EigenSolve(K, M, DOFT, NM,.False.,Init,p, PhiCB, OmegaCB,  ErrStat, ErrMsg)
    IF ( ErrStat /= 0 ) RETURN  
-   
-   
+
 END SUBROUTINE Test_CB_Results
 
 !------------------------------------------------------------------------------------------------------
+!> Take the input u LMesh and constructs the appropriate corresponding UFL vector
 SUBROUTINE ConstructUFL( u, p, UFL )
-! This subroutine takes the input u LMesh and constructs the appropriate corresponding UFL vector
-!......................................................................................................
    TYPE(SD_InputType),             INTENT(IN   )  :: u               ! Inputs
    TYPE(SD_ParameterType),         INTENT(IN   )  :: p               ! Parameters
    REAL(ReKi)                                     :: UFL(p%DOFL)
-   
    INTEGER                                        :: I, J, StartDOF  ! integers for indexing into mesh and UFL
 
-      ! note that p%DOFL = p%NNodes_L*6
-
-      DO I = 1, p%NNodes_L   !Only interior nodes here     
-             
-            ! starting index in the master arrays for the current node    
-         startDOF = (I-1)*6 + 1
-                  
-            ! index into the Y2Mesh
-         J  = p%NNodes_I + I
-         
-             ! Construct UFL array from the Force and Moment fields of the input mesh
-         UFL ( startDOF   : startDOF + 2 ) = u%LMesh%Force (:,J)
-         UFL ( startDOF+3 : startDOF + 5 ) = u%LMesh%Moment(:,J)
-  
-      END DO   
-            
+   ! note that p%DOFL = p%NNodes_L*6
+   DO I = 1, p%NNodes_L   !Only interior nodes here     
+      ! starting index in the master arrays for the current node    
+      startDOF = (I-1)*6 + 1
+      ! index into the Y2Mesh
+      J  = p%NNodes_I + I
+      ! Construct UFL array from the Force and Moment fields of the input mesh
+      UFL ( startDOF   : startDOF + 2 ) = u%LMesh%Force (:,J)
+      UFL ( startDOF+3 : startDOF + 5 ) = u%LMesh%Moment(:,J)
+   END DO   
 
 END SUBROUTINE
-!------------------------------------------------------------------------------------------------------
 
 !------------------------------------------------------------------------------------------------------
+!> Output the summary file    
 SUBROUTINE OutSummary(Init, p, FEMparams,CBparams, ErrStat,ErrMsg)
-    !This sub takes care of outputting the summary file    
-    
    TYPE(SD_InitType),      INTENT(IN)     :: Init           ! Input data for initialization routine, this structure contains many variables needed for summary file
    TYPE(SD_ParameterType), INTENT(IN)     :: p              ! Parameters,this structure contains many variables needed for summary file
    TYPE(CB_MatArrays),     INTENT(IN)     :: CBparams       ! CB parameters that will be passed in for summary file use
    TYPE(FEM_MatArrays),    INTENT(IN)     :: FEMparams      ! FEM parameters that will be passed in for summary file use
-   
    INTEGER(IntKi),         INTENT(OUT)    :: ErrStat        ! Error status of the operation
    CHARACTER(*),           INTENT(OUT)    :: ErrMsg         ! Error message if ErrStat /= ErrID_None
-   
    !LOCALS
-   INTEGER(IntKi)                         :: UnSum          ! unit number for this summary file   
-   INTEGER(IntKi)                         :: ErrStat2       ! Temporary storage for local errors
-   CHARACTER(ErrMsgLen)                   :: ErrMsg2       ! Temporary storage for local errors             
-   CHARACTER(1024)                        :: SummaryName    ! name of the SubDyn summary file          
-   
+   INTEGER(IntKi)         :: UnSum          ! unit number for this summary file
+   INTEGER(IntKi)         :: ErrStat2       ! Temporary storage for local errors
+   CHARACTER(ErrMsgLen)   :: ErrMsg2       ! Temporary storage for local errors
+   CHARACTER(1024)        :: SummaryName    ! name of the SubDyn summary file
+   INTEGER(IntKi)         :: i, j, k, propids(2)  !counter and temporary holders
+   INTEGER(IntKi)         :: SDtoMeshIndx(Init%NNode)
+   REAL(ReKi)             :: MRB(6,6)    !REDUCED SYSTEM Kmatrix, equivalent mass matrix
+   REAL(ReKi)             :: XYZ1(3),XYZ2(3), DirCos(3,3), mlength !temporary arrays, member i-th direction cosine matrix (global to local) and member length
    CHARACTER(*),PARAMETER                 :: SectionDivide = '____________________________________________________________________________________________________'
    CHARACTER(*),PARAMETER                 :: SubSectionDivide = '__________'
-   
-   INTEGER(IntKi)                  ::  i, j, k, propids(2)  !counter and temporary holders 
-   
-   INTEGER(IntKi)                         :: SDtoMeshIndx(Init%NNode)
-   REAL(ReKi)                      :: MRB(6,6)    !REDUCED SYSTEM Kmatrix, equivalent mass matrix
-   REAL(ReKi)                      :: XYZ1(3),XYZ2(3), DirCos(3,3), mlength !temporary arrays, member i-th direction cosine matrix (global to local) and member length
-   CHARACTER(2),  DIMENSION(6), PARAMETER     :: MatHds= (/'X ', 'Y ', 'Z ', 'XX', 'YY', 'ZZ'/)  !Headers for the columns and rows of 6x6 matrices
-      
-   
+   CHARACTER(2),  DIMENSION(6), PARAMETER :: MatHds= (/'X ', 'Y ', 'Z ', 'XX', 'YY', 'ZZ'/)  !Headers for the columns and rows of 6x6 matrices
    
    ErrStat = ErrID_None
    ErrMsg  = ""
     
    CALL SD_Y2Mesh_Mapping(p, SDtoMeshIndx )
-   
+
    !-------------------------------------------------------------------------------------------------------------
    ! open txt file
    !-------------------------------------------------------------------------------------------------------------
@@ -2773,7 +2544,6 @@ SUBROUTINE OutSummary(Init, p, FEMparams,CBparams, ErrStat,ErrMsg)
          RETURN
       END IF
       
-      
    !-------------------------------------------------------------------------------------------------------------
    ! write discretized data to a txt file
    !-------------------------------------------------------------------------------------------------------------
@@ -2781,7 +2551,6 @@ SUBROUTINE OutSummary(Init, p, FEMparams,CBparams, ErrStat,ErrMsg)
 ! (it helps in debugging)
    WRITE(UnSum, '(A)')  'Unless specified, units are consistent with Input units, [SI] system is advised.'
    WRITE(UnSum, '(A)') SectionDivide
-   
       
    WRITE(UnSum, '()')    
    WRITE(UnSum, '(A,I6)')  'Number of nodes (NNodes):',Init%NNode
@@ -2928,7 +2697,6 @@ SUBROUTINE OutSummary(Init, p, FEMparams,CBparams, ErrStat,ErrMsg)
    WRITE(UnSum, '()') 
    WRITE(UnSum, '(A,E15.6)')    "SubDyn's Total Mass (structural and non-structural)=", MRB(1,1) 
    WRITE(UnSum, '(A,3(E15.6))') "SubDyn's Total Mass CM coordinates (Xcm,Ycm,Zcm)   =", (/-MRB(3,5),-MRB(1,6), MRB(1,5)/) /MRB(1,1)        
-
    
 #ifdef SD_SUMMARY_DEBUG
 
@@ -2936,11 +2704,9 @@ SUBROUTINE OutSummary(Init, p, FEMparams,CBparams, ErrStat,ErrMsg)
    WRITE(UnSum, '(A)') SectionDivide
    WRITE(UnSum, '(A)') '**** Additional Debugging Information ****'
 
-
    !-------------------------------------------------------------------------------------------------------------
    ! write assembed K M to a txt file
    !-------------------------------------------------------------------------------------------------------------
-   
    WRITE(UnSum, '(A)') SectionDivide
    WRITE(UnSum, '(A, I6)') 'FULL FEM K and M matrices. TOTAL FEM TDOFs:', Init%TDOF 
    WRITE(UnSum, '(A)') ('Stiffness matrix K' )
@@ -2997,9 +2763,8 @@ SUBROUTINE OutSummary(Init, p, FEMparams,CBparams, ErrStat,ErrMsg)
    CALL SDOut_CloseSum( UnSum, ErrStat, ErrMsg )  
 
 END SUBROUTINE OutSummary
-!------------------------------------------------------------------------------------------------------
-!------------------------------------------------------------------------------------------------------
 
+!------------------------------------------------------------------------------------------------------
 !> This function calculates the length of a member 
 FUNCTION MemberLength(MemberID,Init,ErrStat,ErrMsg)
     TYPE(SD_InitType), INTENT(IN)             :: Init         !< Input data for initialization routine, this structure contains many variables needed for summary file
@@ -3118,8 +2883,8 @@ SUBROUTINE SymMatDebug(M,MAT)
 
    !--------------------------------------
    ! write discretized data to a txt file
-   WRITE(*, '(A,e15.6)')  'Matrix SYmmetry Check: Largest (abs) relative error is:', MaxErr
-   WRITE(*, '(A,I4,I4)')  'Matrix SYmmetry Check: (I,J)=', imax,jmax
+   WRITE(*, '(A,e15.6)')  'Matrix Symmetry Check: Largest (abs) relative error is:', MaxErr
+   WRITE(*, '(A,I4,I4)')  'Matrix Symmetry Check: (I,J)=', imax,jmax
 
 END SUBROUTINE SymMatDebug
 

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -738,7 +738,7 @@ CALL GetNewUnit( UnIn )
 CALL OpenFInpfile(UnIn, TRIM(SDInputFile), ErrStat2, ErrMsg2)
 
 IF ( ErrStat2 /= ErrID_None ) THEN
-   Call Abort('Could not open SubDyn input file')
+   Call Fatal('Could not open SubDyn input file')
    return
 END IF
 
@@ -756,7 +756,7 @@ CALL ReadVar(UnIn, SDInputFile, Echo, 'Echo', 'Echo Input File Logic Variable',E
 IF ( Echo )  THEN 
    CALL OpenEcho ( UnEc, TRIM(Init%RootName)//'.ech' ,ErrStat2, ErrMsg2)
    IF ( ErrStat2 /= 0 ) THEN
-      CALL Abort("Could not open SubDyn echo file")
+      CALL Fatal("Could not open SubDyn echo file")
       return
    END IF
    REWIND(UnIn)
@@ -778,7 +778,7 @@ ELSE                                   ! The input must have been specified nume
    CALL CheckIOS ( IOS, SDInputFile, 'SDdeltaT', NumType, ErrStat2,ErrMsg2 ); if(Failed()) return
 
    IF ( ( p%SDdeltaT <=  0 ) )  THEN 
-      call Abort('SDdeltaT must be greater than or equal to 0.')
+      call Fatal('SDdeltaT must be greater than or equal to 0.')
       return         
    END IF  
 END IF
@@ -811,7 +811,7 @@ IF (Init%CBMod) THEN
       ! last entry to fill in remaining values.
       !Check 1st value, we need at least one good value from user or throw error
       IF ((Init%JDampings(1) .LT. 0 ) .OR. (Init%JDampings(1) .GE. 100.0)) THEN
-            CALL Abort('Damping ratio should be larger than 0 and less than 100')
+            CALL Fatal('Damping ratio should be larger than 0 and less than 100')
             return
       ELSE
          DO I = 2, p%Nmodes
@@ -823,7 +823,7 @@ IF (Init%CBMod) THEN
                END IF
                EXIT
             ELSEIF ( ( Init%JDampings(I) .LT. 0 ) .OR.( Init%JDampings(I) .GE. 100.0 ) ) THEN    
-               CALL Abort('Damping ratio should be larger than 0 and less than 100')
+               CALL Fatal('Damping ratio should be larger than 0 and less than 100')
                return
             ENDIF      
         ENDDO
@@ -844,7 +844,7 @@ ELSE   !CBMOD=FALSE  : all modes are retained, not sure how many they are yet
    CALL AllocAry(Init%JDampings, 1, 'JDamping', ErrStat2, ErrMsg2) ; if(Failed()) return
    CALL ReadVar ( UnIn, SDInputFile, Init%JDampings(1), 'JDampings', 'Damping ratio',ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
    IF ( ( Init%JDampings(1) .LT. 0 ) .OR.( Init%JDampings(1) .GE. 100.0 ) ) THEN 
-         CALL Abort('Damping ratio should be larger than 0 and less than 100.')
+         CALL Fatal('Damping ratio should be larger than 0 and less than 100.')
          RETURN
    ENDIF
 ENDIF
@@ -970,7 +970,7 @@ Swtch: SELECT CASE (p%OutSwtch)
  CASE (2)  Swtch
     !pass to glue code
  CASE DEFAULT Swtch
-    CALL Abort(' Error in file "'//TRIM(SDInputFile)//'": OutSwtch must be >0 and <4')
+    CALL Fatal(' Error in file "'//TRIM(SDInputFile)//'": OutSwtch must be >0 and <4')
     return
  END SELECT Swtch
      
@@ -997,7 +997,7 @@ IF ( p%NMOutputs > 0 ) THEN
    ! Allocate memory for filled group arrays
    ALLOCATE ( p%MOutLst(p%NMOutputs), STAT = ErrStat2 )     !this list contains different arrays for each of its elements
    IF ( ErrStat2 /= ErrID_None ) THEN
-      CALL  Abort(' Error in file "'//TRIM(SDInputFile)//': Error allocating MOutLst arrays')
+      CALL  Fatal(' Error in file "'//TRIM(SDInputFile)//': Error allocating MOutLst arrays')
       RETURN
    END IF
 
@@ -1006,7 +1006,7 @@ IF ( p%NMOutputs > 0 ) THEN
       IF (ErrStat2 == 0) THEN
          READ(Line,*,IOSTAT=ErrStat2) p%MOutLst(I)%MemberID, p%MOutLst(I)%NOutCnt
          IF ( ErrStat2 /= 0 .OR. p%MOutLst(I)%NOutCnt < 1 .OR. p%MOutLst(I)%NOutCnt > 9 .OR. p%MOutLst(I)%NOutCnt > Init%Ndiv+1) THEN
-            CALL Abort(' Error in file "'//TRIM(SDInputFile)//'": NOutCnt must be >= 1 and <= minimim(Ndiv+1,9)')
+            CALL Fatal(' Error in file "'//TRIM(SDInputFile)//'": NOutCnt must be >= 1 and <= minimim(Ndiv+1,9)')
             RETURN
          END IF            
          CALL AllocAry( p%MOutLst(I)%NodeCnt, p%MOutLst(I)%NOutCnt, 'NodeCnt', ErrStat2, ErrMsg2); if(Failed()) return
@@ -1023,12 +1023,12 @@ IF ( p%NMOutputs > 0 ) THEN
                   DO K = 1,p%MOutLst(I)%NOutCnt
                      ! node number should be less than NDiv + 1
                      IF( (p%MOutLst(I)%NodeCnt(k) .GT. (Init%NDiv+1)) .or. (p%MOutLst(I)%NodeCnt(k) .LT. 1) ) THEN
-                        CALL Abort(' NodeCnt should be less than NDIV+1 and greater than 0. ')
+                        CALL Fatal(' NodeCnt should be less than NDIV+1 and greater than 0. ')
                         RETURN
                      ENDIF
                   ENDDO
                ELSE
-                  CALL Abort(' NOutCnt should be less than 10 and greater than 0. ')
+                  CALL Fatal(' NOutCnt should be less than 10 and greater than 0. ')
                   RETURN
                ENDIF
             ENDIF
@@ -1059,7 +1059,7 @@ CONTAINS
         logical, intent(in) :: Condition
         character(len=*), intent(in) :: ErrMsg_in
         Check=Condition
-        if (Check) call Abort(' Error in file '//TRIM(SDInputFile)//': '//trim(ErrMsg_in))
+        if (Check) call Fatal(' Error in file '//TRIM(SDInputFile)//': '//trim(ErrMsg_in))
    END FUNCTION Check
 
    LOGICAL FUNCTION Failed()
@@ -1068,11 +1068,11 @@ CONTAINS
         if (Failed) call CleanUp()
    END FUNCTION Failed
 
-   SUBROUTINE Abort(ErrMsg_in)
+   SUBROUTINE Fatal(ErrMsg_in)
       character(len=*), intent(in) :: ErrMsg_in
       CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'SD_Input');
       CALL CleanUp()
-   END SUBROUTINE Abort
+   END SUBROUTINE Fatal
 
    SUBROUTINE CleanUp()
       CLOSE( UnIn )

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -810,7 +810,7 @@ IF (Init%CBMod) THEN
       ! note that we don't check the ErrStat2 here; if the user entered fewer than Nmodes values, we will use the
       ! last entry to fill in remaining values.
       !Check 1st value, we need at least one good value from user or throw error
-      IF ((Init%JDampings(1) .LT. 0 ) .OR. (Init%JDampings(1) .GE. 100.0)) THEN
+      IF ((Init%JDampings(1) < 0 ) .OR. (Init%JDampings(1) >= 100.0)) THEN
             CALL Fatal('Damping ratio should be larger than 0 and less than 100')
             return
       ELSE
@@ -822,7 +822,7 @@ IF (Init%CBMod) THEN
                   ErrMsg  = 'Using damping ratio '//trim(num2lstr(Init%JDampings(I-1)))//' for modes '//trim(num2lstr(I))//' - '//trim(num2lstr(p%Nmodes))//'.'
                END IF
                EXIT
-            ELSEIF ( ( Init%JDampings(I) .LT. 0 ) .OR.( Init%JDampings(I) .GE. 100.0 ) ) THEN    
+            ELSEIF ( ( Init%JDampings(I) < 0 ) .OR.( Init%JDampings(I) >= 100.0 ) ) THEN    
                CALL Fatal('Damping ratio should be larger than 0 and less than 100')
                return
             ENDIF      
@@ -843,7 +843,7 @@ ELSE   !CBMOD=FALSE  : all modes are retained, not sure how many they are yet
    !Read 1 damping value for all modes
    CALL AllocAry(Init%JDampings, 1, 'JDamping', ErrStat2, ErrMsg2) ; if(Failed()) return
    CALL ReadVar ( UnIn, SDInputFile, Init%JDampings(1), 'JDampings', 'Damping ratio',ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
-   IF ( ( Init%JDampings(1) .LT. 0 ) .OR.( Init%JDampings(1) .GE. 100.0 ) ) THEN 
+   IF ( ( Init%JDampings(1) < 0 ) .OR.( Init%JDampings(1) >= 100.0 ) ) THEN 
          CALL Fatal('Damping ratio should be larger than 0 and less than 100.')
          RETURN
    ENDIF
@@ -1019,10 +1019,10 @@ IF ( p%NMOutputs > 0 ) THEN
          DO J = 1, p%NMembers
             IF(p%MOutLst(I)%MemberID .EQ. Init%Members(j, 1)) THEN
                flg = flg + 1 ! flg could be greater than 1, when there are more than 9 internal nodes of a member.
-               IF( (p%MOutLst(I)%NOutCnt .LT. 10) .and. ((p%MOutLst(I)%NOutCnt .GT. 0)) ) THEN
+               IF( (p%MOutLst(I)%NOutCnt < 10) .and. ((p%MOutLst(I)%NOutCnt > 0)) ) THEN
                   DO K = 1,p%MOutLst(I)%NOutCnt
                      ! node number should be less than NDiv + 1
-                     IF( (p%MOutLst(I)%NodeCnt(k) .GT. (Init%NDiv+1)) .or. (p%MOutLst(I)%NodeCnt(k) .LT. 1) ) THEN
+                     IF( (p%MOutLst(I)%NodeCnt(k) > (Init%NDiv+1)) .or. (p%MOutLst(I)%NodeCnt(k) < 1) ) THEN
                         CALL Fatal(' NodeCnt should be less than NDIV+1 and greater than 0. ')
                         RETURN
                      ENDIF
@@ -1174,13 +1174,13 @@ SUBROUTINE SD_AB4( t, n, u, utimes, p, x, xd, z, OtherState, m, ErrStat, ErrMsg 
       CALL SD_CalcContStateDeriv( t, u_interp, p, x, xd, z, OtherState, m, xdot, ErrStat, ErrMsg ) ! initializes xdot
       CALL SD_DestroyInput( u_interp, ErrStat, ErrMsg)   ! we don't need this local copy anymore
 
-      if (n .le. 2) then
+      if (n <= 2) then
          OtherState%n = n
          !OtherState%xdot ( 3 - n ) = xdot
          CALL SD_CopyContState( xdot, OtherState%xdot ( 3 - n ), MESH_UPDATECOPY, ErrStat, ErrMsg )
          CALL SD_RK4(t, n, u, utimes, p, x, xd, z, OtherState, m, ErrStat, ErrMsg )
       else
-         if (OtherState%n .lt. n) then
+         if (OtherState%n < n) then
             OtherState%n = n
             CALL SD_CopyContState( OtherState%xdot ( 3 ), OtherState%xdot ( 4 ), MESH_UPDATECOPY, ErrStat, ErrMsg )
             CALL SD_CopyContState( OtherState%xdot ( 2 ), OtherState%xdot ( 3 ), MESH_UPDATECOPY, ErrStat, ErrMsg )
@@ -1188,7 +1188,7 @@ SUBROUTINE SD_AB4( t, n, u, utimes, p, x, xd, z, OtherState, m, ErrStat, ErrMsg 
             !OtherState%xdot(4)    = OtherState%xdot(3)
             !OtherState%xdot(3)    = OtherState%xdot(2)
             !OtherState%xdot(2)    = OtherState%xdot(1)
-         elseif (OtherState%n .gt. n) then
+         elseif (OtherState%n > n) then
             ErrStat = ErrID_Fatal
             ErrMsg = ' Backing up in time is not supported with a multistep method '
             RETURN
@@ -1243,7 +1243,7 @@ SUBROUTINE SD_ABM4( t, n, u, utimes, p, x, xd, z, OtherState, m, ErrStat, ErrMsg
       CALL SD_CopyContState(x, x_pred, MESH_NEWCOPY, ErrStat, ErrMsg) !initialize x_pred      
       CALL SD_AB4( t, n, u, utimes, p, x_pred, xd, z, OtherState, m, ErrStat, ErrMsg )
 
-      if (n .gt. 2) then
+      if (n > 2) then
          CALL SD_CopyInput( u(1), u_interp, MESH_NEWCOPY, ErrStat, ErrMsg) ! make copy so that arrays/meshes get initialized/allocated for ExtrapInterp
          CALL SD_Input_ExtrapInterp(u, utimes, u_interp, t + p%SDDeltaT, ErrStat, ErrMsg)
 
@@ -2873,7 +2873,7 @@ SUBROUTINE SymMatDebug(M,MAT)
             IF (MAT(i,j).NE.0) THEN
                 Error=ABS(Error)/MAT(i,j)
             ENDIF    
-            IF (Error.GT.MaxErr) THEN
+            IF (Error > MaxErr) THEN
                 imax=i
                 jmax=j
                 MaxErr=Error


### PR DESCRIPTION
Complete this sentence
**THIS PULL REQUEST IS READY TO MERGE**

**Feature or improvement description**

Removed about 1500 lines in two of the main SubDyn files, for code readability. I'll be working on a important re-write of the `SubDyn` module, so I'd like to commit this before I start doing updates to the code. 

Most of the lines removed were gained from using a more concise error handling (see #272), and gathering copy-pasted calls into "contained"subroutines at the end. The input file routine for instance is significantly more condensed and readable. Note that I usually use the concise error handling on parts of the code that are only called "once", to limit additional overhead. 

**Automated test results**

I've run 5 different SubDyn test cases. Hopefully the regression test will capture that as well.  


Below is an example of the subfunctions I usually introduce at the end of a routine

```fortran
   LOGICAL FUNCTION Check(Condition, ErrMsg_in)
        logical, intent(in) :: Condition
        character(len=*), intent(in) :: ErrMsg_in
        Check=Condition
        if (Check) call Abort(' Error in file '//TRIM(SDInputFile)//': '//trim(ErrMsg_in))
   END FUNCTION Check

   LOGICAL FUNCTION Failed()
        call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'SD_Input') 
        Failed =  ErrStat >= AbortErrLev
        if (Failed) call CleanUp()
   END FUNCTION Failed

   SUBROUTINE Abort(ErrMsg_in)
      character(len=*), intent(in) :: ErrMsg_in
      CALL SetErrStat(ErrID_Fatal, ErrMsg_in, ErrStat, ErrMsg, 'SD_Input');
      CALL CleanUp()
   END SUBROUTINE Abort

   SUBROUTINE CleanUp()
      CLOSE( UnIn )
      IF (Echo) CLOSE( UnEc )
   END SUBROUTINE
```