### PR TITLE
Allow MAP++ to be statically linked into Windows builds

### DIFF
--- a/modules/map/src/mapsys.h
+++ b/modules/map/src/mapsys.h
@@ -40,6 +40,27 @@
 #endif
 
 
+
+#if defined _WIN32 || defined __CYGWIN__ || defined _WINDOWS
+#  ifdef BUILD_SHARED_LIC_LIBS
+#    ifdef __GNUC__
+#      define DLL_PUBLIC __attribute__ ((dllexport))
+#    else
+#      define DLL_PUBLIC __declspec(dllexport) // Note: actually gcc seems to also supports this syntax.
+#    endif
+#  else
+#    define DLL_PUBLIC
+#  endif
+#else
+#  if __GNUC__ >= 4
+#    define DLL_PUBLIC __attribute__ ((visibility ("default")))
+#  else
+#    define DLL_PUBLIC
+#  endif
+#endif
+
+#define MAP_EXTERNCALL DLL_PUBLIC
+
 #if defined(_MSC_VER)
   typedef int bool;
   #define false 0
@@ -47,17 +68,11 @@
 //#  include "stdbool.h"
 #  define map_snprintf _snprintf
 #  define map_strcat(a,b,c) strcat_s(a,b,c)
-#  define MAP_EXTERNCALL __declspec( dllexport )
 #  define MAP_STRCPY(a,b,c) strcpy_s(a,b,c)
 #else
 #  include <stdbool.h>
 #  define map_snprintf snprintf
 #  define map_strcat(a,b,c) strncat(a,c,b)
-#  if defined(__MINGW32__)
-#    define MAP_EXTERNCALL __declspec( dllexport )
-#  else
-#    define MAP_EXTERNCALL 
-#  endif  
 #  define MAP_STRCPY(a,b,c) strcpy(a,c)
 #endif
 

--- a/vs-build/MAPlib/MAP_dll.vcxproj
+++ b/vs-build/MAPlib/MAP_dll.vcxproj
@@ -26,26 +26,26 @@
   </PropertyGroup>
   <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>true</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>
     <CharacterSet>Unicode</CharacterSet>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
-    <ConfigurationType>DynamicLibrary</ConfigurationType>
+    <ConfigurationType>StaticLibrary</ConfigurationType>
     <UseDebugLibraries>false</UseDebugLibraries>
     <PlatformToolset>v140</PlatformToolset>
     <WholeProgramOptimization>true</WholeProgramOptimization>


### PR DESCRIPTION
**Feature or improvement description**
This pull request changes the definition of `MAP_EXTERNCALL` so that it does not need to be an external subroutine (i.e., DLL) when building on Windows with MinGW or Visual Studio. This means executables will no longer need a stand-alone MAP.dll file to run the code. 

The Visual Studio solution file has been updated to create a static library instead of a dynamic library when building MAP++.

**Related issue, if one exists**
None.

**Impacted areas of the software**
Windows builds

**Additional supporting information**
I also merged in the main branch since it has changes not currently in dev.

**Test results, if applicable**
This should not affect test results.
