### PR TITLE
Update GH actions to update packages for ubuntu debug regression test

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -106,7 +106,7 @@ jobs:
             install_deps: brew install gcovr
           - os: ubuntu-20.04
             FORTRAN_COMPILER: gfortran-10
-            install_deps: sudo apt-get install -y gcovr
+            install_deps: sudo apt-get update && sudo apt-get install -y gcovr
 
     name: regression-test-debug-${{ matrix.os }}-${{ matrix.FORTRAN_COMPILER }}
     steps:


### PR DESCRIPTION
For the past week, the OpenFAST GH actions for the ubuntu debug regression tests were failing with this error:
```
E: Failed to fetch http://security.ubuntu.com/ubuntu/pool/main/l/lxml/python3-lxml_4.5.0-1ubuntu0.3_amd64.deb 404 Not Found [IP: 52.250.76.244 80]

E: Unable to fetch some archives, maybe run apt-get update or try with --fix-missing?


Error: Process completed with exit code 100.
```
The requested package version wasn't available, but a newer one was. This PR adds the `apt-get update` command to the workflow to fix the problem.
