### PR TITLE
Fix bug that could cause incorrect loads transfer in Line2-to-Line2 or Line2-to-Point mapping

### DIFF
--- a/modules/nwtc-library/src/ModMesh.f90
+++ b/modules/nwtc-library/src/ModMesh.f90
@@ -91,6 +91,7 @@ SUBROUTINE MeshWrBin ( UnIn, M, ErrStat, ErrMsg, FileName)
    WRITE (UnIn, IOSTAT=ErrStat2)   M%fieldmask           ! BJJ: do we need to verify that this is size B4Ki?
    WRITE (UnIn, IOSTAT=ErrStat2)   INT(M%Nnodes,B4Ki)
    WRITE (UnIn, IOSTAT=ErrStat2)   INT(M%nelemlist,B4Ki)
+   if (M%Fieldmask(MASKID_SCALAR))  WRITE (UnIn, IOSTAT=ErrStat2)   INT(M%nScalars,B4Ki)
 
 
    !...........
@@ -2411,7 +2412,7 @@ SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputF
 
         Mesh%ElemTable(ELEMENT_LINE2)%Elements(J)%det_jac  = 0.5_ReKi * TwoNorm( n1_n2_vector )   ! = L / 2
         
-        IF ( EqualRealNos( 2.0_ReKi*Mesh%ElemTable(ELEMENT_LINE2)%Elements(J)%det_jac, 0.0_Reki ) ) THEN
+        IF ( 2.0_ReKi*Mesh%ElemTable(ELEMENT_LINE2)%Elements(J)%det_jac < MIN_LINE2_ELEMENT_LENGTH ) THEN
            ErrStat = ErrID_Fatal
            ErrMess = trim(ErrMess)//"MeshCommit: Line2 element "//TRIM(Num2Lstr(j))//" has 0 length."//NewLine// &
                      "   n2 = n("//TRIM(Num2Lstr(n2))//") = ("//TRIM(Num2Lstr(Mesh%Position(1,n2)))//','//TRIM(Num2Lstr(mesh%position(2,n2)))//','//TRIM(Num2Lstr(mesh%position(3,n2))) //')'//NewLine// &

--- a/modules/nwtc-library/src/ModMesh_Types.f90
+++ b/modules/nwtc-library/src/ModMesh_Types.f90
@@ -71,6 +71,10 @@ MODULE ModMesh_Types
 
    LOGICAL, PARAMETER :: mesh_debug = .FALSE.
 
+
+!   REAL(ReKi), PARAMETER            :: MIN_LINE2_ELEMENT_LENGTH = 0.001 ! 1 millimeter
+   REAL(ReKi), PARAMETER            :: MIN_LINE2_ELEMENT_LENGTH = sqrt(epsilon(1.0_ReKi)) ! old length
+   
       !> element record type: fields for a particular element
    TYPE, PUBLIC :: ElemRecType 
       ! note: any fields added to this type must be copied in Mesh_MoveAlloc_ElemRecType (modmesh_types::mesh_movealloc_elemrectype)


### PR DESCRIPTION
**Complete this sentence**
THIS PULL REQUEST __IS__ READY TO MERGE

**Feature or improvement description**
This pull request fixes a problem identified in the implementation of the mesh mapping line2-to-line2 and line2-to-point loads-transfer algorithm. The algorithm to create the augmented source mesh would split an element but--in certain (fairly rare?) instances--incorrectly calculate the position of the new node, effectively increasing the load being transferred.

**Related issue, if one exists**
None

**Impacted areas of the software**
This may impact any modules that have distributed loads output. This includes any models that use
- AeroDyn15 to transfer loads to ElastoDyn or BeamDyn, or
- HydroDyn to transfer loads to SubDyn.

**Additional supporting information**
I have attached a plot showing a case where this bug was triggered. The red line shows the smooth loads expected from AeroDyn's output mesh; the blue line indicates how the loads input to the structural code were being calculated prior to this bug fix:
![problem2](https://user-images.githubusercontent.com/6108781/86952431-39b4a900-c110-11ea-9ee8-8a642002fe8b.png)

**Test results, if applicable**
The regression tests look the same (with the exception of the numerical instability in the SWRT case), indicating that this bug probably wasn't triggered in any of these test cases. 
