### PR TITLE
Disable gfortran stack-reuse compiler option

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -107,6 +107,10 @@ macro(set_fast_gfortran)
   #set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -cpp -fopenmp")
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -ffree-line-length-none -cpp")
 
+  # Disable stack reuse within routines: issues seen with gfortran 9.x, but others may also exhibit
+  #   see section 3.16 of https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc.pdf
+  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fstack-reuse='none'")
+
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DOPENFAST_DOUBLE_PRECISION)

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -109,6 +109,7 @@ macro(set_fast_gfortran)
 
   # Disable stack reuse within routines: issues seen with gfortran 9.x, but others may also exhibit
   #   see section 3.16 of https://gcc.gnu.org/onlinedocs/gcc-9.2.0/gcc.pdf
+  #   and https://github.com/OpenFAST/openfast/pull/595
   set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fstack-reuse='none'")
 
   # Deal with Double/Single precision


### PR DESCRIPTION
This PR is ready for merging

No test cases are expected to change as gfortran 7.4 is used for testing on GitHub actions.


**Feature or improvement description**
This PR disables the `-fstack-reuse` option for gfortran.  In some cases gfortran 9.1.0 (and possibly others) will not correctly figure out the scope of a variable within a routine and it's nested subroutine or subfunction.  This can result in the same stack location used for a variable in scope and another variable in scope that the compiler thinks is out of scope.  This is seen in c35dc09b using gfortran 9.1.0 on mac.

**Details of case c35dc09b**
The subroutine `ParseInputFileInfo` contains the function `Failed` that accesses the `ErrStat` variable in the parent routine.  The variable `CurLine` is used only in the `ParseInputFileInfo` parent routine.  However, gfortran 9.1.0 on mac with `-O3` optimzation assigns the same stack location to both variables, resulting in `ErrStat` getting overwritten by `CurLine` and OpenFAST failing with an unknown error id.  While this case can be remedied by including `CurLine=CurLine` in the contained `Failed` function, it may be an indicator that gfortran is making this kind of error elsewhere, which may be affecting the numerical stability of OpenFAST.  For safety reasons, I propose disabling this optimization option in gfortran.

Code snippet from this commit:
```
print*,'Before setting CurLine=4: ',ErrStat2,'     ---> ErrStat: ',ErrStat,'      ---> Curline: ',Curline
   CurLine = 4
print*,'After  setting CurLine=4: ',ErrStat2,'     ---> ErrStat: ',ErrStat,'      ---> Curline: ',Curline
   call ParseVar( FileInfo_In, CurLine, 'Echo', InputFileData%Echo, ErrStat2, ErrMsg2 )   ! Note: ParseVar increments CurLine
print*,'After  call to Parsevar:  ',ErrStat2,'     ---> ErrStat: ',ErrStat,'      ---> Curline: ',Curline
```

Resulting output:
```
 Before setting CurLine=4:            0      ---> ErrStat:            0       ---> Curline:            0
 After  setting CurLine=4:            0      ---> ErrStat:            4       ---> Curline:            4
 After  call to Parsevar:             0      ---> ErrStat:            5       ---> Curline:            5

 FAST_InitializeAll:SrvD_Init:

 FAST encountered an error during module initialization.
  Simulation error level: Unknown ErrID

  Aborting OpenFAST.
```

**Related issue, if one exists**
No prior issue

**Impacted areas of the software**
Seen in one isolated instance, but may be present in numerics elsewhere in the code that we have never been able to isolate.

**Additional supporting information**
I cannot find any known bug reports in the `gcc` bug reports.
