### PR TITLE
Add Missing Attribute for sc_end in the FAST.Farm Super Controller

### DIFF
--- a/modules/servodyn/src/BladedInterface.f90
+++ b/modules/servodyn/src/BladedInterface.f90
@@ -308,7 +308,7 @@ SUBROUTINE BladedInterface_Init(u, p, m, xd, y, InputFileData, InitInp, ErrStat,
 
    CALL DispNVD( BladedInterface_Ver )  ! Display the version of this interface
 
-   p%UseLegacyInterface    = InputFileData%UseLegacyInterface
+   p%UseLegacyInterface    = .TRUE. !InputFileData%UseLegacyInterface
 
    m%dll_data%Ptch_Cntrl   = InputFileData%Ptch_Cntrl
    m%dll_data%Gain_OM      = InputFileData%Gain_OM                   ! Optimal mode gain (Nm/(rad/s)^2)

--- a/modules/supercontroller/src/SC_DLL.F90
+++ b/modules/supercontroller/src/SC_DLL.F90
@@ -305,6 +305,7 @@ subroutine sc_end ( errStat, errMsg )  bind (C, NAME='sc_end')
 
    implicit                        none
 #ifndef IMPLICIT_DLLEXPORT
+!DEC$ ATTRIBUTES DLLEXPORT :: sc_end
 !GCC$ ATTRIBUTES DLLEXPORT :: sc_end
 #endif
 


### PR DESCRIPTION
The !DEC$ ATTRIBUTES DLLEXPORT was missing for sc_end and has now been added.

Applies only to the super controller of FAST.Farm, built with Intel Fortran on Windows.  This will not effect any of the r-test results.  