### PR TITLE
[bugfix] Incorrect reference frame used in HD for WAMIT/WAMIT2

### DIFF
--- a/modules/hydrodyn/src/HydroDyn.f90
+++ b/modules/hydrodyn/src/HydroDyn.f90
@@ -1584,7 +1584,7 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
             CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
 
          do iBody = 1, p%NBody
-            theta = (/ 0.0_R8Ki, 0.0_R8Ki, InputFileData%PtfmRefztRot(iBody)/)
+            theta = (/ 0.0_R8Ki, 0.0_R8Ki, 0.0_R8Ki /)
             orientation = EulerConstruct(theta)
 
             CALL MeshPositionNode (u%WAMITMesh                                                                              &
@@ -1612,7 +1612,6 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
             CALL CleanUp()
             RETURN
          END IF
-
 
       ! Output mesh for loads at each WAMIT body
          CALL MeshCopy (   SrcMesh    = u%WAMITMesh            &

--- a/modules/hydrodyn/src/WAMIT.f90
+++ b/modules/hydrodyn/src/WAMIT.f90
@@ -1362,7 +1362,7 @@ end if
          
       do iBody = 1, p%NBody
 
-         theta = (/ 0.0_R8Ki, 0.0_R8Ki, InitInp%PtfmRefztRot(iBody)/)
+         theta = (/ 0.0_R8Ki, 0.0_R8Ki, 0.0_R8Ki /)
          orientation = EulerConstruct(theta)
          
          

--- a/modules/hydrodyn/src/WAMIT2.f90
+++ b/modules/hydrodyn/src/WAMIT2.f90
@@ -693,7 +693,7 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
       DO IBody = 1,p%NBody
 
             ! Set orientation and position for each body in mesh
-         theta       = (/ 0.0_R8Ki, 0.0_R8Ki, InitInp%PtfmRefztRot(IBody)/)      ! angle in radians
+         theta = (/ 0.0_R8Ki, 0.0_R8Ki, 0.0_R8Ki /)
          orientation = EulerConstruct(theta)
          XYZloc      = (/InitInp%PtfmRefxt(IBody), InitInp%PtfmRefyt(IBody), InitInp%PtfmRefzt(IBody)/)
 


### PR DESCRIPTION
This PR is ready to merge

**Bug description**
An incorrect reference frame was applied to mesh used for the potential flow bodies when rotated using the `PtfmRefztRot` input in the main HydroDyn input file.  This mesh reference orientation should have been set to the identity.

@rdamiani found this bug in testing a proprietary floating platform design including both Morison and potential flow elements.  He had noticed that rotating the `WAMIT` body produced a different period in a pitch free decay test.  It is expected that this frequency would be identical for an axisymmetric `WAMIT` body.  See #914 for plots.

For further testing, a very simple test using a purely potential flow (`WAMIT` body) floating platform from the ITI Barge test case (`5MW_ITIBarge_DLL_WTurb_WavesIrr` regression test).  Turning off waves and wind, a free decay test from -5 degrees initial pitch is performed.

Before fix:
![Screen Shot 2021-11-10 at 2 08 33 PM](https://user-images.githubusercontent.com/2745453/141193777-0978d9b2-6f96-421a-b1e3-049e0f2056e1.png)

After bug fix:
![Screen Shot 2021-11-10 at 2 12 34 PM](https://user-images.githubusercontent.com/2745453/141194226-f2dd3210-1eaf-4ef6-9ddb-9f5c2f1aeed3.png)


**Related issue, if one exists**
#914 

**Impacted areas of the software**
Potential flow (WAMIT) bodies in HydroDyn that are rotated will be affected.  No regression tests currently exist using this feature.
