### PR TITLE
AllBldOuts more forgiving and support for 0

### DIFF
--- a/modules/aerodyn/src/AeroDyn_AllBldNdOuts_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_AllBldNdOuts_IO.f90
@@ -195,6 +195,11 @@ SUBROUTINE Calc_WriteAllBldNdOutput( p, p_AD, u, m, m_AD, y, OtherState, Indx, E
          ! Initialize some things
       ErrMsg = ''
       ErrStat = ErrID_None
+      ! NOTE: if no blade outputs, we return
+      if (p%BldNd_BladesOut<=0 .or. p%BldNd_NumOuts<=0) then
+         return
+      endif
+
 
          ! Precalculate the M_ph matrix -- no reason to recalculate for each output
       DO IdxBlade=1,p%NumBlades
@@ -1113,9 +1118,11 @@ SUBROUTINE AllBldNdOuts_SetParameters( InputFileData, p, p_AD, ErrStat, ErrMsg )
 
 
       ! Check if the requested blades exist
-   IF ( (InputFileData%BldNd_BladesOut < 0_IntKi) .OR. (InputFileData%BldNd_BladesOut > p%NumBlades) ) THEN
-      CALL SetErrStat( ErrID_Warn, " Number of blades to output data at all blade nodes (BldNd_BladesOut) must be between 0 and "//TRIM(Num2LStr(p%NumBlades))//".", ErrStat, ErrMsg, RoutineName)
+   IF ( (InputFileData%BldNd_BladesOut < 0_IntKi) ) then
       p%BldNd_BladesOut = 0_IntKi
+   ELSE IF ((InputFileData%BldNd_BladesOut > p%NumBlades) ) THEN
+      CALL SetErrStat( ErrID_Warn, " Number of blades to output data at all blade nodes (BldNd_BladesOut) must be less than "//TRIM(Num2LStr(p%NumBlades))//".", ErrStat, ErrMsg, RoutineName)
+      p%BldNd_BladesOut = p%NumBlades ! NOTE: we are forgiving and plateau to numBlades
    ELSE
       p%BldNd_BladesOut = InputFileData%BldNd_BladesOut
    ENDIF


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
AllBldNdsOuts would fail if the user specified 0 blades or more than the current number of blades. This fix is more forgiving, and returns when the number of outputs is 0 to avoid accessing some unallocated array.


**Impacted areas of the software**
AeroDyn 

