### PR TITLE
BugFix in documentation: Fix bulleted list formatting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -58,6 +58,7 @@ if readTheDocs and useDoxygen:
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
+    'sphinx_rtd_theme',
     'sphinx.ext.autodoc',
     'sphinx.ext.autosummary',
     'sphinx.ext.mathjax',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,5 +1,5 @@
 breathe>=4.4
-docutils>=0.13
+docutils==0.16
 Pygments>=2.2
 pyparsing>=2.1
 Sphinx>=1.8.5


### PR DESCRIPTION
**Feature or improvement description**
Currently, the documentation does not render bulleted lists correctly. This can be seen in lots of places, including: https://openfast.readthedocs.io/en/main/source/install/index.html#dependencies. This commit fixes dependencies and configuration for Sphinx/readthedocs in order to properly render bulleted lists.