### PR TITLE
Checkout the branch making the change

### DIFF
--- a/.github/actions/compile-and-test/Dockerfile
+++ b/.github/actions/compile-and-test/Dockerfile
@@ -18,8 +18,8 @@ FROM rafmudaf/openfast-ubuntu:dev
 
 # Move into the openfast directory and update
 WORKDIR /openfast
-RUN git fetch
-RUN git pull
+RUN git fetch origin ${GITHUB_REF}:CI
+RUN git checkout CI
 RUN git submodule update
 
 # Move into the "build" directory, remove the old reg tests, and compile


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS NOT__ READY TO MERGE

**Feature or improvement description**
Currently, the GitHub Actions/Docker workflow always runs the `dev` branch from `openfast/openfast`. This is not super useful for incoming pull requests, so I'm working on fixing that.

**Impacted areas of the software**
GitHub Actions