### PR TITLE
[BugFix] Raise an error if reg test results contain NaN or infinity

### DIFF
--- a/reg_tests/lib/fast_io.py
+++ b/reg_tests/lib/fast_io.py
@@ -67,7 +67,7 @@ def load_ascii_output(filename):
         if np.any(np.isnan(data)):
             raise ValueError("NaN found in test data: {}".format(filename))
         if np.any(np.isinf(data)):
-            raise ValueError("NaN found in test data: {}".format(filename))
+            raise ValueError("Infinity found in test data: {}".format(filename))
         return data, info
 
 def load_binary_output(filename):

--- a/reg_tests/lib/fast_io.py
+++ b/reg_tests/lib/fast_io.py
@@ -59,16 +59,16 @@ def load_ascii_output(filename):
     with open(filename) as f:
         info = {}
         info['name'] = os.path.splitext(os.path.basename(filename))[0]
-        try:
-            header = [f.readline() for _ in range(8)]
-            info['description'] = header[4].strip()
-            info['attribute_names'] = header[6].split()
-            info['attribute_units'] = [unit[1:-1] for unit in header[7].split()]  #removing "()"
-            data = np.array([line.split() for line in f.readlines()]).astype(np.float)
-            return data, info
-
-        except (ValueError, AssertionError):
-            raise
+        header = [f.readline() for _ in range(8)]
+        info['description'] = header[4].strip()
+        info['attribute_names'] = header[6].split()
+        info['attribute_units'] = [unit[1:-1] for unit in header[7].split()]  #removing "()"
+        data = np.array([line.split() for line in f.readlines()], dtype=np.float)
+        if np.any(np.isnan(data)):
+            raise ValueError("NaN found in test data: {}".format(filename))
+        if np.any(np.isinf(data)):
+            raise ValueError("NaN found in test data: {}".format(filename))
+        return data, info
 
 def load_binary_output(filename):
     """


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
The regression test framework currently does not catch NaN's or Infinity in the test results since these are represented as floats in Numpy. This pull request adds an explicit check for any NaN or Infinity values in the results and throws an error is they are encountered.

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/711

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

**Test results, if applicable**
The debug test is expected to fail, but it fails differently than in the previous commit. Whereas the previous commit failed as if the results were different, this one fails and notes that a NaN was encountered.
