### PR TITLE
Simulink

### DIFF
--- a/glue-codes/simulink/examples/Run_OpenLoop.m
+++ b/glue-codes/simulink/examples/Run_OpenLoop.m
@@ -6,7 +6,7 @@
 % addpath(genpath('../../../install')); % cmake default install location
 
 % these variables are defined in the OpenLoop model's FAST_SFunc block:
-FAST_InputFileName = '../../../reg_tests/r-test/glue-codes/openfast/5MW_Land_DLL_WTurb/5MW_Land_DLL_WTurb.fst';
+FAST_InputFileName = '../../../reg_tests/r-test/glue-codes/openfast/AOC_WSt/AOC_WSt.fst';
 TMax               = 60; % seconds
 
 sim('OpenLoop.mdl',[0,TMax]);

--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -134,7 +134,7 @@ subroutine FAST_Sizes(iTurb, TMax, InitInpAry, InputFileName_c, AbortErrLev_c, N
    CALL FAST_InitializeAll_T( t_initial, 1_IntKi, Turbine(iTurb), ErrStat, ErrMsg, InputFileName, ExternInitData )
                   
    AbortErrLev_c = AbortErrLev   
-   NumOuts_c     = min(MAXOUTPUTS, 1 + SUM( Turbine(iTurb)%y_FAST%numOuts )) ! includes time
+   NumOuts_c     = min(MAXOUTPUTS, SUM( Turbine(iTurb)%y_FAST%numOuts ))
    dt_c          = Turbine(iTurb)%p_FAST%dt
 
    ErrStat_c     = ErrStat


### PR DESCRIPTION
**Feature or improvement description**
This fixes an issue where the Simulink interface assumed channel names being passed did not include the time channel. This was likely introduced when Envision gave NREL code that contained changes for the upcoming steady-state solver.

**Related issue, if one exists**
Fixes "size of NumOutputs is invalid" errors in #692 and #695

**Impacted areas of the software**
Simulink interface

**Test results, if applicable**
There are no regression tests for the Simulink interface, so this error was not caught and will not change any other results.
