### PR TITLE
GH Actions: run module tests with debug build

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -25,7 +25,7 @@ env:
 #     os: [macOS-10.14, ubuntu-18.04]
 
 jobs:
-  regression-test:
+  regression-tests-release:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
@@ -79,7 +79,7 @@ jobs:
         uses: actions/upload-artifact@v2
         if: failure()
         with:
-          name: test-results
+          name: regression-tests-release
           path: |
             ${{runner.workspace}}/build/reg_tests/modules
             ${{runner.workspace}}/build/reg_tests/glue-codes/openfast
@@ -89,6 +89,64 @@ jobs:
             !${{runner.workspace}}/build/reg_tests/glue-codes/openfast/SWRT
             !${{runner.workspace}}/build/reg_tests/glue-codes/openfast/UAE_VI
             !${{runner.workspace}}/build/reg_tests/glue-codes/openfast/WP_Baseline
+
+  regression-tests-debug:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Bokeh==1.4
+
+      - name: Setup Workspace
+        run: cmake -E make_directory ${{runner.workspace}}/build
+      - name: Configure Build
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
+            -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
+            -DCMAKE_BUILD_TYPE:STRING=Debug \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
+
+      - name: Build OpenFAST
+        working-directory: ${{runner.workspace}}/build
+        run: |
+          cmake --build . --target aerodyn_driver -- -j ${{env.NUM_PROCS}}
+          cmake --build . --target beamdyn_driver -- -j ${{env.NUM_PROCS}}
+          cmake --build . --target hydrodyn_driver -- -j ${{env.NUM_PROCS}}
+
+      - name: Run AeroDyn tests
+        uses: ./.github/actions/tests-module-aerodyn
+        with:
+          test-target: regression
+      - name: Run BeamDyn tests
+        uses: ./.github/actions/tests-module-beamdyn
+        with:
+          test-target: regression
+      - name: Run HydroDyn tests
+        uses: ./.github/actions/tests-module-hydrodyn
+      - name: Run SubDyn tests
+        uses: ./.github/actions/tests-module-subdyn
+
+      - name: Failing test artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: regression-tests-debug
+          path: |
+            ${{runner.workspace}}/build/reg_tests/modules
 
   unit-test:
     runs-on: ubuntu-20.04

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -120,7 +120,7 @@ macro(set_fast_gfortran)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -fcheck=all,no-array-temps -pedantic -fbacktrace " )
+    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -fcheck=all,no-array-temps -pedantic -fbacktrace -finit-real=inf -finit-integer=9999." )
   endif()
 
   if(CYGWIN)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request adds a job in the GitHub Actions configuration to run all module regression tests with binaries compiled in Debug mode. This also adds two run-time-checking flags to the GNU Fortran Debug configuration.

**Related issue, if one exists**
None

**Impacted areas of the software**
GitHub Actions and CMake for Debug mode with Fortran

** Test results**
This test is expected to fail since there is a known issue with HydroDyn uninitialized variables (https://github.com/OpenFAST/openfast/pull/713).