### PR TITLE
Big fix in NWTC Library unit tests

### DIFF
--- a/modules/nwtc-library/tests/NWTC_Library_test_tools.F90
+++ b/modules/nwtc-library/tests/NWTC_Library_test_tools.F90
@@ -1,0 +1,27 @@
+module nwtc_library_test_tools
+
+use NWTC_IO
+
+implicit none
+
+#ifdef _WIN32
+    character(9), parameter :: nullfile="NUL"
+    character(11), parameter :: terminal="CON"
+#else
+    character(9), parameter :: nullfile="/dev/null"
+    character(11), parameter :: terminal="/dev/stdout"
+#endif
+
+integer, parameter :: stdout=CU
+
+contains
+
+subroutine hide_terminal_output()
+    open(unit=stdout, file=trim(nullfile))
+end subroutine
+
+subroutine show_terminal_output()
+    open(unit=stdout, file=terminal, status="old")
+end subroutine
+
+end module

--- a/modules/nwtc-library/tests/test_NWTC_IO_CheckArgs.F90
+++ b/modules/nwtc-library/tests/test_NWTC_IO_CheckArgs.F90
@@ -2,12 +2,9 @@ module test_NWTC_IO_CheckArgs
 
     use pFUnit_mod
     use NWTC_IO
+    use nwtc_library_test_tools
     
     implicit none
-
-    integer, parameter :: stdout=6
-    character(9), parameter :: nullfile="/dev/null"
-    character(11), parameter :: terminal="/dev/stdout"
 
 contains
 
@@ -31,9 +28,9 @@ contains
         argument_array = (/      &
             "first_arg.txt   "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -52,9 +49,9 @@ contains
 
         filename = "default.txt"
         allocate(argument_array(0))
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "default.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -74,9 +71,9 @@ contains
         argument_array = (/      &
             "first_arg.txt   "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -105,9 +102,9 @@ contains
             "first_arg.txt   ",  &
             "second_arg      "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "second_arg", second_argument )
@@ -131,9 +128,9 @@ contains
             "-restart        ",  &
             "second_arg      "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "second_arg", second_argument )
@@ -156,9 +153,9 @@ contains
             "-restart        ",  &
             "first_arg.txt   "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "first_arg.txt", second_argument )
@@ -185,9 +182,9 @@ contains
             "first_arg.txt   ",  &
             "second_arg      "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "second_arg", second_argument )
@@ -214,9 +211,9 @@ contains
             "-h              ",  &
             "first_arg.txt   "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -239,9 +236,9 @@ contains
             "first_arg.txt   ",  &
             "-h              "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -268,9 +265,9 @@ contains
             "-v              ",  &
             "first_arg.txt   "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -293,9 +290,9 @@ contains
             "first_arg.txt   ",  &
             "-VERSION        "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 0, error_status )
         @assertEqual( "", second_argument )
@@ -317,9 +314,9 @@ contains
 
         filename = ""
         allocate(argument_array(0))
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "", filename )
         @assertEqual( 4, error_status )
         @assertEqual( "", second_argument )
@@ -343,9 +340,9 @@ contains
             "first_arg.txt   ",  &
             "-flag           "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "first_arg.txt", filename )
         @assertEqual( 4, error_status )
         @assertEqual( "", second_argument )
@@ -368,9 +365,9 @@ contains
         argument_array = (/      &
             "-restart        "   &
         /)
-        open(unit=stdout, file=nullfile, status="old")
+        call hide_terminal_output()
         call CheckArgs( filename, error_status, second_argument, flag, argument_array )
-        open(unit=stdout, file=terminal, status="old")
+        call show_terminal_output()
         @assertEqual( "", filename )
         @assertEqual( 4, error_status )
         @assertEqual( "", second_argument )

--- a/modules/nwtc-library/tests/test_NWTC_RandomNumber.F90
+++ b/modules/nwtc-library/tests/test_NWTC_RandomNumber.F90
@@ -2,12 +2,11 @@ module test_NWTC_RandomNumber
 
     use pFUnit_mod
     use NWTC_RandomNumber
+    use nwtc_library_test_tools
     
     implicit none
 
-    integer, parameter :: stdout=6
-    character(9), parameter :: nullfile="/dev/null"
-    character(11), parameter :: terminal="/dev/stdout"
+    character(1024), parameter :: dumpfile="randnumber.temp"
 
 contains
     
@@ -45,9 +44,9 @@ subroutine test_INTRINSIC()
     p%RandSeed(1) = 1
     p%RandSeed(2) = 2
 
-    open(unit=stdout, file=nullfile, status="old")
+    call hide_terminal_output()
     call RandNum_Init(p, error_status, error_message)
-    open(unit=stdout, file=terminal, status="old")
+    call show_terminal_output()
     @assertEqual( 0, error_status )
 
     ! We cant use this test since it will fail for various machine/compiler combinations

--- a/unit_tests/nwtc-library/CMakeLists.txt
+++ b/unit_tests/nwtc-library/CMakeLists.txt
@@ -31,6 +31,7 @@ include_directories(
 )
 
 set(testlist
+    NWTC_Library_test_tools
     test_NWTC_IO_CheckArgs
     test_NWTC_IO_FileInfo
     test_NWTC_RandomNumber


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
The NWTC Library unit tests have a feature to pipe output to `/dev/null/` for Unix, but this of course does not work well with Windows. This pull request pipes the output to `NUL` in Windows and brings it back to `CON` when it would otherwise go to `/dev/stdout`.