### PR TITLE
Use Intel 2021 Toolset for regression test

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -158,7 +158,11 @@ macro(set_fast_intel_fortran_posix)
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DOPENFAST_DOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double_size 128")
+    if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER "19")
+      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double-size 128")
+    else()
+      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -r8 -double_size 128")
+    endif()
   endif (DOUBLE_PRECISION)
 
   # debug flags
@@ -204,7 +208,11 @@ macro(set_fast_intel_fortran_windows)
   # Deal with Double/Single precision
   if (DOUBLE_PRECISION)
     add_definitions(-DOPENFAST_DOUBLE_PRECISION)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /real_size:64 /double_size:128")
+    if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER "19")
+      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /real-size:64 /double-size:128")
+    else()
+      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} /real_size:64 /double_size:128")
+    endif()
   endif (DOUBLE_PRECISION)
 
   # increase the default 2MB stack size to 16 MB

--- a/modules/aerodyn/src/FVW_Wings.f90
+++ b/modules/aerodyn/src/FVW_Wings.f90
@@ -175,9 +175,13 @@ contains
             DP1                   = P6-P8
             DP2                   = P10-P9
             DP3                   = P7-P5
+
+            ! NOTE: The denominator below has seg-faulted with Intel Fortran in Release mode, possibly due to nuances in copmiler optimizations.
+            !       This code was previously after the m%Norm calculations, but moving it up "fixes" the bug.
+            m%Tang(1:3,iSpan,iW)  = (DP1)/TwoNorm(DP1)                       ! tangential unit vector, along chord
+
             m%Norm(1:3,iSpan,iW)  = cross_product(DP1,DP2)
             m%Norm(1:3,iSpan,iW)  = m%Norm(1:3,iSpan,iW)/TwoNorm(m%Norm(1:3,iSpan,iW))
-            m%Tang(1:3,iSpan,iW)  = (DP1)/TwoNorm(DP1)                       ! tangential unit vector, along chord
             ! m%Tscoord(1:3,iSpan) = (DP3)/norm2(DP3)                      ! tangential unit vector, along span, follows ref line
             m%dl  (1:3,iSpan,iW)  = DP2
             m%Orth(1:3,iSpan,iW)  = cross_product(m%Norm(1:3,iSpan,iW),m%Tang(1:3,iSpan,iW)) ! orthogonal vector to N and T

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -164,6 +164,9 @@ if not noExec:
 
 ### Get a list of all the files in the baseline directory
 baselineOutFiles = os.listdir(targetOutputDirectory)
+# Drop the log file, if its listed
+if caseName + '.log' in baselineOutFiles:
+    baselineOutFiles.remove(caseName + '.log')
 
 # these should all exist in the local outputs directory
 localFiles = os.listdir(testBuildDirectory)

--- a/reg_tests/manualRegressionTest.py
+++ b/reg_tests/manualRegressionTest.py
@@ -65,14 +65,20 @@ if case != "":
 else:
     with open(os.path.join("r-test", "glue-codes", "openfast", "CaseList.md")) as listfile:
         caselist = listfile.readlines()
+# allow comments with '#'
 casenames = [c.rstrip("\n\r").strip() for c in caselist if "#" not in c]
+# allow empty lines
+casenames = [c for c in casenames if len(c.strip()) > 0]
 
 results = []
 prefix, passString, failString = "executing", "PASS", "FAIL"
 longestName = max(casenames, key=len)
 for case in casenames:
     print(strFormat(prefix).format(prefix), strFormat(longestName+" ").format(case), end="", flush=True)
-    command = "\"{}\" executeOpenfastRegressionCase.py {} {} {} {} {} {} {} {} {}".format(pythonCommand, case, openfast_executable, sourceDirectory, buildDirectory, tolerance, machine, compiler, plotFlag, noExecFlag)
+    if "linear" in case.lower():
+        command = "\"{}\" executeOpenfastLinearRegressionCase.py {} {} {} {} {} {} {} {} {}".format(pythonCommand, case, openfast_executable, sourceDirectory, buildDirectory, tolerance, machine, compiler, plotFlag, noExecFlag)
+    else:
+        command = "\"{}\" executeOpenfastRegressionCase.py {} {} {} {} {} {} {} {} {}".format(pythonCommand, case, openfast_executable, sourceDirectory, buildDirectory, tolerance, machine, compiler, plotFlag, noExecFlag)
     returnCode = subprocess.call(command, stdout=outstd, shell=True)
     resultString = passString if returnCode == 0 else failString
     results.append((case, resultString))


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This updates the regression test baseline solutions to use the latest Intel compiler.

**Related issue, if one exists**
None.

**Impacted areas of the software**
Regression test baselines.

**Additional supporting information**
This update makes the life of anyone maintaining the baselines easier since the new Intel toolset is freely available. This will also enable adding an Intel compiler branch in the existing test matrix.
