### PR TITLE
CMake: set CMP0074 policy explicitly to avoid warnings

### DIFF
--- a/glue-codes/openfast-cpp/CMakeLists.txt
+++ b/glue-codes/openfast-cpp/CMakeLists.txt
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+if (${CMAKE_VERSION} VERSION_GREATER_EQUAL "3.12.0")
+  cmake_policy(SET CMP0074 NEW)
+endif()
+
 set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 


### PR DESCRIPTION
For CMake versions newer than 3.12.0, this PR adds an explicit policy declaration that will stop CMake from emitting warnings. 

```
CMake Warning (dev) at glue-codes/openfast-cpp/CMakeLists.txt:23 (find_package):
  Policy CMP0074 is not set: find_package uses <PackageName>_ROOT variables.
  Run "cmake --help-policy CMP0074" for policy details.  Use the cmake_policy
  command to set the policy and suppress this warning.

  CMake variable HDF5_ROOT is set to:

    /nopt/nrel/ecom/hpacf/software/2020-07/spack/opt/spack/linux-centos7-skylake_avx512/gcc-8.4.0/hdf5-1.10.4-77byf2hlexhhd5r6r6b6kadw7dw6hum4

  For compatibility, CMake is ignoring the variable.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

This affects the CMake configuration phase when `BUILD_OPENFAST_CPP_API=ON`. Doesn't affect any other part of the software. 