### PR TITLE
Properly support yaw rate command integration from controller

### DIFF
--- a/modules/elastodyn/src/ElastoDyn_Types.f90
+++ b/modules/elastodyn/src/ElastoDyn_Types.f90
@@ -11168,14 +11168,8 @@ ENDIF
     IntKiBuf( Int_Xferred + 1) = UBOUND(InData%AngVelEM,3)
     Int_Xferred = Int_Xferred + 2
 
-      DO i3 = LBOUND(InData%AngVelEM,3), UBOUND(InData%AngVelEM,3)
-        DO i2 = LBOUND(InData%AngVelEM,2), UBOUND(InData%AngVelEM,2)
-          DO i1 = LBOUND(InData%AngVelEM,1), UBOUND(InData%AngVelEM,1)
-            ReKiBuf(Re_Xferred) = InData%AngVelEM(i1,i2,i3)
-            Re_Xferred = Re_Xferred + 1
-          END DO
-        END DO
-      END DO
+      IF (SIZE(InData%AngVelEM)>0) ReKiBuf ( Re_Xferred:Re_Xferred+(SIZE(InData%AngVelEM))-1 ) = PACK(InData%AngVelEM,.TRUE.)
+      Re_Xferred   = Re_Xferred   + SIZE(InData%AngVelEM)
   END IF
   IF ( .NOT. ALLOCATED(InData%PAngVelEN) ) THEN
     IntKiBuf( Int_Xferred ) = 0
@@ -12952,14 +12946,15 @@ ENDIF
        CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%AngVelEM.', ErrStat, ErrMsg,RoutineName)
        RETURN
     END IF
-      DO i3 = LBOUND(OutData%AngVelEM,3), UBOUND(OutData%AngVelEM,3)
-        DO i2 = LBOUND(OutData%AngVelEM,2), UBOUND(OutData%AngVelEM,2)
-          DO i1 = LBOUND(OutData%AngVelEM,1), UBOUND(OutData%AngVelEM,1)
-            OutData%AngVelEM(i1,i2,i3) = ReKiBuf(Re_Xferred)
-            Re_Xferred = Re_Xferred + 1
-          END DO
-        END DO
-      END DO
+    ALLOCATE(mask3(i1_l:i1_u,i2_l:i2_u,i3_l:i3_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating mask3.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+    mask3 = .TRUE. 
+      IF (SIZE(OutData%AngVelEM)>0) OutData%AngVelEM = UNPACK(ReKiBuf( Re_Xferred:Re_Xferred+(SIZE(OutData%AngVelEM))-1 ), mask3, 0.0_ReKi )
+      Re_Xferred   = Re_Xferred   + SIZE(OutData%AngVelEM)
+    DEALLOCATE(mask3)
   END IF
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! PAngVelEN not allocated
     Int_Xferred = Int_Xferred + 1

--- a/modules/servodyn/src/ServoDyn_Registry.txt
+++ b/modules/servodyn/src/ServoDyn_Registry.txt
@@ -161,6 +161,7 @@ typedef	^	OtherStateType	DbKi	TPitManE	{:}	-	-	"Time to end pitch maneuvers for 
 typedef	^	OtherStateType	Logical	BegYawMan	-	-	-	"Whether the yaw maneuver actually began"	-
 typedef	^	OtherStateType	ReKi	NacYawI	-	-	-	"Initial yaw angle at the start of the override yaw maneuver"	radians
 typedef	^	OtherStateType	DbKi	TYawManE	-	-	-	"Time to end override yaw maneuver"	s
+typedef	^	OtherStateType	ReKi	YawPosComInt	-	-	-	"Internal variable that integrates the commanded yaw rate and passes it to YawPosCom"	radians
 # other states for tip-brake deployment:
 typedef	^	OtherStateType	Logical	BegTpBr	{:}	-	-	"Whether the tip brakes actually deployed"	-
 typedef	^	OtherStateType	DbKi	TTpBrDp	{:}	-	-	"Times to initiate deployment of tip brakes"	s
@@ -178,7 +179,6 @@ typedef	^	MiscVarType	BladedDLLType	dll_data	-	-	-	"data used for Bladed DLL"	-
 typedef	^	MiscVarType	logical	FirstWarn	-	-	-	"Whether or not this is the first warning about the DLL being called without Explicit-Loose coupling."	-
 typedef	^	MiscVarType	DbKi	LastTimeFiltered	-	-	-	"last time the CalcOutput/Bladed DLL was filtered"	s
 typedef	^	MiscVarType	ReKi	xd_BlPitchFilter	{:}	-	-	"blade pitch filter"	-
-typedef	^	MiscVarType	ReKi	YawPosComInt	-	-	-	"Internal variable that integrates the commanded yaw rate and passes it to YawPosCom"	radians
 typedef	^	MiscVarType	TMD_MiscVarType	NTMD	-	-	-	"TMD module misc vars - nacelle"	-
 typedef	^	MiscVarType	TMD_MiscVarType	TTMD	-	-	-	"TMD module misc vars - tower"	-
 

--- a/modules/servodyn/src/ServoDyn_Registry.txt
+++ b/modules/servodyn/src/ServoDyn_Registry.txt
@@ -178,6 +178,7 @@ typedef	^	MiscVarType	BladedDLLType	dll_data	-	-	-	"data used for Bladed DLL"	-
 typedef	^	MiscVarType	logical	FirstWarn	-	-	-	"Whether or not this is the first warning about the DLL being called without Explicit-Loose coupling."	-
 typedef	^	MiscVarType	DbKi	LastTimeFiltered	-	-	-	"last time the CalcOutput/Bladed DLL was filtered"	s
 typedef	^	MiscVarType	ReKi	xd_BlPitchFilter	{:}	-	-	"blade pitch filter"	-
+typedef	^	MiscVarType	ReKi	YawPosComInt	-	-	-	"Internal variable that integrates the commanded yaw rate and passes it to YawPosCom"	radians
 typedef	^	MiscVarType	TMD_MiscVarType	NTMD	-	-	-	"TMD module misc vars - nacelle"	-
 typedef	^	MiscVarType	TMD_MiscVarType	TTMD	-	-	-	"TMD module misc vars - tower"	-
 


### PR DESCRIPTION
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
Integration of the yawrate command from the DLL is now properly supported.
This has been tested by @nikhar-abbas and @ewquon

**Related issue, if one exists**
Issue #25 

**Impacted areas of the software**
This resolves issue #25.  When a DLL was controlling the yaw, the position was incorrectly integrated.

**Test results, if applicable**
No test cases are affected by this PR as none of the glue-code DLL cases use yaw control.

Closes #25