### PR TITLE
Lin: CalcSteady, forcing linearization at end of simulation

### DIFF
--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -5351,13 +5351,15 @@ SUBROUTINE FAST_CalcSteady( n_t_global, t_global, p_FAST, y_FAST, m_FAST, ED, BD
                m_FAST%Lin%AzimIndx = 1
                m_FAST%Lin%CopyOP_CtrlCode = MESH_UPDATECOPY
             end if
-            ! Forcing linearization if time is close to tmax (with small margin)
+            ! Forcing linearization if time is close to tmax (with sufficient margin) and error in rotor speed less than 0.1%
             if (.not.m_FAST%Lin%FoundSteady) then
                if (ED%p%RotSpeed>0) then
                   if (t_global >= p_FAST%TMax - 2._DbKi*(TwoPi_D)/ED%p%RotSpeed) then
-                     call WrScr('')
-                     call WrScr('[WARNING] Steady state not found before end of simulation. Forcing linearization.')
-                     m_FAST%Lin%ForceLin = .True. 
+                     if (abs(ED%y%RotSpeed-ED%p%RotSpeed)/ED%p%RotSpeed<0.001) then
+                        call WrScr('')
+                        call WrScr('[WARNING] Steady state not found before end of simulation. Forcing linearization.')
+                        m_FAST%Lin%ForceLin = .True. 
+                     endif
                   endif
                else
                   if (t_global >= p_FAST%TMax - 1.5_DbKi*p_FAST%DT) then

--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -5351,11 +5351,21 @@ SUBROUTINE FAST_CalcSteady( n_t_global, t_global, p_FAST, y_FAST, m_FAST, ED, BD
                m_FAST%Lin%AzimIndx = 1
                m_FAST%Lin%CopyOP_CtrlCode = MESH_UPDATECOPY
             end if
-            ! Forcing linearization if time is close to tmax
-            if ((t_global> p_FAST%TMax - 1.5*TwoPi_D/ED%y%RotSpeed) .and. .not.m_FAST%Lin%FoundSteady)  then
-               call WrScr('')
-               call WrScr('[WARNING] Steady state not found before end of simulation. Forcing linearization')
-               m_FAST%Lin%ForceLin = .True. 
+            ! Forcing linearization if time is close to tmax (with small margin)
+            if (.not.m_FAST%Lin%FoundSteady) then
+               if (ED%p%RotSpeed>0) then
+                  if (t_global >= p_FAST%TMax - 2._DbKi*(TwoPi_D)/ED%p%RotSpeed) then
+                     call WrScr('')
+                     call WrScr('[WARNING] Steady state not found before end of simulation. Forcing linearization.')
+                     m_FAST%Lin%ForceLin = .True. 
+                  endif
+               else
+                  if (t_global >= p_FAST%TMax - 1.5_DbKi*p_FAST%DT) then
+                     call WrScr('')
+                     call WrScr('[WARNING] Steady state not found before end of simulation. Forcing linearization.')
+                     m_FAST%Lin%ForceLin = .True. 
+                  endif
+               endif
             endif
          end if
          

--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -5351,10 +5351,11 @@ SUBROUTINE FAST_CalcSteady( n_t_global, t_global, p_FAST, y_FAST, m_FAST, ED, BD
                m_FAST%Lin%AzimIndx = 1
                m_FAST%Lin%CopyOP_CtrlCode = MESH_UPDATECOPY
             end if
-            ! Forcing linearization if time is close to tmax (with sufficient margin) and error in rotor speed less than 0.1%
+            ! Forcing linearization if time is close to tmax (with sufficient margin) 
             if (.not.m_FAST%Lin%FoundSteady) then
                if (ED%p%RotSpeed>0) then
-                  if (t_global >= p_FAST%TMax - 2._DbKi*(TwoPi_D)/ED%p%RotSpeed) then
+                  ! If simulation is at least 10 revolutions, and error in rotor speed less than 0.1%
+                  if ((p_FAST%TMax>10*(TwoPi_D)/ED%p%RotSpeed) .and. ( t_global >= p_FAST%TMax - 2._DbKi*(TwoPi_D)/ED%p%RotSpeed)) then
                      if (abs(ED%y%RotSpeed-ED%p%RotSpeed)/ED%p%RotSpeed<0.001) then
                         call WrScr('')
                         call WrScr('[WARNING] Steady state not found before end of simulation. Forcing linearization.')

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -325,6 +325,7 @@ typedef  ^  FAST_MiscLinType  IntKi    CopyOP_CtrlCode -  -  -  "mesh control co
 typedef  ^  FAST_MiscLinType  DbKi     AzimTarget     {:} -  -  "target azimuth positions in CalcSteady algorithm" rad
 typedef  ^  FAST_MiscLinType  logical  IsConverged     -  -  -  "whether the error calculation in the CalcSteady algorithm is converged" -
 typedef  ^  FAST_MiscLinType  logical  FoundSteady     -  -  -  "whether the CalcSteady algorithm found a steady-state solution" -
+typedef  ^  FAST_MiscLinType  logical  ForceLin        -  -  -  "whether the CalcSteady algorithm found a steady-state solution" -
 typedef  ^  FAST_MiscLinType  IntKi    n_rot           -  -  -  "number of rotations completed in CalcSteady algorithm" -
 typedef  ^  FAST_MiscLinType  IntKi    AzimIndx        -  -  -  "index into target azimuth array in CalcSteady algorithm" -
 typedef  ^  FAST_MiscLinType  IntKi    NextLinTimeIndx -  -  -  "index for next time in LinTimes where linearization should occur" -

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -6131,6 +6131,9 @@ SUBROUTINE FAST_Linearize_T(t_initial, n_t_global, Turbine, ErrStat, ErrMsg)
             call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
       if (Turbine%m_FAST%Lin%FoundSteady) then
+         if (Turbine%m_FAST%Lin%ForceLin) then
+            Turbine%p_FAST%NLinTimes=1
+         endif
 
          do iLinTime=1,Turbine%p_FAST%NLinTimes
             t_global = Turbine%m_FAST%Lin%LinTimes(iLinTime)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -6162,6 +6162,12 @@ SUBROUTINE FAST_Linearize_T(t_initial, n_t_global, Turbine, ErrStat, ErrMsg)
 
          if (Turbine%p_FAST%WrVTK == VTK_ModeShapes) CALL WrVTKCheckpoint()
 
+         if (Turbine%m_FAST%Lin%ForceLin) then
+            ErrStat2 = ErrID_Warn
+            ErrMsg2  = 'Linearization was forced at simulation end. The linearized model may not be sufficiently representative of the solution in steady state.'
+            CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+         endif
+
       end if
 
    end if

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -325,6 +325,7 @@ IMPLICIT NONE
     REAL(DbKi) , DIMENSION(:), ALLOCATABLE  :: AzimTarget      !< target azimuth positions in CalcSteady algorithm [rad]
     LOGICAL  :: IsConverged      !< whether the error calculation in the CalcSteady algorithm is converged [-]
     LOGICAL  :: FoundSteady      !< whether the CalcSteady algorithm found a steady-state solution [-]
+    LOGICAL  :: ForceLin      !< whether the CalcSteady algorithm found a steady-state solution [-]
     INTEGER(IntKi)  :: n_rot      !< number of rotations completed in CalcSteady algorithm [-]
     INTEGER(IntKi)  :: AzimIndx      !< index into target azimuth array in CalcSteady algorithm [-]
     INTEGER(IntKi)  :: NextLinTimeIndx      !< index for next time in LinTimes where linearization should occur [-]
@@ -14769,6 +14770,7 @@ IF (ALLOCATED(SrcMiscLinTypeData%AzimTarget)) THEN
 ENDIF
     DstMiscLinTypeData%IsConverged = SrcMiscLinTypeData%IsConverged
     DstMiscLinTypeData%FoundSteady = SrcMiscLinTypeData%FoundSteady
+    DstMiscLinTypeData%ForceLin = SrcMiscLinTypeData%ForceLin
     DstMiscLinTypeData%n_rot = SrcMiscLinTypeData%n_rot
     DstMiscLinTypeData%AzimIndx = SrcMiscLinTypeData%AzimIndx
     DstMiscLinTypeData%NextLinTimeIndx = SrcMiscLinTypeData%NextLinTimeIndx
@@ -14901,6 +14903,7 @@ ENDIF
   END IF
       Int_BufSz  = Int_BufSz  + 1  ! IsConverged
       Int_BufSz  = Int_BufSz  + 1  ! FoundSteady
+      Int_BufSz  = Int_BufSz  + 1  ! ForceLin
       Int_BufSz  = Int_BufSz  + 1  ! n_rot
       Int_BufSz  = Int_BufSz  + 1  ! AzimIndx
       Int_BufSz  = Int_BufSz  + 1  ! NextLinTimeIndx
@@ -14986,6 +14989,8 @@ ENDIF
     IntKiBuf(Int_Xferred) = TRANSFER(InData%IsConverged, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = TRANSFER(InData%FoundSteady, IntKiBuf(1))
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = TRANSFER(InData%ForceLin, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = InData%n_rot
     Int_Xferred = Int_Xferred + 1
@@ -15129,6 +15134,8 @@ ENDIF
     OutData%IsConverged = TRANSFER(IntKiBuf(Int_Xferred), OutData%IsConverged)
     Int_Xferred = Int_Xferred + 1
     OutData%FoundSteady = TRANSFER(IntKiBuf(Int_Xferred), OutData%FoundSteady)
+    Int_Xferred = Int_Xferred + 1
+    OutData%ForceLin = TRANSFER(IntKiBuf(Int_Xferred), OutData%ForceLin)
     Int_Xferred = Int_Xferred + 1
     OutData%n_rot = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
Perform linearization at end of simulation if no steady state is found. Only one linearization is done at the final time step. 


**Impacted areas of the software**
OpenFAST-library / linearization

**Additional supporting information**
At times, the trim algorithm does not find a steady state. This might indicate an issue in the model or in the algorithm itself. It is yet slightly unfortunate if no linearization occurs even if the user specify a large TMax. 

A warning is displayed and it's the user responsibility to check that the linearization occur at a somehow close to periodic steady state. 




