### PR TITLE
Fixes for Intel in debug mode

### DIFF
--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -2460,18 +2460,18 @@ END SUBROUTINE Alloc_CoordSys
 SUBROUTINE SetBladeParameters( p, BladeInData, BladeMeshData, ErrStat, ErrMsg )
 !..................................................................................................................................
 
-   TYPE(ED_ParameterType),        INTENT(INOUT)  :: p                                   !< The parameters of the structural dynamics module
-   TYPE(BladeInputData),          INTENT(IN)     :: BladeInData(:)                      !< Program input data for all blades
-   TYPE(ED_BladeMeshInputData),   INTENT(IN)     :: BladeMeshData(:)                    !< Program input mesh data for all blades
-   INTEGER(IntKi),                INTENT(OUT)    :: ErrStat                             !< Error status
-   CHARACTER(*),                  INTENT(OUT)    :: ErrMsg                              !< Error message
+   TYPE(ED_ParameterType),                      INTENT(INOUT)  :: p                 !< The parameters of the structural dynamics module
+   TYPE(BladeInputData),         ALLOCATABLE,   INTENT(IN)     :: BladeInData(:)    !< Program input data for all blades
+   TYPE(ED_BladeMeshInputData),  ALLOCATABLE,   INTENT(IN)     :: BladeMeshData(:)  !< Program input mesh data for all blades
+   INTEGER(IntKi),                              INTENT(OUT)    :: ErrStat           !< Error status
+   CHARACTER(*),                                INTENT(OUT)    :: ErrMsg            !< Error message
 
       ! Local variables:
-   REAL(ReKi)                                    :: x                                   ! Fractional location between two points in linear interpolation
-   INTEGER(IntKi )                               :: K                                   ! Blade number
-   INTEGER(IntKi )                               :: J                                   ! Index for the node arrays
-   INTEGER(IntKi)                                :: InterpInd                           ! Index for the interpolation routine
-   LOGICAL                                       :: SetAdmVals                          ! Logical to determine if Adams inputs should be set
+   REAL(ReKi)                                                  :: x                 ! Fractional location between two points in linear interpolation
+   INTEGER(IntKi )                                             :: K                 ! Blade number
+   INTEGER(IntKi )                                             :: J                 ! Index for the node arrays
+   INTEGER(IntKi)                                              :: InterpInd         ! Index for the interpolation routine
+   LOGICAL                                                     :: SetAdmVals        ! Logical to determine if Adams inputs should be set
 
       ! initialize variables
    ErrStat = ErrID_None

--- a/modules/hydrodyn/src/HydroDyn_Output.f90
+++ b/modules/hydrodyn/src/HydroDyn_Output.f90
@@ -1127,25 +1127,25 @@ SUBROUTINE HDOut_MapOutputs( CurrentTime, p, y, m_WAMIT, m_WAMIT2, NWaveElev, Wa
 ! This subroutine writes the data stored in the y variable to the correct indexed postions in WriteOutput
 ! This is called by HydroDyn_CalcOutput() at each time step.
 !---------------------------------------------------------------------------------------------------- 
-   REAL(DbKi),                         INTENT( IN    )  :: CurrentTime    ! Current simulation time in seconds
-   TYPE(HydroDyn_ParameterType),       INTENT( IN    )  :: p              ! HydroDyn's parameter data
-   TYPE(HydroDyn_OutputType),          INTENT( INOUT )  :: y              ! HydroDyn's output data
-   type(WAMIT_MiscVarType),            intent( in    )  :: m_WAMIT(:)     ! WAMIT object's MiscVar data
-   type(WAMIT2_MiscVarType),           intent( in    )  :: m_WAMIT2(:)    ! WAMIT2 object's MiscVar data
-   INTEGER,                            INTENT( IN    )  :: NWaveElev      ! Number of wave elevation locations to output
-   REAL(ReKi),                         INTENT( IN    )  :: WaveElev(:)    ! Instantaneous total elevation of incident waves at each of the NWaveElev points where the incident wave elevations can be output (meters)   
-   REAL(ReKi),                         INTENT( IN    )  :: WaveElev1(:)    ! Instantaneous first order elevation of incident waves at each of the NWaveElev points where the incident wave elevations can be output (meters)   
-   REAL(ReKi),                         INTENT( IN    )  :: WaveElev2(:)    ! Instantaneous second order elevation of incident waves at each of the NWaveElev points where the incident wave elevations can be output (meters)   
-   REAL(ReKi),                         INTENT( IN    )  :: F_Add(:)
-   REAL(ReKi),                         INTENT( IN    )  :: F_Waves(:)
-   REAL(ReKi),                         INTENT( IN    )  :: F_Hydro(:)     ! All hydrodynamic loads integrated at (0,0,0) in the global coordinate system
-   type(MeshType),                     INTENT( IN    )  :: PRPmesh        ! the PRP mesh -- for motions output
-   REAL(ReKi),                         INTENT( IN    )  :: q(:)           ! WAMIT body translations and rotations
-   REAL(ReKi),                         INTENT( IN    )  :: qdot(:)        ! WAMIT body translational and rotational velocities
-   REAL(ReKi),                         INTENT( IN    )  :: qdotdot(:)     ! WAMIT body translational and rotational accelerations
-   REAL(ReKi),                         INTENT(   OUT )  :: AllOuts(MaxHDOutputs)
-   INTEGER(IntKi),                     INTENT(   OUT )  :: ErrStat        ! Error status of the operation
-   CHARACTER(*),                       INTENT(   OUT )  :: ErrMsg         ! Error message if ErrStat /= ErrID_None
+   REAL(DbKi),                            INTENT( IN    )  :: CurrentTime    ! Current simulation time in seconds
+   TYPE(HydroDyn_ParameterType),          INTENT( IN    )  :: p              ! HydroDyn's parameter data
+   TYPE(HydroDyn_OutputType),             INTENT( INOUT )  :: y              ! HydroDyn's output data
+   type(WAMIT_MiscVarType),  ALLOCATABLE, intent( in    )  :: m_WAMIT(:)     ! WAMIT object's MiscVar data
+   type(WAMIT2_MiscVarType), ALLOCATABLE, intent( in    )  :: m_WAMIT2(:)    ! WAMIT2 object's MiscVar data
+   INTEGER,                               INTENT( IN    )  :: NWaveElev      ! Number of wave elevation locations to output
+   REAL(ReKi),                            INTENT( IN    )  :: WaveElev(:)    ! Instantaneous total elevation of incident waves at each of the NWaveElev points where the incident wave elevations can be output (meters)   
+   REAL(ReKi),                            INTENT( IN    )  :: WaveElev1(:)    ! Instantaneous first order elevation of incident waves at each of the NWaveElev points where the incident wave elevations can be output (meters)   
+   REAL(ReKi),                            INTENT( IN    )  :: WaveElev2(:)    ! Instantaneous second order elevation of incident waves at each of the NWaveElev points where the incident wave elevations can be output (meters)   
+   REAL(ReKi),               ALLOCATABLE, INTENT( IN    )  :: F_Add(:)
+   REAL(ReKi),               ALLOCATABLE, INTENT( IN    )  :: F_Waves(:)
+   REAL(ReKi),                            INTENT( IN    )  :: F_Hydro(:)     ! All hydrodynamic loads integrated at (0,0,0) in the global coordinate system
+   type(MeshType),                        INTENT( IN    )  :: PRPmesh        ! the PRP mesh -- for motions output
+   REAL(ReKi),                            INTENT( IN    )  :: q(:)           ! WAMIT body translations and rotations
+   REAL(ReKi),                            INTENT( IN    )  :: qdot(:)        ! WAMIT body translational and rotational velocities
+   REAL(ReKi),                            INTENT( IN    )  :: qdotdot(:)     ! WAMIT body translational and rotational accelerations
+   REAL(ReKi),                            INTENT(   OUT )  :: AllOuts(MaxHDOutputs)
+   INTEGER(IntKi),                        INTENT(   OUT )  :: ErrStat        ! Error status of the operation
+   CHARACTER(*),                          INTENT(   OUT )  :: ErrMsg         ! Error message if ErrStat /= ErrID_None
 
    INTEGER                                              :: I, iBody, startIndx, endIndx
    integer(IntKi)                                       :: ErrStat2

--- a/modules/hydrodyn/src/Morison.f90
+++ b/modules/hydrodyn/src/Morison.f90
@@ -519,27 +519,27 @@ SUBROUTINE WriteSummaryFile( UnSum, g, MSL2SWL, WtrDpth, numJoints, numNodes, no
                              NOutputs, OutParam, NMOutputs, MOutLst,  NJOutputs, JOutLst, uMesh, yMesh, &
                              p, m, errStat, errMsg ) 
                              
-   INTEGER,                  INTENT ( IN    )  :: UnSum
-   REAL(ReKi),               INTENT ( IN    )  :: g                    ! gravity
-   REAL(ReKi),               INTENT ( IN    )  :: MSL2SWL
-   REAL(ReKi),               INTENT ( IN    )  :: WtrDpth
-   INTEGER,                  INTENT ( IN    )  :: numJoints
-   INTEGER,                  INTENT ( IN    )  :: numNodes
-   TYPE(Morison_NodeType),   INTENT ( IN    )  :: nodes(:)  
-   INTEGER,                  INTENT ( IN    )  :: numMembers
-   TYPE(Morison_MemberType), INTENT ( IN    )  :: members(:)
-   INTEGER,                  INTENT ( IN    )  :: NOutputs
-   TYPE(OutParmType),        INTENT ( IN    )  :: OutParam(:)
-   INTEGER,                  INTENT ( IN    )  :: NMOutputs
-   TYPE(Morison_MOutput),    INTENT ( IN    )  :: MOutLst(:)
-   INTEGER,                  INTENT ( IN    )  :: NJOutputs
-   TYPE(Morison_JOutput),    INTENT ( IN    )  :: JOutLst(:)
-   TYPE(MeshType),           INTENT ( INOUT )  :: uMesh
-   TYPE(MeshType),           INTENT ( INOUT )  :: yMesh
-   TYPE(Morison_ParameterType), INTENT ( IN    ) :: p
-   TYPE(Morison_MiscVarType), INTENT ( IN    ) :: m 
-   INTEGER,                  INTENT (   OUT )  :: errStat             ! returns a non-zero value when an error occurs  
-   CHARACTER(*),             INTENT (   OUT )  :: errMsg              ! Error message if errStat /= ErrID_None
+   INTEGER,                               INTENT ( IN    )  :: UnSum
+   REAL(ReKi),                            INTENT ( IN    )  :: g                    ! gravity
+   REAL(ReKi),                            INTENT ( IN    )  :: MSL2SWL
+   REAL(ReKi),                            INTENT ( IN    )  :: WtrDpth
+   INTEGER,                               INTENT ( IN    )  :: numJoints
+   INTEGER,                               INTENT ( IN    )  :: numNodes
+   TYPE(Morison_NodeType),   ALLOCATABLE, INTENT ( IN    )  :: nodes(:)  
+   INTEGER,                               INTENT ( IN    )  :: numMembers
+   TYPE(Morison_MemberType), ALLOCATABLE, INTENT ( IN    )  :: members(:)
+   INTEGER,                               INTENT ( IN    )  :: NOutputs
+   TYPE(OutParmType),        ALLOCATABLE, INTENT ( IN    )  :: OutParam(:)
+   INTEGER,                               INTENT ( IN    )  :: NMOutputs
+   TYPE(Morison_MOutput),    ALLOCATABLE, INTENT ( IN    )  :: MOutLst(:)
+   INTEGER,                               INTENT ( IN    )  :: NJOutputs
+   TYPE(Morison_JOutput),    ALLOCATABLE, INTENT ( IN    )  :: JOutLst(:)
+   TYPE(MeshType),                        INTENT ( INOUT )  :: uMesh
+   TYPE(MeshType),                        INTENT ( INOUT )  :: yMesh
+   TYPE(Morison_ParameterType),           INTENT ( IN    ) :: p
+   TYPE(Morison_MiscVarType),             INTENT ( IN    ) :: m 
+   INTEGER,                               INTENT (   OUT )  :: errStat             ! returns a non-zero value when an error occurs  
+   CHARACTER(*),                          INTENT (   OUT )  :: errMsg              ! Error message if errStat /= ErrID_None
 
    INTEGER                                     :: I, J
    REAL(ReKi)                                  :: l                   ! length of an element
@@ -1119,27 +1119,27 @@ SUBROUTINE SetExternalHydroCoefs(  MSL2SWL, MCoefMod, MmbrCoefIDIndx, SimplCd, S
 !     This private subroutine generates the Cd, Ca, Cp, CdMG, CaMG and CpMG coefs for the member based on
 !     the input data.  
 !---------------------------------------------------------------------------------------------------- 
-   real(ReKi),                intent(in   )  :: MSL2SWL
-   integer(IntKi),            intent(in   )  :: MCoefMod
-   integer(IntKi),            intent(in   )  :: MmbrCoefIDIndx
-   real(ReKi),                intent(in   )  :: SimplCd 
-   real(ReKi),                intent(in   )  :: SimplCdMG
-   real(ReKi),                intent(in   )  :: SimplCa
-   real(ReKi),                intent(in   )  :: SimplCaMG 
-   real(ReKi),                intent(in   )  :: SimplCp
-   real(ReKi),                intent(in   )  :: SimplCpMG 
-   real(ReKi),                intent(in   )  :: SimplAxCd
-   real(ReKi),                intent(in   )  :: SimplAxCdMG 
-   real(ReKi),                intent(in   )  :: SimplAxCa
-   real(ReKi),                intent(in   )  :: SimplAxCaMG 
-   real(ReKi),                intent(in   )  :: SimplAxCp
-   real(ReKi),                intent(in   )  :: SimplAxCpMG 
-   type(Morison_CoefMembers), intent(in   )  :: CoefMembers(:)
-   integer(IntKi),            intent(in   )  :: NCoefDpth
-   type(Morison_CoefDpths),   intent(in   )  :: CoefDpths(:)
-   integer(IntKi),            intent(in   )  :: numNodes
-   type(Morison_NodeType),    intent(in   )  :: nodes(:)
-   type(Morison_MemberType),  intent(inout)  :: member
+   real(ReKi),                             intent(in   )  :: MSL2SWL
+   integer(IntKi),                         intent(in   )  :: MCoefMod
+   integer(IntKi),                         intent(in   )  :: MmbrCoefIDIndx
+   real(ReKi),                             intent(in   )  :: SimplCd 
+   real(ReKi),                             intent(in   )  :: SimplCdMG
+   real(ReKi),                             intent(in   )  :: SimplCa
+   real(ReKi),                             intent(in   )  :: SimplCaMG 
+   real(ReKi),                             intent(in   )  :: SimplCp
+   real(ReKi),                             intent(in   )  :: SimplCpMG 
+   real(ReKi),                             intent(in   )  :: SimplAxCd
+   real(ReKi),                             intent(in   )  :: SimplAxCdMG 
+   real(ReKi),                             intent(in   )  :: SimplAxCa
+   real(ReKi),                             intent(in   )  :: SimplAxCaMG 
+   real(ReKi),                             intent(in   )  :: SimplAxCp
+   real(ReKi),                             intent(in   )  :: SimplAxCpMG 
+   type(Morison_CoefMembers), allocatable, intent(in   )  :: CoefMembers(:)
+   integer(IntKi),                         intent(in   )  :: NCoefDpth
+   type(Morison_CoefDpths),   allocatable, intent(in   )  :: CoefDpths(:)
+   integer(IntKi),                         intent(in   )  :: numNodes
+   type(Morison_NodeType),    allocatable, intent(in   )  :: nodes(:)
+   type(Morison_MemberType),               intent(inout)  :: member
    
    type(Morison_NodeType)                      :: node, node1, node2
    integer(IntKi)                              :: i, j
@@ -1199,12 +1199,12 @@ end subroutine SetExternalHydroCoefs
 
 SUBROUTINE SetNodeMG( numMGDepths, MGDepths, node, MSL2SWL, tMG, MGdensity )
    ! sets the margine growth thickness of a single node (previously all nodes)
-   INTEGER,                      INTENT( IN    )  :: numMGDepths
-   TYPE(Morison_MGDepthsType),   INTENT( IN    )  :: MGDepths(:)
-   TYPE(Morison_NodeType),       INTENT( IN    )  :: node
-   real(ReKi),                   intent( in    )  :: MSL2SWL
-   real(ReKi),                   intent( inout )  :: tMG
-   real(ReKi),                   intent( inout )  :: MGdensity
+   INTEGER,                                  INTENT( IN    )  :: numMGDepths
+   TYPE(Morison_MGDepthsType), ALLOCATABLE,  INTENT( IN    )  :: MGDepths(:)
+   TYPE(Morison_NodeType),                   INTENT( IN    )  :: node
+   real(ReKi),                               intent( in    )  :: MSL2SWL
+   real(ReKi),                               intent( inout )  :: tMG
+   real(ReKi),                               intent( inout )  :: MGdensity
    
    INTEGER                 :: I, J
    REAL(ReKi)              :: z

--- a/modules/map/src/map.f90
+++ b/modules/map/src/map.f90
@@ -1061,16 +1061,16 @@ IF (ErrStat >= AbortErrLev) RETURN
           
          SELECT CASE( p%InputLineType(iLine) )
          CASE('C')             
-            InitInp%C_obj%library_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%library_input_str )
+            InitInp%C_obj%library_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%library_input_str,   SIZE(InitInp%C_obj%library_input_str) )
             CALL MAP_SetCableLibraryData(InitInp%C_obj)
          CASE ('N')            
-            InitInp%C_obj%node_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%node_input_str )
+            InitInp%C_obj%node_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%node_input_str,         SIZE(InitInp%C_obj%library_input_str) )
             CALL MAP_SetNodeData(InitInp%C_obj)                 
          CASE ('E')
-            InitInp%C_obj%line_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%line_input_str )
+            InitInp%C_obj%line_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%line_input_str,         SIZE(InitInp%C_obj%library_input_str) )
             CALL MAP_SetElementData(InitInp%C_obj)                 
          CASE ('S')
-            InitInp%C_obj%option_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%option_input_str )
+            InitInp%C_obj%option_input_str = TRANSFER(TRIM(p%InputLines(iLine))//" "//C_NULL_CHAR, InitInp%C_obj%option_input_str,     SIZE(InitInp%C_obj%library_input_str) )
             CALL MAP_SetSolverOptions(InitInp%C_obj)                  
          END SELECT
              

--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -3669,7 +3669,7 @@ SUBROUTINE Create_FullOpt1_UVector(u, ED_PlatformPtMesh, SD_TPMesh, SD_LMesh, HD
    TYPE(MeshType)                    , INTENT(IN   ) :: HD_M_Mesh                 !< HydroDyn Morison Lumped mesh
    TYPE(MeshType)                    , INTENT(IN   ) :: HD_WAMIT_Mesh             !< HydroDyn WAMIT mesh
    TYPE(MeshType)                    , INTENT(IN   ) :: ED_HubPtLoad              !< ElastoDyn HubPt mesh
-   TYPE(MeshType)                    , INTENT(IN   ) :: BD_RootMotion(:)          !< BeamDyn RootMotion meshes
+   TYPE(MeshType),      ALLOCATABLE  , INTENT(IN   ) :: BD_RootMotion(:)          !< BeamDyn RootMotion meshes
    TYPE(MeshType)                    , INTENT(IN   ) :: Orca_PtfmMesh             !< OrcaFlex interface PtfmMesh
    TYPE(MeshType)                    , INTENT(IN   ) :: ExtPtfm_PtfmMesh          !< ExtPtfm interface PtfmMesh
    TYPE(StC_InputType), ALLOCATABLE  , INTENT(IN   ) :: SrvD_u_SStC(:)            !< ServoDyn SStC inputs (this will be changed later to mesh)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1275,28 +1275,6 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
 
 
    ! ........................
-   ! Allocate y%WriteOutput to size zero for modules not in use
-   !     NOTE: intel compiler in debug does not like passing unallocated variables in
-   !           the WrOutputLine routine, so allocating them to size zero works around it somewhat
-   ! ........................
-   if (.not. allocated(IfW%y%WriteOutput))      allocate(IfW%y%WriteOutput(0))
-   if (.not. allocated(OpFM%y%WriteOutput))     allocate(OpFM%y%WriteOutput(0))
-   if (.not. allocated(ED%y%WriteOutput))       allocate(ED%y%WriteOutput(0))
-   !if (.not. allocated(AD%y))                   allocate(AD%y(0))                  ! WriteOutput resides in the allocatable var y%Rotors and is handled differently
-   if (.not. allocated(SrvD%y%WriteOutput))     allocate(SrvD%y%WriteOutput(0))
-   if (.not. allocated(HD%y%WriteOutput))       allocate(HD%y%WriteOutput(0))
-   if (.not. allocated(SD%y%WriteOutput))       allocate(SD%y%WriteOutput(0))
-   if (.not. allocated(ExtPtfm%y%WriteOutput))  allocate(ExtPtfm%y%WriteOutput(0))
-   if (.not. allocated(MAPp%y%WriteOutput))     allocate(MAPp%y%WriteOutput(0))
-   if (.not. allocated(FEAM%y%WriteOutput))     allocate(FEAM%y%WriteOutput(0))
-   if (.not. allocated(MD%y%WriteOutput))       allocate(MD%y%WriteOutput(0))
-   if (.not. allocated(Orca%y%WriteOutput))     allocate(Orca%y%WriteOutput(0))
-   if (.not. allocated(IceF%y%WriteOutput))     allocate(IceF%y%WriteOutput(0))
-   if (.not. allocated(IceD%y))                 allocate(IceD%y(0))                 ! We pass IceD%y unallocated otherwise
-   if (.not. allocated(BD%y))                   allocate(BD%y(0))                   ! We pass BD%y   unallocated otherwise
-
-
-   ! ........................
    ! Set up output for glue code (must be done after all modules are initialized so we have their WriteOutput information)
    ! ........................
 
@@ -4995,19 +4973,19 @@ SUBROUTINE WrOutputLine( t, p_FAST, y_FAST, IfWOutput, OpFMOutput, EDOutput, y_A
    TYPE(FAST_OutputFileType),INTENT(INOUT) :: y_FAST                             !< Glue-code simulation outputs
 
 
-   REAL(ReKi),               INTENT(IN)    :: IfWOutput (:)                      !< InflowWind WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: OpFMOutput (:)                     !< OpenFOAM WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: EDOutput (:)                       !< ElastoDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: IfWOutput (:)                      !< InflowWind WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: OpFMOutput (:)                     !< OpenFOAM WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: EDOutput (:)                       !< ElastoDyn WriteOutput values
    TYPE(AD_OutputType),      INTENT(IN)    :: y_AD                               !< AeroDyn outputs (WriteOutput values are subset of allocated Rotors)
-   REAL(ReKi),               INTENT(IN)    :: SrvDOutput (:)                     !< ServoDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: HDOutput (:)                       !< HydroDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: SDOutput (:)                       !< SubDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: ExtPtfmOutput (:)                  !< ExtPtfm_MCKF WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: MAPOutput (:)                      !< MAP WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: FEAMOutput (:)                     !< FEAMooring WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: MDOutput (:)                       !< MoorDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: OrcaOutput (:)                     !< OrcaFlex interface WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: IceFOutput (:)                     !< IceFloe WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: SrvDOutput (:)                     !< ServoDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: HDOutput (:)                       !< HydroDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: SDOutput (:)                       !< SubDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: ExtPtfmOutput (:)                  !< ExtPtfm_MCKF WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: MAPOutput (:)                      !< MAP WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: FEAMOutput (:)                     !< FEAMooring WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: MDOutput (:)                       !< MoorDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: OrcaOutput (:)                     !< OrcaFlex interface WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: IceFOutput (:)                     !< IceFloe WriteOutput values
    TYPE(IceD_OutputType),    INTENT(IN)    :: y_IceD (:)                         !< IceDyn outputs (WriteOutput values are subset)
    TYPE(BD_OutputType),      INTENT(IN)    :: y_BD (:)                           !< BeamDyn outputs (WriteOutput values are subset)
 
@@ -5099,19 +5077,19 @@ SUBROUTINE FillOutputAry(p_FAST, y_FAST, IfWOutput, OpFMOutput, EDOutput, y_AD, 
    TYPE(FAST_ParameterType), INTENT(IN)    :: p_FAST                             !< Glue-code simulation parameters
    TYPE(FAST_OutputFileType),INTENT(IN)    :: y_FAST                             !< Glue-code simulation outputs
 
-   REAL(ReKi),               INTENT(IN)    :: IfWOutput (:)                      !< InflowWind WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: OpFMOutput (:)                     !< OpenFOAM WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: EDOutput (:)                       !< ElastoDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: IfWOutput (:)                      !< InflowWind WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: OpFMOutput (:)                     !< OpenFOAM WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: EDOutput (:)                       !< ElastoDyn WriteOutput values
    TYPE(AD_OutputType),      INTENT(IN)    :: y_AD                               !< AeroDyn outputs (WriteOutput values are subset of allocated Rotors)
-   REAL(ReKi),               INTENT(IN)    :: SrvDOutput (:)                     !< ServoDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: HDOutput (:)                       !< HydroDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: SDOutput (:)                       !< SubDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: ExtPtfmOutput (:)                  !< ExtPtfm_MCKF WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: MAPOutput (:)                      !< MAP WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: FEAMOutput (:)                     !< FEAMooring WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: MDOutput (:)                       !< MoorDyn WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: OrcaOutput (:)                     !< OrcaFlex interface WriteOutput values
-   REAL(ReKi),               INTENT(IN)    :: IceFOutput (:)                     !< IceFloe WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: SrvDOutput (:)                     !< ServoDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: HDOutput (:)                       !< HydroDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: SDOutput (:)                       !< SubDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: ExtPtfmOutput (:)                  !< ExtPtfm_MCKF WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: MAPOutput (:)                      !< MAP WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: FEAMOutput (:)                     !< FEAMooring WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: MDOutput (:)                       !< MoorDyn WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: OrcaOutput (:)                     !< OrcaFlex interface WriteOutput values
+   REAL(ReKi), ALLOCATABLE,  INTENT(IN)    :: IceFOutput (:)                     !< IceFloe WriteOutput values
    TYPE(IceD_OutputType),    INTENT(IN)    :: y_IceD (:)                         !< IceDyn outputs (WriteOutput values are subset)
    TYPE(BD_OutputType),      INTENT(IN)    :: y_BD (:)                           !< BeamDyn outputs (WriteOutput values are subset)
 

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1275,6 +1275,28 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
 
 
    ! ........................
+   ! Allocate y%WriteOutput to size zero for modules not in use
+   !     NOTE: intel compiler in debug does not like passing unallocated variables in
+   !           the WrOutputLine routine, so allocating them to size zero works around it somewhat
+   ! ........................
+   if (.not. allocated(IfW%y%WriteOutput))      allocate(IfW%y%WriteOutput(0))
+   if (.not. allocated(OpFM%y%WriteOutput))     allocate(OpFM%y%WriteOutput(0))
+   if (.not. allocated(ED%y%WriteOutput))       allocate(ED%y%WriteOutput(0))
+   !if (.not. allocated(AD%y))                   allocate(AD%y(0))                  ! WriteOutput resides in the allocatable var y%Rotors and is handled differently
+   if (.not. allocated(SrvD%y%WriteOutput))     allocate(SrvD%y%WriteOutput(0))
+   if (.not. allocated(HD%y%WriteOutput))       allocate(HD%y%WriteOutput(0))
+   if (.not. allocated(SD%y%WriteOutput))       allocate(SD%y%WriteOutput(0))
+   if (.not. allocated(ExtPtfm%y%WriteOutput))  allocate(ExtPtfm%y%WriteOutput(0))
+   if (.not. allocated(MAPp%y%WriteOutput))     allocate(MAPp%y%WriteOutput(0))
+   if (.not. allocated(FEAM%y%WriteOutput))     allocate(FEAM%y%WriteOutput(0))
+   if (.not. allocated(MD%y%WriteOutput))       allocate(MD%y%WriteOutput(0))
+   if (.not. allocated(Orca%y%WriteOutput))     allocate(Orca%y%WriteOutput(0))
+   if (.not. allocated(IceF%y%WriteOutput))     allocate(IceF%y%WriteOutput(0))
+   if (.not. allocated(IceD%y))                 allocate(IceD%y(0))                 ! We pass IceD%y unallocated otherwise
+   if (.not. allocated(BD%y))                   allocate(BD%y(0))                   ! We pass BD%y   unallocated otherwise
+
+
+   ! ........................
    ! Set up output for glue code (must be done after all modules are initialized so we have their WriteOutput information)
    ! ........................
 

--- a/modules/servodyn/src/BladedInterface.f90
+++ b/modules/servodyn/src/BladedInterface.f90
@@ -221,10 +221,11 @@ SUBROUTINE CallBladedLegacyDLL ( u, filt_fromSCglob, filt_fromSC, p, dll_data, E
    aviFAIL = 0                ! bjj, this won't necessarially work if aviFAIL is INTENT(OUT) in DLL_Procedure()--could be undefined???
 
       !Convert to C-type characters: the "C_NULL_CHAR" converts the Fortran string to a C-type string (i.e., adds //CHAR(0) to the end)
+      ! Note: the optional size is specified to avoid an array mismatch issue with some intel compilers in debug (gfortran doesn't notice)
 
-   avcOUTNAME = TRANSFER( TRIM(dll_data%RootName)//C_NULL_CHAR,   avcOUTNAME )
-   accINFILE  = TRANSFER( TRIM(dll_data%DLL_InFile)//C_NULL_CHAR, accINFILE  )
-   avcMSG     = TRANSFER( C_NULL_CHAR,                            avcMSG     ) !bjj this is intent(out), so we shouldn't have to do this, but, to be safe...
+   avcOUTNAME  = TRANSFER( TRIM(dll_data%RootName)//C_NULL_CHAR,   avcOUTNAME, p%avcOUTNAME_LEN )
+   accINFILE   = TRANSFER( TRIM(dll_data%DLL_InFile)//C_NULL_CHAR, accINFILE,  LEN_TRIM(dll_data%DLL_InFile)+1 )
+   avcMSG      = TRANSFER( C_NULL_CHAR,                            avcMSG,     LEN(ErrMsg)+1 ) !bjj this is intent(out), so we shouldn't have to do this, but, to be safe...
 
 #ifdef STATIC_DLL_LOAD
 


### PR DESCRIPTION
**This PR is ready for merging, pending review**

**Feature or improvement description**
The Intel compiler (ifort (IFORT) 2021.4.0 20210910 from the OneAPI install on Ubuntu) throws runtime errors without these changes.

1. In _ServoDyn_, the `TRANSFER` function was throwing an error at runtime about the result of the `TRANSFER` not matching the size of the `C_CHAR` array on the LHS.  Adding the optional size seems to fix this (probably not necessary for `avcOUTNAME`, but added to eliminate confusion... or from my failure to note it wasn't necessary at the time). 
2. Passing the various unallocated `y%WriteOutput` arrays to the `WrOutputLine` resulted in the following error at runtime in debug:
```
forrtl: severe (408): fort: (8): Attempt to fetch from allocatable variable WRITEOUTPUT when it is not allocated

Image              PC                Routine            Line        Source
FAST.Farm          0000000007220FC2  Unknown               Unknown  Unknown
FAST.Farm          0000000000AF4F99  fast_subs_mp_writ        4948  FAST_Subs.f90
FAST.Farm          0000000000AD84BB  fast_subs_mp_fast        4016  FAST_Subs.f90
FAST.Farm          0000000000AD79B2  fast_subs_mp_fast        3934  FAST_Subs.f90
FAST.Farm          0000000000867D0F  fastwrapper_mp_fw         504  FASTWrapper.f90
FAST.Farm          00000000007ED72D  fast_farm_subs_mp        1711  FAST_Farm_Subs.f90
FAST.Farm          000000000089027F  MAIN__                    109  FAST_Farm.f90
FAST.Farm          0000000000406E12  Unknown               Unknown  Unknown
libc-2.31.so       00007FE06F5E00B3  __libc_start_main     Unknown  Unknown
```

**Related issue, if one exists**
Related conversation on PR #664:  https://github.com/OpenFAST/openfast/pull/664/files/2d5a2cd5fc456a77a6dc6cca444e3e0763d5548c..41579a7ed30e0f05c47ebd5260b47852eee85d8d#diff-bc64b5f80cb30c32b06ed3e52051ba117d0f3e765f375de9cd5bc7a81c6e0006

**Impacted areas of the software**
No changes in software operation for other compilers or compile settings is expected.

**Test results, if applicable**
No test results change with this.  And no, I'm not writing a unit test for this...