### PR TITLE
Add NWTC Library infrastructure for parsing string inputs

### DIFF
--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -4445,14 +4445,25 @@ END SUBROUTINE CheckR16Var
    RETURN
    END SUBROUTINE PremEOF
 !=======================================================================
-   SUBROUTINE InitFileInfo( StringArray, FileInfo )
+   SUBROUTINE InitFileInfo( StringArray, FileInfo, ErrStat, ErrMsg )
 
-      CHARACTER(1024), DIMENSION(:), INTENT(IN) :: StringArray
-      TYPE(FileInfoType), INTENT(OUT) :: FileInfo
+      CHARACTER(*), DIMENSION(:), INTENT(IN   ) :: StringArray
+      TYPE(FileInfoType),         INTENT(  OUT) :: FileInfo
+      INTEGER(IntKi),             INTENT(  OUT) :: ErrStat
+      CHARACTER(*),               INTENT(  OUT) :: ErrMsg
+
+      CHARACTER(*), PARAMETER :: RoutineName = 'InitFileInfo'
       INTEGER :: i, n_lines
 
-      n_lines = size(StringArray)
+      ErrStat = ErrID_None
+      ErrMsg  = ""
 
+      IF (.NOT. ALLOCATED(StringArray)) THEN
+         CALL SetErrStat( ErrID_Fatal, 'Attempting to use StringArray before it is allocated.' , ErrStat, ErrMsg, RoutineName )
+         RETURN
+      END IF
+
+      n_lines = size(StringArray)
       FileInfo%NumLines = n_lines
       FileInfo%NumFiles = 1
 
@@ -4461,7 +4472,7 @@ END SUBROUTINE CheckR16Var
       ALLOCATE( FileInfo%FileIndx(n_lines) )
       ALLOCATE( FileInfo%FileList(n_lines) )
 
-      FileInfo%Lines = StringArray
+      FileInfo%Lines = StringArray( 1:min( len( FileInfo%Lines(1) ), len(StringArray(1)) ) )
       FileInfo%FileLine = (/ (i, i = 1, FileInfo%NumLines) /)
       FileInfo%FileIndx = (/ (1, i = 1, FileInfo%NumLines) /)
       FileInfo%FileList = (/ "passed file info" /)

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -3362,20 +3362,14 @@ END SUBROUTINE CheckR16Var
 
          ! Arguments declarations.
 
-      INTEGER, INTENT(IN)                    :: AryLen                        !< The length of the array to parse.
-
-      CHARACTER(1024), INTENT(OUT)            :: Ary(AryLen)                  !< The array to receive the input values.
-
-      INTEGER(IntKi), INTENT(OUT)            :: ErrStat                       !< The error status.
-      INTEGER(IntKi), INTENT(INOUT)          :: LineNum                       !< The number of the line to parse.
-
-      INTEGER,        INTENT(IN), OPTIONAL   :: UnEc                          !< I/O unit for echo file. If present and > 0, write to UnEc.
-
-      CHARACTER(*),   INTENT(In)             :: AryName                       !< The array name we are trying to fill.
-      CHARACTER(*),   INTENT(OUT)            :: ErrMsg                        !< The error message, if ErrStat /= 0.
-
-      TYPE (FileInfoType), INTENT(IN)        :: FileInfo                      !< The derived type for holding the file information.
-
+      TYPE (FileInfoType), INTENT(IN)             :: FileInfo                      !< The derived type for holding the file information.
+      INTEGER(IntKi),      INTENT(INOUT)          :: LineNum                       !< The number of the line to parse.
+      CHARACTER(*),        INTENT(IN)             :: AryName                       !< The array name we are trying to fill.
+      CHARACTER(*),        INTENT(OUT)            :: Ary(AryLen)                   !< The array to receive the input values.
+      INTEGER,             INTENT(IN)             :: AryLen                        !< The length of the array to parse.
+      INTEGER(IntKi),      INTENT(OUT)            :: ErrStat                       !< The error status.
+      CHARACTER(*),        INTENT(OUT)            :: ErrMsg                        !< The error message, if ErrStat /= 0.
+      INTEGER,             INTENT(IN), OPTIONAL   :: UnEc                          !< I/O unit for echo file. If present and > 0, write to UnEc.
 
          ! Local declarations.
 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -4470,7 +4470,7 @@ END SUBROUTINE CheckR16Var
       ALLOCATE( FileInfo%Lines(n_lines) )
       ALLOCATE( FileInfo%FileLine(n_lines) )
       ALLOCATE( FileInfo%FileIndx(n_lines) )
-      ALLOCATE( FileInfo%FileList(n_lines) )
+      ALLOCATE( FileInfo%FileList(FileInfo%NumFiles) )
 
       FileInfo%Lines = StringArray( 1:min( len( FileInfo%Lines(1) ), len(StringArray(1)) ) )
       FileInfo%FileLine = (/ (i, i = 1, FileInfo%NumLines) /)

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -4447,28 +4447,30 @@ END SUBROUTINE CheckR16Var
       CHARACTER(*),               INTENT(  OUT) :: ErrMsg
 
       CHARACTER(*), PARAMETER :: RoutineName = 'InitFileInfo'
-      INTEGER :: i, n_lines
+      INTEGER :: i
 
       ErrStat = ErrID_None
       ErrMsg  = ""
 
-      IF (.NOT. ALLOCATED(StringArray)) THEN
-         CALL SetErrStat( ErrID_Fatal, 'Attempting to use StringArray before it is allocated.' , ErrStat, ErrMsg, RoutineName )
-         RETURN
-      END IF
-
-      n_lines = size(StringArray)
-      FileInfo%NumLines = n_lines
+      FileInfo%NumLines = size(StringArray)
       FileInfo%NumFiles = 1
 
-      ALLOCATE( FileInfo%Lines(n_lines) )
-      ALLOCATE( FileInfo%FileLine(n_lines) )
-      ALLOCATE( FileInfo%FileIndx(n_lines) )
+      ALLOCATE( FileInfo%Lines(FileInfo%NumLines) )
+      ALLOCATE( FileInfo%FileLine(FileInfo%NumLines) )
+      ALLOCATE( FileInfo%FileIndx(FileInfo%NumFiles) )
       ALLOCATE( FileInfo%FileList(FileInfo%NumFiles) )
 
-      FileInfo%Lines = StringArray( 1:min( len( FileInfo%Lines(1) ), len(StringArray(1)) ) )
+      DO i = 1, FileInfo%NumLines
+
+         IF ( LEN(StringArray(i)) > LEN(FileInfo%Lines(i)) ) THEN
+            CALL SetErrStat( ErrID_Fatal, 'Input string exceeds the bounds of FileInfoType.' , ErrStat, ErrMsg, RoutineName )
+            RETURN
+         END IF
+
+         FileInfo%Lines(i) = StringArray(i)
+      END DO      
       FileInfo%FileLine = (/ (i, i = 1, FileInfo%NumLines) /)
-      FileInfo%FileIndx = (/ (1, i = 1, FileInfo%NumLines) /)
+      FileInfo%FileIndx = (/ (i, i = 1, FileInfo%NumFiles) /)
       FileInfo%FileList = (/ "passed file info" /)
 
    END SUBROUTINE

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -153,6 +153,7 @@ MODULE NWTC_IO
       MODULE PROCEDURE ParseInAry                                             ! Parse an array of whole numbers.
       MODULE PROCEDURE ParseLoAry                                             ! Parse an array of LOGICAL values.
       MODULE PROCEDURE ParseSiAry                                             ! Parse an array of single-precision REAL values.
+      MODULE PROCEDURE ParseChAry
    END INTERFACE
 
       !> \copydoc nwtc_io::checkr4var
@@ -3320,6 +3321,99 @@ END SUBROUTINE CheckR16Var
    RETURN
    END SUBROUTINE OpenUOutfile
 !=======================================================================
+!> This subroutine prints the contents of the FileInfo data structure to the screen
+!! This may be useful for diagnostic purposes.  this is written to unit U
+   subroutine Print_FileInfo_Struct( U, FileInfo )
+      integer(IntKi),      intent(in   ) :: U         !< Unit number to print to
+      type(FileInfoType),  intent(in   ) :: FileInfo  !< derived type containing everything read from file
+      integer(IntKi)                     :: i         !< generic counter
+      character(20)                      :: TmpStr20
+      character(45)                      :: TmpStr45
+      write(U,*)  '-------------- Print_FileInfo_Struct ------------'
+      write(U,*)  '  info stored in the FileInfo data type'
+      write(U,*)  '        %NumLines           (integer): ',FileInfo%NumLines
+      write(U,*)  '        %NumFiles           (integer): ',FileInfo%NumFiles
+      write(U,*)  '        %FileList  (array of strings): ',size(FileInfo%FileList)
+      write(U,*)  '        %FileIndx  (array of integer): ',size(FileInfo%FileIndx)
+      write(U,*)  '        %FileLine  (array of integer): ',size(FileInfo%FileLine)
+      write(U,*)  '        %Lines     (array of strings): ',size(FileInfo%Lines   )
+      if (allocated(FileInfo%FileList)) then
+         write(U,*)  '  list of files read:'
+         write(U,*)  '     FileIdx     FileName'
+         do i=1,FileInfo%NumFiles
+            write(TmpStr20,'(7x,I3,10x)')  i
+            write(U,*) TmpStr20//trim(FileInfo%FileList(i))
+         enddo
+      endif
+      if (allocated(FileInfo%FileLine) .and. allocated(FileInfo%FileIndx) .and. allocated(FileInfo%Lines)) then
+         write(U,*) '  Non-comment lines stored in memory from files:'
+         write(U,*) '         i       FileIndx       FileLine     Lines(i)'
+         do i=1,FileInfo%NumLines
+            write(TmpStr45, '(5x,I5,10x,I5,10x,I5,5x)') i, FileInfo%FileIndx(i), FileInfo%FileLine(i)
+            write(U,*) TmpStr45, trim(FileInfo%Lines(i))
+         enddo
+      endif
+   end subroutine Print_FileInfo_Struct
+!=======================================================================
+!> This subroutine parses the specified line of text for AryLen CHARACTER values.
+!! Generate an error message if the value is the wrong type.
+!! Use ParseAry (nwtc_io::parseary) instead of directly calling a specific routine in the generic interface.   
+   SUBROUTINE ParseChAry ( FileInfo, LineNum, AryName, Ary, AryLen, ErrStat, ErrMsg, UnEc )
+
+         ! Arguments declarations.
+
+      INTEGER, INTENT(IN)                    :: AryLen                        !< The length of the array to parse.
+
+      CHARACTER(1024), INTENT(OUT)            :: Ary(AryLen)                  !< The array to receive the input values.
+
+      INTEGER(IntKi), INTENT(OUT)            :: ErrStat                       !< The error status.
+      INTEGER(IntKi), INTENT(INOUT)          :: LineNum                       !< The number of the line to parse.
+
+      INTEGER,        INTENT(IN), OPTIONAL   :: UnEc                          !< I/O unit for echo file. If present and > 0, write to UnEc.
+
+      CHARACTER(*),   INTENT(In)             :: AryName                       !< The array name we are trying to fill.
+      CHARACTER(*),   INTENT(OUT)            :: ErrMsg                        !< The error message, if ErrStat /= 0.
+
+      TYPE (FileInfoType), INTENT(IN)        :: FileInfo                      !< The derived type for holding the file information.
+
+
+         ! Local declarations.
+
+      INTEGER(IntKi)                         :: ErrStatLcl                    ! Error status local to this routine.
+      INTEGER(IntKi)                         :: i                             ! Error status local to this routine.
+
+      CHARACTER(*), PARAMETER                :: RoutineName = 'ParseChAry'
+
+      ErrStat = ErrID_None
+      ErrMsg  = ""
+   
+      IF (LineNum > size(FileInfo%Lines) ) THEN
+         CALL SetErrStat ( ErrID_Fatal, NewLine//' >> A fatal error occurred when parsing data.'//NewLine//  &
+                  ' >> The "'//TRIM( AryName )//'" array was not assigned because the file is too short.' &
+                  , ErrStat, ErrMsg, RoutineName )
+         RETURN
+      END IF
+   
+      READ (FileInfo%Lines(LineNum),*,IOSTAT=ErrStatLcl) Ary
+      IF ( ErrStatLcl /= 0 )  THEN
+         CALL SetErrStat ( ErrID_Fatal, 'A fatal error occurred when parsing data from "' &
+                  //TRIM( FileInfo%FileList(FileInfo%FileIndx(LineNum)) )//'".'//NewLine//  &
+                  ' >> The "'//TRIM( AryName )//'" array was not assigned valid REAL values on line #' &
+                  //TRIM( Num2LStr( FileInfo%FileLine(LineNum) ) )//'.'//NewLine//' >> The text being parsed was :'//NewLine &
+                  //'    "'//TRIM( FileInfo%Lines(LineNum) )//'"',ErrStat,ErrMsg,RoutineName )
+         RETURN
+      ENDIF
+
+      IF ( PRESENT(UnEc) )  THEN
+         IF ( UnEc > 0 )  WRITE (UnEc,'(A)')  TRIM( FileInfo%Lines(LineNum) )
+      END IF
+
+      LineNum = LineNum + 1
+
+      RETURN
+
+   END SUBROUTINE ParseChAry
+!=======================================================================
 !> This subroutine parses the specified line of text for two words.  One should be a
 !! the name of a variable and the other the value of the variable.
 !! Generate an error message if the value is the wrong type or if only one "word" is found.
@@ -3532,7 +3626,7 @@ END SUBROUTINE CheckR16Var
       INTEGER(IntKi)                         :: ErrStatLcl                    ! Error status local to this routine.
       INTEGER(IntKi)                         :: NameIndx                      ! The index into the Words array that points to the variable name.
 
-      CHARACTER(20)                          :: Words       (2)               ! The two "words" parsed from the line.
+      CHARACTER(200)                         :: Words       (2)               ! The two "words" parsed from the line.
       CHARACTER(ErrMsgLen)                   :: ErrMsg2
       CHARACTER(*), PARAMETER                :: RoutineName = 'ParseDbVar'
 
@@ -3828,7 +3922,7 @@ END SUBROUTINE CheckR16Var
       INTEGER(IntKi)                         :: ErrStatLcl                    ! Error status local to this routine.
       INTEGER(IntKi)                         :: NameIndx                      ! The index into the Words array that points to the variable name.
 
-      CHARACTER(20)                          :: Words       (2)               ! The two "words" parsed from the line.
+      CHARACTER(200)                         :: Words       (2)               ! The two "words" parsed from the line.
       CHARACTER(ErrMsgLen)                   :: ErrMsg2
       CHARACTER(*), PARAMETER                :: RoutineName = 'ParseInVar'
 
@@ -4013,7 +4107,7 @@ END SUBROUTINE CheckR16Var
       INTEGER(IntKi)                         :: ErrStatLcl                    ! Error status local to this routine.
       INTEGER(IntKi)                         :: NameIndx                      ! The index into the Words array that points to the variable name.
 
-      CHARACTER(20)                          :: Words       (2)               ! The two "words" parsed from the line.
+      CHARACTER(200)                         :: Words       (2)               ! The two "words" parsed from the line.
       CHARACTER(ErrMsgLen)                   :: ErrMsg2
       CHARACTER(*), PARAMETER                :: RoutineName = 'ParseLoVar'
 
@@ -4189,7 +4283,7 @@ END SUBROUTINE CheckR16Var
       INTEGER(IntKi)                         :: ErrStatLcl                    ! Error status local to this routine.
       INTEGER(IntKi)                         :: NameIndx                      ! The index into the Words array that points to the variable name.
 
-      CHARACTER(20)                          :: Words       (2)               ! The two "words" parsed from the line.
+      CHARACTER(200)                         :: Words       (2)               ! The two "words" parsed from the line.
       CHARACTER(ErrMsgLen)                   :: ErrMsg2
       CHARACTER(*), PARAMETER                :: RoutineName = 'ParseSiVar'
 
@@ -4350,6 +4444,29 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE PremEOF
+!=======================================================================
+   SUBROUTINE InitFileInfo( StringArray, FileInfo )
+
+      CHARACTER(1024), DIMENSION(:), INTENT(IN) :: StringArray
+      TYPE(FileInfoType), INTENT(OUT) :: FileInfo
+      INTEGER :: i, n_lines
+
+      n_lines = size(StringArray)
+
+      FileInfo%NumLines = n_lines
+      FileInfo%NumFiles = 1
+
+      ALLOCATE( FileInfo%Lines(n_lines) )
+      ALLOCATE( FileInfo%FileLine(n_lines) )
+      ALLOCATE( FileInfo%FileIndx(n_lines) )
+      ALLOCATE( FileInfo%FileList(n_lines) )
+
+      FileInfo%Lines = StringArray
+      FileInfo%FileLine = (/ (i, i = 1, FileInfo%NumLines) /)
+      FileInfo%FileIndx = (/ (1, i = 1, FileInfo%NumLines) /)
+      FileInfo%FileList = (/ "passed file info" /)
+
+   END SUBROUTINE
 !=======================================================================
 !> This routine calls ScanComFile (nwtc_io::scancomfile) and ReadComFile (nwtc_io::readcomfile) 
 !! to move non-comments in a set of nested files starting with TopFile into the FileInfo (nwtc_io::fileinfo) structure.
@@ -5949,6 +6066,99 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE ReadOutputList
+!=======================================================================
+!> This routine reads up to MaxAryLen values from an input file and store them in CharAry(:).
+!! These values represent the names of output channels, and they are specified in the format
+!! required for OutList(:) in FAST input files.
+!! The end of this list is specified with the line beginning with the 3 characters "END".
+   SUBROUTINE ReadOutputListFromFileInfo ( FileInfo, LineNum, CharAry, AryLenRead, AryName, AryDescr, ErrStat, ErrMsg, UnEc )
+
+      ! Argument declarations:
+
+   TYPE (FileInfoType), INTENT(IN)   :: FileInfo                                   !< The derived type for holding the file information.
+   INTEGER(IntKi),      INTENT(INOUT):: LineNum                                    !< The number of the line to parse.
+   INTEGER,             INTENT(OUT)  :: AryLenRead                                 !< Length of the array that was actually read.
+   INTEGER,             INTENT(IN), OPTIONAL :: UnEc                               !< I/O unit for echo file (if > 0).
+   INTEGER,             INTENT(OUT)  :: ErrStat                                    !< Error status
+   CHARACTER(*),        INTENT(OUT)  :: ErrMsg                                     !< Error message
+
+   CHARACTER(*),        INTENT(OUT)  :: CharAry(:)                                 !< Character array being read (calling routine dimensions it to max allowable size).
+
+   CHARACTER(*),        INTENT(IN)   :: AryDescr                                   !< Text string describing the variable.
+   CHARACTER(*),        INTENT(IN)   :: AryName                                    !< Text string containing the variable name.
+
+
+      ! Local declarations:
+
+   INTEGER                          :: MaxAryLen                                   ! Maximum length of the array being read
+   INTEGER                          :: NumWords                                    ! Number of words contained on a line
+
+   INTEGER                          :: QuoteCh                                     ! Character position.
+
+   CHARACTER(1000)                  :: OutLine                                     ! Character string read from file, containing output list
+   CHARACTER(3)                     :: EndOfFile
+
+
+      ! Initialize some values
+
+   ErrStat = ErrID_None
+   ErrMsg  = ''
+   MaxAryLen  = SIZE(CharAry)
+   AryLenRead = 0
+
+   CharAry = ''
+
+
+      ! Read in all of the lines containing output parameters and store them in CharAry(:).
+      ! The end of this list is specified with the line beginning with END.
+
+   DO
+
+      IF ( PRESENT(UnEc) )  THEN
+         if (UnEc > 0) WRITE(UnEc, '(A)')  FileInfo%Lines(LineNum)
+      ENDIF
+      OutLine = adjustl(trim(FileInfo%Lines(LineNum)))   ! remove leading whitespace
+
+      EndOfFile = OutLine(1:3)            ! EndOfFile is the 1st 3 characters of OutLine
+      CALL Conv2UC( EndOfFile )           ! Convert EndOfFile to upper case
+      IF ( EndOfFile == 'END' ) THEN
+         LineNum = LineNum + 1
+         EXIT     ! End of OutList has been reached; therefore, exit this DO
+      ENDIF
+
+      ! Check if we have a quoted string at the begining.  Ignore anything outside the quotes if so (this is the ReadVar behaviour for quoted strings).
+      if (SCAN(OutLine(1:1), '''"' ) == 1_IntKi ) then
+         QuoteCh = SCAN( OutLine(2:), '''"' )            ! last quote
+         if (QuoteCh < 1)  QuoteCh = LEN_TRIM(OutLine)   ! in case no end quote
+         OutLine(QuoteCh+2:) = ' '    ! blank out everything after last quote
+      endif
+
+      NumWords = CountWords( OutLine )    ! The number of words in OutLine.
+
+      AryLenRead = AryLenRead + NumWords  ! The total number of output channels read in so far.
+
+         ! Check to see if the maximum # allowable in the array has been reached.
+
+      IF ( AryLenRead > MaxAryLen )  THEN
+
+         ErrStat = ErrID_Fatal
+         ErrMsg = 'ReadOutputList:The maximum number of output channels allowed is '//TRIM( Int2LStr(MaxAryLen) )//'.'
+         RETURN
+
+      ELSE
+
+         CALL GetWords ( OutLine, CharAry((AryLenRead - NumWords + 1):AryLenRead), NumWords )
+
+      END IF
+
+      LineNum = LineNum+1
+
+   END DO
+
+
+   RETURN
+   END SUBROUTINE ReadOutputListFromFileInfo
+
 !=======================================================================
 !> \copydoc nwtc_io::readcary
    SUBROUTINE ReadR4Ary ( UnIn, Fil, Ary, AryLen, AryName, AryDescr, ErrStat, ErrMsg, UnEc )

--- a/modules/nwtc-library/src/NWTC_Library_Types.f90
+++ b/modules/nwtc-library/src/NWTC_Library_Types.f90
@@ -70,11 +70,11 @@ IMPLICIT NONE
 ! =========  FileInfoType  =======
   TYPE, PUBLIC :: FileInfoType
     INTEGER(IntKi)  :: NumLines 
-    INTEGER(IntKi)  :: NumFiles 
+    CHARACTER(1024) , DIMENSION(:), ALLOCATABLE  :: Lines 
     INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: FileLine 
+    INTEGER(IntKi)  :: NumFiles 
     INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: FileIndx 
     CHARACTER(1024) , DIMENSION(:), ALLOCATABLE  :: FileList 
-    CHARACTER(512) , DIMENSION(:), ALLOCATABLE  :: Lines 
   END TYPE FileInfoType
 ! =======================
 ! =========  Quaternion  =======

--- a/modules/nwtc-library/src/Registry_NWTC_Library.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library.txt
@@ -25,11 +25,11 @@ usefrom     ^             ^                 CHARACTER(ChanLen)       Units
 usefrom     ^             ^                 IntKi                    SignM
 
 usefrom   NWTC_Library  FileInfoType        IntKi                    NumLines
-usefrom     ^             ^                 IntKi                    NumFiles
+usefrom     ^             ^                 CHARACTER(1024)          Lines     {:}
 usefrom     ^             ^                 IntKi                    FileLine  {:}
+usefrom     ^             ^                 IntKi                    NumFiles
 usefrom     ^             ^                 IntKi                    FileIndx  {:}
 usefrom     ^             ^                 CHARACTER(1024)          FileList  {:}
-usefrom     ^             ^                 CHARACTER(512)           Lines     {:}
 
 usefrom   NWTC_Library  Quaternion          ReKi                     q0
 usefrom     ^             ^                 ReKi                     v  {3}

--- a/modules/nwtc-library/tests/test_NWTC_IO_FileInfo.F90
+++ b/modules/nwtc-library/tests/test_NWTC_IO_FileInfo.F90
@@ -1,0 +1,84 @@
+module test_NWTC_IO_FileInfo
+
+    use pFUnit_mod
+    use NWTC_IO
+    
+    implicit none
+
+contains
+
+@test
+subroutine test_initfileinfo()
+
+    ! This case should result in error status 0.
+    ! It's a normal initialization of FileInfoType.
+
+    integer, parameter :: num_lines = 5
+    integer, parameter :: num_files = 1
+
+    integer(IntKi) :: error_status
+    character(ErrMsgLen) :: error_message
+    character(1024) :: input_strings(num_lines)
+    type(FileInfoType) :: file_info_type
+    integer :: i
+
+    input_strings = (/ &
+        "line 0",  &
+        "line 1",  &
+        "line 2",  &
+        "line 3",  &
+        "line 4"   &
+    /)
+    call InitFileInfo( input_strings, file_info_type, error_status, error_message )
+
+    @assertEqual(num_lines, file_info_type%NumLines)
+    @assertEqual(num_files, file_info_type%NumFiles)
+    do i = 1, num_lines
+        @assertEqual(i, file_info_type%FileLine(i))
+    end do
+    do i = 1, num_files
+        @assertEqual(i, file_info_type%FileIndx(i))
+    end do
+
+    ! TODO: test FileList when we actually use it
+
+    do i = 1, num_lines
+        @assertEqual( trim(input_strings(i)), trim(file_info_type%Lines(i)) )
+    end do
+
+    @assertEqual( 0, error_status )
+    @assertEqual( "", error_message )
+end subroutine
+
+@test
+subroutine test_initfileinfo2()
+    
+    ! This case should result in a non-zero error status.
+    ! It attempts to initialize FileInfoType without having
+    ! properly initializing the input strings array.
+
+    integer, parameter :: num_lines = 5
+    integer, parameter :: num_files = 1
+
+    integer(IntKi) :: error_status
+    character(ErrMsgLen) :: error_message
+    character(1025) :: input_strings(num_lines)
+    type(FileInfoType) :: file_info_type
+    integer :: i
+
+    input_strings = (/ &
+        "line 0",  &
+        "line 1",  &
+        "line 2",  &
+        "line 3",  &
+        "line 4"   &
+    /)
+    call InitFileInfo( input_strings, file_info_type, error_status, error_message )
+
+    @assertEqual(num_lines, file_info_type%NumLines)
+    @assertEqual(num_files, file_info_type%NumFiles)
+    @assertEqual( 4, error_status )
+    
+end subroutine
+
+end module

--- a/unit_tests/nwtc-library/CMakeLists.txt
+++ b/unit_tests/nwtc-library/CMakeLists.txt
@@ -32,6 +32,7 @@ include_directories(
 
 set(testlist
     test_NWTC_IO_CheckArgs
+    test_NWTC_IO_FileInfo
     test_NWTC_RandomNumber
 )
 foreach(test ${testlist})


### PR DESCRIPTION
**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This pull request includes infrastructure for parsing arrays of strings as inputs. This feature will be used in various ongoing projects and eventually incorporated into most OpenFAST physics modules.

**Related issue, if one exists**
None

**Impacted areas of the software**
NWTC Library IO module

**Test results, if applicable**
See GitHub Actions