### PR TITLE
Update cpp API to provide consistent definition of hub position

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.H
+++ b/glue-codes/openfast-cpp/src/OpenFAST.H
@@ -161,7 +161,7 @@ class OpenFAST {
   OpenFAST() ;
   
   // Destructor
-  ~OpenFAST() {} ;
+  ~OpenFAST() ;
 
   void setInputs(const fastInputs &);  
 

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -194,7 +194,7 @@ void fast::OpenFAST::init() {
       if(positionChange){
         std::vector<double> temp(globTurbineData[i].TurbineHubPos);
         MPI_Bcast(globTurbineData[i].TurbineHubPos.data(), 3, MPI_DOUBLE, get_procNo(i), mpiComm);
-        if(isDebug()){
+        if(isDebug() && worldMPIRank==0){
           std::cout << "WARNING::Hub position for turbine "<< i <<
             " changed from "<<
             temp[0] << " " <<

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -177,6 +177,19 @@ void fast::OpenFAST::init() {
      
     }
 
+    //UPDATE HUB POSITION
+    for (int i=0; i<nTurbinesGlob; ++i){
+      if(worldMPIRank == get_procNo(i)){
+        std::vector<double> hubCalc(3);
+        getVelNodeCoordinates(hubCalc, 0, i);
+        for(int j=0; j<3; j++){
+          // TODO send message notifying if hub position is changing
+          globTurbineData[i].TurbineHubPos[j] = hubCalc[j];
+        }
+      }
+      MPI_Bcast(globTurbineData[i].TurbineHubPos.data(), 3, MPI_DOUBLE, get_procNo(i), mpiComm);
+    }
+
   }
 }
 

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -191,12 +191,20 @@ void fast::OpenFAST::init() {
         }
       }
       MPI_Bcast(&positionChange, 1, MPI_C_BOOL, get_procNo(i), mpiComm);
-      if(positionChange && isDebug()){
+      if(positionChange){
+        std::vector<double> temp(globTurbineData[i].TurbineHubPos);
         MPI_Bcast(globTurbineData[i].TurbineHubPos.data(), 3, MPI_DOUBLE, get_procNo(i), mpiComm);
-        std::cout << "WARNING::Hub position changed from value specified in C++ API to: "<<
+        if(isDebug()){
+          std::cout << "WARNING::Hub position for turbine "<< i <<
+            " changed from "<<
+            temp[0] << " " <<
+            temp[1] << " " <<
+            temp[2] << " " <<
+            " to: "<<
             globTurbineData[i].TurbineHubPos[0] <<" "<<
             globTurbineData[i].TurbineHubPos[1] <<" "<<
             globTurbineData[i].TurbineHubPos[2] << std::endl;
+        }
       }
     }
 

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -341,6 +341,9 @@ void fast::OpenFAST::stepNoWrite() {
   
 }
 
+fast::OpenFAST::~OpenFAST(){
+}
+
 void fast::OpenFAST::calc_nacelle_force(
         const float & u, 
         const float & v, 
@@ -847,6 +850,7 @@ void fast::OpenFAST::end() {
     for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
       FAST_End(&iTurb, &stopTheProgram);
     }
+    FAST_DeallocateTurbines(&ErrStat, ErrMsg);
   }
   
   MPI_Group_free(&fastMPIGroup);

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -191,7 +191,7 @@ void fast::OpenFAST::init() {
         }
       }
       MPI_Bcast(&positionChange, 1, MPI_C_BOOL, get_procNo(i), mpiComm);
-      if(positionChange){
+      if(positionChange && isDebug()){
         MPI_Bcast(globTurbineData[i].TurbineHubPos.data(), 3, MPI_DOUBLE, get_procNo(i), mpiComm);
         std::cout << "WARNING::Hub position changed from value specified in C++ API to: "<<
             globTurbineData[i].TurbineHubPos[0] <<" "<<

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -180,6 +180,7 @@ void fast::OpenFAST::init() {
     //UPDATE HUB POSITION
     for (int i=0; i<nTurbinesGlob; ++i){
       bool positionChange = false;
+      std::vector<double> temp(globTurbineData[i].TurbineHubPos);
       if(worldMPIRank == get_procNo(i)){
         std::vector<double> hubCalc(3);
         getVelNodeCoordinates(hubCalc, 0, i);
@@ -192,7 +193,6 @@ void fast::OpenFAST::init() {
       }
       MPI_Bcast(&positionChange, 1, MPI_C_BOOL, get_procNo(i), mpiComm);
       if(positionChange){
-        std::vector<double> temp(globTurbineData[i].TurbineHubPos);
         MPI_Bcast(globTurbineData[i].TurbineHubPos.data(), 3, MPI_DOUBLE, get_procNo(i), mpiComm);
         if(isDebug() && worldMPIRank==0){
           std::cout << "WARNING::Hub position for turbine "<< i <<

--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -60,6 +60,23 @@ subroutine FAST_AllocateTurbines(nTurbines, ErrStat_c, ErrMsg_c) BIND (C, NAME='
    
 end subroutine FAST_AllocateTurbines
 
+subroutine FAST_DeallocateTurbines(ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_DeallocateTurbines')
+   IMPLICIT NONE
+#ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: FAST_DeallocateTurbines
+!GCC$ ATTRIBUTES DLLEXPORT :: FAST_DeallocateTurbines
+#endif
+   INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
+   CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+
+   if (Allocated(Turbine)) then
+      deallocate(Turbine)
+   end if
+
+   ErrStat_c = ErrID_None
+   ErrMsg_c = ''
+end subroutine
+
 subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, NumOuts_c, dt_c, ErrStat_c, ErrMsg_c, ChannelNames_c) BIND (C, NAME='FAST_Sizes')
    IMPLICIT NONE 
 #ifndef IMPLICIT_DLLEXPORT

--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -12,6 +12,7 @@
 #endif
 
 EXTERNAL_ROUTINE void FAST_AllocateTurbines(int * iTurb, int *ErrStat, char *ErrMsg);
+EXTERNAL_ROUTINE void FAST_DeallocateTurbines(int *ErrStat, char *ErrMsg);
 
 EXTERNAL_ROUTINE void FAST_OpFM_Restart(int * iTurb, const char *CheckpointRootName, int *AbortErrLev, double * dt, int * NumBl, int * NumBlElem, int * n_t_global,
    OpFM_InputType_t* OpFM_Input, OpFM_OutputType_t* OpFM_Output, SC_InputType_t* SC_Input, SC_OutputType_t* SC_Output, int *ErrStat, char *ErrMsg);


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST  IS READY TO MERGE

The C++ API currently defines a hub position that never gets updated or checked against the force location.  This can lead to serious bugs if the users specify a hub position that is quite different than the calculated hub position from elastodyn (i.e. a different height). These changes synchronize the hub position across all processors after OpenFAST is initialized so the hub position is the C++ API is the initial position of velocity/force point for the hub.
