### PR TITLE
Fix issue with uninitialized variables in InflowWind's Direct Scaling method

### DIFF
--- a/modules/inflowwind/src/IfW_FFWind_Base.f90
+++ b/modules/inflowwind/src/IfW_FFWind_Base.f90
@@ -539,6 +539,11 @@ SUBROUTINE ScaleTurbulence(InitInp, FFData, ScaleFactors, ErrStat, ErrMsg)
    ErrStat = ErrID_None
    ErrMsg  = ""
    
+   nz = size(FFData,1)
+   ny = size(FFData,2)
+   nc = size(FFData,3)
+   nx = size(FFData,4)
+   
    if ( InitInp%ScaleMethod == ScaleMethod_None ) then
       
       ! don't scale FFWind:      
@@ -556,11 +561,6 @@ SUBROUTINE ScaleTurbulence(InitInp, FFData, ScaleFactors, ErrStat, ErrMsg)
          
       else !if ( InitInp%ScaleMethod == ScaleMethod_StdDev ) then
          ! compute the scale factor to get requested sigma:
-         
-         nz = size(FFData,1)
-         ny = size(FFData,2)
-         nc = size(FFData,3)
-         nx = size(FFData,4)
          
             ! find the center point of the grid (if we don't have an odd number of grid points, we'll pick the point closest to the center)
          iz = (nz + 1) / 2 ! integer division


### PR DESCRIPTION
Reported in https://github.com/OpenFAST/openfast/issues/925

**Feature or improvement description**
Initializes array-size constants when Direct Scaling method is used to scale HAWC-formatted wind files.

**Related issue, if one exists**
Fixes #925

**Impacted areas of the software**
InflowWind, when using HAWC-formatted wind files and the direct scaling method.

**Test results, if applicable**
To my knowledge, there are no tests with HAWC-formatted wind files, so no test results should change.

