### PR TITLE
Remove unused import to C++ driver code

### DIFF
--- a/glue-codes/openfast-cpp/src/FAST_Prog.cpp
+++ b/glue-codes/openfast-cpp/src/FAST_Prog.cpp
@@ -3,8 +3,6 @@
 #include <iostream>
 #include <mpi.h>
 
-#include <filesystem>
-
 inline bool checkFileExists(const std::string& name) {
     struct stat buffer;   
     return (stat (name.c_str(), &buffer) == 0); 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request removes an unused import in the C++ driver code. This import unnecessarily bumped the minimum C++ standard to C++17.

**Related issue, if one exists**
#708 

**Impacted areas of the software**
C++ driver code