### PR TITLE
Fix GH Actions Checkout usage

### DIFF
--- a/.github/workflows/continuous-integration-workflow.yml
+++ b/.github/workflows/continuous-integration-workflow.yml
@@ -15,8 +15,8 @@ jobs:
         name: OpenFAST tests on Ubuntu
         steps:
         - name: Checkout
-          uses: actions/checkout@master
+          uses: actions/checkout@main
           with:
-            submodule: recursive
+            submodules: recursive
         - name: Build and test step
           uses: ./.github/actions/compile-and-test


### PR DESCRIPTION
**Feature or improvement description**
The Checkout action usage is outdated and leads to a warning when run. This pull request updates the version that is used in that action and the arguments passed to it.

**Impacted areas of the software**
CI