### PR TITLE
VTK folder and Vx sign for OLAF

### DIFF
--- a/modules/aerodyn/src/AeroDyn_AllBldNdOuts_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_AllBldNdOuts_IO.f90
@@ -791,7 +791,7 @@ SUBROUTINE Calc_WriteAllBldNdOutput( p, u, m, y, OtherState, Indx, ErrStat, ErrM
             else 
                DO IdxBlade=1,p%BldNd_BladesOut
                   DO IdxNode=1,p%NumBlNds
-                     y%WriteOutput( OutIdx )  = -m%FVW%BN_UrelWind_s(1,IdxNode,IdxBlade)
+                     y%WriteOutput( OutIdx )  = m%FVW%BN_UrelWind_s(1,IdxNode,IdxBlade)
                      OutIdx = OutIdx + 1
                   END DO
                END DO

--- a/modules/aerodyn/src/FVW.f90
+++ b/modules/aerodyn/src/FVW.f90
@@ -377,6 +377,7 @@ SUBROUTINE FVW_SetParametersFromInputs( InitInp, p, ErrStat, ErrMsg )
    integer(IntKi),             intent(  out) :: ErrStat       !< Error status of the operation
    character(*),               intent(  out) :: ErrMsg        !< Error message if ErrStat /= ErrID_None
    ! Local variables
+   character(1024)          :: rootDir, baseName  ! Simulation root dir and basename
    !integer(IntKi)          :: ErrStat2
    !character(ErrMsgLen)    :: ErrMsg2
    character(*), parameter :: RoutineName = 'FVW_SetParametersFromInputs'
@@ -388,6 +389,9 @@ SUBROUTINE FVW_SetParametersFromInputs( InitInp, p, ErrStat, ErrMsg )
    p%DTaero       = InitInp%DTaero          ! AeroDyn Time step
    p%KinVisc      = InitInp%KinVisc         ! Kinematic air viscosity
    p%RootName     = InitInp%RootName        ! Rootname for outputs
+   call GetPath( p%RootName, rootDir, baseName ) 
+   p%VTK_OutFileRoot = trim(rootDir) // 'vtk_fvw'  ! Directory for VTK outputs
+   p%VTK_OutFileBase = trim(rootDir) // 'vtk_fvw' // PathSep // trim(baseName) ! Basename for VTK files
    ! Set indexing to AFI tables -- this is set from the AD15 calling code.
    call AllocAry(p%AFindx,size(InitInp%AFindx,1),size(InitInp%AFindx,2),'AFindx',ErrStat,ErrMsg)
    p%AFindx = InitInp%AFindx     ! Copying in case AD15 still needs these
@@ -414,7 +418,7 @@ SUBROUTINE FVW_SetParametersFromInputFile( InputFileData, p, m, ErrStat, ErrMsg 
    p%IntMethod            = InputFileData%IntMethod
    p%CirculationMethod    = InputFileData%CirculationMethod
    p%CircSolvConvCrit     = InputFileData%CircSolvConvCrit
-   p%CircSolvRelaxation   = InputFileData%CircSolvRelaxation
+   p%CircSolvRelaxation   = InputFileData%CircSolvRelaxation 
    p%CircSolvMaxIter      = InputFileData%CircSolvMaxIter
    p%FreeWakeStart        = InputFileData%FreeWakeStart
    p%CircSolvPolar        = InputFileData%CircSolvPolar
@@ -964,19 +968,19 @@ subroutine FVW_CalcOutput( t, u, p, x, xd, z, OtherState, AFInfo, y, m, ErrStat,
          m%VTKStep = m%iStep+1 ! We use glue code step number for outputs
       endif
       if (m%FirstCall) then
-         call MKDIR('vtk_fvw')
+         call MKDIR(p%VTK_OutFileRoot)
       endif
       if ( ( t - m%VTKlastTime ) >= p%DTvtk*OneMinusEpsilon )  then
          m%VTKlastTime = t
          if ((p%VTKCoord==2).or.(p%VTKCoord==3)) then
             ! Hub reference coordinates, for export only, ALL VTK Will be exported in this coordinate system!
             ! Note: hubOrientation and HubPosition are optional, but required for bladeFrame==TRUE
-            call WrVTK_FVW(p, x, z, m, 'vtk_fvw/'//trim(p%RootName)//'FVW_Hub', m%VTKStep, 9, bladeFrame=.TRUE.,  &
+            call WrVTK_FVW(p, x, z, m, trim(p%VTK_OutFileBase)//'FVW_Hub', m%VTKStep, 9, bladeFrame=.TRUE.,  &
                      HubOrientation=real(u%HubOrientation,ReKi),HubPosition=real(u%HubPosition,ReKi))
          endif
          if ((p%VTKCoord==1).or.(p%VTKCoord==3)) then
             ! Global coordinate system, ALL VTK will be exported in global
-            call WrVTK_FVW(p, x, z, m, 'vtk_fvw/'//trim(p%RootName)//'FVW_Glb', m%VTKStep, 9, bladeFrame=.FALSE.)
+            call WrVTK_FVW(p, x, z, m, trim(p%VTK_OutFileBase)//'FVW_Glb', m%VTKStep, 9, bladeFrame=.FALSE.)
          endif
       endif
    endif

--- a/modules/aerodyn/src/FVW_Registry.txt
+++ b/modules/aerodyn/src/FVW_Registry.txt
@@ -49,6 +49,8 @@ typedef     ^                   ^               IntKi                           
 typedef     ^                   ^               DbKi                             DTvtk         -  - -   "DT between vtk writes" s
 typedef     ^                   ^               IntKi                            VTKCoord      -  - -    "Switch for VTK outputs coordinate  system" -
 typedef     ^                   ^               CHARACTER(1024)                  RootName      -  -  - "RootName for writing output files"	-
+typedef     ^                   ^               CHARACTER(1024)                  VTK_OutFileRoot - - - "Rootdirectory for writing VTK files"	-
+typedef     ^                   ^               CHARACTER(1024)                  VTK_OutFileBase - - - "Basename for writing VTK files"	-
 
 # ....... MiscVars ............
 # FVW_MiscVarType

--- a/modules/aerodyn/src/FVW_Types.f90
+++ b/modules/aerodyn/src/FVW_Types.f90
@@ -74,6 +74,8 @@ IMPLICIT NONE
     REAL(DbKi)  :: DTvtk      !< DT between vtk writes [s]
     INTEGER(IntKi)  :: VTKCoord      !< Switch for VTK outputs coordinate  system [-]
     CHARACTER(1024)  :: RootName      !< RootName for writing output files [-]
+    CHARACTER(1024)  :: VTK_OutFileRoot      !< Rootdirectory for writing VTK files [-]
+    CHARACTER(1024)  :: VTK_OutFileBase      !< Basename for writing VTK files [-]
   END TYPE FVW_ParameterType
 ! =======================
 ! =========  FVW_MiscVarType  =======
@@ -341,6 +343,8 @@ ENDIF
     DstParamData%DTvtk = SrcParamData%DTvtk
     DstParamData%VTKCoord = SrcParamData%VTKCoord
     DstParamData%RootName = SrcParamData%RootName
+    DstParamData%VTK_OutFileRoot = SrcParamData%VTK_OutFileRoot
+    DstParamData%VTK_OutFileBase = SrcParamData%VTK_OutFileBase
  END SUBROUTINE FVW_CopyParam
 
  SUBROUTINE FVW_DestroyParam( ParamData, ErrStat, ErrMsg )
@@ -447,6 +451,8 @@ ENDIF
       Db_BufSz   = Db_BufSz   + 1  ! DTvtk
       Int_BufSz  = Int_BufSz  + 1  ! VTKCoord
       Int_BufSz  = Int_BufSz  + 1*LEN(InData%RootName)  ! RootName
+      Int_BufSz  = Int_BufSz  + 1*LEN(InData%VTK_OutFileRoot)  ! VTK_OutFileRoot
+      Int_BufSz  = Int_BufSz  + 1*LEN(InData%VTK_OutFileBase)  ! VTK_OutFileBase
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -597,6 +603,14 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     DO I = 1, LEN(InData%RootName)
       IntKiBuf(Int_Xferred) = ICHAR(InData%RootName(I:I), IntKi)
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    DO I = 1, LEN(InData%VTK_OutFileRoot)
+      IntKiBuf(Int_Xferred) = ICHAR(InData%VTK_OutFileRoot(I:I), IntKi)
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    DO I = 1, LEN(InData%VTK_OutFileBase)
+      IntKiBuf(Int_Xferred) = ICHAR(InData%VTK_OutFileBase(I:I), IntKi)
       Int_Xferred = Int_Xferred + 1
     END DO ! I
  END SUBROUTINE FVW_PackParam
@@ -763,6 +777,14 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     DO I = 1, LEN(OutData%RootName)
       OutData%RootName(I:I) = CHAR(IntKiBuf(Int_Xferred))
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    DO I = 1, LEN(OutData%VTK_OutFileRoot)
+      OutData%VTK_OutFileRoot(I:I) = CHAR(IntKiBuf(Int_Xferred))
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    DO I = 1, LEN(OutData%VTK_OutFileBase)
+      OutData%VTK_OutFileBase(I:I) = CHAR(IntKiBuf(Int_Xferred))
       Int_Xferred = Int_Xferred + 1
     END DO ! I
  END SUBROUTINE FVW_UnPackParam


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
 - Vx sign was wrong for aero outputs per node with OLAF
-  Folder fvw_vtk was not in the right location when openfast called from a different folder, no vtk files were produced


**Impacted areas of the software**
OLAF

