### PR TITLE
InflowWind: Return if fatal error occurs in FFWind_Base::GetInterpValues

### DIFF
--- a/modules/inflowwind/src/IfW_FFWind_Base.f90
+++ b/modules/inflowwind/src/IfW_FFWind_Base.f90
@@ -368,7 +368,7 @@ FUNCTION FFWind_Interp(Time, Position, p, ErrStat, ErrMsg)
 
    IF ( OnGrid ) THEN      ! The tower points don't use this
 
-      CALL GetInterpValues()
+      CALL GetInterpValues();       if (ErrStat >= AbortErrLev) return
       
       !-------------------------------------------------------------------------------------------------
       ! Interpolate on the grid


### PR DESCRIPTION
This PR is ready to merge

**Feature or improvement description**

The `GetInterpValues()` routine in `IfW_FFWind_Base.f90` checks the bounds of the full field wind data in the y direction and sets an error.  However, the array was accessed immediately afterwards potentially with an invalid index to the array and may trigger a segmentation fault.

A check was added to ensure that no fatal errors occured in the `GetInterpValues()` call and return at that point before attempting to read from an invalid location outside the `p%FFData` array.

**Related issue, if one exists**
No known issues.  This showed up in testing of the LidarSim module in development.

**Impacted areas of the software**
InflowWind full field wind interpolation only.  And only if outside the bounds.

**Test results, if applicable**
No tests will be affected.