### PR TITLE
CTest: Add FF reg tests when FF build is enabled

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -188,8 +188,10 @@ of_regression_linear("5MW_Land_BD_Linear"           "openfast;linear;beamdyn;ser
 of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn")
 
 # FAST Farm regression tests
-ff_regression("TSinflow"  "fastfarm")
-ff_regression("LESinflow"  "fastfarm")
+if(BUILD_FASTFARM)
+  ff_regression("TSinflow"  "fastfarm")
+  ff_regression("LESinflow"  "fastfarm")
+endif()
 
 # AeroDyn regression tests
 ad_regression("ad_timeseries_shutdown"      "aerodyn;bem")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
CTest currently always includes FAST.Farm tests but the FAST.Farm build is conditional on a CMake flag (`BUILD_FASTFARM`). This pull request includes the FAST Farm tests in CTest only when the flag to build FAST Farm is ON.

**Related issue, if one exists**
None, but this bit @andrew-platt.

**Impacted areas of the software**
Automated testing