### PR TITLE
Fix AD15 input file documentation for OLAF

### DIFF
--- a/docs/source/user/aerodyn-olaf/InputFiles.rst
+++ b/docs/source/user/aerodyn-olaf/InputFiles.rst
@@ -1,4 +1,4 @@
-.. _Input-files:
+.. _OLAF-Input-Files:
 
 Input Files
 ===========

--- a/docs/source/user/aerodyn-olaf/Introduction.rst
+++ b/docs/source/user/aerodyn-olaf/Introduction.rst
@@ -145,7 +145,7 @@ viscous diffusion may be accounted for by dynamically changing the
 regularization parameter. Wake visualization output options are also available.
 
 This document is organized as follows. :numref:`Running-OLAF` covers
-downloading, compiling, and running OLAF. :numref:`Input-Files` describes the
+downloading, compiling, and running OLAF. :numref:`OLAF-Input-Files` describes the
 OLAF input file and modifications to the *AeroDyn15* input file.
 :numref:`Output-Files` details the OLAF output file.  :numref:`OLAF-Theory`
 provides an overview of the OLAF theory, including the free vortex wake method

--- a/docs/source/user/aerodyn-olaf/index.rst
+++ b/docs/source/user/aerodyn-olaf/index.rst
@@ -1,3 +1,5 @@
+.. _OLAF:
+
 OLAF User's Guide and Theory Manual (Free Vortex Wake in AeroDyn15)
 ===================================================================
 

--- a/docs/source/user/aerodyn/examples/ad_primary_example.inp
+++ b/docs/source/user/aerodyn/examples/ad_primary_example.inp
@@ -30,6 +30,8 @@ True          TIDrag             - Include the drag term in the tangential-induc
 ======  Dynamic Blade-Element/Momentum Theory Options  ============================================== [used only when WakeMod=2]
           2   DBEMT_Mod          - Type of dynamic BEMT (DBEMT) model {1=constant tau1, 2=time-dependent tau1} (-) [used only when WakeMod=2]
           4   tau1_const         - Time constant for DBEMT (s) [used only when WakeMod=2 and DBEMT_Mod=1]
+======  OLAF -- cOnvecting LAgrangian Filaments (Free Vortex Wake) Theory Options  ================== [used only when WakeMod=3]
+"unused"      OLAFInputFileName - Input file for OLAF [used only when WakeMod=3]
 ======  Beddoes-Leishman Unsteady Airfoil Aerodynamics Options  ===================================== [used only when AFAeroMod=2]
           1   UAMod              - Unsteady Aero Model Switch (switch) {1=Baseline model (Original), 2=Gonzalez's variant (changes in Cn,Cc,Cm), 3=Minnema/Pierce variant (changes in Cc and Cm)} [used only when AFAeroMod=2]
 FALSE         FLookup            - Flag to indicate whether a lookup for f' will be calculated (TRUE) or whether best-fit exponential equations will be used (FALSE); if FALSE S1-S4 must be provided in airfoil input files (flag) [used only when AFAeroMod=2]

--- a/docs/source/user/aerodyn/input.rst
+++ b/docs/source/user/aerodyn/input.rst
@@ -155,8 +155,10 @@ program).
 Set ``WakeMod`` to 0 if you want to disable rotor wake/induction effects or 1 to
 include these effects using the (quasi-steady) BEM theory model. When
 ``WakeMod`` is set to 2, a dynamic BEM theory model (DBEMT) is used (also
-referred to as dynamic inflow or dynamic wake model).  ``WakeMod`` cannot be set
-to 2 during linearization analyses.
+referred to as dynamic inflow or dynamic wake model).  When ``WakeMod`` is set
+to 3, the free vortex wake model is used, also referred to as OLAF (see
+:numref:`OLAF`). ``WakeMod`` cannot be set to 2 or 3 during linearization
+analyses.
 
 Set ``AFAeroMod`` to 1 to include steady blade airfoil aerodynamics or 2
 to enable UA; ``AFAeroMod`` must be 1 during linearization analyses
@@ -258,6 +260,16 @@ to use a model where tau1 varies with time.
 
 If ``DBEMT_Mod=1`` (constant-tau1 model), set ``tau1_const`` to the time 
 constant to use for DBEMT.
+
+OLAF -- cOnvecting LAgrangian Filaments (Free Vortex Wake) Theory Options
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The input parameters in this section are used only when ``WakeMod = 3``.
+
+The settings for the free vortex wake model are set in the OLAF input file
+described in :numref:`OLAF-Input-Files`.  ``OLAFInputFileName`` is the filename
+for this input file.
+
 
 Unsteady Airfoil Aerodynamics Options
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Some documentation for AeroDyn15 was not updated with PR #447.  This PR updates the AD15 example input file, and description of the new lines for the OLAF submodule.

Only the `readthedocs` documentation for AD15 is affected by these changes.