### PR TITLE
Fix bug with setting initial properties in SubDyn

### DIFF
--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -396,7 +396,7 @@ SUBROUTINE SD_Discrt(Init,p, ErrStat, ErrMsg)
        Init%Props(1:Init%NProp, 1:PropSetsCol) = TempProps(1:Init%NProp, 1:PropSetsCol)
     endif
     !Init%Props(1:kprop, 1:Init%PropSetsCol) = TempProps
-    Init%Props = TempProps(1:Init%NProp, :)  !!RRD fixed it on 1/23/14 to account for NDIV=1
+    !Init%Props = TempProps(1:Init%NProp, :)  !!RRD fixed it on 1/23/14 to account for NDIV=1
 
     CALL CleanUp_Discrt()
 


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Fixed a bug that was introduced in #356. When `NDiv = 1`, an array holding the property data was set to an unallocated array, which caused serious issues (simulation never completes or numerical errors) when running the `5MW_OC3Trpd_DLL_WSt_WavesReg` regression test. 

**Impacted areas of the software**
SubDyn

I made this fix based on a quick scan of the logic in `SD_Discrt` and comparing the code with the previous version of the subroutine. @ebranlard should verify that this fix does what is intended.
