### PR TITLE
Fix a compiler warning regarding the iso_fortran_env module

### DIFF
--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2245,8 +2245,8 @@ END SUBROUTINE CheckR16Var
 !>
    SUBROUTINE DispCompileRuntimeInfo()
      
-      USE iso_fortran_env
-      
+      USE iso_fortran_env, ONLY: compiler_version
+
       CHARACTER(200) :: compiler_version_str
       CHARACTER(200) :: name
       CHARACTER(200) :: git_commit, architecture, compiled_precision


### PR DESCRIPTION
**Feature or improvement description**
When compiling `nwtclibs`, the a recent addition that uses the `iso_fortran_env` module leads to a compiler warning regarding an incompatibility in another defined parameter in that module. This fix is limited to the compiler warning since the referenced module parameter was not used.

**Related issue, if one exists**
#504

**Impacted areas of the software**
NWTC_IO