### PR TITLE
[bugfix] incorrect init of aggregated output index arrays in FAST.Farm

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -167,7 +167,7 @@ macro(set_fast_intel_fortran_posix)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,no-array-temps -traceback -init=huge,infinity" )
+    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,noarg_temp_created -traceback -init=huge,infinity" )
   endif()
 
   # OPENMP

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -167,7 +167,7 @@ macro(set_fast_intel_fortran_posix)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,no-array-temps -traceback" )
+    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,no-array-temps -traceback -init=huge,infinity" )
   endif()
 
   # OPENMP
@@ -221,7 +221,7 @@ macro(set_fast_intel_fortran_windows)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all /traceback" )
+    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all /traceback /Qinit=huge,infinity" )
   endif()
 
   # OPENMP

--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -221,7 +221,7 @@ macro(set_fast_intel_fortran_windows)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all /traceback /Qinit=huge,infinity" )
+    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all,noarg_temp_created /traceback /Qinit=huge,infinity" )
   endif()
 
   # OPENMP

--- a/glue-codes/fast-farm/src/FAST_Farm_IO.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_IO.f90
@@ -9939,26 +9939,8 @@ WRITE (UnSum,'(2X,A)')      'Calibrated parameter for wake meandering (-): '//tr
 RETURN
 END SUBROUTINE Farm_PrintSum
 
-!----------------------------------------------------------------------------------------------------------------------------------
-!> This routine initializes the output for the glue code, including writing the header for the primary output file.
-SUBROUTINE Farm_InitOutput( farm, ErrStat, ErrMsg )
-
-   IMPLICIT NONE
-
-      ! Passed variables
-   type(All_FastFarm_Data),        INTENT(INOUT)        :: farm                                  !< FAST.Farm data
-   INTEGER(IntKi),                 INTENT(OUT)          :: ErrStat                               !< Error status
-   CHARACTER(*),                   INTENT(OUT)          :: ErrMsg                                !< Error message corresponding to ErrStat
-
-
-      ! Local variables.
-
-   INTEGER(IntKi)                   :: I, J                                            ! Generic index for DO loops.
-   INTEGER(IntKi)                   :: indxLast                                        ! The index of the last value to be written to an array
-   INTEGER(IntKi)                   :: indxNext                                        ! The index of the next value to be written to an array
-   INTEGER(IntKi)                   :: NumOuts                                         ! number of channels to be written to the output file(s)
-   
-   
+! These must be set prior to usage in the SetOutParam routine 
+SUBROUTINE Farm_SetAggregatedChannelOutArrays()
 WkDfVxTND(:,:,1) = RESHAPE(  & 
                           (/WkDfVxT1N01D1,WkDfVxT1N02D1,WkDfVxT1N03D1,WkDfVxT1N04D1,WkDfVxT1N05D1,WkDfVxT1N06D1,WkDfVxT1N07D1,WkDfVxT1N08D1,WkDfVxT1N09D1,WkDfVxT1N10D1, &
                             WkDfVxT1N11D1,WkDfVxT1N12D1,WkDfVxT1N13D1,WkDfVxT1N14D1,WkDfVxT1N15D1,WkDfVxT1N16D1,WkDfVxT1N17D1,WkDfVxT1N18D1,WkDfVxT1N19D1,WkDfVxT1N20D1, &
@@ -10828,7 +10810,28 @@ EddShrTND(:,:,9) = RESHAPE(  &
                             EddShrT9N11D8,EddShrT9N12D8,EddShrT9N13D8,EddShrT9N14D8,EddShrT9N15D8,EddShrT9N16D8,EddShrT9N17D8,EddShrT9N18D8,EddShrT9N19D8,EddShrT9N20D8, &
                             EddShrT9N01D9,EddShrT9N02D9,EddShrT9N03D9,EddShrT9N04D9,EddShrT9N05D9,EddShrT9N06D9,EddShrT9N07D9,EddShrT9N08D9,EddShrT9N09D9,EddShrT9N10D9, &
                             EddShrT9N11D9,EddShrT9N12D9,EddShrT9N13D9,EddShrT9N14D9,EddShrT9N15D9,EddShrT9N16D9,EddShrT9N17D9,EddShrT9N18D9,EddShrT9N19D9,EddShrT9N20D9/),   (/20,9/) )
+END SUBROUTINE Farm_SetAggregatedChannelOutArrays
 
+
+
+!----------------------------------------------------------------------------------------------------------------------------------
+!> This routine initializes the output for the glue code, including writing the header for the primary output file.
+SUBROUTINE Farm_InitOutput( farm, ErrStat, ErrMsg )
+
+   IMPLICIT NONE
+
+      ! Passed variables
+   type(All_FastFarm_Data),        INTENT(INOUT)        :: farm                                  !< FAST.Farm data
+   INTEGER(IntKi),                 INTENT(OUT)          :: ErrStat                               !< Error status
+   CHARACTER(*),                   INTENT(OUT)          :: ErrMsg                                !< Error message corresponding to ErrStat
+
+
+      ! Local variables.
+
+   INTEGER(IntKi)                   :: I, J                                            ! Generic index for DO loops.
+   INTEGER(IntKi)                   :: indxLast                                        ! The index of the last value to be written to an array
+   INTEGER(IntKi)                   :: indxNext                                        ! The index of the next value to be written to an array
+   INTEGER(IntKi)                   :: NumOuts                                         ! number of channels to be written to the output file(s)
    
    if ( (farm%p%NumOuts == 0) ) then ! .or. .not. ( (farm%p%WrTxtOutFile) .or. (farm%p%WrBinOutFile) ) ) then
       return
@@ -14755,6 +14758,9 @@ SUBROUTINE Farm_SetOutParam(OutList, farm, ErrStat, ErrMsg )
    ErrStat = ErrID_None
    ErrMsg = ""
    InvalidOutput = .FALSE.
+   
+   ! Setup the aggregated channel arrays used below
+   call Farm_SetAggregatedChannelOutArrays()
    
 !   ..... Developer must add checking for invalid inputs here: .....
   


### PR DESCRIPTION
This PR is ready for merging.

**Feature or improvement description**
The arrays `WkDfVxTND, WkDfVrTND, EddVisTND, EddAmbTND, EddShrTND` are used to aggregate output channels in 
FAST_Farm_IO.f90.  These had been used prior to actually getting set.  So they may point to random garbage in memory.

This error could be caught when the `-finit-integer=9999.` flag was set on the debug gcc compile.  Running the LESinflow or TSinflow case with this debug compile would trigger a segfault such as 

```
    Start 37: LESinflow

37: Test command: /usr/local/bin/python3 "/Users/aplatt/software-development/GitHub/openfast-4/reg_tests/executeFASTFarmRegressionCase.py" "LESinflow" "/Users/aplatt/software-development/GitHub/openfast-4/build-Double-Debug-ff/glue-codes/fast-farm/FAST.Farm" "/Users/aplatt/software-development/GitHub/openfast-4/reg_tests/.." "/Users/aplatt/software-development/GitHub/openfast-4/build-Double-Debug-ff/reg_tests/glue-codes/fast-farm" "0.00001" "Darwin" "GNU"
37: Test timeout computed to be: 5400
37: At line 14886 of file /Users/aplatt/software-development/GitHub/openfast-4/glue-codes/fast-farm/src/FAST_Farm_IO.f90
37: Fortran runtime error: Index '9999' of dimension 1 of array 'invalidoutput' outside of expected range (0:9423)
37:
37: Error termination. Backtrace:
37: #0  0x10ff808cd
37: #1  0x10ff81555
37: #2  0x10ff819e6
37: #3  0x109c8346a
37: #4  0x109ee7738
37: #5  0x109faaf24
37: #6  0x109fab275
```

This PR also includes additional flags for the intel compiler in debug mode build with cmake to set all reals and integers to large numbers or infinity, which should help catch this kind of issue in those cmake builds.  VS builds have not been modified.  Also a correction to a flag for the intel debug builds on linux/mac.

**Impacted areas of the software**
FAST.Farm

**Additional supporting information**
It doesn't appear than anyone has used these particular outputs, so it may not have affected anyone using FAST.Farm to date.  If it did, they would potentially see an invalid channel, or garbage in that channel.

**Test results, if applicable**
No test results change.