### PR TITLE
Add a super-controller library target to CMake

### DIFF
--- a/modules/supercontroller/CMakeLists.txt
+++ b/modules/supercontroller/CMakeLists.txt
@@ -36,7 +36,10 @@ add_library(scfastlib
   src/SuperController.f90)
 target_link_libraries(scfastlib sctypeslib openfast_prelib nwtclibs)
 
-install(TARGETS sctypeslib scfastlib scdataextypeslib scdataexlib
+add_library(sclib SHARED
+  src/SC_DLL.F90)
+
+install(TARGETS sctypeslib scfastlib scdataextypeslib scdataexlib sclib
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib

--- a/modules/supercontroller/CMakeLists.txt
+++ b/modules/supercontroller/CMakeLists.txt
@@ -14,6 +14,10 @@
 # limitations under the License.
 #
 
+if(APPLE OR UNIX)
+  add_definitions(-DIMPLICIT_DLLEXPORT)
+endif()
+
 if (GENERATE_TYPES)
   generate_f90_types(src/SuperController_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/SuperController_Types.f90 -ccode)
   generate_f90_types(src/SC_DataEx_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/SCDataEx_Types.f90 -ccode -noextrap)

--- a/modules/supercontroller/src/SC_DLL.F90
+++ b/modules/supercontroller/src/SC_DLL.F90
@@ -1,43 +1,29 @@
 
-!subroutine sc_init_obfuscator()
-!
-!   CALL RANDOM_SEED ( SIZE = 1 )
-!   CALL RANDOM_SEED ( PUT=3459872 )      
-!  
-!end subroutine sc_init_obfuscator   
-   
-   
-   
+
 !=======================================================================
-!SUBROUTINE sc_init (  ) BIND (C, NAME='sc_init')
-!subroutine sc_init ( nTurbines, nInpGlobal, NumCtrl2SC, NumParamGlobal, ParamGlobal, NumParamTurbine, &
-!                        ParamTurbine, NumStatesGlobal, NumStatesTurbine, NumSC2CtrlGlob, &
-!                        NumSC2Ctrl, errStat, errMsg )  bind (C, NAME='sc_init')
 subroutine sc_init ( nTurbines, nInpGlobal, NumCtrl2SC, NumParamGlobal,  NumParamTurbine, &
-                         NumStatesGlobal, NumStatesTurbine, NumSC2CtrlGlob, &
-                        NumSC2Ctrl, errStat, errMsg )  bind (C, NAME='sc_init')
-!subroutine sc_init ( t, nTurbines, nInpGlobal, to_SCglob, NumCtrl2SC, to_SC, &
-!                        nStatesGlobal, StatesGlob, nStatesTurbine, StatesTurbine, NumSC2CtrlGlob, from_SCglob, &
-!                        NumSC2Ctrl, from_SC, errStat, errMsg )  bind (C, NAME='sc_calcOutputs')
-         
+                     NumStatesGlobal, NumStatesTurbine, NumSC2CtrlGlob, &
+                     NumSC2Ctrl, errStat, errMsg )  bind (C, NAME='sc_init')
 
    ! This DLL super controller is used to implement a ...
    
    ! Modified by B. Jonkman to conform to ISO C Bindings (standard Fortran 2003) and 
    ! compile with either gfortran or Intel Visual Fortran (IVF)
    ! DO NOT REMOVE or MODIFY LINES starting with "!DEC$" or "!GCC$"
-   ! !DEC$ specifies attributes for IVF and !GCC$ specifies attributes for gfortran
+   ! !DEC$ specifies attributes for Intel Fortran and !GCC$ specifies attributes for GNU Fortran
    !
    ! Note that gfortran v5.x on Mac produces compiler errors with the DLLEXPORT attribute,
    ! so I've added the compiler directive IMPLICIT_DLLEXPORT.
    
    use, intrinsic :: ISO_C_Binding
 
-   implicit                        none
+   implicit none
+
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: sc_init
 !GCC$ ATTRIBUTES DLLEXPORT :: sc_init
 #endif
+
    integer(C_INT),            intent(in   ) :: nTurbines         !< number of turbines connected to this supercontroller
    integer(C_INT),            intent(  out) :: nInpGlobal          !< number of global inputs to supercontroller
    integer(C_INT),            intent(  out) :: NumCtrl2SC          !< number of turbine controller outputs [inputs to supercontroller]
@@ -62,22 +48,25 @@ subroutine sc_init ( nTurbines, nInpGlobal, NumCtrl2SC, NumParamGlobal,  NumPara
    NumStatesTurbine  = 2
    NumSC2CtrlGlob    = 2 
    NumSC2Ctrl        = 3 
-    
-  
+
    return
    
-   end subroutine sc_init
+end subroutine sc_init
+
 subroutine sc_getInitData(nTurbines, NumParamGlobal, NumParamTurbine, ParamGlobal, ParamTurbine, &
         NumSC2CtrlGlob, from_SCglob, NumSC2Ctrl, from_SC,&
         & nStatesGlobal, StatesGlob, nStatesTurbine, StatesTurbine,&
         & errStat, errMsg )  bind (C, NAME='sc_getInitData')
-use, intrinsic :: ISO_C_Binding
 
-   implicit                        none
+   use, intrinsic :: ISO_C_Binding
+
+   implicit none
+
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: sc_getInitData
 !GCC$ ATTRIBUTES DLLEXPORT :: sc_getInitData
 #endif
+
    integer(C_INT),            intent(in   ) :: nTurbines         !< number of turbines connected to this supercontroller
    integer(C_INT),            intent(in   ) :: NumParamGlobal      !< number of global parameters
    integer(C_INT),            intent(in   ) :: NumParamTurbine     !< number of parameters per turbine
@@ -127,14 +116,14 @@ use, intrinsic :: ISO_C_Binding
          from_SC((j-1)*NumSC2Ctrl+i) = real((j-1)*NumSC2Ctrl+i,C_FLOAT)
       end do
    end do
-     
-   end subroutine sc_getInitData
+
+end subroutine sc_getInitData
+
 !=======================================================================
-!SUBROUTINE sc_calcOutputs (  ) BIND (C, NAME='sc_calcOutputs')                      
-subroutine sc_calcOutputs ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurbine, paramTurbine, nInpGlobal, to_SCglob, NumCtrl2SC, to_SC, &
-                        nStatesGlobal, StatesGlob, nStatesTurbine, StatesTurbine, NumSC2CtrlGlob, from_SCglob, &
-                        NumSC2Ctrl, from_SC, errStat, errMsg )  bind (C, NAME='sc_calcOutputs')
-         
+subroutine sc_calcOutputs ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurbine, paramTurbine, &
+                           nInpGlobal, to_SCglob, NumCtrl2SC, to_SC, &
+                           nStatesGlobal, StatesGlob, nStatesTurbine, StatesTurbine, NumSC2CtrlGlob, from_SCglob, &
+                           NumSC2Ctrl, from_SC, errStat, errMsg )  bind (C, NAME='sc_calcOutputs')
 
    ! This DLL super controller is used to implement a ...
    
@@ -148,7 +137,8 @@ subroutine sc_calcOutputs ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurbi
    
    use, intrinsic :: ISO_C_Binding
 
-   implicit                        none
+   implicit none
+
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: sc_calcOutputs
 !GCC$ ATTRIBUTES DLLEXPORT :: sc_calcOutputs
@@ -204,10 +194,10 @@ subroutine sc_calcOutputs ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurbi
 end subroutine sc_calcOutputs
 
 !=======================================================================
-!SUBROUTINE sc_updateStates (  ) BIND (C, NAME='sc_updateStates')
-subroutine sc_updateStates ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurbine, paramTurbine, nInpGlobal, to_SCglob, NumCtrl2SC, to_SC, &
-                        nStatesGlobal, StatesGlob, nStatesTurbine, StatesTurbine, errStat, errMsg )  bind (C, NAME='sc_updateStates')
-         
+subroutine sc_updateStates ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurbine, paramTurbine, &
+                           nInpGlobal, to_SCglob, NumCtrl2SC, to_SC, &
+                           nStatesGlobal, StatesGlob, nStatesTurbine, StatesTurbine, &
+                           errStat, errMsg )  bind (C, NAME='sc_updateStates')
 
    ! This DLL super controller is used to implement a ...
    
@@ -221,7 +211,8 @@ subroutine sc_updateStates ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurb
    
    use, intrinsic :: ISO_C_Binding
 
-   implicit                        none
+   implicit none
+
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: sc_updateStates
 !GCC$ ATTRIBUTES DLLEXPORT :: sc_updateStates
@@ -289,7 +280,6 @@ subroutine sc_updateStates ( t, nTurbines, nParamGlobal, paramGlobal, nParamTurb
 end subroutine sc_updateStates
 
 subroutine sc_end ( errStat, errMsg )  bind (C, NAME='sc_end')
-         
 
    ! This DLL super controller is used to implement a ...
    
@@ -303,7 +293,8 @@ subroutine sc_end ( errStat, errMsg )  bind (C, NAME='sc_end')
    
    use, intrinsic :: ISO_C_Binding
 
-   implicit                        none
+   implicit none
+
 #ifndef IMPLICIT_DLLEXPORT
 !DEC$ ATTRIBUTES DLLEXPORT :: sc_end
 !GCC$ ATTRIBUTES DLLEXPORT :: sc_end
@@ -311,13 +302,6 @@ subroutine sc_end ( errStat, errMsg )  bind (C, NAME='sc_end')
 
    integer(C_INT),         intent(inout) :: errStat           !< error status code (uses NWTC_Library error codes)
    character(kind=C_CHAR), intent(inout) :: errMsg       (*)  !< Error Message from DLL to simulation code        
- 
-
    
    return
 end subroutine sc_end
-
-
-
-
-


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This pull request adds a CMake target to compile the super-controller library via CMake.

**Related issue, if one exists**
No open GitHub issue but this was discussed in this forum post: https://wind.nrel.gov/forum/wind/viewtopic.php?p=18191#p18191

**Impacted areas of the software**
Super-controller library CMake config

**Additional supporting information**
This has not been tested for validity in a simulation and it should be.