### PR TITLE
Fix compiler error: switch arguments

### DIFF
--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -3365,8 +3365,8 @@ END SUBROUTINE CheckR16Var
       TYPE (FileInfoType), INTENT(IN)             :: FileInfo                      !< The derived type for holding the file information.
       INTEGER(IntKi),      INTENT(INOUT)          :: LineNum                       !< The number of the line to parse.
       CHARACTER(*),        INTENT(IN)             :: AryName                       !< The array name we are trying to fill.
-      CHARACTER(*),        INTENT(OUT)            :: Ary(AryLen)                   !< The array to receive the input values.
       INTEGER,             INTENT(IN)             :: AryLen                        !< The length of the array to parse.
+      CHARACTER(*),        INTENT(OUT)            :: Ary(AryLen)                   !< The array to receive the input values.
       INTEGER(IntKi),      INTENT(OUT)            :: ErrStat                       !< The error status.
       CHARACTER(*),        INTENT(OUT)            :: ErrMsg                        !< The error message, if ErrStat /= 0.
       INTEGER,             INTENT(IN), OPTIONAL   :: UnEc                          !< I/O unit for echo file. If present and > 0, write to UnEc.

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -3362,10 +3362,10 @@ END SUBROUTINE CheckR16Var
 
          ! Arguments declarations.
 
+      INTEGER,             INTENT(IN)             :: AryLen                        !< The length of the array to parse.
       TYPE (FileInfoType), INTENT(IN)             :: FileInfo                      !< The derived type for holding the file information.
       INTEGER(IntKi),      INTENT(INOUT)          :: LineNum                       !< The number of the line to parse.
       CHARACTER(*),        INTENT(IN)             :: AryName                       !< The array name we are trying to fill.
-      INTEGER,             INTENT(IN)             :: AryLen                        !< The length of the array to parse.
       CHARACTER(*),        INTENT(OUT)            :: Ary(AryLen)                   !< The array to receive the input values.
       INTEGER(IntKi),      INTENT(OUT)            :: ErrStat                       !< The error status.
       CHARACTER(*),        INTENT(OUT)            :: ErrMsg                        !< The error message, if ErrStat /= 0.


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
On my Mac with Intel Fortran compiler 19.1.2.258 20200623, I get this error when compiling `nwtclibs` on the dev branch:

```
Scanning dependencies of target nwtclibs
[  1%] Building Fortran object modules/nwtc-library/CMakeFiles/nwtclibs.dir/src/SingPrec.f90.o
[  1%] Building Fortran object modules/nwtc-library/CMakeFiles/nwtclibs.dir/src/NWTC_Base.f90.o
[  1%] Building Fortran object modules/nwtc-library/CMakeFiles/nwtclibs.dir/src/SysIFL.f90.o
[  1%] Building Fortran object modules/nwtc-library/CMakeFiles/nwtclibs.dir/src/NWTC_Library_Types.f90.o
[  2%] Building Fortran object modules/nwtc-library/CMakeFiles/nwtclibs.dir/src/NWTC_IO.f90.o
/Users/rmudafor/Development/openfast/modules/nwtc-library/src/NWTC_IO.f90(3369): error #6415: This name cannot be assigned this data type because it conflicts with prior uses of the name.   [ARYLEN]
      INTEGER,             INTENT(IN)             :: AryLen                        !< The length of the array to parse.
-----------------------------------------------------^
compilation aborted for /Users/rmudafor/Development/openfast/modules/nwtc-library/src/NWTC_IO.f90 (code 1)
make[2]: *** [modules/nwtc-library/CMakeFiles/nwtclibs.dir/src/NWTC_IO.f90.o] Error 1
make[1]: *** [modules/nwtc-library/CMakeFiles/nwtclibs.dir/all] Error 2
make: *** [all] Error 2
```

I think this is due to to the subroutine using an intent-in variable, `AryLen`, before it is declared:


```
   SUBROUTINE ParseChAry ( FileInfo, LineNum, AryName, Ary, AryLen, ErrStat, ErrMsg, UnEc )

         ! Arguments declarations.

      TYPE (FileInfoType), INTENT(IN)             :: FileInfo                      !< The derived type for holding the file information.
      INTEGER(IntKi),      INTENT(INOUT)          :: LineNum                       !< The number of the line to parse.
      CHARACTER(*),        INTENT(IN)             :: AryName                       !< The array name we are trying to fill.
      CHARACTER(*),        INTENT(OUT)            :: Ary(AryLen)                   !< The array to receive the input values.
      INTEGER,             INTENT(IN)             :: AryLen                        !< The length of the array to parse.
      INTEGER(IntKi),      INTENT(OUT)            :: ErrStat                       !< The error status.
      CHARACTER(*),        INTENT(OUT)            :: ErrMsg                        !< The error message, if ErrStat /= 0.
      INTEGER,             INTENT(IN), OPTIONAL   :: UnEc                          !< I/O unit for echo file. If present and > 0, write to UnEc.

```

Simply swapping `AryLen` and `Ary` declarations allows ifort to continue.

**Related issue, if one exists**
None.

**Impacted areas of the software**
Compiling with Intel Fortran 19 on macOS.

**Additional supporting information**
Unfortunately, we cannot easily add a test to capture this since we can't easily configure the CI to use the Intel compiler.
