### PR TITLE
Make channel length consistent between C and Fortran sides of interface

### DIFF
--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -41,10 +41,10 @@ EXTERNAL_ROUTINE void FAST_CreateCheckpoint(int * iTurb, const char *CheckpointR
 
 #define SensorType_None -1
 
-// make sure these parameters match with FAST_Library.f90
+// make sure these parameters match with FAST_Library.f90 and NWTC_Base.f90
 #define MAXIMUM_BLADES 3
 #define MAXIMUM_OUTPUTS 4000
-#define CHANNEL_LENGTH 10  
+#define CHANNEL_LENGTH 20
 #define MAXInitINPUTS 10
 
 #define NumFixedInputs  2 + 2 + MAXIMUM_BLADES + 1


### PR DESCRIPTION
**Feature or improvement description**
Fixes a run-time error in the Simulink interface that was introduced with increased channel-name lengths in https://github.com/OpenFAST/openfast/pull/373.

**Related issue, if one exists**
Fixes https://github.com/OpenFAST/openfast/issues/548

**Impacted areas of the software**
Simulink interface and possibly the C++ interface (depending on if it does anything with the channel names/units)

**Test results, if applicable**
This does not change any of the current test results.
