### PR TITLE
Node outputs in AD15 using DBG_OUTS preprocessor directive

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -83,7 +83,7 @@ subroutine AD_SetInitOut(p, InputFileData, InitOut, errStat, errMsg)
    integer(IntKi)                               :: NumCoords
 #ifdef DBG_OUTS
    integer(IntKi)                               :: m
-   character(5)                                 ::chanPrefix
+   character(6)                                 ::chanPrefix
 #endif   
       ! Initialize variables for this routine
 

--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -84,6 +84,7 @@ subroutine AD_SetInitOut(p, InputFileData, InitOut, errStat, errMsg)
 #ifdef DBG_OUTS
    integer(IntKi)                               :: m
    character(6)                                 ::chanPrefix
+   character(3)                                 :: TmpChar
 #endif   
       ! Initialize variables for this routine
 
@@ -109,7 +110,8 @@ subroutine AD_SetInitOut(p, InputFileData, InitOut, errStat, errMsg)
          
          m = (k-1)*p%NumBlNds*23 + (j-1)*23 
          
-         chanPrefix = "B"//trim(num2lstr(k))//"N"//trim(num2lstr(j))
+         WRITE (TmpChar,'(I3.3)') j
+         chanPrefix = "B"//trim(num2lstr(k))//"N"//TmpChar
          InitOut%WriteOutputHdr( m + 1 ) = trim(chanPrefix)//"Twst"
          InitOut%WriteOutputUnt( m + 1 ) = '  (deg)  '
          InitOut%WriteOutputHdr( m + 2 ) = trim(chanPrefix)//"Psi"

--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -2721,7 +2721,7 @@ SUBROUTINE AD_PrintSum( InputFileData, p, u, y, ErrStat, ErrMsg )
       
       WRITE (UnSu,"(15x,A)")  'Blade nodes selected for output:  Output node  Analysis node'
       WRITE (UnSu,"(15x,A)")  '                                  -----------  -------------'
-      DO I = 1,p%NBlOuts
+      DO I = 1,size(p%BlOutNd)
          WRITE (UnSu,OutPFmt)  I, p%BlOutNd(I)
       END DO  
    end if


### PR DESCRIPTION
This PR is ready to merge

**Feature or improvement description**
AD15 contains a preprocessor flag `DBG_OUTS` that allows outputting AD15 outputs for all nodes.  This is not a commonly used feature, and will be eventually replaced by more user friendly code.

**Related issue, if one exists**
No existing issue that we want this associated with.

**Impacted areas of the software**
This only affects AD15 when it is compiled with the `DBG_OUTS` preprocessor flag.

No regression test results change.

**Additional supporting information**
The change now creates node names containing 3 digit node numbers with leading zeros.  This was requested by the CFD team.


**Test results, if applicable**
@tonyinme says it works.