### PR TITLE
Build FAST.Farm when configured via BUILD_FASTFARM

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -175,6 +175,7 @@ jobs:
             -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DOPENMP:BOOL=ON \
+            -DBUILD_FASTFARM:BOOL=ON \
             -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ option(USE_DLL_INTERFACE "Enable runtime loading of dynamic libraries" on)
 option(FPE_TRAP_ENABLED "Enable FPE trap in compiler options" off)
 option(ORCA_DLL_LOAD "Enable OrcaFlex Library Load" on)
 option(BUILD_OPENFAST_CPP_API "Enable building OpenFAST - C++ API" off)
+option(BUILD_FASTFARM "Enable building FAST.Farm" off)
 option(OPENMP "Enable OpenMP support" off)
 if(CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
   # Configure the default install path to openfast/install

--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -642,6 +642,25 @@ compile the C++ interface.
     # Compile the C++ API
     make openfastcpplib
 
+FAST.Farm
+~~~~~~~~~
+The FAST.Farm glue-code is included in the CMake project similar to the
+OpenFAST glue-code. See :ref:`compile_from_source` for a full description
+on installing dependencies, configuring the project, and compiling.
+FAST.Farm is enabled in the CMake project with an additional flag:
+
+.. code-block:: bash
+
+    # Enable compiling FAST.Farm
+    cmake .. -DBUILD_FASTFARM:BOOL=ON
+
+    # Compile FAST.Farm
+    make FAST.Farm
+
+OpenMP-Fortran is an additional dependency for FAST.Farm. These libraries
+can be installed with any package manager for macOS and Linux or
+through the Intel oneAPI distributions.
+
 .. _installation_appendix:
 
 Appendix

--- a/glue-codes/CMakeLists.txt
+++ b/glue-codes/CMakeLists.txt
@@ -5,4 +5,6 @@ if(BUILD_OPENFAST_CPP_API)
    add_subdirectory(openfast-cpp)
 endif()
 
-add_subdirectory(fast-farm)
+if(BUILD_FASTFARM)
+   add_subdirectory(fast-farm)
+endif()


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request removes FAST.Farm from the default build target and requires configuring CMake with `-DBUILD_FASTFARM=ON` in order to add the FAST.Farm build target.

Currently, compiling the FAST Farm types modules require a large amount of memory. The high memory overhead causes problems in the automated continuous deployment infrastructure such as conda-forge. Ideally, the memory requirements to compile FAST.Farm could be reduced and that glue-code could be distributed through conda-forge along with the OpenFAST glue-code.

**Related issue, if one exists**
None, but see the failing build on [conda-forge](https://dev.azure.com/conda-forge/feedstock-builds/_build/results?buildId=305724&view=logs&j=656edd35-690f-5c53-9ba3-09c10d0bea97&t=e5c8ab1d-8ff9-5cae-b332-e15ae582ed2d).

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->