### PR TITLE
OpenFAST should exit normally on help prompt

### DIFF
--- a/glue-codes/openfast/src/FAST_Prog.f90
+++ b/glue-codes/openfast/src/FAST_Prog.f90
@@ -63,7 +63,10 @@ INTEGER(IntKi)                        :: Restart_step                           
 
    CALL CheckArgs( InputFile, Flag=FlagArg, Arg2=CheckpointRoot )
 
-   IF ( TRIM(FlagArg) == 'RESTART' ) THEN ! Restart from checkpoint file
+   IF ( TRIM(FlagArg) == 'H' ) THEN ! Exit after help prompt
+      CALL NormStop()
+
+   ELSE IF ( TRIM(FlagArg) == 'RESTART' ) THEN ! Restart from checkpoint file
       CALL FAST_RestoreFromCheckpoint_Tary(t_initial, Restart_step, Turbine, CheckpointRoot, ErrStat, ErrMsg  )
          CALL CheckError( ErrStat, ErrMsg, 'during restore from checkpoint'  )            
    ELSE


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
The calling routines should handle the behavior after the help flag is returned from CheckArgs. This is a follow on to PR #408.

**Related issue, if one exists**
#105

**Impacted areas of the software**
OpenFAST program command line interface.

**Additional supporting information**
Truthfully, this should have been included in PR #408 but it was left out so here it is.

**Test results, if applicable**
See GitHub Actions.