### PR TITLE
NWTC_IO: Add InitFileInfo_FromNullCString subroutine

### DIFF
--- a/modules/nwtc-library/src/NWTC_Base.f90
+++ b/modules/nwtc-library/src/NWTC_Base.f90
@@ -38,6 +38,7 @@ MODULE NWTC_Base
    INTEGER(IntKi), PARAMETER     :: ChanLen   = 20                                !< The maximum allowable length of channel names (i.e., width of output columns) in the FAST framework
    INTEGER(IntKi), PARAMETER     :: MinChanLen = 10                               !< The min allowable length of channel names (i.e., width of output columns), used because some modules (like Bladed DLL outputs) have excessively long names
    INTEGER(IntKi), PARAMETER     :: LinChanLen = 200                              !< The allowable length of row/column names in linearization files
+   INTEGER(IntKi), PARAMETER     :: MaxFileInfoLineLen = 1024                     !< The allowable length of an input line stored in FileInfoType%Lines
 
    INTEGER(IntKi), PARAMETER     :: NWTC_Verbose = 10                             !< The maximum level of verbosity
    INTEGER(IntKi), PARAMETER     :: NWTC_VerboseLevel = 5                         !< a number in [0, NWTC_Verbose]: 0 = no output; NWTC_Verbose=verbose; 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -4566,6 +4566,7 @@ END SUBROUTINE CheckR16Var
       NumLines = 0      ! Initialize counter for non-comment populated lines
       TmpFileLine = 0   ! Line number that was passed in 
       NumCommChars = LEN_TRIM( CommChars )   ! Number of globally specified CommChars
+      TmpStringArray = ""
 
          ! Find how many non-comment lines we have
       do i=1,size(StringArray)
@@ -4598,16 +4599,17 @@ END SUBROUTINE CheckR16Var
       ALLOCATE( FileInfo%FileIndx(FileInfo%NumLines) )
       ALLOCATE( FileInfo%FileList(FileInfo%NumFiles) )
 
+      FileInfo%FileIndx = FileInfo%NumFiles
+      FileInfo%FileList = (/ "passed file info" /)
+      FileInfo%Lines    = ""  ! initialize empty in case of error
+      FileInfo%FileLine =  0  ! initialize empyt in case of later error
       DO i = 1, FileInfo%NumLines
          IF ( LEN_TRIM(TmpStringArray(i)) > MaxFileInfoLineLen ) THEN
             CALL SetErrStat( ErrID_Fatal, 'Input string '//trim(Num2LStr(i))//' exceeds the bounds of FileInfoType.' , ErrStat, ErrMsg, RoutineName )
-            RETURN
          END IF
-         FileInfo%Lines(i)    = TmpStringArray(i)
+         FileInfo%Lines(i)    = trim(TmpStringArray(i))
          FileInfo%FileLine(i) = TmpFileLine(i)
       END DO      
-      FileInfo%FileIndx = FileInfo%NumFiles
-      FileInfo%FileList = (/ "passed file info" /)
 
    END SUBROUTINE InitFileInfo_FromStringArray
 !=======================================================================

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -83,6 +83,11 @@ MODULE NWTC_IO
 
 !=======================================================================
 
+   INTERFACE InitFileInfo
+      MODULE PROCEDURE InitFileInfo_FromNullCString
+      MODULE PROCEDURE InitFileInfo_FromStringArray
+   END INTERFACE
+
       !> \copydoc nwtc_io::allcary1
    INTERFACE AllocAry
       MODULE PROCEDURE AllCAry1
@@ -3353,6 +3358,10 @@ END SUBROUTINE CheckR16Var
       character(45)                      :: TmpStr45
       write(U,*)  '-------------- Print_FileInfo_Struct ------------'
       write(U,*)  '  info stored in the FileInfo data type'
+      if (.not. allocated(FileInfo%FileLine) .and. .not. allocated(FileInfo%FileIndx) .and. .not. allocated(FileInfo%Lines)) then
+         write(U,*) '            Data not allocated'
+         return
+      endif
       write(U,*)  '        %NumLines           (integer): ',FileInfo%NumLines
       write(U,*)  '        %NumFiles           (integer): ',FileInfo%NumFiles
       write(U,*)  '        %FileList  (array of strings): ',size(FileInfo%FileList)
@@ -4461,7 +4470,84 @@ END SUBROUTINE CheckR16Var
    RETURN
    END SUBROUTINE PremEOF
 !=======================================================================
-   SUBROUTINE InitFileInfo( StringArray, FileInfo, ErrStat, ErrMsg )
+!> The following takes an input file as a C_Char string with C_NULL_CHAR deliniating line endings
+   subroutine InitFileInfo_FromNullCString(FileString, FileInfo, ErrStat, ErrMsg)
+      CHARACTER(kind=C_char,len=*), intent(in   )  :: FileString  !< input file as single C string with C_NULL_CHAR separated lines
+      TYPE(FileInfoType),           intent(  out)  :: FileInfo
+      INTEGER(IntKi),               intent(  out)  :: ErrStat
+      CHARACTER(*),                 intent(  out)  :: ErrMsg
+
+      integer                                    :: ErrStat2                   !< temporary error status  from a call
+      character(ErrMsgLen)                       :: ErrMsg2                    !< temporary error message from a call
+      character(MaxFileInfoLineLen), allocatable :: FileStringArray(:)
+      character(*),                    parameter :: RoutineName = 'InitFileInfo_FromNullCString'
+      integer :: idx, NumLines, MaxLineLen, NullLoc, Line
+
+      ErrStat = ErrID_None
+      ErrMsg  = ""
+      NumLines = 0      ! Initialize counter for lines
+      NullLoc  = 0
+      MaxLineLen = 0
+
+         ! Find how many non-comment lines we have
+      do idx=1,len(FileString)
+         if(FileString(idx:idx) == C_NULL_CHAR) then
+            MaxLineLen = max(MaxLineLen,idx-NullLoc)
+            NumLines = NumLines + 1    ! Increment line number
+            NullLoc  = idx
+         endif 
+      enddo
+
+      if (NumLines == 0) then
+         ErrStat2 = ErrID_Fatal
+         ErrMsg2  = "Input string contains no C_NULL_CHAR characters. "// &
+                  " Cannot separete passed file info into string array."
+         if (Failed()) return;
+      endif
+      if (MaxLineLen > MaxFileInfoLineLen) then
+         ErrStat2 = ErrID_Warn
+         ErrMsg2  = "Input string contains lines longer than "//trim(Num2LStr(MaxFileInfoLineLen))// &
+                  " characters.  Check that the flat input file string is properly C_NULL_CHAR delineated"
+         if (Failed()) return;
+      endif
+
+         ! Now allocate a string array
+      call AllocAry( FileStringArray, NumLines, "FileStringArray", ErrStat2, ErrMsg2 )
+      if (Failed()) return;
+      FileStringArray = ""
+
+         ! Now step through the FileString and parse it into the array
+      idx      = 1   ! Index of start
+      do Line=1,NumLines
+         ! Index into the next segment
+         NullLoc = index(FileString(idx:len(FileString)),C_NULL_CHAR)
+         ! started indexing at idx, so add that back in for location in FileString
+         NullLoc = NullLoc + idx - 1
+         if (NullLoc > 0) then
+            FileStringArray(Line) = trim(FileString(idx:NullLoc-1))
+         else
+            exit  ! exit loop as we didn't find any more
+         endif
+         idx = min(NullLoc + 1,len(FileString))    ! Start next segment of file, but overstep end
+      enddo
+
+         ! Pass through to the FileInfo initialize routine
+      call InitFileInfo(FileStringArray, FileInfo, ErrStat2, ErrMsg2)
+      if (Failed()) return;
+   contains
+      logical function Failed()
+         CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+         Failed = ErrStat >= AbortErrLev
+         if (Failed) then
+            call Cleanup()
+         endif
+      end function Failed
+      subroutine Cleanup()
+         if (allocated(FileStringArray))  deallocate(FileStringArray)
+      end subroutine Cleanup
+   end subroutine InitFileInfo_FromNullCString
+!=======================================================================
+   SUBROUTINE InitFileInfo_FromStringArray( StringArray, FileInfo, ErrStat, ErrMsg )
 
       CHARACTER(*), DIMENSION(:), INTENT(IN   ) :: StringArray
       TYPE(FileInfoType),         INTENT(  OUT) :: FileInfo
@@ -4472,7 +4558,7 @@ END SUBROUTINE CheckR16Var
       character(len=len(StringArray))  :: Line
       integer                          :: TmpFileLine(size(StringArray))
 
-      CHARACTER(*), PARAMETER :: RoutineName = 'InitFileInfo'
+      CHARACTER(*), PARAMETER :: RoutineName = 'InitFileInfo_FromStringArray'
       INTEGER :: i, NumLines, IC, NumCommChars, LineLen, FirstComm, CommLoc
 
       ErrStat = ErrID_None
@@ -4513,8 +4599,8 @@ END SUBROUTINE CheckR16Var
       ALLOCATE( FileInfo%FileList(FileInfo%NumFiles) )
 
       DO i = 1, FileInfo%NumLines
-         IF ( LEN(TmpStringArray(i)) > LEN(FileInfo%Lines(i)) ) THEN
-            CALL SetErrStat( ErrID_Fatal, 'Input string exceeds the bounds of FileInfoType.' , ErrStat, ErrMsg, RoutineName )
+         IF ( LEN_TRIM(TmpStringArray(i)) > MaxFileInfoLineLen ) THEN
+            CALL SetErrStat( ErrID_Fatal, 'Input string '//trim(Num2LStr(i))//' exceeds the bounds of FileInfoType.' , ErrStat, ErrMsg, RoutineName )
             RETURN
          END IF
          FileInfo%Lines(i)    = TmpStringArray(i)
@@ -4523,7 +4609,7 @@ END SUBROUTINE CheckR16Var
       FileInfo%FileIndx = FileInfo%NumFiles
       FileInfo%FileList = (/ "passed file info" /)
 
-   END SUBROUTINE
+   END SUBROUTINE InitFileInfo_FromStringArray
 !=======================================================================
 !> This routine calls ScanComFile (nwtc_io::scancomfile) and ReadComFile (nwtc_io::readcomfile) 
 !! to move non-comments in a set of nested files starting with TopFile into the FileInfo (nwtc_io::fileinfo) structure.

--- a/modules/nwtc-library/src/NWTC_Library_Types.f90
+++ b/modules/nwtc-library/src/NWTC_Library_Types.f90
@@ -65,8 +65,8 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: NumFiles 
     INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: FileLine 
     INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: FileIndx 
-    CHARACTER(1024) , DIMENSION(:), ALLOCATABLE  :: FileList 
-    CHARACTER(1024) , DIMENSION(:), ALLOCATABLE  :: Lines 
+    CHARACTER(MaxFileInfoLineLen) , DIMENSION(:), ALLOCATABLE  :: FileList 
+    CHARACTER(MaxFileInfoLineLen) , DIMENSION(:), ALLOCATABLE  :: Lines 
   END TYPE FileInfoType
 ! =======================
 ! =========  Quaternion  =======

--- a/modules/nwtc-library/src/Registry_NWTC_Library.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library.txt
@@ -28,8 +28,8 @@ usefrom   NWTC_Library  FileInfoType        IntKi                    NumLines
 usefrom     ^             ^                 IntKi                    NumFiles
 usefrom     ^             ^                 IntKi                    FileLine  {:}
 usefrom     ^             ^                 IntKi                    FileIndx  {:}
-usefrom     ^             ^                 CHARACTER(1024)          FileList  {:}
-usefrom     ^             ^                 CHARACTER(1024)          Lines     {:}
+usefrom     ^             ^                 CHARACTER(MaxFileInfoLineLen)  FileList  {:}
+usefrom     ^             ^                 CHARACTER(MaxFileInfoLineLen)  Lines     {:}
 
 usefrom   NWTC_Library  Quaternion          ReKi                     q0
 usefrom     ^             ^                 ReKi                     v  {3}

--- a/modules/nwtc-library/test/ReadMe.md
+++ b/modules/nwtc-library/test/ReadMe.md
@@ -1,0 +1,5 @@
+# Older test
+
+The test cases contained within this directory and subdirectories are old tests that are not currently used.  Some of these test cases do not currently work, but are kept here for eventual merging into the active unit tests in the `tests` directory.
+
+

--- a/modules/nwtc-library/tests/test_NWTC_IO_FileInfo.F90
+++ b/modules/nwtc-library/tests/test_NWTC_IO_FileInfo.F90
@@ -18,7 +18,7 @@ subroutine test_initfileinfo()
 
     integer(IntKi) :: error_status
     character(ErrMsgLen) :: error_message
-    character(1024) :: input_strings(num_lines)
+    character(MaxFileInfoLineLen) :: input_strings(num_lines)
     type(FileInfoType) :: file_info_type
     integer :: i
 
@@ -62,7 +62,8 @@ subroutine test_initfileinfo2()
 
     integer(IntKi) :: error_status
     character(ErrMsgLen) :: error_message
-    character(1025) :: input_strings(num_lines)
+    character(MaxFileInfoLineLen*2) :: input_strings(num_lines)
+    character(MaxFileInfoLineLen*2) :: tmpstring
     type(FileInfoType) :: file_info_type
     integer :: i
 
@@ -73,11 +74,45 @@ subroutine test_initfileinfo2()
         "line 3",  &
         "line 4"   &
     /)
+    ! make the last character a + so a trim does not reduce this string length
+    tmpstring=input_strings(5)
+    tmpstring(MaxFileInfoLineLen+1:MaxFileInfoLineLen+1) = 'a'
+    input_strings(5)=tmpstring
     call InitFileInfo( input_strings, file_info_type, error_status, error_message )
-
     @assertEqual(num_lines, file_info_type%NumLines)
     @assertEqual(num_files, file_info_type%NumFiles)
     @assertEqual( 4, error_status )
+    
+end subroutine
+
+@test
+subroutine test_initfileinfo3()
+    USE ISO_C_BINDING, only: C_CHAR, C_NULL_CHAR
+
+    ! This case should result in zero error status.
+    ! It attempts to initialize FileInfoType with a C_NULL_CHAR delimited string 
+
+    integer, parameter :: num_lines = 7
+    integer, parameter :: num_files = 1
+
+    integer(IntKi) :: error_status
+    character(ErrMsgLen) :: error_message
+    character(kind=C_CHAR,len=MaxFileInfoLineLen*2) :: input_string
+    type(FileInfoType) :: file_info_type
+    integer :: i
+
+    ! Note: the rest of the input string is empty.  That should pass ok
+    input_string =   "line  0"//C_NULL_CHAR//   &
+                     "line  1"//C_NULL_CHAR//   &
+                     "line  2"//C_NULL_CHAR//   &
+                     "line  3"//C_NULL_CHAR//   &
+                     "line  4"//C_NULL_CHAR//   &
+                     "line  5"//C_NULL_CHAR//   &
+                     "line  6"//C_NULL_CHAR
+    call InitFileInfo( input_string, file_info_type, error_status, error_message )
+    @assertEqual(num_lines, file_info_type%NumLines)
+    @assertEqual(num_files, file_info_type%NumFiles)
+    @assertEqual( 0, error_status )
     
 end subroutine
 

--- a/modules/nwtc-library/tests/test_NWTC_IO_FileInfo.F90
+++ b/modules/nwtc-library/tests/test_NWTC_IO_FileInfo.F90
@@ -90,7 +90,7 @@ subroutine test_initfileinfo3()
     USE ISO_C_BINDING, only: C_CHAR, C_NULL_CHAR
 
     ! This case should result in zero error status.
-    ! It attempts to initialize FileInfoType with a C_NULL_CHAR delimited string 
+    ! It attempts to initialize FileInfoType with a C_NULL_CHAR delimited string and compare with the equivalent array parsing
 
     integer, parameter :: num_lines = 7
     integer, parameter :: num_files = 1
@@ -98,10 +98,29 @@ subroutine test_initfileinfo3()
     integer(IntKi) :: error_status
     character(ErrMsgLen) :: error_message
     character(kind=C_CHAR,len=MaxFileInfoLineLen*2) :: input_string
+    character(MaxFileInfoLineLen) :: input_string_array(num_lines)
     type(FileInfoType) :: file_info_type
+    type(FileInfoType) :: file_info_type_array
     integer :: i
 
-    ! Note: the rest of the input string is empty.  That should pass ok
+    ! Fortron string array pass
+    input_string_array = (/ &
+        "line  0",  &
+        "line  1",  &
+        "line  2",  &
+        "line  3",  &
+        "line  4",  &
+        "line  5",  &
+        "line  6"   &
+    /)
+    call InitFileInfo( input_string_array, file_info_type_array, error_status, error_message )
+    @assertEqual(num_lines, file_info_type_array%NumLines)
+    @assertEqual(num_files, file_info_type_array%NumFiles)
+    @assertEqual( 0, error_status )
+   
+
+    ! Equivalent C_CHAR string to pass
+    ! Note: the rest of the input string is empty.  This won't pose an issue since the remainder of the empty string is ignored.
     input_string =   "line  0"//C_NULL_CHAR//   &
                      "line  1"//C_NULL_CHAR//   &
                      "line  2"//C_NULL_CHAR//   &
@@ -113,6 +132,11 @@ subroutine test_initfileinfo3()
     @assertEqual(num_lines, file_info_type%NumLines)
     @assertEqual(num_files, file_info_type%NumFiles)
     @assertEqual( 0, error_status )
+
+    ! Now check that the entries are identical
+    do i = 1, num_lines
+        @assertEqual( trim(file_info_type_array%Lines(i)), trim(file_info_type%Lines(i)) )
+    end do
     
 end subroutine
 


### PR DESCRIPTION
This PR is ready to be merged

**Feature or improvement description**
This routine allows for passing an input file as one long string with `C_NULL_CHAR` delimiters between lines of the input file.
Also added a new interface for `InitFileInfo` to simplify usage.

**Related issue, if one exists**
Related to PR #720 -- this new interface allows simpler construction of the string for the input file on the python side.

**Impacted areas of the software**
No direct impacts on any existing modules.

**Test results, if applicable**
The `nwtc_library_utest` was updated to account for the updated parsing.
