### PR TITLE
Add support for initializing InflowWind with string inputs

### DIFF
--- a/.github/actions/tests-module-inflowwind/action.yml
+++ b/.github/actions/tests-module-inflowwind/action.yml
@@ -1,0 +1,9 @@
+name: 'InflowWind module tests'
+description: 'Run tests specific to the InflowWind module'
+author: 'Rafael Mudafort https://github.com/rafmudaf'
+runs:
+  using: "composite"
+  steps: 
+    - run: ctest -VV -R inflowwind_utest
+      working-directory: "/openfast/build"
+      shell: bash

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -59,6 +59,8 @@ jobs:
         uses: ./.github/actions/tests-module-aerodyn
       - name: 'Run BeamDyn tests'
         uses: ./.github/actions/tests-module-beamdyn
+      - name: 'Run InflowWind tests'
+        uses: ./.github/actions/tests-module-inflowwind
       - name: 'Run OpenFAST tests'
         # if: contains(github.event.head_commit.message, 'Action - Test All') || contains(github.event.pull_request.labels.*.name, 'Action - Test All') 
         uses: ./.github/actions/tests-gluecode-openfast

--- a/modules/inflowwind/src/IfW_UniformWind.txt
+++ b/modules/inflowwind/src/IfW_UniformWind.txt
@@ -12,10 +12,12 @@ include Registry_NWTC_Library.txt
 
 #########################
 
-typedef IfW_UniformWind/IfW_UniformWind InitInputType CHARACTER(1024) WindFileName  -     -     -     "Name of the wind file to use"                                 -
-typedef  ^                       ^                       ReKi     ReferenceHeight   -     -     -     "Hub height of the turbine"                                    meters
-typedef  ^                       ^                       ReKi     RefLength         -     -     -     "RefLength of the wind field to use"                           meters
-typedef  ^                       ^                       IntKi    SumFileUnit       -     -     -     "Unit number for the summary file (-1 for none).  Provided by IfW." -
+typedef IfW_UniformWind/IfW_UniformWind InitInputType CHARACTER(1024) WindFileName      -     -     -     "Name of the wind file to use"                                 -
+typedef  ^                       ^                       ReKi         ReferenceHeight   -     -     -     "Hub height of the turbine"                                    meters
+typedef  ^                       ^                       ReKi         RefLength         -     -     -     "RefLength of the wind field to use"                           meters
+typedef  ^                       ^                       IntKi        SumFileUnit       -     -     -     "Unit number for the summary file (-1 for none).  Provided by IfW." -
+typedef  ^                       ^                       LOGICAL      UseInputFile      -   .TRUE.  -     "Flag for toggling file based IO in wind type 2."                -
+typedef  ^                       ^                       FileInfoType   PassedFileData  -     -     -     "Optional slot for wind type 2 data if file IO is not used."                -
 
 
 
@@ -30,7 +32,7 @@ typedef  ^                       ^                       LOGICAL  WindFileConsta
 # ..... Misc/Optimization variables.................................................................................................
 # Define any data that are used only for efficiency purposes (these variables are not associated with time):
 #   e.g. indices for searching in an array, large arrays that are local variables in any routine called multiple times, etc.
-typedef  ^                       MiscVarType          IntKi    TimeIndex         -     -     -     "An Index into the TData array"                                -
+typedef  ^                       MiscVarType          IntKi    TimeIndex         -     0     -     "An Index into the TData array"                                -
 
 
 # ..... Parameters ................................................................................................................

--- a/modules/inflowwind/src/IfW_UniformWind_Types.f90
+++ b/modules/inflowwind/src/IfW_UniformWind_Types.f90
@@ -39,6 +39,8 @@ IMPLICIT NONE
     REAL(ReKi)  :: ReferenceHeight      !< Hub height of the turbine [meters]
     REAL(ReKi)  :: RefLength      !< RefLength of the wind field to use [meters]
     INTEGER(IntKi)  :: SumFileUnit      !< Unit number for the summary file (-1 for none).  Provided by IfW. [-]
+    LOGICAL  :: UseInputFile = .TRUE.      !< Flag for toggling file based IO in wind type 2. [-]
+    TYPE(FileInfoType)  :: PassedFileData      !< Optional slot for wind type 2 data if file IO is not used. [-]
   END TYPE IfW_UniformWind_InitInputType
 ! =======================
 ! =========  IfW_UniformWind_InitOutputType  =======
@@ -52,7 +54,7 @@ IMPLICIT NONE
 ! =======================
 ! =========  IfW_UniformWind_MiscVarType  =======
   TYPE, PUBLIC :: IfW_UniformWind_MiscVarType
-    INTEGER(IntKi)  :: TimeIndex      !< An Index into the TData array [-]
+    INTEGER(IntKi)  :: TimeIndex = 0      !< An Index into the TData array [-]
   END TYPE IfW_UniformWind_MiscVarType
 ! =======================
 ! =========  IfW_UniformWind_ParameterType  =======
@@ -101,6 +103,10 @@ CONTAINS
     DstInitInputData%ReferenceHeight = SrcInitInputData%ReferenceHeight
     DstInitInputData%RefLength = SrcInitInputData%RefLength
     DstInitInputData%SumFileUnit = SrcInitInputData%SumFileUnit
+    DstInitInputData%UseInputFile = SrcInitInputData%UseInputFile
+      CALL NWTC_Library_Copyfileinfotype( SrcInitInputData%PassedFileData, DstInitInputData%PassedFileData, CtrlCode, ErrStat2, ErrMsg2 )
+         CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg,RoutineName)
+         IF (ErrStat>=AbortErrLev) RETURN
  END SUBROUTINE IfW_UniformWind_CopyInitInput
 
  SUBROUTINE IfW_UniformWind_DestroyInitInput( InitInputData, ErrStat, ErrMsg )
@@ -112,6 +118,7 @@ CONTAINS
 ! 
   ErrStat = ErrID_None
   ErrMsg  = ""
+  CALL NWTC_Library_Destroyfileinfotype( InitInputData%PassedFileData, ErrStat, ErrMsg )
  END SUBROUTINE IfW_UniformWind_DestroyInitInput
 
  SUBROUTINE IfW_UniformWind_PackInitInput( ReKiBuf, DbKiBuf, IntKiBuf, Indata, ErrStat, ErrMsg, SizeOnly )
@@ -153,6 +160,25 @@ CONTAINS
       Re_BufSz   = Re_BufSz   + 1  ! ReferenceHeight
       Re_BufSz   = Re_BufSz   + 1  ! RefLength
       Int_BufSz  = Int_BufSz  + 1  ! SumFileUnit
+      Int_BufSz  = Int_BufSz  + 1  ! UseInputFile
+   ! Allocate buffers for subtypes, if any (we'll get sizes from these) 
+      Int_BufSz   = Int_BufSz + 3  ! PassedFileData: size of buffers for each call to pack subtype
+      CALL NWTC_Library_Packfileinfotype( Re_Buf, Db_Buf, Int_Buf, InData%PassedFileData, ErrStat2, ErrMsg2, .TRUE. ) ! PassedFileData 
+        CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+        IF (ErrStat >= AbortErrLev) RETURN
+
+      IF(ALLOCATED(Re_Buf)) THEN ! PassedFileData
+         Re_BufSz  = Re_BufSz  + SIZE( Re_Buf  )
+         DEALLOCATE(Re_Buf)
+      END IF
+      IF(ALLOCATED(Db_Buf)) THEN ! PassedFileData
+         Db_BufSz  = Db_BufSz  + SIZE( Db_Buf  )
+         DEALLOCATE(Db_Buf)
+      END IF
+      IF(ALLOCATED(Int_Buf)) THEN ! PassedFileData
+         Int_BufSz = Int_BufSz + SIZE( Int_Buf )
+         DEALLOCATE(Int_Buf)
+      END IF
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -190,6 +216,36 @@ CONTAINS
     Re_Xferred = Re_Xferred + 1
     IntKiBuf(Int_Xferred) = InData%SumFileUnit
     Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = TRANSFER(InData%UseInputFile, IntKiBuf(1))
+    Int_Xferred = Int_Xferred + 1
+      CALL NWTC_Library_Packfileinfotype( Re_Buf, Db_Buf, Int_Buf, InData%PassedFileData, ErrStat2, ErrMsg2, OnlySize ) ! PassedFileData 
+        CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+        IF (ErrStat >= AbortErrLev) RETURN
+
+      IF(ALLOCATED(Re_Buf)) THEN
+        IntKiBuf( Int_Xferred ) = SIZE(Re_Buf); Int_Xferred = Int_Xferred + 1
+        IF (SIZE(Re_Buf) > 0) ReKiBuf( Re_Xferred:Re_Xferred+SIZE(Re_Buf)-1 ) = Re_Buf
+        Re_Xferred = Re_Xferred + SIZE(Re_Buf)
+        DEALLOCATE(Re_Buf)
+      ELSE
+        IntKiBuf( Int_Xferred ) = 0; Int_Xferred = Int_Xferred + 1
+      ENDIF
+      IF(ALLOCATED(Db_Buf)) THEN
+        IntKiBuf( Int_Xferred ) = SIZE(Db_Buf); Int_Xferred = Int_Xferred + 1
+        IF (SIZE(Db_Buf) > 0) DbKiBuf( Db_Xferred:Db_Xferred+SIZE(Db_Buf)-1 ) = Db_Buf
+        Db_Xferred = Db_Xferred + SIZE(Db_Buf)
+        DEALLOCATE(Db_Buf)
+      ELSE
+        IntKiBuf( Int_Xferred ) = 0; Int_Xferred = Int_Xferred + 1
+      ENDIF
+      IF(ALLOCATED(Int_Buf)) THEN
+        IntKiBuf( Int_Xferred ) = SIZE(Int_Buf); Int_Xferred = Int_Xferred + 1
+        IF (SIZE(Int_Buf) > 0) IntKiBuf( Int_Xferred:Int_Xferred+SIZE(Int_Buf)-1 ) = Int_Buf
+        Int_Xferred = Int_Xferred + SIZE(Int_Buf)
+        DEALLOCATE(Int_Buf)
+      ELSE
+        IntKiBuf( Int_Xferred ) = 0; Int_Xferred = Int_Xferred + 1
+      ENDIF
  END SUBROUTINE IfW_UniformWind_PackInitInput
 
  SUBROUTINE IfW_UniformWind_UnPackInitInput( ReKiBuf, DbKiBuf, IntKiBuf, Outdata, ErrStat, ErrMsg )
@@ -229,6 +285,48 @@ CONTAINS
     Re_Xferred = Re_Xferred + 1
     OutData%SumFileUnit = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1
+    OutData%UseInputFile = TRANSFER(IntKiBuf(Int_Xferred), OutData%UseInputFile)
+    Int_Xferred = Int_Xferred + 1
+      Buf_size=IntKiBuf( Int_Xferred )
+      Int_Xferred = Int_Xferred + 1
+      IF(Buf_size > 0) THEN
+        ALLOCATE(Re_Buf(Buf_size),STAT=ErrStat2)
+        IF (ErrStat2 /= 0) THEN 
+           CALL SetErrStat(ErrID_Fatal, 'Error allocating Re_Buf.', ErrStat, ErrMsg,RoutineName)
+           RETURN
+        END IF
+        Re_Buf = ReKiBuf( Re_Xferred:Re_Xferred+Buf_size-1 )
+        Re_Xferred = Re_Xferred + Buf_size
+      END IF
+      Buf_size=IntKiBuf( Int_Xferred )
+      Int_Xferred = Int_Xferred + 1
+      IF(Buf_size > 0) THEN
+        ALLOCATE(Db_Buf(Buf_size),STAT=ErrStat2)
+        IF (ErrStat2 /= 0) THEN 
+           CALL SetErrStat(ErrID_Fatal, 'Error allocating Db_Buf.', ErrStat, ErrMsg,RoutineName)
+           RETURN
+        END IF
+        Db_Buf = DbKiBuf( Db_Xferred:Db_Xferred+Buf_size-1 )
+        Db_Xferred = Db_Xferred + Buf_size
+      END IF
+      Buf_size=IntKiBuf( Int_Xferred )
+      Int_Xferred = Int_Xferred + 1
+      IF(Buf_size > 0) THEN
+        ALLOCATE(Int_Buf(Buf_size),STAT=ErrStat2)
+        IF (ErrStat2 /= 0) THEN 
+           CALL SetErrStat(ErrID_Fatal, 'Error allocating Int_Buf.', ErrStat, ErrMsg,RoutineName)
+           RETURN
+        END IF
+        Int_Buf = IntKiBuf( Int_Xferred:Int_Xferred+Buf_size-1 )
+        Int_Xferred = Int_Xferred + Buf_size
+      END IF
+      CALL NWTC_Library_Unpackfileinfotype( Re_Buf, Db_Buf, Int_Buf, OutData%PassedFileData, ErrStat2, ErrMsg2 ) ! PassedFileData 
+        CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+        IF (ErrStat >= AbortErrLev) RETURN
+
+      IF(ALLOCATED(Re_Buf )) DEALLOCATE(Re_Buf )
+      IF(ALLOCATED(Db_Buf )) DEALLOCATE(Db_Buf )
+      IF(ALLOCATED(Int_Buf)) DEALLOCATE(Int_Buf)
  END SUBROUTINE IfW_UniformWind_UnPackInitInput
 
  SUBROUTINE IfW_UniformWind_CopyInitOutput( SrcInitOutputData, DstInitOutputData, CtrlCode, ErrStat, ErrMsg )

--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -139,13 +139,14 @@ SUBROUTINE InflowWind_Init( InitInp,   InputGuess,    p, ContStates, DiscStates,
 
       TYPE(IfW_4Dext_InitOutputType)                        :: FDext_InitOutData    !< initialization info
 
+      TYPE(FileInfoType)                                    :: InFileInfo    !< The derived type for holding the full input file for parsing -- we may pass this in the future
 !!!     TYPE(CTBladed_Backgr)                                        :: BackGrndValues
 
 
          ! Temporary variables for error handling
       INTEGER(IntKi)                                        :: TmpErrStat
       CHARACTER(ErrMsgLen)                                  :: TmpErrMsg         !< temporary error message
-
+      CHARACTER(1024)                                       :: PriPath
 
          ! Local Variables
       INTEGER(IntKi)                                        :: I, j              !< Generic counter
@@ -182,37 +183,51 @@ SUBROUTINE InflowWind_Init( InitInp,   InputGuess,    p, ContStates, DiscStates,
       EchoFileName  = TRIM(p%RootFileName)//".ech"
       SumFileName   = TRIM(p%RootFileName)//".sum"
 
+         ! these values (and others hard-coded in lidar_init) should be set in the input file, too
+      InputFileData%SensorType = InitInp%lidar%SensorType
+      InputFileData%NumPulseGate = InitInp%lidar%NumPulseGate
+      InputFileData%RotorApexOffsetPos = InitInp%lidar%RotorApexOffsetPos
+      InputFileData%LidRadialVel = InitInp%lidar%LidRadialVel
 
          ! Parse all the InflowWind related input files and populate the *_InitDataType derived types
+      CALL GetPath( InitInp%InputFileName, PriPath )
 
       IF ( InitInp%UseInputFile ) THEN
-         CALL InflowWind_ReadInput( InitInp%InputFileName, EchoFileName, InputFileData, TmpErrStat, TmpErrMsg )
+         CALL ProcessComFile( InitInp%InputFileName, InFileInfo, TmpErrStat, TmpErrMsg )
+         ! For diagnostic purposes, the following can be used to display the contents
+         ! of the InFileInfo data structure.
+         ! call Print_FileInfo_Struct( CU, InFileInfo ) ! CU is the screen -- different number on different systems.
+
          CALL SetErrStat(TmpErrStat,TmpErrMsg,ErrStat,ErrMsg,RoutineName)
          IF ( ErrStat >= AbortErrLev ) THEN
             CALL Cleanup()
             RETURN
          ENDIF
-         
-         ! these values (and others hard-coded in lidar_init) should be set in the input file, too
-        InputFileData%SensorType = InitInp%lidar%SensorType
-        InputFileData%NumPulseGate = InitInp%lidar%NumPulseGate
-        InputFileData%RotorApexOffsetPos = InitInp%lidar%RotorApexOffsetPos
-        InputFileData%LidRadialVel = InitInp%lidar%LidRadialVel
                         
       ELSE
-                  
-         CALL InflowWind_CopyInputFile( InitInp%PassedFileData, InputFileData, MESH_NEWCOPY, TmpErrStat, TmpErrMsg )
-            CALL SetErrStat(TmpErrStat,TmpErrMsg,ErrStat,ErrMsg,RoutineName)          
+         CALL NWTC_Library_CopyFileInfoType( InitInp%PassedFileData, InFileInfo, MESH_NEWCOPY, TmpErrStat, TmpErrMsg )
+         CALL SetErrStat(TmpErrStat,TmpErrMsg,ErrStat,ErrMsg,RoutineName)
+         IF ( ErrStat >= AbortErrLev ) THEN
+            CALL Cleanup()
+            RETURN
+         ENDIF          
          
       ENDIF
 
+      CALL InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, TmpErrStat, TmpErrMsg )
+      CALL SetErrStat(TmpErrStat,TmpErrMsg,ErrStat,ErrMsg,RoutineName)
+      IF ( ErrStat >= AbortErrLev ) THEN
+         CALL Cleanup()
+         CALL InflowWind_DestroyInputFile( InputFileData, TmpErrStat, TmpErrMsg )
+         RETURN
+      ENDIF
          ! let's tell InflowWind if an external module (e.g., FAST.Farm) is going to set the velocity grids.
+      
       IF ( InitInp%Use4Dext) then
          InputFileData%WindType = FDext_WindNumber      
          InputFileData%PropagationDir = 0.0_ReKi ! wind is in XYZ coordinates (already rotated if necessary), so don't rotate it again
       END IF
-      
-      
+
          ! initialize sensor data:   
       CALL Lidar_Init( InitInp, InputGuess, p, ContStates, DiscStates, ConstrStateGuess, OtherStates,   &
                        y, m, TimeInterval, InitOutData, TmpErrStat, TmpErrMsg )
@@ -386,6 +401,9 @@ SUBROUTINE InflowWind_Init( InitInp,   InputGuess,    p, ContStates, DiscStates,
             Uniform_InitData%RefLength                =  InputFileData%Uniform_RefLength 
             Uniform_InitData%WindFileName             =  InputFileData%Uniform_FileName
             Uniform_InitData%SumFileUnit              =  SumFileUnit
+
+            Uniform_InitData%UseInputFile             =  InitInp%WindType2UseInputFile
+            Uniform_InitData%PassedFileData           =  InitInp%WindType2Data
 
                ! Initialize the UniformWind module
             CALL IfW_UniformWind_Init(Uniform_InitData, p%UniformWind, &

--- a/modules/inflowwind/src/InflowWind.txt
+++ b/modules/inflowwind/src/InflowWind.txt
@@ -73,7 +73,7 @@ typedef  ^                       ^                 ReKi              Uniform_Ref
 typedef  ^                       ^                 CHARACTER(1024)   TSFF_FileName     -     -     -     "TurbSim Full-Field -- filename"                         -
 typedef  ^                       ^                 CHARACTER(1024)   BladedFF_FileName -     -     -     "Bladed-style Full-Field -- filename"                    -
 typedef  ^                       ^                 LOGICAL           BladedFF_TowerFile -    -     -     "Bladed-style Full-Field -- tower file exists"           -
-typedef  ^                       ^                 LOGICAL           CTTS_CoherentTurb -     -     -     "Coherent turbulence data exists"                        -
+typedef  ^                       ^                 LOGICAL           CTTS_CoherentTurb -     .FALSE.     -     "Coherent turbulence data exists"                        -
 typedef  ^                       ^                 CHARACTER(1024)   CTTS_FileName     -     -     -     "Name of coherent turbulence file"                       -
 typedef  ^                       ^                 CHARACTER(1024)   CTTS_Path         -     -     -     "Path to coherent turbulence binary data files"          -
 typedef  ^                       ^                 CHARACTER(1024)   HAWC_FileName_u   -     -     -     "HAWC -- u component binary data file name"              -
@@ -116,7 +116,9 @@ typedef  ^                       ^                 LOGICAL           Use4Dext   
 typedef  ^                       ^                 IntKi             NumWindPoints     -     -     -     "Number of wind velocity points expected"                                     -
 typedef  ^                       ^                 LOGICAL           UseInputFile      -   .TRUE.  -     "Should we read everthing from an input file, or do we get it some other way" -
 typedef  ^                       ^                 CHARACTER(1024)	 RootName          -     -     -     "RootName for writing output files"
-typedef  ^                       ^          InflowWind_InputFile     PassedFileData    -     -     -     "If we don't use the input file, pass everything through this"                -
+typedef  ^                       ^                 FileInfoType      PassedFileData    -     -     -     "If we don't use the input file, pass everything through this"                -
+typedef  ^                       ^                 LOGICAL           WindType2UseInputFile    -     .TRUE.     -      "Flag for toggling file based IO in wind type 2."                -
+typedef  ^                       ^                 FileInfoType      WindType2Data    -     -     -      "Optional slot for wind type 2 data if file IO is not used."                -
 typedef  ^                       ^          Lidar_InitInputType      lidar             -     -     -     "InitInput for lidar data"                                             -
 typedef  ^                       ^          IfW_4Dext_InitInputType  FDext             -     -     -     "InitInput for lidar data"                                             -
 

--- a/modules/inflowwind/tests/ifw_test_tools.F90
+++ b/modules/inflowwind/tests/ifw_test_tools.F90
@@ -1,0 +1,143 @@
+module ifw_test_tools
+
+    use NWTC_IO
+    use NWTC_Library
+    use NWTC_Library_Types
+
+    implicit none
+
+contains
+
+    function getInputFileData()
+
+        INTEGER                             :: ErrStat
+        CHARACTER(ErrMsgLen)                :: ErrMsg
+        TYPE(FileInfoType)                  :: getInputFileData
+        CHARACTER(1024), DIMENSION(54)      :: data = (/ &
+            '------- InflowWind v3.01.* INPUT FILE -------------------------------------------------------------------------                                                ', &
+            'Steady 8 m/s winds with no shear for FAST CertTests #20 and #25                                                                                                ', &
+            '---------------------------------------------------------------------------------------------------------------                                                ', &
+            '        true  Echo           - Echo input data to <RootName>.ech (flag)                                                                                        ', &
+            '          1   WindType       - switch for wind file type (1=steady; 2=uniform; 3=binary TurbSim FF; 4=binary Bladed-style FF; 5=HAWC format; 6=User defined)   ', &
+            '          0   PropagationDir - Direction of wind propagation (meteoroligical rotation from aligned with X (positive rotates towards -Y) -- degrees)            ', &
+            '          1   NWindVel       - Number of points to output the wind velocity    (0 to 9)                                                                        ', &
+            '          0   WindVxiList    - List of coordinates in the inertial X direction (m)                                                                             ', &
+            '          0   WindVyiList    - List of coordinates in the inertial Y direction (m)                                                                             ', &
+            '         90   WindVziList    - List of coordinates in the inertial Z direction (m)                                                                             ', &
+            '================== Parameters for Steady Wind Conditions [used only for WindType = 1] =========================                                                ', &
+            '        8.0   HWindSpeed     - Horizontal windspeed                            (m/s)                                                                           ', &
+            '         90   RefHt          - Reference height for horizontal wind speed      (m)                                                                             ', &
+            '        0.1   PLexp          - Power law exponent                              (-)                                                                             ', &
+            '================== Parameters for Uniform wind file   [used only for WindType = 2] ============================                                                ', &
+            '"Wind/08ms.wnd"    UniformFileName       - Filename of time series data for uniform wind field.      (-)                                                       ', &
+            '         90   RefHt          - Reference height for horizontal wind speed                (m)                                                                   ', &
+            '     125.88   RefLength      - Reference length for linear horizontal and vertical sheer (-)                                                                   ', &
+            '================== Parameters for Binary TurbSim Full-Field files   [used only for WindType = 3] ==============                                                ', &
+            '"Wind/08ms.wnd"    TurbSimFileName       - Name of the Full field wind file to use (.bts)                                                                      ', &
+            '================== Parameters for Binary Bladed-style Full-Field files   [used only for WindType = 4] =========                                                ', &
+            '"unused"      FilenameRoot   - Rootname of the full-field wind file to use (.wnd, .sum)                                                                        ', &
+            'False         TowerFile      - Have tower file (.twr) (flag)                                                                                                   ', &
+            '================== Parameters for HAWC-format binary files  [Only used with WindType = 5] =====================                                                ', &
+            '"wasp\Output\basic_5u.bin"    FileName_u     - name of the file containing the u-component fluctuating wind (.bin)                                             ', &
+            '"wasp\Output\basic_5v.bin"    FileName_v     - name of the file containing the v-component fluctuating wind (.bin)                                             ', &
+            '"wasp\Output\basic_5w.bin"    FileName_w     - name of the file containing the w-component fluctuating wind (.bin)                                             ', &
+            '         64   nx             - number of grids in the x direction (in the 3 files above) (-)                                                                   ', &
+            '         32   ny             - number of grids in the y direction (in the 3 files above) (-)                                                                   ', &
+            '         32   nz             - number of grids in the z direction (in the 3 files above) (-)                                                                   ', &
+            '         16   dx             - distance (in meters) between points in the x direction    (m)                                                                   ', &
+            '          3   dy             - distance (in meters) between points in the y direction    (m)                                                                   ', &
+            '          3   dz             - distance (in meters) between points in the z direction    (m)                                                                   ', &
+            '         90   RefHt          - reference height; the height (in meters) of the vertical center of the grid (m)                                                 ', &
+            ' -------------   Scaling parameters for turbulence   ---------------------------------------------------------                                                 ', &
+            '          1   ScaleMethod    - Turbulence scaling method   [0 = none, 1 = direct scaling, 2 = calculate scaling factor based on a desired standard deviation]  ', &
+            '          1   SFx            - Turbulence scaling factor for the x direction (-)   [ScaleMethod=1]                                                             ', &
+            '          1   SFy            - Turbulence scaling factor for the y direction (-)   [ScaleMethod=1]                                                             ', &
+            '          1   SFz            - Turbulence scaling factor for the z direction (-)   [ScaleMethod=1]                                                             ', &
+            '         12   SigmaFx        - Turbulence standard deviation to calculate scaling from in x direction (m/s)    [ScaleMethod=2]                                 ', &
+            '          8   SigmaFy        - Turbulence standard deviation to calculate scaling from in y direction (m/s)    [ScaleMethod=2]                                 ', &
+            '          2   SigmaFz        - Turbulence standard deviation to calculate scaling from in z direction (m/s)    [ScaleMethod=2]                                 ', &
+            '  -------------   Mean wind profile parameters (added to HAWC-format files)   ---------------------------------                                                ', &
+            '          5   URef           - Mean u-component wind speed at the reference height (m/s)                                                                       ', &
+            '          2   WindProfile    - Wind profile type (0=constant;1=logarithmic,2=power law)                                                                        ', &
+            '          0   PLExp          - Power law exponent (-) (used for PL wind profile type only)                                                                     ', &
+            '       0.03   Z0             - Surface roughness length (m) (used for LG wind profile type only)                                                               ', &
+            '      0   InitPosition(x) - Initial offset in +x direction (shift of wind box)                                                                                 ', &
+            '====================== OUTPUT ==================================================                                                                               ', &
+            'False         SumPrint     - Print summary data to <RootName>.IfW.sum (flag)                                                                                   ', &
+            '              OutList      - The next line(s) contains a list of output parameters.  See OutListParameters.xlsx for a listing of available output channels, (-)', &
+            '"Wind1VelX,Wind1VelY,Wind1VelZ"     - Wind velocity at point WindVxiList(1),WindVyiList(1),WindVziList(1).  X, Y, and Z direction components.                  ', &
+            'END of input file (the word "END" must appear in the first 3 columns of this last OutList line)                                                                ', &
+            '---------------------------------------------------------------------------------------                                                                        ' &
+        /)
+
+        CALL InitFileInfo(data, getInputFileData, ErrStat, ErrMsg)
+
+    end function
+
+    function getInputFileDataWindType2()
+
+        INTEGER                             :: ErrStat
+        CHARACTER(ErrMsgLen)                :: ErrMsg
+        TYPE(FileInfoType)                  :: getInputFileDataWindType2
+        CHARACTER(1024), DIMENSION(54)      :: data = (/ &
+            '------- InflowWind v3.01.* INPUT FILE -------------------------------------------------------------------------                                                ', &
+            'Steady 8 m/s winds with no shear for FAST CertTests #20 and #25                                                                                                ', &
+            '---------------------------------------------------------------------------------------------------------------                                                ', &
+            '        true  Echo           - Echo input data to <RootName>.ech (flag)                                                                                        ', &
+            '          2   WindType       - switch for wind file type (1=steady; 2=uniform; 3=binary TurbSim FF; 4=binary Bladed-style FF; 5=HAWC format; 6=User defined)   ', &
+            '          0   PropagationDir - Direction of wind propagation (meteoroligical rotation from aligned with X (positive rotates towards -Y) -- degrees)            ', &
+            '          1   NWindVel       - Number of points to output the wind velocity    (0 to 9)                                                                        ', &
+            '          0   WindVxiList    - List of coordinates in the inertial X direction (m)                                                                             ', &
+            '          0   WindVyiList    - List of coordinates in the inertial Y direction (m)                                                                             ', &
+            '         90   WindVziList    - List of coordinates in the inertial Z direction (m)                                                                             ', &
+            '================== Parameters for Steady Wind Conditions [used only for WindType = 1] =========================                                                ', &
+            '        8.0   HWindSpeed     - Horizontal windspeed                            (m/s)                                                                           ', &
+            '         90   RefHt          - Reference height for horizontal wind speed      (m)                                                                             ', &
+            '        0.1   PLexp          - Power law exponent                              (-)                                                                             ', &
+            '================== Parameters for Uniform wind file   [used only for WindType = 2] ============================                                                ', &
+            '"Wind/08ms.wnd"    UniformFileName       - Filename of time series data for uniform wind field.      (-)                                                       ', &
+            '         90   RefHt          - Reference height for horizontal wind speed                (m)                                                                   ', &
+            '     125.88   RefLength      - Reference length for linear horizontal and vertical sheer (-)                                                                   ', &
+            '================== Parameters for Binary TurbSim Full-Field files   [used only for WindType = 3] ==============                                                ', &
+            '"Wind/08ms.wnd"    TurbSimFileName       - Name of the Full field wind file to use (.bts)                                                                      ', &
+            '================== Parameters for Binary Bladed-style Full-Field files   [used only for WindType = 4] =========                                                ', &
+            '"unused"      FilenameRoot   - Rootname of the full-field wind file to use (.wnd, .sum)                                                                        ', &
+            'False         TowerFile      - Have tower file (.twr) (flag)                                                                                                   ', &
+            '================== Parameters for HAWC-format binary files  [Only used with WindType = 5] =====================                                                ', &
+            '"wasp\Output\basic_5u.bin"    FileName_u     - name of the file containing the u-component fluctuating wind (.bin)                                             ', &
+            '"wasp\Output\basic_5v.bin"    FileName_v     - name of the file containing the v-component fluctuating wind (.bin)                                             ', &
+            '"wasp\Output\basic_5w.bin"    FileName_w     - name of the file containing the w-component fluctuating wind (.bin)                                             ', &
+            '         64   nx             - number of grids in the x direction (in the 3 files above) (-)                                                                   ', &
+            '         32   ny             - number of grids in the y direction (in the 3 files above) (-)                                                                   ', &
+            '         32   nz             - number of grids in the z direction (in the 3 files above) (-)                                                                   ', &
+            '         16   dx             - distance (in meters) between points in the x direction    (m)                                                                   ', &
+            '          3   dy             - distance (in meters) between points in the y direction    (m)                                                                   ', &
+            '          3   dz             - distance (in meters) between points in the z direction    (m)                                                                   ', &
+            '         90   RefHt          - reference height; the height (in meters) of the vertical center of the grid (m)                                                 ', &
+            ' -------------   Scaling parameters for turbulence   ---------------------------------------------------------                                                 ', &
+            '          1   ScaleMethod    - Turbulence scaling method   [0 = none, 1 = direct scaling, 2 = calculate scaling factor based on a desired standard deviation]  ', &
+            '          1   SFx            - Turbulence scaling factor for the x direction (-)   [ScaleMethod=1]                                                             ', &
+            '          1   SFy            - Turbulence scaling factor for the y direction (-)   [ScaleMethod=1]                                                             ', &
+            '          1   SFz            - Turbulence scaling factor for the z direction (-)   [ScaleMethod=1]                                                             ', &
+            '         12   SigmaFx        - Turbulence standard deviation to calculate scaling from in x direction (m/s)    [ScaleMethod=2]                                 ', &
+            '          8   SigmaFy        - Turbulence standard deviation to calculate scaling from in y direction (m/s)    [ScaleMethod=2]                                 ', &
+            '          2   SigmaFz        - Turbulence standard deviation to calculate scaling from in z direction (m/s)    [ScaleMethod=2]                                 ', &
+            '  -------------   Mean wind profile parameters (added to HAWC-format files)   ---------------------------------                                                ', &
+            '          5   URef           - Mean u-component wind speed at the reference height (m/s)                                                                       ', &
+            '          2   WindProfile    - Wind profile type (0=constant;1=logarithmic,2=power law)                                                                        ', &
+            '          0   PLExp          - Power law exponent (-) (used for PL wind profile type only)                                                                     ', &
+            '       0.03   Z0             - Surface roughness length (m) (used for LG wind profile type only)                                                               ', &
+            '      0   InitPosition(x) - Initial offset in +x direction (shift of wind box)                                                                                 ', &
+            '====================== OUTPUT ==================================================                                                                               ', &
+            'False         SumPrint     - Print summary data to <RootName>.IfW.sum (flag)                                                                                   ', &
+            '              OutList      - The next line(s) contains a list of output parameters.  See OutListParameters.xlsx for a listing of available output channels, (-)', &
+            '"Wind1VelX,Wind1VelY,Wind1VelZ"     - Wind velocity at point WindVxiList(1),WindVyiList(1),WindVziList(1).  X, Y, and Z direction components.                  ', &
+            'END of input file (the word "END" must appear in the first 3 columns of this last OutList line)                                                                ', &
+            '---------------------------------------------------------------------------------------                                                                        ' &
+        /)
+
+        CALL InitFileInfo(data, getInputFileDataWindType2, ErrStat, ErrMsg)
+
+    end function
+
+end module

--- a/modules/inflowwind/tests/test_bladed_wind.F90
+++ b/modules/inflowwind/tests/test_bladed_wind.F90
@@ -1,0 +1,35 @@
+module test_bladed_wind
+
+    use pFUnit_mod
+    use ifw_test_tools
+    use InflowWind_Subs
+    use InflowWind_Types
+
+    implicit none
+
+contains
+
+    @test
+    subroutine test_bladed_wind_input()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData
+        CHARACTER(1024)                 :: PriPath 
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        CHARACTER(16)                   :: expected
+
+        expected = "unused.wnd"
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%BladedFF_FileName, trim(expected))
+        @assertEqual(InputFileData%BladedFF_TowerFile, .FALSE.)
+
+    end subroutine
+
+end module

--- a/modules/inflowwind/tests/test_hawc_wind.F90
+++ b/modules/inflowwind/tests/test_hawc_wind.F90
@@ -1,0 +1,64 @@
+module test_hawc_wind
+
+    use pFUnit_mod
+    use ifw_test_tools
+    use InflowWind_Subs
+    use InflowWind_Types
+
+    implicit none
+
+contains
+
+    @test
+    subroutine test_hawc_wind_input()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData
+        CHARACTER(1024)                 :: PriPath 
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        CHARACTER(32)                   :: expected_fnu
+        CHARACTER(32)                   :: expected_fnv
+        CHARACTER(32)                   :: expected_fnw
+
+        PriPath = ""
+        expected_fnu = "wasp\Output\basic_5u.bin"
+        expected_fnv = "wasp\Output\basic_5v.bin"
+        expected_fnw = "wasp\Output\basic_5w.bin"
+
+        InFileInfo = getInputFileData()
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+
+        @assertEqual(InputFileData%HAWC_FileName_u, trim(expected_fnu))
+        @assertEqual(InputFileData%HAWC_FileName_v, trim(expected_fnv))
+        @assertEqual(InputFileData%HAWC_FileName_w, trim(expected_fnw))
+        @assertEqual(InputFileData%HAWC_nx, 64)
+        @assertEqual(InputFileData%HAWC_ny, 32)
+        @assertEqual(InputFileData%HAWC_nz, 32)
+        @assertEqual(InputFileData%HAWC_dx, 16)
+        @assertEqual(InputFileData%HAWC_dy, 3)
+        @assertEqual(InputFileData%HAWC_dz, 3)
+        @assertEqual(InputFileData%HAWC_RefHt, 90)
+
+        @assertEqual(InputFileData%HAWC_ScaleMethod, 1)
+        @assertEqual(InputFileData%HAWC_SFx, 1)
+        @assertEqual(InputFileData%HAWC_SFy, 1)
+        @assertEqual(InputFileData%HAWC_SFz, 1)
+        @assertEqual(InputFileData%HAWC_SigmaFx, 12)
+        @assertEqual(InputFileData%HAWC_SigmaFy, 8)
+        @assertEqual(InputFileData%HAWC_SigmaFz, 2)
+
+        @assertEqual(InputFileData%HAWC_URef, 5)
+        @assertEqual(InputFileData%HAWC_ProfileType, 2)
+        @assertEqual(InputFileData%HAWC_PLExp, 0)
+        @assertEqual(InputFileData%HAWC_Z0, 0.03)
+        @assertEqual(InputFileData%HAWC_InitPosition(1), 0)
+        @assertEqual(InputFileData%HAWC_InitPosition(2), 0)
+        @assertEqual(InputFileData%HAWC_InitPosition(3), 0)
+
+    end subroutine
+
+end module

--- a/modules/inflowwind/tests/test_outputs.F90
+++ b/modules/inflowwind/tests/test_outputs.F90
@@ -1,0 +1,62 @@
+module test_outputs
+
+    use pFUnit_mod
+    use ifw_test_tools
+    use InflowWind_Subs
+    use InflowWind_Types
+
+    implicit none
+
+contains
+
+    @test
+    subroutine test_outputs_parsing()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData
+        CHARACTER(1024)                 :: PriPath 
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%SumPrint, .FALSE.)
+        @assertEqual(InputFileData%OutList(1), "Wind1VelX")
+        @assertEqual(InputFileData%OutList(2), "Wind1VelY")
+        @assertEqual(InputFileData%OutList(3), "Wind1VelZ")
+
+    end subroutine
+
+
+    @test
+    subroutine test_outputs_parsing_alternate()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData 
+        CHARACTER(1024)                 :: PriPath
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        InFileInfo%Lines(50:52) = (/ &
+            'True          SumPrint     - Print summary data to <RootName>.IfW.sum (flag)                                                                                   ', &
+            '              OutList      - The next line(s) contains a list of output parameters.  See OutListParameters.xlsx for a listing of available output channels, (-)', &
+            '"Wind1VelX,Wind1VelY"      - Wind velocity at point WindVxiList(1),WindVyiList(1),WindVziList(1).  X, Y, and Z direction components.                           ' &
+        /)
+
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%SumPrint, .TRUE.)
+        @assertEqual(InputFileData%OutList(1), "Wind1VelX")
+        @assertEqual(InputFileData%OutList(2), "Wind1VelY")
+
+    end subroutine
+
+end module

--- a/modules/inflowwind/tests/test_steady_wind.F90
+++ b/modules/inflowwind/tests/test_steady_wind.F90
@@ -1,0 +1,63 @@
+module test_steady_wind
+
+    use pFUnit_mod
+    use ifw_test_tools
+    use InflowWind_Subs
+    use InflowWind_Types
+
+    implicit none
+
+contains
+
+    @test
+    subroutine test_steady_wind_input_single_height()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData
+        CHARACTER(1024)                 :: PriPath 
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%WindType, 1)
+        @assertEqual(InputFileData%NWindVel, 1)
+        @assertEqual(InputFileData%WindVziList(1), 90)
+
+    end subroutine
+
+
+    @test
+    subroutine test_steady_wind_input_mult_heights()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData 
+        CHARACTER(1024)                 :: PriPath
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        InFileInfo%Lines(7:10) = (/ &
+            '          2   NWindVel       - Number of points to output the wind velocity    (0 to 9)                                                                        ', &
+            '        0,0   WindVxiList    - List of coordinates in the inertial X direction (m)                                                                             ', &
+            '        0,0   WindVyiList    - List of coordinates in the inertial Y direction (m)                                                                             ', &
+            '     80,100   WindVziList    - List of coordinates in the inertial Z direction (m)                                                                             ' &
+        /)
+
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%WindType, 1)
+        @assertEqual(InputFileData%NWindVel, 2)
+        @assertEqual(InputFileData%WindVziList(1), 80)
+        @assertEqual(InputFileData%WindVziList(2), 100)
+
+    end subroutine
+
+end module

--- a/modules/inflowwind/tests/test_turbsim_wind.F90
+++ b/modules/inflowwind/tests/test_turbsim_wind.F90
@@ -1,0 +1,34 @@
+module test_turbsim_wind
+
+    use pFUnit_mod
+    use ifw_test_tools
+    use InflowWind_Subs
+    use InflowWind_Types
+
+    implicit none
+
+contains
+
+    @test
+    subroutine test_steady_wind_input_single_height()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData
+        CHARACTER(1024)                 :: PriPath 
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        CHARACTER(16)                   :: expected
+
+        expected = "Wind/08ms.wnd"
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%TSFF_FileName, trim(expected))
+
+    end subroutine
+
+end module

--- a/modules/inflowwind/tests/test_uniform_wind.F90
+++ b/modules/inflowwind/tests/test_uniform_wind.F90
@@ -1,0 +1,99 @@
+module test_uniform_wind
+
+    use pFUnit_mod
+    use ifw_test_tools
+    use InflowWind
+    use InflowWind_Subs
+    use InflowWind_Types
+
+    implicit none
+
+contains
+
+    @test
+    subroutine test_uniform_wind_input()
+
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(InflowWind_InputFile)      :: InputFileData
+        CHARACTER(1024)                 :: PriPath 
+        INTEGER(IntKi)                  :: TmpErrStat
+        CHARACTER(ErrMsgLen)            :: TmpErrMsg
+
+        CHARACTER(16)                   :: expected
+
+        expected = "Wind/08ms.wnd"
+        PriPath = ""
+
+        InFileInfo = getInputFileData()
+        CALL InflowWind_ParseInputFileInfo(InputFileData , InFileInfo, PriPath, TmpErrStat, TmpErrMsg)
+
+        @assertEqual(TmpErrStat, 0)
+        @assertEqual(InputFileData%Uniform_FileName, trim(expected))
+        @assertEqual(InputFileData%Uniform_RefHt, 90)
+        @assertEqual(InputFileData%Uniform_RefLength, 125.88)
+
+    end subroutine
+
+    @test
+    subroutine test_uniform_wind_direct_data()
+
+            ! Types for setting up module
+        TYPE(InflowWind_InitInputType)                     :: InitInp           !< Input data for initialization
+        TYPE(InflowWind_InputType)                         :: InputGuess        !< An initial guess for the input; the input mesh must be defined
+        TYPE(InflowWind_ParameterType)                     :: p                 !< Parameters
+        TYPE(InflowWind_ContinuousStateType)               :: ContStates        !< Initial continuous states
+        TYPE(InflowWind_DiscreteStateType)                 :: DiscStates        !< Initial discrete states
+        TYPE(InflowWind_ConstraintStateType)               :: ConstrStateGuess  !< Initial guess of the constraint states
+        TYPE(InflowWind_OtherStateType)                    :: OtherStates       !< Initial other/optimization states
+        TYPE(InflowWind_OutputType)                        :: y                 !< Initial output (outputs are not calculated; only the output mesh is initialized)
+        TYPE(InflowWind_MiscVarType)                       :: m                 !< Misc variables for optimization (not copied in glue code)
+        REAL(DbKi)                                         :: TimeInterval      !< Coupling time interval in seconds: InflowWind does not change this.
+        TYPE(InflowWind_InitOutputType)                    :: InitOutData 
+
+            ! Variables for testing
+        INTEGER                         :: ErrStat
+        CHARACTER(ErrMsgLen)            :: ErrMsg
+        TYPE(FileInfoType)              :: InFileInfo
+        TYPE(FileInfoType)              :: WindType2Data
+        CHARACTER(1024), DIMENSION(6)   :: data = (/ &
+            '! Wind file for sheared 18 m/s wind with 30 degree direction.    ', &
+            '! Time Wind Wind  Vert. Horiz. Vert. LinV Gust                   ', &
+            '!      Speed Dir Speed Shear Shear Shear Speed                   ', &
+            ' 0.0 12.0 0.0 0.0 0.0 0.0 0.0 0.0                                ', &
+            ' 0.1 12.0 0.0 0.0 0.0 0.0 0.0 0.0                                ', &
+            ' 999.9 12.0 0.0 0.0 0.0 0.0 0.0 0.0                              ' &
+        /)
+
+            ! Error handling
+        INTEGER(IntKi)                                        :: TmpErrStat
+        CHARACTER(ErrMsgLen)                                  :: TmpErrMsg         !< temporary error message
+
+        InFileInfo = getInputFileDataWindType2()
+        CALL InitFileInfo(data, WindType2Data, ErrStat, ErrMsg)
+
+            ! Variable definitions
+        InitInp%InputFileName = ""
+        InitInp%NumWindPoints = 5
+        InitInp%UseInputFile = .FALSE.
+        InitInp%RootName = ""
+        InitInp%PassedFileData = InFileInfo
+        InitInp%WindType2UseInputFile = .FALSE.
+        InitInp%WindType2Data = WindType2Data
+
+        CALL InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, &
+                        ConstrStateGuess, OtherStates, y, m, TimeInterval, &
+                        InitOutData, TmpErrStat, TmpErrMsg)
+
+            ! Results
+
+        @assertEqual(0.0, p%UniformWind%TData(1))
+        @assertEqual(0.1, p%UniformWind%TData(2))
+        @assertEqual(999.9, p%UniformWind%TData(3))
+
+        @assertEqual(12.0, p%UniformWind%V(1))
+        @assertEqual(12.0, p%UniformWind%V(2))
+        @assertEqual(12.0, p%UniformWind%V(3))
+
+    end subroutine
+
+end module

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -72,8 +72,9 @@ endif()
 add_subdirectory("beamdyn")
 add_subdirectory("nwtc-library")
 add_subdirectory("aerodyn")
+add_subdirectory("inflowwind")
 
 add_custom_target(
   unit_tests
-  DEPENDS beamdyn_utest nwtc_library_utest fvw_utest
+  DEPENDS beamdyn_utest nwtc_library_utest fvw_utest inflowwind_utest
 )

--- a/unit_tests/inflowwind/CMakeLists.txt
+++ b/unit_tests/inflowwind/CMakeLists.txt
@@ -1,0 +1,67 @@
+#
+# Copyright 2017 National Renewable Energy Laboratory
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+set_source_files_properties(${pfunit_directory}/include/driver.F90 PROPERTIES GENERATED 1)
+
+set(module_name "inflowwind")
+set(module_directory "inflowwind")
+set(module_library "ifwlib")
+
+file(MAKE_DIRECTORY ${build_testdirectory}/${module_directory})
+file(WRITE ${build_testdirectory}/${module_directory}/testSuites.inc "")
+
+include_directories(
+  ${PROJECT_SOURCE_DIR}
+  ${pfunit_directory}/mod
+  ${build_testdirectory}/${module_directory}
+)
+
+set(testlist
+    ifw_test_tools
+    test_steady_wind
+    test_uniform_wind
+    test_turbsim_wind
+    test_bladed_wind
+    test_hawc_wind
+    test_outputs
+)
+foreach(test ${testlist})
+    set(test_dependency pfunit ${source_modulesdirectory}/${module_directory}/tests/${test}.F90)
+    add_custom_command(
+        OUTPUT ${build_testdirectory}/${module_directory}/${test}.F90
+        COMMAND ${PYTHON_EXECUTABLE} ${pfunit_directory}/bin/pFUnitParser.py ${source_modulesdirectory}/${module_directory}/tests/${test}.F90 ${build_testdirectory}/${module_directory}/${test}.F90
+        DEPENDS ${test_dependency}
+    )
+    set(test_sources ${test_sources} ${build_testdirectory}/${module_directory}/${test}.F90)
+    file(APPEND ${build_testdirectory}/${module_directory}/testSuites.inc "ADD_TEST_SUITE(${test}_suite)\n")
+endforeach()
+  
+add_executable(
+    ${module_name}_utest
+    ${pfunit_directory}/include/driver.F90
+    ${test_sources}
+)
+
+target_link_libraries(
+    ${module_name}_utest
+    ${pfunit_directory}${pfunit_lib}
+    ${module_library}
+)
+
+add_test(
+    ${module_name}_utest
+    ${PROJECT_BINARY_DIR}/${module_directory}/${module_name}_utest
+)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request uses the recently added infrastructure to NWTC Library to parse string arrays as inputs. The objective is to allow driver codes to instantiate the InflowWind module without an input file.

**Related issue, if one exists**
None

**Impacted areas of the software**
InflowWind

**Test results, if applicable**
GH Actions - unit tests are included