### PR TITLE
Fixed output member ID issue (fix #378)

### DIFF
--- a/modules/subdyn/src/SubDyn_Output.f90
+++ b/modules/subdyn/src/SubDyn_Output.f90
@@ -3787,6 +3787,7 @@ SUBROUTINE SDOut_Init( Init, y,  p, misc, InitOut, WtrDpth, ErrStat, ErrMsg )
 
  INTEGER(IntKi)                                   :: I,J,K,K2,L,NconEls   !Counters
  INTEGER(IntKi)                                   :: Junk  !Temporary Holders
+ INTEGER(IntKi)                                   :: iMember  ! Member index (not member ID)
  INTEGER(IntKi), Dimension(2)                     :: M   !counter for two nodes at a time
 !-------------------------------------------------------------------------------------------------      
 ! Initialize local variables
@@ -3855,7 +3856,8 @@ p%OutAllDims=12*p%Nmembers*2    !size of AllOut Member Joint forces
       ErrMsg  = 'Error allocating p%MOutLst(I)%NodeIDs arrays in SDOut_Init'
       RETURN
    END IF
-   p%MOutLst(I)%NodeIDs=Init%MemberNodes(p%MoutLst(I)%MemberID,p%MOutLst(I)%NodeCnt)  !We are storing the actual node numbers corresponding to what the user ordinal number is requesting
+   iMember = FINDLOCI(Init%Members(:,1), p%MoutLst(I)%MemberID) ! Reindexing from MemberID to 1:nMembers
+   p%MOutLst(I)%NodeIDs=Init%MemberNodes(iMember ,p%MOutLst(I)%NodeCnt)  !We are storing the actual node numbers corresponding to what the user ordinal number is requesting
 
    ALLOCATE( p%MOutLst(I)%ElmIDs(p%MoutLst(I)%NoutCnt,p%NAvgEls), STAT = ErrStat ) !ElmIDs has for each selected node within the member, several element numbers to refer to for averaging (max 2 elements)
    IF ( ErrStat/= 0 ) THEN
@@ -3907,7 +3909,7 @@ p%OutAllDims=12*p%Nmembers*2    !size of AllOut Member Joint forces
             Junk=M(1)
             IF (M(1) .EQ. p%MoutLst(I)%NodeIDs(J)) Junk=M(2)
                         
-         IF (ANY(Init%MemberNodes(p%MoutLst(I)%MemberID,:) .EQ. Junk)) THEN  !This means we are in the selected member
+         IF (ANY(Init%MemberNodes(iMember,:) .EQ. Junk)) THEN  !This means we are in the selected member
             IF (K2 .EQ. 2) EXIT
             K2=K2+1
             p%MoutLst(I)%ElmIDs(J,K2)=L        !This array has for each node requested NODEID(J), for each memberMOutLst(I)%MemberID, the 2 elements to average from, it may have 1 if one of the numbers is 0 
@@ -3945,7 +3947,7 @@ p%OutAllDims=12*p%Nmembers*2    !size of AllOut Member Joint forces
     
      
     DO I=1,p%NMembers
-      p%MOutLst2(I)%MemberID=I !Assign memberID for all members
+      p%MOutLst2(I)%MemberID=Init%Members(I,1) 
       
       ALLOCATE( p%MOutLst2(I)%NodeIDs(Init%Ndiv+1), STAT = ErrStat )  !1st and last node of member
       IF ( ErrStat/= 0 ) THEN
@@ -3975,7 +3977,7 @@ p%OutAllDims=12*p%Nmembers*2    !size of AllOut Member Joint forces
              Junk=M(1)
              IF (M(1) .EQ. p%MoutLst2(I)%NodeIDs(J)) Junk=M(2)
              
-             IF (ANY(Init%MemberNodes(p%MoutLst2(I)%MemberID,:) .EQ. Junk)) THEN  !This means we are in the selected member
+             IF (ANY(Init%MemberNodes(I,:) .EQ. Junk)) THEN  !This means we are in the selected member
                  
                   p%MoutLst2(I)%ElmID2s(K2)=L     !This array has for each node requested NODEID(J), for each member I, the element to get results for 
                   


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Related issue, if one exists**
See #378

Will only affect simulations where member ID are not a continuous sequence of integers starting at 1 (uncommon practice).

**Notes**
`Init%Members(:,1)` contains members IDs as given in the input file.
`MoutLst(I)%MemberID` : Is a member ID requested by the user to be outputted 
`Init%MemberNodes` : is indexed from 1 to n, in the order of the members