### PR TITLE
[bugfix] Minor bugfix in AirfoilInfo

### DIFF
--- a/modules/aerodyn/src/AirfoilInfo.f90
+++ b/modules/aerodyn/src/AirfoilInfo.f90
@@ -1043,10 +1043,12 @@ ALPHA_LOOP: DO Row=1,p%Table(iTable)%NumAlf-1
                         fullySeparate = p%Coefs(Row,ColCl) / 2.0_ReKi                      ! Eq. 61
                      end if
                   
+                     p%Coefs(Row,col_fs) = fullySeparate
+
                   end if
                
                   p%Coefs(Row,ColUAf) = f_st
-                  p%Coefs(Row,col_fs) = fullySeparate
+
                end do
                
                ! Compute variables to help x3 state with +/-180-degree wrap-around issues


### PR DESCRIPTION
fullySeparate was not used at the right place and could be used when not defined.

Ready to be merged.
