### PR TITLE
Fix memory memory leak during shutdown

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.H
+++ b/glue-codes/openfast-cpp/src/OpenFAST.H
@@ -161,7 +161,7 @@ class OpenFAST {
   OpenFAST() ;
   
   // Destructor
-  ~OpenFAST() {} ;
+  ~OpenFAST() ;
 
   void setInputs(const fastInputs &);  
 

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -341,6 +341,9 @@ void fast::OpenFAST::stepNoWrite() {
   
 }
 
+fast::OpenFAST::~OpenFAST(){
+}
+
 void fast::OpenFAST::calc_nacelle_force(
         const float & u, 
         const float & v, 
@@ -847,6 +850,7 @@ void fast::OpenFAST::end() {
     for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
       FAST_End(&iTurb, &stopTheProgram);
     }
+    FAST_DeallocateTurbines(&ErrStat, ErrMsg);
   }
   
   MPI_Group_free(&fastMPIGroup);

--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -60,6 +60,23 @@ subroutine FAST_AllocateTurbines(nTurbines, ErrStat_c, ErrMsg_c) BIND (C, NAME='
    
 end subroutine FAST_AllocateTurbines
 
+subroutine FAST_DeallocateTurbines(ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_DeallocateTurbines')
+   IMPLICIT NONE
+#ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_DeallocateTurbines
+!GCC$ ATTRIBUTES DLLEXPORT :: FAST_DeallocateTurbines
+#endif
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
+   if (Allocated(Turbine)) then
+      deallocate(Turbine)
+   end if
+
+   ErrStat_c = ErrID_None
+   ErrMsg_c = ''
+end subroutine
+
 subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, NumOuts_c, dt_c, ErrStat_c, ErrMsg_c, ChannelNames_c) BIND (C, NAME='FAST_Sizes')
    IMPLICIT NONE 
 #ifndef IMPLICIT_DLLEXPORT

--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -12,6 +12,7 @@
 #endif
 
 EXTERNAL_ROUTINE void FAST_AllocateTurbines(int * iTurb, int *ErrStat, char *ErrMsg);
+EXTERNAL_ROUTINE void FAST_DeallocateTurbines(int *ErrStat, char *ErrMsg);
 
 EXTERNAL_ROUTINE void FAST_OpFM_Restart(int * iTurb, const char *CheckpointRootName, int *AbortErrLev, double * dt, int * NumBl, int * NumBlElem, int * n_t_global,
    OpFM_InputType_t* OpFM_Input, OpFM_OutputType_t* OpFM_Output, SC_InputType_t* SC_Input, SC_OutputType_t* SC_Output, int *ErrStat, char *ErrMsg);


### PR DESCRIPTION
 - Deallocate Turbine data when shutting down
 - Verified by running openfast in gtest in multiple unittests


**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

