### PR TITLE
Workaround DOUBLE_PRECISION macro when building with HPE MPT

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -109,7 +109,7 @@ macro(set_fast_gfortran)
 
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
-    add_definitions(-DDOUBLE_PRECISION)
+    add_definitions(-DOPENFAST_DOUBLE_PRECISION)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fdefault-real-8")
   endif (DOUBLE_PRECISION)
 
@@ -152,7 +152,7 @@ macro(set_fast_intel_fortran_posix)
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpic -fpp")
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
-    add_definitions(-DDOUBLE_PRECISION)
+    add_definitions(-DOPENFAST_DOUBLE_PRECISION)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double_size 128")
   endif (DOUBLE_PRECISION)
 
@@ -182,7 +182,7 @@ macro(set_fast_intel_fortran_windows)
 
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
-    add_definitions(-DDOUBLE_PRECISION)
+    add_definitions(-DOPENFAST_DOUBLE_PRECISION)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /real_size:64 /double_size:128")
   endif (DOUBLE_PRECISION)
 

--- a/modules/nwtc-library/src/SingPrec.f90
+++ b/modules/nwtc-library/src/SingPrec.f90
@@ -60,7 +60,7 @@ INTEGER, PARAMETER              :: BYTES_IN_QuKi = 16                           
 INTEGER, PARAMETER              :: IntKi          = B4Ki                        !< Default kind for integers
 INTEGER, PARAMETER              :: BYTES_IN_INT   = 4                           !< Number of bytes per IntKi number    - use SIZEOF()
 
-#ifndef DOUBLE_PRECISION
+#if !defined (DOUBLE_PRECISION) && !defined (OPENFAST_DOUBLE_PRECISION)
 INTEGER, PARAMETER              :: ReKi           = SiKi                        !< Default kind for floating-point numbers
 INTEGER, PARAMETER              :: DbKi           = R8Ki                        !< Default kind for double floating-point numbers
                                                   


### PR DESCRIPTION
OpenFAST currently uses `DOUBLE_PRECISION` compile-time definition to activate double precision as default during build. This conflicts with the define in the MPI header file (for HPE MPT) when building the C++ API interface. This commit works around this issue by using `OPENFAST_DOUBLE_PRECISION` variable when building with CMake. The code checks for the original `DOUBLE_PRECISION` macro for backward compatibility. The VS build pathway is unaffected.

Fixes #522

THIS PULL REQUEST IS READY TO MERGE

**Impacted areas of the software**
- `NWTC_Library`
