### PR TITLE
Automate incrementing the dev-label conda build

### DIFF
--- a/.github/actions/utils/increment_conda_build.py
+++ b/.github/actions/utils/increment_conda_build.py
@@ -1,0 +1,35 @@
+
+from shutil import copyfile
+
+# Open existing meta.yaml and another one
+metayaml = open('meta.yaml')
+outyaml = open('out.yaml', 'w')
+
+# Find the build number, increment it, and write to the new yaml
+found = False
+for line in metayaml:
+    if "number:" in line:
+        found = True
+        # For the line containing the build number, parse the number and increment
+        elements = [e.strip() for e in line.split(":")]
+        if not elements[1].isnumeric():
+            raise ValueError("Build number is not parsable: {}".format(line))
+
+        old_build_number = int(elements[1])
+        new_build_number = old_build_number + 1
+
+        # Write new build number to new yaml
+        outyaml.write(line.replace(str(old_build_number), str(new_build_number)))
+    else:
+        # Write all other lines to new yaml
+        outyaml.write(line)
+
+if not found:
+    raise Exception("Error incrementing the build number.")
+
+# Clean up
+metayaml.close()
+outyaml.close()
+
+# Replace original meta.yaml with the new one
+copyfile('out.yaml', 'meta.yaml')

--- a/.github/workflows/conda-deploy.yml
+++ b/.github/workflows/conda-deploy.yml
@@ -1,0 +1,46 @@
+
+name: 'Conda Deployment Pipeline'
+
+on:
+  push:
+    paths-ignore:
+      - 'docs/**'
+      - 'share/**'
+      - 'vs-build/**'
+    branches:
+      - 'dev'
+
+jobs:
+  update-dev:
+    runs-on: ubuntu-20.04
+    steps:
+      # - name: Echo path
+      #   run: |
+      #     echo ${{runner.workspace}} # /home/runner/work/openfast
+      #     echo $GITHUB_WORKSPACE     # /home/runner/work/openfast/openfast
+      - name: Checkout OpenFAST/dev
+        uses: actions/checkout@main
+        with:
+          path: ${{runner.workspace}}/openfast
+          ref: dev
+
+      - name: Checkout openfast-feedstock
+        uses: actions/checkout@main
+        with: 
+          repository: conda-forge/openfast-feedstock
+          token: ${{ secrets.ACTIONS_TOKEN }}
+          path: ./openfast-feedstock
+          ref: dev
+
+      - name: Prep the meta.yaml
+        run: python ${{runner.workspace}}/openfast/.github/actions/utils/increment_conda_build.py
+        working-directory: ./openfast-feedstock/recipe
+
+      - name: Push Project B
+        run: |
+          cd ./openfast-feedstock
+          git add recipe/meta.yaml
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+          git commit -m "Increment build number for dev label"
+          git push


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request adds automation to the process for triggering Conda to rebuild the dev label. On push to the dev branch, it creates a new commit to https://github.com/conda-forge/openfast-feedstock with the build number incremented by one.

**Related issue, if one exists**
None, but currently the dev label in Conda-forge must be triggered to rebuild manually.

**Impacted areas of the software**
dev label on Conda-forge. That is, the Conda distribution for the OpenFAST dev branch.

**Additional supporting information**
This is very helpful.

**Test results, if applicable**
Here's a demo: https://github.com/conda-forge/openfast-feedstock/commit/ef22c79c8573990b7b44ff425de60bcb8a5fe13d
