### PR TITLE
[BugFix] unallocated AD%y%Rotors when AD14 is used with cpp interface

### DIFF
--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -214,7 +214,7 @@ subroutine FAST_Start(iTurb, NumInputs_c, NumOutputs_c, InputAry, OutputAry, Err
          OutputAry(1)              = Turbine(iTurb)%m_FAST%t_global 
          OutputAry(2:NumOutputs_c) = Outputs 
 
-         CALL FAST_Linearize_T(t_initial, 0, Turbine(iTurb), ErrStat, ErrMsg)
+         CALL FAST_Linearize_T(t_initial, 0, Turbine(iTurb), ErrStat2, ErrMsg2)
          if (ErrStat2 /= ErrID_None) then
             ErrStat = max(ErrStat,ErrStat2)
             ErrMsg = TRIM(ErrMsg)//NewLine//TRIM(ErrMsg2)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -4954,9 +4954,11 @@ SUBROUTINE FillOutputAry(p_FAST, y_FAST, IfWOutput, OpFMOutput, EDOutput, y_AD, 
       
       IF ( y_FAST%numOuts(Module_AD) > 0 ) THEN
          do i=1,SIZE(y_AD%Rotors)
-            indxLast = indxNext + SIZE(y_AD%Rotors(i)%WriteOutput) - 1
-            OutputAry(indxNext:indxLast) = y_AD%Rotors(i)%WriteOutput
-            indxNext = IndxLast + 1
+            if (allocated(y_AD%Rotors(i)%WriteOutput)) then
+               indxLast = indxNext + SIZE(y_AD%Rotors(i)%WriteOutput) - 1
+               OutputAry(indxNext:indxLast) = y_AD%Rotors(i)%WriteOutput
+               indxNext = IndxLast + 1
+            endif
          end do         
       END IF            
          


### PR DESCRIPTION
When using the cpp interface with AD14, the `FillOutputAry_T` routine tried to pass `Turbine(iTurb)%AD%y%Rotors(1)` to `FillOutputAry`, but the `AD%y%Rotors` was not allocated.  This bug was introduced with PR #672.

The logic within `FillOutputAry` and the variables passed into it have been modified somewhat similarly to how BeamDyn and IceDyn outputs are handled.

NOTE: this set of routines is only called from the FAST_Library, so this issue would only appear with the cpp interface when AD14 is used (I only know of one Simulink example case that this would affect)

*This PR is ready to merge*


The example Simulink case `Run_Test01_SIG.m` used AD14 with Simulink.  A segmentation fault occurred with this example case (this case is not included in the regression tests).

Close #692