### PR TITLE
Manual regression tests: Fix plot labels

### DIFF
--- a/reg_tests/lib/errorPlotting.py
+++ b/reg_tests/lib/errorPlotting.py
@@ -56,8 +56,8 @@ def _plotError(xseries, y1series, y2series, xlabel, title1, title2):
     p1.title.align = 'center'
     p1.grid.grid_line_alpha=0.3
     p1.xaxis.axis_label = 'Time (s)'
-    p1.line(xseries, y1series, color='green', line_width=3, legend='Baseline')
-    p1.line(xseries, y2series, color='red', line_width=1, legend_label='Local')
+    p1.line(xseries, y2series, color='green', line_width=3, legend_label='Baseline')
+    p1.line(xseries, y1series, color='red', line_width=1, legend_label='Local')
     p1.add_tools(HoverTool(tooltips=[('Time','$x'), ('Value', '$y')],mode='vline'))
 
     p2 = figure(title=title2, x_range=p1.x_range)


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
The baseline and local results were mislabeled on the plots generated by `manualRegressionTest.py`.
I also updated the deprecated syntax of the legend text.

**Related issue, if one exists**
none.

**Impacted areas of the software**
Regression test plots
