### PR TITLE
multiple fortran compilers with pfunit

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -35,6 +35,7 @@ endif()
 include(ExternalProject)
 set(ExternalProjectCMakeArgs
   -DCMAKE_INSTALL_PREFIX=${PROJECT_BINARY_DIR}/pfunit
+  -DCMAKE_Fortran_COMPILER=${CMAKE_Fortran_COMPILER}
   -DROBUST=OFF
 )
 set(PFUNIT_INSTALL ${PROJECT_BINARY_DIR}/pfunit)


### PR DESCRIPTION
This is ready to merge

When multiple version of the Fortran compiler exist on a system, pfunit defaults to the newest.  So if an older compiler is wanted (for running regression test baselines etc), OpenFAST and pfunit will be compiled with different versions of the Fortran compiler and will be incompatible.

To reproduce on MacOSX:

- Install `gfortran@7` and `gfortran@9` with homebrew
- in clean build directory
   ```
    export CC=`which gcc-7`; export CXX=`which g++-7`; export FC=`which gfortron-7`;
    cmake -DBUILD_TESTING=ON -DCTEST_PLOT_ERRORS=ON -DCMAKE_Fortran_COMPILER=`which gfortran-7` ..
    make -j6
    ```
Despite setting the environment variable and setting the `CMAKE_Fortran_COMPILER` directly, it fails.  Solution is to pass the compiler to pfunit with the `ExternalProjectCMakeArgs` argument list.