### PR TITLE
[BugFix] incorrect pitch/roll moments on tapered elements crossing water line

### DIFF
--- a/modules/hydrodyn/src/Morison.f90
+++ b/modules/hydrodyn/src/Morison.f90
@@ -2687,7 +2687,7 @@ SUBROUTINE Morison_CalcOutput( Time, u, p, x, xd, z, OtherState, y, m, errStat, 
          z2      = pos2(3)
          r1      = mem%RMG(i  )                         ! outer radius element nodes including marine growth
          r2      = mem%RMG(i+1)
-         dRdl_mg = mem%dRdl_mg(i)                                    ! mass of element including marine growth
+         dRdl_mg = mem%dRdl_mg(i)                                    ! Taper of element including marine growth
          a_s1    = u%Mesh%TranslationAcc(:, mem%NodeIndx(i  ))
          alpha_s1= u%Mesh%RotationAcc   (:, mem%NodeIndx(i  ))
          omega_s1= u%Mesh%RotationVel   (:, mem%NodeIndx(i  ))
@@ -2816,7 +2816,7 @@ SUBROUTINE Morison_CalcOutput( Time, u, p, x, xd, z, OtherState, y, m, errStat, 
                      a0   = rh/((C_1)*cosPhi)             ! simplified from what's in ConicalCalcs.ipynb
                      a0b0 = a0*b0
                      C_2  = a0b0*rh*cosPhi - r1**3
-                     cl   = (0.75*a0b0*r1**2*cosPhi + 0.75*r1**4*C_1 + r1*C_1*C_2) / (dRdl_mg*C_1*C_2)
+                     cl   = -(-0.75*a0b0*rh**2*cosPhi + 0.75*r1**4*C_1 + r1*C_1*C_2) / (dRdl_mg*C_1*C_2)
                      cr   = (0.75*a0b0*dRdl_mg*rh**2*sinPhi)/(C_1*C_2)
                      cx   = cr*cosPhi + cl*sinPhi 
                      Vs   = pi*(a0b0*rh*cosPhi - r1**3)/(3.0*dRdl_mg)       

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -197,6 +197,7 @@ hd_regression("hd_5MW_ITIBarge_DLL_WTurb_WavesIrr"          "hydrodyn;offshore")
 hd_regression("hd_5MW_OC3Spar_DLL_WTurb_WavesIrr"           "hydrodyn;offshore")
 hd_regression("hd_5MW_OC4Semi_WSt_WavesWN"                  "hydrodyn;offshore")
 hd_regression("hd_5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti"    "hydrodyn;offshore")
+hd_regression("hd_TaperCylinderPitchMoment"                 "hydrodyn;offshore")
 
 # SubDyn regression tests
 sd_regression("SD_Cable_5Joints"                              "subdyn;offshore")


### PR DESCRIPTION
** This pull request is ready to be merged**


<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**

There were two negative signs missing in the calculation of the centroid for tapered members crossing the still water line, and one incorrect variable name.  The negative signs were missing in the original implementation plan.

**Related issue, if one exists**
This had been reported by a collaborator on an ARPA-E ATLANTIS project.

**Impacted areas of the software**
HydroDyn module.  Only tapered members crossing the still water surface are affected

**Additional supporting information**

**Test results, if applicable**
Added a very simple test case of a tapered cylinder (0.1m taper over 40 m) with a prescribed pitch motion.

Original results showing pitching moment that was way too large:
![hd_taper_HydroMyi--orig](https://user-images.githubusercontent.com/2745453/111804560-cf0a5e80-8895-11eb-8f95-3945ac84cfcd.png)

Corrected results in this PR:
![hd_taper_HydroMyi--corrected](https://user-images.githubusercontent.com/2745453/111804639-e0536b00-8895-11eb-8f4b-697ebe3ee409.png)
