### PR TITLE
Feature/update if w hawc

### DIFF
--- a/modules/inflowwind/src/IfW_HAWCWind.f90
+++ b/modules/inflowwind/src/IfW_HAWCWind.f90
@@ -96,8 +96,9 @@ SUBROUTINE IfW_HAWCWind_Init(InitInp, p, MiscVars, Interval, InitOut, ErrStat, E
    p%nz           = InitInp%nz   
    p%RefHt        = InitInp%RefHt
    p%URef         = InitInp%URef
-   p%InitPosition = 0.0_ReKi  ! bjj: someday we may want to let the users give an offset time/position
-   p%InitPosition(1) = InitInp%dx
+   p%InitPosition = InitInp%InitPosition
+   if (EqualRealNos(InitInp%InitPosition(1), 0.0_ReKi)) p%InitPosition(1) = InitInp%dx        ! This is the old behaviour
+
 
    p%deltaXInv   = 1.0 / InitInp%dx
    p%deltaYInv   = 1.0 / InitInp%dy

--- a/modules/inflowwind/src/IfW_HAWCWind.f90
+++ b/modules/inflowwind/src/IfW_HAWCWind.f90
@@ -146,7 +146,7 @@ SUBROUTINE IfW_HAWCWind_Init(InitInp, p, MiscVars, Interval, InitOut, ErrStat, E
       WRITE(InitInp%SumFileUnit,'(A)', IOSTAT=TmpErrStat)    'HAWC wind type.  Read by InflowWind sub-module '//TRIM(GetNVD(IfW_HAWCWind_Ver))      
       
       WRITE(InitInp%SumFileUnit,'(A34,G12.4)',IOSTAT=TmpErrStat)    '     Reference height (m):        ',p%RefHt
-      WRITE(InitInp%SumFileUnit,'(A34,G12.4)',IOSTAT=TmpErrStat)    '     Timestep (s):                ',p%deltaXInv / p%URef
+      WRITE(InitInp%SumFileUnit,'(A34,G12.4)',IOSTAT=TmpErrStat)    '     Timestep (s):                ',1.0_ReKi / (p%deltaXInv * p%URef)
       WRITE(InitInp%SumFileUnit,'(A34,I12)',  IOSTAT=TmpErrStat)    '     Number of timesteps:         ',p%nx
       WRITE(InitInp%SumFileUnit,'(A34,G12.4)',IOSTAT=TmpErrStat)    '     Mean windspeed (m/s):        ',p%URef
       WRITE(InitInp%SumFileUnit,'(A)',        IOSTAT=TmpErrStat)    '     Time range (s):              [ '// &

--- a/modules/inflowwind/src/IfW_HAWCWind.f90
+++ b/modules/inflowwind/src/IfW_HAWCWind.f90
@@ -42,6 +42,7 @@ MODULE IfW_HAWCWind
    PUBLIC                                    :: IfW_HAWCWind_CalcOutput
 
    INTEGER(IntKi), PARAMETER  :: nc = 3                           !< number of wind components
+   INTEGER(IntKi), PARAMETER  :: WindProfileType_None     = -1    !< don't add wind profile; already included in input data
    INTEGER(IntKi), PARAMETER  :: WindProfileType_Constant = 0     !< constant wind
    INTEGER(IntKi), PARAMETER  :: WindProfileType_Log      = 1     !< logarithmic
    INTEGER(IntKi), PARAMETER  :: WindProfileType_PL       = 2     !< power law
@@ -213,7 +214,7 @@ SUBROUTINE ValidateInput(InitInp, ErrStat, ErrMsg)
    if (InitInp%WindProfileType == WindProfileType_Log) then
       if ( InitInp%z0 < 0.0_ReKi .or. EqualRealNos( InitInp%z0, 0.0_ReKi ) ) &
          call SetErrStat( ErrID_Fatal, 'The surface roughness length, Z0, must be greater than zero', ErrStat, ErrMsg, RoutineName )
-   elseif ( InitInp%WindProfileType < WindProfileType_Constant .or. InitInp%WindProfileType > WindProfileType_PL)  then                              
+   elseif ( InitInp%WindProfileType < WindProfileType_None .or. InitInp%WindProfileType > WindProfileType_PL)  then                              
        call SetErrStat( ErrID_Fatal, 'The WindProfile type must be 0 (constant), 1 (logarithmic) or 2 (power law).', ErrStat, ErrMsg, RoutineName )
    end if
 

--- a/modules/inflowwind/src/IfW_HAWCWind.txt
+++ b/modules/inflowwind/src/IfW_HAWCWind.txt
@@ -31,6 +31,7 @@ typedef  ^                       ^                 ReKi              RefHt      
 typedef  ^                       ^                 ReKi              URef              -     0     -     "Mean u-component wind speed at the reference height"       meters
 typedef  ^                       ^                 ReKi              PLExp             -     0     -     "Power law exponent (used for PL wind profile type only)"   -
 typedef  ^                       ^                 ReKi              Z0                -     0     -     "Surface roughness length (used for LOG wind profile type only)"  -
+typedef  ^                       ^                 ReKi              InitPosition      3     0     -     "the initial position of grid (distance in FF is offset)"    meters
 
 
 # Init Output

--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -557,6 +557,7 @@ SUBROUTINE InflowWind_Init( InitInp,   InputGuess,    p, ContStates, DiscStates,
             HAWC_InitData%URef               = InputFileData%HAWC_URef 
             HAWC_InitData%PLExp              = InputFileData%HAWC_PLExp
             HAWC_InitData%Z0                 = InputFileData%HAWC_Z0   
+            HAWC_InitData%InitPosition       = InputFileData%HAWC_InitPosition
                    
             
                ! Initialize the HAWCWind module

--- a/modules/inflowwind/src/InflowWind.txt
+++ b/modules/inflowwind/src/InflowWind.txt
@@ -99,6 +99,7 @@ typedef  ^                       ^                 ReKi              HAWC_URef  
 typedef  ^                       ^                 IntKi             HAWC_ProfileType  -     -     -     "HAWC -- Wind profile type (0=constant;1=logarithmic;2=power law)" -
 typedef  ^                       ^                 ReKi              HAWC_PLExp        -     -     -     "HAWC -- Power law exponent (used for PL wind profile type only)"   -
 typedef  ^                       ^                 ReKi              HAWC_Z0           -     -     -     "HAWC -- Surface roughness length (used for LOG wind profile type only)"  -
+typedef  ^                       ^                 ReKi              HAWC_InitPosition 3     -     -     "HAWC -- initial position (offset for wind file box)" meters
 typedef  ^                       ^                 LOGICAL           SumPrint          -     -     -     "Write summary info to a file <ROOTNAME>.IfW.Sum"        -
 typedef  ^                       ^                 IntKi             NumOuts           -     -     -     "Number of parameters in the output list (number of outputs requested)" -
 typedef  ^                       ^                 CHARACTER(10)     OutList           :     -     -     "List of user-requested output channels"                 -

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -789,14 +789,24 @@ SUBROUTINE InflowWind_ReadInput( InputFileName, EchoFileName, InputFileData, Err
       RETURN
    END IF
 
-
-   !---------------------- OUTPUT --------------------------------------------------         
-   CALL ReadCom( UnitInput, InputFileName, 'Section Header: Output', TmpErrStat, TmpErrMsg, UnitEcho )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
-   IF (ErrStat >= AbortErrLev) THEN
-      CALL Cleanup()
-      RETURN
-   END IF
+      ! Read HAWC_InitPosition   (Shift of wind box)  NOTE: This an optional input!!!!
+   InputFileData%HAWC_InitPosition(2:3) = 0.0_ReKi    ! We are only using X, so only read in one.  The data can handle 3 coords
+   CALL ReadVar( UnitInput, InputFileName, InputFileData%HAWC_InitPosition(1), 'HAWC_Position', &
+               'Initial position of the HAWC wind file (shift along X usually)', TmpErrStat, TmpErrMsg, UnitEcho )
+   if (TmpErrStat == ErrID_None) then
+      !---------------------- OUTPUT --------------------------------------------------         
+      CALL ReadCom( UnitInput, InputFileName, 'Section Header: Output', TmpErrStat, TmpErrMsg, UnitEcho )
+      CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
+      IF (ErrStat >= AbortErrLev) THEN
+         CALL Cleanup()
+         RETURN
+      END IF
+   else
+      InputFileData%HAWC_InitPosition = 0.0_ReKi
+      TmpErrStat  =  ErrID_None  ! reset
+      TmpErrMsg   =  ""
+      ! NOTE: since we read in a line that wasn't a number, what we actually read was the header.
+   endif
 
       ! SumPrint - Print summary data to <RootName>.IfW.sum (flag):
    CALL ReadVar( UnitInput, InputFileName, InputFileData%SumPrint, "SumPrint", "Print summary data to <RootName>.IfW.sum (flag)", TmpErrStat, TmpErrMsg, UnitEcho)

--- a/modules/inflowwind/src/InflowWind_Types.f90
+++ b/modules/inflowwind/src/InflowWind_Types.f90
@@ -115,6 +115,7 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: HAWC_ProfileType      !< HAWC -- Wind profile type (0=constant;1=logarithmic;2=power law) [-]
     REAL(ReKi)  :: HAWC_PLExp      !< HAWC -- Power law exponent (used for PL wind profile type only) [-]
     REAL(ReKi)  :: HAWC_Z0      !< HAWC -- Surface roughness length (used for LOG wind profile type only) [-]
+    REAL(ReKi) , DIMENSION(1:3)  :: HAWC_InitPosition      !< HAWC -- initial position (offset for wind file box) [meters]
     LOGICAL  :: SumPrint      !< Write summary info to a file <ROOTNAME>.IfW.Sum [-]
     INTEGER(IntKi)  :: NumOuts      !< Number of parameters in the output list (number of outputs requested) [-]
     CHARACTER(10) , DIMENSION(:), ALLOCATABLE  :: OutList      !< List of user-requested output channels [-]
@@ -590,6 +591,7 @@ ENDIF
     DstInputFileData%HAWC_ProfileType = SrcInputFileData%HAWC_ProfileType
     DstInputFileData%HAWC_PLExp = SrcInputFileData%HAWC_PLExp
     DstInputFileData%HAWC_Z0 = SrcInputFileData%HAWC_Z0
+    DstInputFileData%HAWC_InitPosition = SrcInputFileData%HAWC_InitPosition
     DstInputFileData%SumPrint = SrcInputFileData%SumPrint
     DstInputFileData%NumOuts = SrcInputFileData%NumOuts
 IF (ALLOCATED(SrcInputFileData%OutList)) THEN
@@ -722,6 +724,7 @@ ENDIF
       Int_BufSz  = Int_BufSz  + 1  ! HAWC_ProfileType
       Re_BufSz   = Re_BufSz   + 1  ! HAWC_PLExp
       Re_BufSz   = Re_BufSz   + 1  ! HAWC_Z0
+      Re_BufSz   = Re_BufSz   + SIZE(InData%HAWC_InitPosition)  ! HAWC_InitPosition
       Int_BufSz  = Int_BufSz  + 1  ! SumPrint
       Int_BufSz  = Int_BufSz  + 1  ! NumOuts
   Int_BufSz   = Int_BufSz   + 1     ! OutList allocated yes/no
@@ -893,6 +896,8 @@ ENDIF
       Re_Xferred   = Re_Xferred   + 1
       ReKiBuf ( Re_Xferred:Re_Xferred+(1)-1 ) = InData%HAWC_Z0
       Re_Xferred   = Re_Xferred   + 1
+      ReKiBuf ( Re_Xferred:Re_Xferred+(SIZE(InData%HAWC_InitPosition))-1 ) = PACK(InData%HAWC_InitPosition,.TRUE.)
+      Re_Xferred   = Re_Xferred   + SIZE(InData%HAWC_InitPosition)
       IntKiBuf ( Int_Xferred:Int_Xferred+1-1 ) = TRANSFER( InData%SumPrint , IntKiBuf(1), 1)
       Int_Xferred   = Int_Xferred   + 1
       IntKiBuf ( Int_Xferred:Int_Xferred+(1)-1 ) = InData%NumOuts
@@ -1120,6 +1125,17 @@ ENDIF
       Re_Xferred   = Re_Xferred + 1
       OutData%HAWC_Z0 = ReKiBuf( Re_Xferred )
       Re_Xferred   = Re_Xferred + 1
+    i1_l = LBOUND(OutData%HAWC_InitPosition,1)
+    i1_u = UBOUND(OutData%HAWC_InitPosition,1)
+    ALLOCATE(mask1(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating mask1.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+    mask1 = .TRUE. 
+      OutData%HAWC_InitPosition = UNPACK(ReKiBuf( Re_Xferred:Re_Xferred+(SIZE(OutData%HAWC_InitPosition))-1 ), mask1, 0.0_ReKi )
+      Re_Xferred   = Re_Xferred   + SIZE(OutData%HAWC_InitPosition)
+    DEALLOCATE(mask1)
       OutData%SumPrint = TRANSFER( IntKiBuf( Int_Xferred ), mask0 )
       Int_Xferred   = Int_Xferred + 1
       OutData%NumOuts = IntKiBuf( Int_Xferred ) 


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST IS READY TO MERGE

**Feature or improvement description**
Add an additional option to the `WindProfile` parameter: -1 is allowable so that the mean profile is not added on. Use case would be when a user wants to directly supply inflow planes that include both the mean wind and turbulence, e.g., when using sampled output from SOWFA and using it as inflow data. 
