### PR TITLE
Fix install for openfast cpp API

### DIFF
--- a/glue-codes/openfast-cpp/CMakeLists.txt
+++ b/glue-codes/openfast-cpp/CMakeLists.txt
@@ -78,7 +78,7 @@ install(TARGETS openfastcpplib
   LIBRARY DESTINATION lib)
 
 install(FILES
-  src/OpenFAST.H src/SC.H
+  src/OpenFAST.H src/SC.h
   DESTINATION include)
 
 install(TARGETS openfastcpp


### PR DESCRIPTION
Header file listed has wrong suffix. Fix it to match the main branch.
