### PR TITLE
Vectorize a section of VariousWaves_Init

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -173,6 +173,22 @@ macro(set_fast_intel_fortran_posix)
   endif()
 
   check_f2008_features()
+
+  ### Intel profiling flags
+
+  # https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/compiler-option-details/optimization-report-options/qopt-report-qopt-report.html
+  # phases: vec, par, openmp
+  # set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} -qopt-report-phase=vec,openmp -qopt-report=5")
+  # set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} -qopt-report-routine=Create_Augmented_Ln2_Src_Mesh") # Create_Augmented_Ln2_Src_Mesh, Morison_CalcOutput, VariousWaves_Init
+
+  # https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/compiler-option-details/output-debug-and-precompiled-header-pch-options/debug-linux-and-macos.html
+  # set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} -debug all")
+  # set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} -debug inline-debug-info")
+
+  # Intel processor feature sets
+  # https://software.intel.com/content/www/us/en/develop/documentation/fortran-compiler-developer-guide-and-reference/top/compiler-reference/compiler-options/compiler-option-details/code-generation-options/xhost-qxhost.html
+  # set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} -xHOST")   # Use feature set for CPU used to compile
+  # set(CMAKE_Fortran_FLAGS_RELWITHDEBINFO "${CMAKE_Fortran_FLAGS_RELWITHDEBINFO} -xSKYLAKE-AVX512")   # Use Eagle processor feature set
 endmacro(set_fast_intel_fortran_posix)
 
 #

--- a/modules/hydrodyn/src/Waves.f90
+++ b/modules/hydrodyn/src/Waves.f90
@@ -1922,44 +1922,38 @@ SUBROUTINE VariousWaves_Init ( InitInp, InitOut, ErrStat, ErrMsg )
       !   the mean sea level are left unchanged; below the seabed or above the
       !   mean sea level, the wave kinematics are zero:
 
-        
-         DO I = 0,InitOut%NStepWave-1       ! Loop through all time steps
-            K = 1
-            DO J = 1,InitInp%NWaveKin      ! Loop through all points where the incident wave kinematics will be computed
-               
-               InitOut%PWaveDynP0(I,J  )  = 0.0 ! PWaveDynP0BPz0 (I,J)
-               InitOut%PWaveVel0 (I,J,1)  = 0.0 !PWaveVel0HxiPz0(I,J)
-               InitOut%PWaveVel0 (I,J,2)  = 0.0 !PWaveVel0HyiPz0(I,J)
-               InitOut%PWaveVel0 (I,J,3)  = 0.0 !PWaveVel0VPz0  (I,J)
-               InitOut%PWaveAcc0 (I,J,1)  = 0.0 !PWaveAcc0HxiPz0(I,J)
-               InitOut%PWaveAcc0 (I,J,2)  = 0.0 !PWaveAcc0HyiPz0(I,J)
-               InitOut%PWaveAcc0 (I,J,3)  = 0.0 !PWaveAcc0VPz0  (I,J)
-                  
-                  
-                  ! NOTE: We test to 0 instead of MSL2SWL because the locations of WaveKinzi and WtrDpth have already been adjusted using MSL2SWL
-               IF (   ( InitInp%WaveKinzi(J) < -InitInp%WtrDpth ) .OR. ( InitInp%WaveKinzi(J) > 0.0          ) )  THEN   ! .TRUE. if the elevation of the point defined by WaveKinzi(J) lies below the seabed or above mean sea level (exclusive)
+      InitOut%PWaveDynP0(:,:)   = 0.0
+      InitOut%PWaveVel0 (:,:,:) = 0.0
+      InitOut%PWaveVel0 (:,:,:) = 0.0
+      InitOut%PWaveVel0 (:,:,:) = 0.0
+      InitOut%PWaveAcc0 (:,:,:) = 0.0
+      InitOut%PWaveAcc0 (:,:,:) = 0.0
+      InitOut%PWaveAcc0 (:,:,:) = 0.0
+      K = 1
+      DO J = 1,InitInp%NWaveKin      ! Loop through all points where the incident wave kinematics will be computed
 
-                  InitOut%WaveDynP(I,J  )  = 0.0
-                  InitOut%WaveVel (I,J,:)  = 0.0
-                  InitOut%WaveAcc (I,J,:)  = 0.0        
+         IF (   ( InitInp%WaveKinzi(J) < -InitInp%WtrDpth ) .OR. ( InitInp%WaveKinzi(J) > 0.0 ) ) THEN
+            ! .TRUE. if the elevation of the point defined by WaveKinzi(J) lies below the seabed or above mean sea level (exclusive)
+            ! NOTE: We test to 0 instead of MSL2SWL because the locations of WaveKinzi and WtrDpth have already been adjusted using MSL2SWL
 
-               ELSE                                                                                 ! The elevation of the point defined by WaveKinzi(J) must lie between the seabed and the mean sea level (inclusive)
+            InitOut%WaveDynP(:,J  )  = 0.0
+            InitOut%WaveVel (:,J,:)  = 0.0
+            InitOut%WaveAcc (:,J,:)  = 0.0        
 
-                  InitOut%WaveDynP(I,J  )  = WaveDynP0B (I,K)
-                  InitOut%WaveVel (I,J,1)  = WaveVel0Hxi(I,K)
-                  InitOut%WaveVel (I,J,2)  = WaveVel0Hyi(I,K)
-                  InitOut%WaveVel (I,J,3)  = WaveVel0V  (I,K)
-                  InitOut%WaveAcc (I,J,1)  = WaveAcc0Hxi(I,K)
-                  InitOut%WaveAcc (I,J,2)  = WaveAcc0Hyi(I,K)
-                  InitOut%WaveAcc (I,J,3)  = WaveAcc0V  (I,K)
-                  
-                  K = K + 1
-               END IF
+         ELSE
+            ! The elevation of the point defined by WaveKinzi(J) must lie between the seabed and the mean sea level (inclusive)
 
-            END DO                   ! J - All points where the incident wave kinematics will be computed
+            InitOut%WaveDynP(:,J  ) = WaveDynP0B(:,K)
+            InitOut%WaveVel (:,J,1) = WaveVel0Hxi(:,K)
+            InitOut%WaveVel (:,J,2) = WaveVel0Hyi(:,K)
+            InitOut%WaveVel (:,J,3) = WaveVel0V(:,K)
+            InitOut%WaveAcc (:,J,1)  = WaveAcc0Hxi(:,K)
+            InitOut%WaveAcc (:,J,2)  = WaveAcc0Hyi(:,K)
+            InitOut%WaveAcc (:,J,3)  = WaveAcc0V(:,K)
+            K = K + 1
+         END IF
 
-         END DO                      ! I - All time steps
-
+      END DO                   ! J - All points where the incident wave kinematics will be computed
 
     !  CASE ( 1 )                 ! Vertical stretching.
 

--- a/modules/hydrodyn/src/Waves.f90
+++ b/modules/hydrodyn/src/Waves.f90
@@ -1924,10 +1924,6 @@ SUBROUTINE VariousWaves_Init ( InitInp, InitOut, ErrStat, ErrMsg )
 
       InitOut%PWaveDynP0(:,:)   = 0.0
       InitOut%PWaveVel0 (:,:,:) = 0.0
-      InitOut%PWaveVel0 (:,:,:) = 0.0
-      InitOut%PWaveVel0 (:,:,:) = 0.0
-      InitOut%PWaveAcc0 (:,:,:) = 0.0
-      InitOut%PWaveAcc0 (:,:,:) = 0.0
       InitOut%PWaveAcc0 (:,:,:) = 0.0
       K = 1
       DO J = 1,InitInp%NWaveKin      ! Loop through all points where the incident wave kinematics will be computed
@@ -1947,9 +1943,9 @@ SUBROUTINE VariousWaves_Init ( InitInp, InitOut, ErrStat, ErrMsg )
             InitOut%WaveVel (:,J,1) = WaveVel0Hxi(:,K)
             InitOut%WaveVel (:,J,2) = WaveVel0Hyi(:,K)
             InitOut%WaveVel (:,J,3) = WaveVel0V(:,K)
-            InitOut%WaveAcc (:,J,1)  = WaveAcc0Hxi(:,K)
-            InitOut%WaveAcc (:,J,2)  = WaveAcc0Hyi(:,K)
-            InitOut%WaveAcc (:,J,3)  = WaveAcc0V(:,K)
+            InitOut%WaveAcc (:,J,1) = WaveAcc0Hxi(:,K)
+            InitOut%WaveAcc (:,J,2) = WaveAcc0Hyi(:,K)
+            InitOut%WaveAcc (:,J,3) = WaveAcc0V(:,K)
             K = K + 1
          END IF
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request improves the vectorization potential of a set of initialization lines in the Waves submodule of HydroDyn. This is relatively small performance improvement as it saves only about 3 seconds of initialization time in the offshore 5MW cases. Its also a fixed-cost improvement since it is in the init; that is, the speed up is similar whether the simulation duration is 60 seconds or 1 second. In any case, faster is faster :)

I've also added commented flags for getting profiling and performance information from the Intel compiler in the CMake configuration. See the attached optimization reports for details regarding the vectorization improvements by the compiler due to this change. These are best viewed as a side-by-side diff.

One question is whether the bounds of the loop are meaningful in the current version. The outer loop goes from 0 to `InitOut%NStepWave-1`, but all of the variables accessed in the loop are allocated to `0:InitOut%NStepWave` in their first dimension. Is the last index of the first dimension required to be empty or uninitialized?

**Related issue, if one exists**
None

**Impacted areas of the software**
Waves submodule of HydroDyn: `VariousWave_Init` subroutine

**Additional supporting information**
This was funded by Intel through their designation of NREL as an Intel Parallel Computing Center (IPCC). The objective was to improve the vectorization of the offshore module by using the Intel compiler and related tools. We wanted to get as much speed up as possible without making significant changed to the OpenFAST source code.

[current_Waves.f90.optrpt.log](https://github.com/OpenFAST/openfast/files/5591450/current_Waves.f90.optrpt.log)
[incoming_Waves.f90.optrpt.log](https://github.com/OpenFAST/openfast/files/5591537/incoming_Waves.f90.optrpt.log)
