### PR TITLE
[BugFix] AD15 routine sub_brent had broken error handling

### DIFF
--- a/modules/aerodyn/src/mod_root1dim.f90
+++ b/modules/aerodyn/src/mod_root1dim.f90
@@ -83,6 +83,10 @@ subroutine sub_brent(x,a_in,b_in, toler_in,maxiter_in,fcnArgs,AFInfo,fa_in,fb_in
     integer                 :: ErrStat_a
     character(ErrMsgLen)    :: ErrMsg_a
     logical                 :: ValidPhi_a
+
+    fcnArgs%errStat  = ErrID_None
+    fcnArgs%ErrMsg   = ""
+
     ! Set of get parameters
     toler = 0.0_SolveKi; if (present(toler_in)) toler = toler_in ! Better to use custom toler here
     xtoler = xtoler_def; if (present(xtoler_in)) xtoler = xtoler_in


### PR DESCRIPTION
The error handling in the `sub_brent` routine in `mod_root1dim.f90` was broken.  On very rare occasions this could cause OpenFAST to end prematurely.

This should not affect any test results.
