### PR TITLE
[BugFix] Uninitialized variables in HydroDyn::Morisson calculations

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -126,6 +126,7 @@ jobs:
           cmake --build . --target aerodyn_driver -- -j ${{env.NUM_PROCS}}
           cmake --build . --target beamdyn_driver -- -j ${{env.NUM_PROCS}}
           cmake --build . --target hydrodyn_driver -- -j ${{env.NUM_PROCS}}
+          cmake --build . --target subdyn_driver -- -j ${{env.NUM_PROCS}}
 
       - name: Run AeroDyn tests
         uses: ./.github/actions/tests-module-aerodyn

--- a/modules/hydrodyn/src/Morison.f90
+++ b/modules/hydrodyn/src/Morison.f90
@@ -2119,6 +2119,7 @@ SUBROUTINE Morison_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, In
       
          ! get rotation matrix for moment of inertia orientations
          call RodrigMat(I_n, R_I, errStat, errMsg)
+         IF ( errStat > AbortErrLev ) RETURN
 
          ! globally-oreinted moment of inertia matrix for joint
          Irl_mat = 0.0
@@ -2183,16 +2184,12 @@ SUBROUTINE RodrigMat(a, R, errStat, errMsg)
 
    REAL(ReKi)                         :: vec(3)  ! scaled and adjusted input vector
    REAL(ReKi)                         :: factor  ! denomenator used for scaling                     
+   ErrStat  = ErrID_None
+   ErrMsg   = ""
    factor = Dot_Product(a,a)
+   ! Return the identity if the vector is zero.  We are defining it this way because of how this is used
    if ( EqualRealNos(factor, 0.0_ReKi) ) then
-   !IF ((a(1) == 0) .AND. (a(2)==0)) THEN    ! return identity if vertical
-   !      CALL EYE(R, errStat,errMsg)
-   !   IF (a(3) < 0) THEN
-   !      R = -R
-   !   END IF
-   !
-      errStat = ErrID_Fatal
-      errMsg  = 'RodrigMat encountered vector of zero length'
+      CALL EYE(R, errStat,errMsg)
    else IF ( EqualRealNos(a(1), 0.0_ReKi) .AND. EqualRealNos(a(2), 0.0_ReKi) ) THEN    ! return identity if vertical
       CALL EYE(R, errStat,errMsg)
       IF (a(3) < 0) THEN

--- a/modules/hydrodyn/src/Morison.f90
+++ b/modules/hydrodyn/src/Morison.f90
@@ -2649,8 +2649,6 @@ SUBROUTINE Morison_CalcOutput( Time, u, p, x, xd, z, OtherState, y, m, errStat, 
    m%F_B_End = 0.0_ReKi
    y%Mesh%Force  = 0.0_ReKi
    y%Mesh%Moment = 0.0_ReKi
-   F_WMG(1) = 0.0_ReKi
-   F_WMG(2) = 0.0_ReKi
    
    ! Loop through each member
    DO im = 1, p%NMembers    
@@ -2698,6 +2696,7 @@ SUBROUTINE Morison_CalcOutput( Time, u, p, x, xd, z, OtherState, y, m, errStat, 
             ! should lumped half-element coefficients get combined at initialization? <<<
               
             ! ------------------ marine growth: Sides: Section 4.1.2 --------------------  
+            F_WMG = 0.0_ReKi
 
             ! lower node
             !m%F_WMG(3, mem%NodeIndx(i  )) = m%F_WMG(3, mem%NodeIndx(i  )) - mem%m_mg_l(i)*g ! weight force  : Note: this is a constant


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
There were a few un-initialized variables in the Morison calculations.  These may have been contributing to noise in regression testing and occasional failures of regression tests.

**Related issue, if one exists**
This was discovered while testing for un-initialized variables.  This was mentioned in #711.

**Impacted areas of the software**
HydroDyn

**Test results, if applicable**
Test cases that had been failing on my Mac + gcc10 now are passing.  It is uncertain if any baselines will change as a result of this or not.  If any do, it will only be in the HydroDyn related cases.