### PR TITLE
[BugFix] Rename Structural Control driver program

### DIFF
--- a/modules/servodyn/CMakeLists.txt
+++ b/modules/servodyn/CMakeLists.txt
@@ -37,10 +37,11 @@ target_link_libraries(servodynlib nwtclibs)
 add_executable(servodyn_driver src/ServoDyn_Driver.f90)
 target_link_libraries(servodyn_driver servodynlib nwtclibs ${CMAKE_DL_LIBS})
 
-add_executable(strucctrl_driver src/StrucCtrl_Driver.f90)
-target_link_libraries(strucctrl_driver servodynlib nwtclibs ${CMAKE_DL_LIBS})
+# The Structural Control driver is currently not functional, so commenting this temporarily
+# add_executable(strucctrl_driver src/StrucCtrl_Driver.f90)
+# target_link_libraries(strucctrl_driver servodynlib nwtclibs ${CMAKE_DL_LIBS})
 
-install(TARGETS servodynlib servodyn_driver strucctrl_driver
+install(TARGETS servodynlib servodyn_driver # strucctrl_driver
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib

--- a/modules/servodyn/src/StrucCtrl_Driver.f90
+++ b/modules/servodyn/src/StrucCtrl_Driver.f90
@@ -644,7 +644,7 @@ END SUBROUTINE StC_WriteOutputFile
 
 end module read_file_module 
 
-PROGRAM StrucCtrl
+PROGRAM StrucCtrl_Driver
     
     USE NWTC_Library
     USE StrucCtrl
@@ -919,4 +919,4 @@ CALL StC_CloseOutputFile(UnOut)
         CALL WrScr( ErrMsg )
     END IF
     
-END PROGRAM StrucCtrl
+END PROGRAM StrucCtrl_Driver


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Fixes an issue where the Intel Fortran compiler could not compile the Structural Control driver code since the Program name was the same as a module it imports.

**Related issue, if one exists**
None

**Impacted areas of the software**
Structural Control driver

**Additional supporting information**
We've also disabled it from CMake. According to @andrew-platt this code is not yet fully functional and will be updated in future work.

**Test results, if applicable**
None. Though Intel tests in the CI are coming soon.
