### PR TITLE
Introduce checks for Fortran 2008 features

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -74,6 +74,27 @@ macro(set_fast_fortran)
 endmacro(set_fast_fortran)
 
 #
+# CHECK_F2008_FEATURES - Check if Fortran2008 features are available
+#
+macro(check_f2008_features)
+  include(CheckFortranSourceCompiles)
+  check_fortran_source_compiles(
+    "program test
+     use iso_fortran_env, only: compiler_version, real32, real64, real128
+     integer, parameter :: quki = real128
+     integer, parameter :: dbki = real64
+     integer, parameter :: reki = real32
+
+     end program test"
+     HAS_FORTRAN2008
+     SRC_EXT F90)
+   if (HAS_FORTRAN2008)
+     message(STATUS "Enabling Fortran 2008 features")
+     add_definitions(-DHAS_FORTRAN2008_FEATURES)
+   endif()
+endmacro(check_f2008_features)
+
+#
 # SET_FAST_GFORTRAN - Customizations for GNU Fortran compiler
 #
 macro(set_fast_gfortran)
@@ -109,6 +130,7 @@ macro(set_fast_gfortran)
      set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -fopenmp" )
   endif()
 
+  check_f2008_features()
 endmacro(set_fast_gfortran)
 
 #
@@ -144,6 +166,8 @@ macro(set_fast_intel_fortran_posix)
      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -qopenmp")
      set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -qopenmp" )
   endif()
+
+  check_f2008_features()
 endmacro(set_fast_intel_fortran_posix)
 
 #
@@ -177,4 +201,5 @@ macro(set_fast_intel_fortran_windows)
      set(CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /qopenmp" )
   endif()
 
+  check_f2008_features()
 endmacro(set_fast_intel_fortran_windows)

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2244,9 +2244,9 @@ END SUBROUTINE CheckR16Var
 !=======================================================================
 !>
    SUBROUTINE DispCompileRuntimeInfo()
-     
+#ifdef HAS_FORTRAN2008_FEATURES
       USE iso_fortran_env, ONLY: compiler_version
-
+#endif
       CHARACTER(200) :: compiler_version_str
       CHARACTER(200) :: name
       CHARACTER(200) :: git_commit, architecture, compiled_precision
@@ -2263,7 +2263,7 @@ END SUBROUTINE CheckR16Var
          compiled_precision = 'unknown'
       END IF
 
-#if defined(__INTEL_COMPILER) && (__INTEL_COMPILER<1800)
+#ifndef HAS_FORTRAN2008_FEATURES
       compiler_version_str = 'Intel(R) Fortran Compiler '//num2lstr(__INTEL_COMPILER)
 #else
       compiler_version_str = compiler_version()

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2263,10 +2263,10 @@ END SUBROUTINE CheckR16Var
          compiled_precision = 'unknown'
       END IF
 
-#ifndef HAS_FORTRAN2008_FEATURES
-      compiler_version_str = 'Intel(R) Fortran Compiler '//num2lstr(__INTEL_COMPILER)
-#else
+#if defined(HAS_FORTRAN2008_FEATURES)
       compiler_version_str = compiler_version()
+#elif defined(__INTEL_COMPILER)
+      compiler_version_str = 'Intel(R) Fortran Compiler '//num2lstr(__INTEL_COMPILER)
 #endif
 
       CALL WrScr(trim(name)//'-'//trim(git_commit))

--- a/modules/nwtc-library/src/SingPrec.f90
+++ b/modules/nwtc-library/src/SingPrec.f90
@@ -28,6 +28,10 @@
 MODULE Precision
 !..................................................................................................................................
 
+#ifdef HAS_FORTRAN2008_FEATURES
+USE, INTRINSIC :: ISO_FORTRAN_ENV, ONLY: real32, real64, real128
+#endif
+
 IMPLICIT                           NONE
 
 INTEGER, PARAMETER              :: B1Ki     = SELECTED_INT_KIND(  2 )           !< Kind for one-byte whole numbers
@@ -35,9 +39,15 @@ INTEGER, PARAMETER              :: B2Ki     = SELECTED_INT_KIND(  4 )           
 INTEGER, PARAMETER              :: B4Ki     = SELECTED_INT_KIND(  9 )           !< Kind for four-byte whole numbers
 INTEGER, PARAMETER              :: B8Ki     = SELECTED_INT_KIND( 18 )           !< Kind for eight-byte whole numbers
 
+#ifdef HAS_FORTRAN2008_FEATURES
+INTEGER, PARAMETER              :: QuKi     = real128    !< Kind for 16-byte, floating-point numbers
+INTEGER, PARAMETER              :: R8Ki     = real64     !< Kind for eight-byte floating-point numbers
+INTEGER, PARAMETER              :: SiKi     = real32     !< Kind for four-byte, floating-point numbers
+#else
 INTEGER, PARAMETER              :: QuKi     = SELECTED_REAL_KIND( 20, 500 )     !< Kind for 16-byte, floating-point numbers
 INTEGER, PARAMETER              :: R8Ki     = SELECTED_REAL_KIND( 14, 300 )     !< Kind for eight-byte floating-point numbers
 INTEGER, PARAMETER              :: SiKi     = SELECTED_REAL_KIND(  6,  30 )     !< Kind for four-byte, floating-point numbers
+#endif
 
 INTEGER, PARAMETER              :: BYTES_IN_SiKi =  4                           !< Number of bytes per SiKi number
 INTEGER, PARAMETER              :: BYTES_IN_R8Ki =  8                           !< Number of bytes per R8Ki number 


### PR DESCRIPTION
- Add new compile-time definition HAS_FORTRAN2008_FEATURES
- Add new macro in CMake to check for features and enable the flag
- Add ifdef statements as necessary to protect F2008 usage


See #502 for a discussion motivating the proposed change. Impacts CMake configuration logic and NWTC_Library. 

Closes #502 