### PR TITLE
HydroDyn Input/Output meshes: change from SWL to MSL for consistency with OF glue code

### DIFF
--- a/modules/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules/hydrodyn/src/HydroDyn_Input.f90
@@ -4003,10 +4003,7 @@ SUBROUTINE HydroDynInput_ProcessInitData( InitInp, ErrStat, ErrMsg )
 
       InitInp%Morison%MGTop    = -999999.0
       InitInp%Morison%MGBottom =  999999.0
-      do I = 1,InitInp%Morison%NMGDepths
-            ! Adjust the depth values based on MSL2SWL
-         InitInp%Morison%MGDepths(I)%MGDpth = InitInp%Morison%MGDepths(I)%MGDpth - InitInp%Morison%MSL2SWL
-      end do
+      
       DO I = 1,InitInp%Morison%NMGDepths
             ! Store the boundaries of the marine growth zone
          IF ( InitInp%Morison%MGDepths(I)%MGDpth > InitInp%Morison%MGTop ) THEN

--- a/modules/hydrodyn/src/Morison.txt
+++ b/modules/hydrodyn/src/Morison.txt
@@ -319,6 +319,7 @@ typedef   ^                            ParameterType                 DbKi       
 typedef   ^                            ^                             ReKi                     Gravity                          -          -        -         "Gravity (scalar, positive-valued)"    m/s^2
 typedef   ^                            ^                             ReKi                     WtrDens                          -          -        -         "Water density"    kg/m^3
 typedef   ^                            ^                             ReKi                     WtrDpth                          -          -        -         "Water depth (positive-valued)"    m
+typedef   ^                            ^                             ReKi                     MSL2SWL                          -          -        -         "Mean Sea Level to Still Water Level offset"    m
 typedef   ^                            ^                             INTEGER                  NMembers                        -          -         -         "number of members"        -
 typedef   ^                            ^                             Morison_MemberType       Members                         {:}             -        -         "Array of Morison members used during simulation"    -
 typedef   ^                            ^                             INTEGER                  NNodes                          -          -         -         ""        -

--- a/modules/hydrodyn/src/Morison_Types.f90
+++ b/modules/hydrodyn/src/Morison_Types.f90
@@ -370,6 +370,7 @@ IMPLICIT NONE
     REAL(ReKi)  :: Gravity      !< Gravity (scalar, positive-valued) [m/s^2]
     REAL(ReKi)  :: WtrDens      !< Water density [kg/m^3]
     REAL(ReKi)  :: WtrDpth      !< Water depth (positive-valued) [m]
+    REAL(ReKi)  :: MSL2SWL      !< Mean Sea Level to Still Water Level offset [m]
     INTEGER(IntKi)  :: NMembers      !< number of members [-]
     TYPE(Morison_MemberType) , DIMENSION(:), ALLOCATABLE  :: Members      !< Array of Morison members used during simulation [-]
     INTEGER(IntKi)  :: NNodes      !<  [-]
@@ -9899,6 +9900,7 @@ ENDIF
     DstParamData%Gravity = SrcParamData%Gravity
     DstParamData%WtrDens = SrcParamData%WtrDens
     DstParamData%WtrDpth = SrcParamData%WtrDpth
+    DstParamData%MSL2SWL = SrcParamData%MSL2SWL
     DstParamData%NMembers = SrcParamData%NMembers
 IF (ALLOCATED(SrcParamData%Members)) THEN
   i1_l = LBOUND(SrcParamData%Members,1)
@@ -10258,6 +10260,7 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! Gravity
       Re_BufSz   = Re_BufSz   + 1  ! WtrDens
       Re_BufSz   = Re_BufSz   + 1  ! WtrDpth
+      Re_BufSz   = Re_BufSz   + 1  ! MSL2SWL
       Int_BufSz  = Int_BufSz  + 1  ! NMembers
   Int_BufSz   = Int_BufSz   + 1     ! Members allocated yes/no
   IF ( ALLOCATED(InData%Members) ) THEN
@@ -10458,6 +10461,8 @@ ENDIF
     ReKiBuf(Re_Xferred) = InData%WtrDens
     Re_Xferred = Re_Xferred + 1
     ReKiBuf(Re_Xferred) = InData%WtrDpth
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%MSL2SWL
     Re_Xferred = Re_Xferred + 1
     IntKiBuf(Int_Xferred) = InData%NMembers
     Int_Xferred = Int_Xferred + 1
@@ -10938,6 +10943,8 @@ ENDIF
     OutData%WtrDens = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
     OutData%WtrDpth = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%MSL2SWL = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
     OutData%NMembers = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1


### PR DESCRIPTION
This pull request is ready to merge.  Please examine why AeroDyn regression is failing for MacOS [@rafmudaf ].  We should add a future test for MSL2SWL.

**Feature or improvement description**
In OpenFAST, the reference positions of all nodes of all module-level input and output meshes are stored in the inertial frame coordinate system, which for offshore wind turbines is defined as the intersection of the undisplaced tower centerline and the mean sea level (MSL). These reference positions are used in the mesh-mapping within OpenFAST to transfer motions and loads between modules, including rigid-body behavior between nodes that are offset across modules.

Within HydroDyn, there is an input MSL2SWL that defines the offset between the MSL and the still water level (SWL), e.g., to represent the change in water depth associated with tidal variations or storm surge. This change in water depth does not change the inertial frame coordinate system, which is relative to MSL regardless. However, in HydroDyn, it is important to know the position of hydrodynamic nodes relative to the SWL, e.g. for the calculation of local wave kinematics and hydrostatic pressure. It has been discovered that the module-level input and output meshes within HydroDyn stored the reference position relative to SWL instead of relative to MSL. This allowed HydroDyn to use the proper relative water depth in its internal calculations, but leads to offset in the mesh mappings between HydroDyn and other modules like ElastoDyn and SubDyn. Thus, any module-to-module coupling will result in errors when MSL2SWL is nonzero.

**Related issue, if one exists**
Bug report: Incorrect Treatment of MSL2SWL within HydroDyn [#830](https://github.com/OpenFAST/openfast/issues/830)

**Impacted areas of the software**
HydroDyn, Morison

**Additional supporting information**
None

**Test results, if applicable**
This feature was never part of the OpenFAST test suite

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] MAP_X64.dll
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
