### PR TITLE
Disallow building with shared libraries and MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,6 +74,13 @@ else()
 endif()
 
 ########################################################################
+# Validate CMake configuration
+#
+if(BUILD_SHARED_LIBS AND MSVC)
+  message(FATAL_ERROR "Shared libraries are not support by OpenFAST with the MSVC build tool (https://github.com/OpenFAST/openfast/issues/448).")
+endif()
+
+########################################################################
 # Build rules for OpenFAST Registry
 #
 if(GENERATE_TYPES)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull requests disallows building with shared libraries while using the MSVC build tool.

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/448

**Impacted areas of the software**
CMake on Windows with MSVC

**Additional supporting information**
~Not tested!~

**Test results, if applicable**
~Not tested!~

Update 5/12/2021: I've verified that with `BUILD_SHARED_LIBS=ON`, the build system (tested with NMake) cannot find the required `.libs` that should accompany a `.dll`. I've also verified that the error message in this pull request prevents the configuration when using MSVC and `BUILD_SHARED_LIBS=ON`. The MSVC CMake variable is True even when using all Intel compilers. 