### PR TITLE
[BugFix] InflowWind_driver crashes due to incorrect file closing

### DIFF
--- a/modules/inflowwind/src/InflowWind_Driver.f90
+++ b/modules/inflowwind/src/InflowWind_Driver.f90
@@ -888,9 +888,9 @@ CONTAINS
    SUBROUTINE DriverCleanup()
 
 
-      CLOSE( Settings%WindGridOutputUnit )
-      CLOSE( Settings%PointsOutputUnit )
-      CLOSE( Settings%FFTOutputUnit )
+      if (Settings%WindGridOutputUnit  > -1_IntKi )   CLOSE( Settings%WindGridOutputUnit )
+      if (Settings%PointsOutputUnit    > -1_IntKi )   CLOSE( Settings%PointsOutputUnit )
+      if (Settings%FFTOutputUnit       > -1_IntKi )   CLOSE( Settings%FFTOutputUnit )
 
 
          ! Find out how long this actually took


### PR DESCRIPTION
THIS PULL REQUEST __IS__ READY TO MERGE

The InflowWind Driver might try to close a file that was never opened.  This causes a segfault.

Solution:
Add if statements around the close so it only attempts to close if the file is open.