### PR TITLE
[BugFix] ReadTheDocs builds failed with multiple bibliographies referencing the same article

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -2,8 +2,8 @@ breathe>=4.4
 docutils>=0.13
 Pygments>=2.2
 pyparsing>=2.1
-Sphinx>=1.5
-sphinxcontrib-bibtex>=0.3
+Sphinx>=1.8.5
+sphinxcontrib-bibtex>=0.3.3
 sphinxcontrib-doxylink>=1.3
 sphinx_rtd_theme>=0.3
 requests[security]

--- a/docs/source/user/aerodyn-olaf/Introduction.rst
+++ b/docs/source/user/aerodyn-olaf/Introduction.rst
@@ -32,18 +32,18 @@ physics. As opposed to the BEM methods, FVW methods do not rely on ad-hoc
 engineering models to account for dynamic inflow, skewed wake, tip losses, or
 ground effects. These effects are inherently part of the model. Numerous
 vorticity-based tools have been implemented, ranging from the early treatments
-by Rosenhead (:cite:`Rosenhead31_1`), the formulation of vortex particle methods
-by Winckelmans and Leonard (:cite:`Winckelmans93_1`), to the recent mixed
+by Rosenhead (:cite:`olaf-Rosenhead31_1`), the formulation of vortex particle methods
+by Winckelmans and Leonard (:cite:`olaf-Winckelmans93_1`), to the recent mixed
 Eulerian-Lagrangian compressible formulations of
-Papadakis (:cite:`Papadakis14_1`). Examples of long-standing codes that have been
-applied in the field of wind energy are GENUVP (:cite:`Voutsinas06_1`), using
-vortex particles methods, and AWSM (:cite:`Garrel03_1`), using vortex filament
+Papadakis (:cite:`olaf-Papadakis14_1`). Examples of long-standing codes that have been
+applied in the field of wind energy are GENUVP (:cite:`olaf-Voutsinas06_1`), using
+vortex particles methods, and AWSM (:cite:`olaf-Garrel03_1`), using vortex filament
 methods. Both tools have successfully been coupled to structural solvers. The
-method was extended by Branlard et al. (:cite:`Branlard15_1`) to consistently use
+method was extended by Branlard et al. (:cite:`olaf-Branlard15_1`) to consistently use
 vortex methods to perform aero-elastic simulations of wind turbines in sheared
 and turbulent inflow. Most formulations rely on a lifting-line representation of
 the blades, but recently, a viscous-inviscid representation was used in
-combination with a structural solver (:cite:`Miras17_1`).
+combination with a structural solver (:cite:`olaf-Miras17_1`).
 
 cOnvecting LAgrangian Filaments (OLAF) is a free vortex wake (FVW) module used
 to compute the aerodynamic forces on moving two- or three-bladed horizontal-axis
@@ -76,7 +76,7 @@ Incorporating the OLAF module within OpenFAST allows for the modeling of
 highly flexible turbines along with the aero-hydro-servo-elastic
 response capabilities of OpenFAST. The OLAF module follows the
 requirements of the OpenFAST modularization framework 
-(:cite:`Sprague15_1,Jonkman13_1`).
+(:cite:`olaf-Sprague15_1,olaf-Jonkman13_1`).
 
 The OLAF module uses a lifting-line representation of the blades, which
 is characterized by a distribution of bound circulation. The spatial and
@@ -86,7 +86,7 @@ manner, which allows the vortices to convect, stretch, and diffuse. The
 OLAF model is based on a Lagrangian approach, in which the turbine wake
 is discretized into Lagrangian markers. There are many methods of
 representing the wake with Lagrangian
-markers (:cite:`Branlard17_1`). In this work, a hybrid
+markers (:cite:`olaf-Branlard17_1`). In this work, a hybrid
 lattice/filament method is used, as depicted in
 Figure :numref:`Lagrangian`.
 
@@ -104,13 +104,13 @@ age, :math:`\zeta`, and azimuthal position, :math:`\psi`. A lattice
 method is used in the near wake of the blade. The near wake spans over a
 user-specified angle or distance for nonrotating cases. Though past
 research has indicated that a near-wake region of :math:`30^\circ` is
-sufficient (:cite:`Leishman_book,Ananthan02_1`), it has been shown that a larger
+sufficient (:cite:`olaf-Leishman_book,olaf-Ananthan02_1`), it has been shown that a larger
 near wake is required for high thrust and other challenging conditions. After
 the near wake region, the wake is assumed to instantaneously roll up into a tip
 vortex and a root vortex, which are assumed to be the most dominant features for
-the remainder of the wake (:cite:`Leishman02_1`). Each Lagrangian marker is
+the remainder of the wake (:cite:`olaf-Leishman02_1`). Each Lagrangian marker is
 connected to adjacent markers by straight-line vortex filaments, approximated to
-second-order accuracy (:cite:`Gupta05_1`). The wake is discretized based on the
+second-order accuracy (:cite:`olaf-Gupta05_1`). The wake is discretized based on the
 spanwise location of the blade sections and a specified time step (:math:`dt`),
 which may be different from the time step of AeroDyn.  After an optional
 initialization period, the wake is allowed to move and distort, thus changing
@@ -121,7 +121,7 @@ violates Helmholtz's first law and hence introduces an erroneous boundary
 condition. To alleviate this, the wake is "frozen" in a buffer zone between a
 specified buffer distance, **FreeWakeLength**, and **WakeLength**. In this
 buffer zone, the markers convect at the average ambient velocity. In this way,
-truncation error is minimized~(:cite:`Leishman02_1`). The buffer zone is
+truncation error is minimized~(:cite:`olaf-Leishman02_1`). The buffer zone is
 typically chosen as the convected distance over one rotor revolution.
 
 As part of OpenFAST, induced velocities at the lifting line/blade are

--- a/docs/source/user/aerodyn-olaf/OLAFTheory.rst
+++ b/docs/source/user/aerodyn-olaf/OLAFTheory.rst
@@ -149,7 +149,7 @@ Panelling
 
 The definitions used for the panelling of the blade are given in
 :numref:`fig:VortexLatticeMethod` d, following the notations of van
-Garrel (:cite:`Garrel03_1`). The leading edge and
+Garrel (:cite:`olaf-Garrel03_1`). The leading edge and
 trailing edge (TE) locations are directly obtained from the AeroDyn
 mesh. At two spanwise locations, the LE and TE define the corner points:
 :math:`\vec{x}_1`, :math:`\vec{x}_2`, :math:`\vec{x}_3`, and
@@ -195,7 +195,7 @@ For an equidistant spacing, this discretization places the control points at the
 middle of the lifting-line (:math:`\eta=0.5`). Theoretical circulation results
 for an elliptic wing with a cosine spacing are retrieved with such
 discretization since it places the control points closer to stronger trailing
-segments at the wing extremities (see e.g. :cite:`Kerwin:lecturenotes`).
+segments at the wing extremities (see e.g. :cite:`olaf-Kerwin:lecturenotes`).
 
 .. _sec:CirculationMethods:
 
@@ -216,7 +216,7 @@ the lift obtained using the angle of attack and the polar data matches
 the lift obtained with the Kutta-Joukowski theorem. At present, it is
 the preferred method to compute the circulation along the blade span. It is
 selected with **CircSolvMethod=[1]**. The method is described in the work from
-van Garrel (:cite:`Garrel03_1`). The algorithm is implemented in at iterative
+van Garrel (:cite:`olaf-Garrel03_1`). The algorithm is implemented in at iterative
 approach using the following steps:
 
 #. The circulation distribution from the previous time step is used as a
@@ -280,9 +280,9 @@ approach using the following steps:
 No-flow-through Method
 ^^^^^^^^^^^^^^^^^^^^^^
 
-A Weissinger-L-based representation (:cite:`Weissinger47_1`)
+A Weissinger-L-based representation (:cite:`olaf-Weissinger47_1`)
 of the lifting surface is also
-available (:cite:`Bagai94_1,Gupta06_1,Ribera07_1`). In this
+available (:cite:`olaf-Bagai94_1,olaf-Gupta06_1,olaf-Ribera07_1`). In this
 method, the circulation is solved by satisfying a no-flow through
 condition at the 1/4-chord points.  It is selected with **CircSolvMethod=[2]**.
 
@@ -339,7 +339,7 @@ Using the chain rule, Eq. :eq:`VortFil` is rewritten as:
    :label: VortFil_expanded
 
 where :math:`d\psi/dt=\Omega` and
-:math:`d\psi=d\zeta` (:cite:`Leishman02_1`). Here,
+:math:`d\psi=d\zeta` (:cite:`olaf-Leishman02_1`). Here,
 :math:`\vec{r}(\psi,\zeta)` is the position vector of a Lagrangian
 marker, and :math:`\vec{V}[\vec{r}(\psi,\zeta)]` is the velocity.
 
@@ -358,11 +358,11 @@ Induced Velocity and Velocity Field
 The velocity term on the right-hand side of
 Eq. :eq:`VortFilCart` is a nonlinear function of the
 vortex position, representing a combination of the freestream and
-induced velocities (:cite:`Hansen08_1`). The induced
+induced velocities (:cite:`olaf-Hansen08_1`). The induced
 velocities at point :math:`\vec{x}`, caused by each straight-line
 filament, are computed using the Biot-Savart law, which considers the
 locations of the Lagrangian markers and the intensity of the vortex
-elements (:cite:`Leishman02_1`):
+elements (:cite:`olaf-Leishman02_1`):
 
 .. math::
    d\vec{v}(\vec{x})=\frac{\Gamma}{4\pi}\frac{d\vec{l}\times\vec{r}}{r^3}
@@ -456,7 +456,7 @@ The regularization parameter is both a function of the physics being modeled
 factors are the chord length, the boundary layer height, and the volume that
 each vortex filament is approximating.  Currently the choice is left to the user
 (**RegDetMethod=[0]**).  Empirical results for a rotating blade are found in the
-work of Gupta (:cite:`Gupta06_1`). As a guideline, the regularization parameter
+work of Gupta (:cite:`olaf-Gupta06_1`). As a guideline, the regularization parameter
 may be chosen as twice the average spanwise discretization of the blade. This
 guideline is implemented when the user chooses **RegDetMethod=[1]**. Further
 refinement of this option will be considered in the future.
@@ -467,7 +467,7 @@ Implemented regularization functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Several regularization functions have been
-developed (:cite:`Rankine58_1,Scully75_1,Vatistas91_1`).  At present, five
+developed (:cite:`olaf-Rankine58_1,olaf-Scully75_1,olaf-Vatistas91_1`).  At present, five
 options are available: 1) No correction, 2) the Rankine method, 3) the
 Lamb-Oseen method, 4) the Vatistas method, or 5) the denominator offset method.
 If no correction method is used, (**RegFunction=[0]**), :math:`F_\nu=1`. The
@@ -478,7 +478,7 @@ to the filament. Both variables are expressed in meters.
 Rankine
 ^^^^^^^
 
-The Rankine method (:cite:`Rankine58_1`) is the simplest
+The Rankine method (:cite:`olaf-Rankine58_1`) is the simplest
 regularization model. With this method, the Rankine vortex has a finite
 core with a solid body rotation near the vortex center and a potential
 vortex away from the center. If this method is used
@@ -516,8 +516,8 @@ correction is given by Eq. :eq:`vatistas`.
    :label: vatistas
 
 Here, :math:`\rho` is the distance from a vortex segment to an arbitrary
-point (:cite:`Abedi16_1`). Research from rotorcraft applications suggests a
-value of :math:`n=2`, which is used in this work (:cite:`Bagai93_1`).
+point (:cite:`olaf-Abedi16_1`). Research from rotorcraft applications suggests a
+value of :math:`n=2`, which is used in this work (:cite:`olaf-Bagai93_1`).
 
 Denominator Offset/Cut-Off
 ^^^^^^^^^^^^^^^^^^^^^^^^^^
@@ -535,7 +535,7 @@ core correction is given by Eq. :eq:`denom`
 Here, the singularity is removed by introducing an additive factor in the
 denominator of Eq. :eq:`eq:BiotSavartSegment`, proportional to the filament
 length :math:`r_0`. In this case, :math:`F_\nu=1`. This method is found in the
-work of van Garrel (:cite:`Garrel03_1`).
+work of van Garrel (:cite:`olaf-Garrel03_1`).
 
 .. _sec:corerad:
 

--- a/docs/source/user/aerodyn-olaf/StateSpace.rst
+++ b/docs/source/user/aerodyn-olaf/StateSpace.rst
@@ -10,7 +10,7 @@ State, Constraint, Input, and Output Variables
 
 The OLAF module has been integrated into the latest version of OpenFAST via
 *AeroDyn15*, following the OpenFAST modularization
-framework (:cite:`Jonkman13_1,Sprague15_1`). To follow the OpenFAST framework,
+framework (:cite:`olaf-Jonkman13_1,olaf-Sprague15_1`). To follow the OpenFAST framework,
 the vortex code is written as a module, and its formulation comprises state,
 constraint, and output equations. The data manipulated by the module include the
 following vectors: constant parameters, :math:`\vec{p}`;  inputs,

--- a/docs/source/user/aerodyn-olaf/zrefs.rst
+++ b/docs/source/user/aerodyn-olaf/zrefs.rst
@@ -4,6 +4,7 @@
    ----------
 
 .. bibliography:: bibliography.bib
-
+   :labelprefix: olaf-
+   :keyprefix: olaf-
 
 


### PR DESCRIPTION
THIS PULL REQUEST _IS_ READY TO MERGE

The documentation build on ReadTheDocs is set to fail on warnings.  The documentation for the newly integrated OLAF feature in AD15 (#447) referenced the article by Jonkman _et al_ for the FAST modular framework, which was also referenced in the BeamDyn documentation.  This produced a duplicate tags warning that caused ReadTheDocs to fail.

This PR prepends `olaf-` onto the entries for the OLAF documentation.  This uses the `:labelprefix:` and `:keyprefix:` options of `sphinxcontrib.bibtex` (https://readthedocs.org/projects/sphinxcontrib-bibtex/downloads/pdf/latest/).