### PR TITLE
Minor clarification in the API_Change.rst

### DIFF
--- a/docs/source/user/api_change.rst
+++ b/docs/source/user/api_change.rst
@@ -29,9 +29,11 @@ AeroDyn        13   CompAA             False                   CompAA           
 AeroDyn        14   AA_InputFile       "unused"                AA_InputFile       - Aeroacoustics input file
 AeroDyn        35   [separator line]   ======  OLAF -- cOnvecting LAgrangian Filaments (Free Vortex Wake) Theory Options  ================== [used only when WakeMod=3]
 AeroDyn        36   OLAFInputFileName  "Elliptic_OLAF.dat"     OLAFInputFileName - Input file for OLAF [used only when WakeMod=3]
-AirFoilTables  11   BL_file            "unused"                BL_file           - The file name including the boundary layer characteristics of the profile. Ignored if the aeroacoustic module is not called.
+AirFoilTables  4\*  BL_file            "unused"                BL_file           - The file name including the boundary layer characteristics of the profile. Ignored if the aeroacoustic module is not called.
 
 ============== ==== ================== =============================================================================================================================================================================
+
+\*non-comment line count
 
 Additional nodal output channels added for :ref:`AeroDyn15<AD-Nodal-Outputs>`,
 :ref:`BeamDyn<BD-Nodal-Outputs>`, and :ref:`ElastoDyn<ED-Nodal-Outputs>`.


### PR DESCRIPTION
Ready to merge.

Very minor note on the line number for the changes in the API for the airfoil table file. Since the airfoil table reader can handle an arbitrary number of header line comments, line numbers aren't very sensible. Instead we will note the new line as 4\* with the note `*non-comment line count`.

<img width="604" alt="Non-commentLineCount" src="https://user-images.githubusercontent.com/2745453/91236109-51fa7a80-e6f4-11ea-911b-635ae146ae2d.png">
