### PR TITLE
Enable types generation in CI

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -121,6 +121,7 @@ jobs:
   compile-all-single-precision:
     # Test if single precision compile completes.
     # Compiles all targets excluding tests.
+    # Run with the OpenFAST registry generating the types files.
     # Do not run the test suite.
 
     runs-on: ubuntu-20.04
@@ -139,6 +140,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_BUILD_TYPE:STRING=Debug \
             -DDOUBLE_PRECISION:BOOL=OFF \
+            -DGENERATE_TYPES:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Build all
         working-directory: ${{runner.workspace}}/build


### PR DESCRIPTION
**Feature or improvement description**
This pull request configures OpenFAST to build the OpenFAST Registry and use it to generate the types-files used throughout OpenFAST. Currently, the OpenFAST Registry is not tested in the automated system.

**Related issue, if one exists**
None.

**Impacted areas of the software**
GitHub Actions

**Additional supporting information**
I chose to add this test to the single precision compile test in order to allow developers to commit changes to the types-files and use the automated regression test as a tool to check the results. If this change were added to other GitHub Actions tests, users would be required to use the registry in their development workflow while changing types-files. I find it much simpler to make changes to the Fortran types-files directly while and then regenerate the types with the registry before submitting the pull request.
