### PR TITLE
Bug fix for regression tests without C++ API enabled

### DIFF
--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -37,8 +37,10 @@ option(CTEST_PLOT_ERRORS "Generate plots of regression test errors." OFF)
 # Set the OpenFAST executable configuration option and default
 set(CTEST_OPENFAST_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/openfast/openfast" CACHE FILEPATH "Specify the OpenFAST executable to use in testing.")
 
-# Set the OpenFAST executable configuration option and default
-set(CTEST_OPENFASTCPP_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/openfast-cpp/openfastcpp" CACHE FILEPATH "Specify the OpenFAST C++ executable to use in testing.")
+if(BUILD_OPENFAST_CPP_API)
+  # Set the OpenFAST executable configuration option and default
+  set(CTEST_OPENFASTCPP_EXECUTABLE "${CMAKE_BINARY_DIR}/glue-codes/openfast-cpp/openfastcpp" CACHE FILEPATH "Specify the OpenFAST C++ executable to use in testing.")
+endif()
 
 # Set the AeroDyn executable configuration option and default
 set(CTEST_AERODYN_EXECUTABLE "${CMAKE_BINARY_DIR}/modules/aerodyn/aerodyn_driver" CACHE FILEPATH "Specify the AeroDyn driver executable to use in testing.")

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -165,7 +165,9 @@ of_regression("EllipticalWing_OLAF"                    "openfast;aerodyn15;olaf"
 of_regression("StC_test_OC4Semi"                       "openfast;servodyn;hydrodyn;moordyn;offshore")
 
 # OpenFAST C++ API test
-of_regression_cpp("5MW_Land_DLL_WTurb_cpp" "openfast;cpp")
+if(BUILD_OPENFAST_CPP_API)
+  of_regression_cpp("5MW_Land_DLL_WTurb_cpp" "openfast;cpp")
+endif()
 
 # AeroAcoustic regression test
 of_regression_aeroacoustic("IEA_LB_RWT-AeroAcoustics"  "openfast;aerodyn15;aeroacoustics")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Currently, the test list in CTest includes the C++ API regression test even if the C++ API is not configured to be built with CMake. Therefore, when building only OpenFAST and running `ctest` (no additional arguments), CTest attempt to run the C++ API test but fails since it is not compiled.

**Impacted areas of the software**
Regression tests
