### PR TITLE
[BugFix] AD15 nacelle reference position was set to hub position

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -1031,7 +1031,7 @@ subroutine Init_u( u, p, p_AD, InputFileData, InitInp, errStat, errMsg )
       if (errStat >= AbortErrLev) return
             
          ! set node initial position/orientation
-      position = InitInp%HubPosition
+      position = InitInp%NacellePosition
       position(1:2) = 0
       call MeshPositionNode(u%NacelleMotion, 1, position, errStat2, errMsg2, orient=InitInp%NacelleOrientation)
          call SetErrStat( errStat2, errMsg2, errStat, errMsg, RoutineName )

--- a/modules/aerodyn/src/AeroDyn_Registry.txt
+++ b/modules/aerodyn/src/AeroDyn_Registry.txt
@@ -42,6 +42,7 @@ typedef	^	RotInitInputType	ReKi	HubPosition	{3}	-	-	"X-Y-Z reference position of
 typedef	^	RotInitInputType	R8Ki	HubOrientation	{3}{3}	-	-	"DCM reference orientation of hub"	-
 typedef	^	RotInitInputType	ReKi	BladeRootPosition	{:}{:}	-	-	"X-Y-Z reference position of each blade root (3 x NumBlades)"	m
 typedef	^	RotInitInputType	R8Ki	BladeRootOrientation	{:}{:}{:}	-	-	"DCM reference orientation of blade roots (3x3 x NumBlades)"	-
+typedef	^	RotInitInputType	R8Ki	NacellePosition	{3}	-	-	"X-Y-Z reference position of hub"	m
 typedef	^	RotInitInputType	R8Ki	NacelleOrientation	{3}{3}	-	-	"DCM reference orientation of nacelle"	-
 typedef	^	RotInitInputType	IntKi	AeroProjMod   	-	0	-	"Flag to switch between different projection models"	-
 

--- a/modules/aerodyn/src/AeroDyn_Types.f90
+++ b/modules/aerodyn/src/AeroDyn_Types.f90
@@ -57,6 +57,7 @@ IMPLICIT NONE
     REAL(R8Ki) , DIMENSION(1:3,1:3)  :: HubOrientation      !< DCM reference orientation of hub [-]
     REAL(ReKi) , DIMENSION(:,:), ALLOCATABLE  :: BladeRootPosition      !< X-Y-Z reference position of each blade root (3 x NumBlades) [m]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: BladeRootOrientation      !< DCM reference orientation of blade roots (3x3 x NumBlades) [-]
+    REAL(R8Ki) , DIMENSION(1:3)  :: NacellePosition      !< X-Y-Z reference position of hub [m]
     REAL(R8Ki) , DIMENSION(1:3,1:3)  :: NacelleOrientation      !< DCM reference orientation of nacelle [-]
     INTEGER(IntKi)  :: AeroProjMod = 0      !< Flag to switch between different projection models [-]
   END TYPE RotInitInputType
@@ -416,6 +417,7 @@ IF (ALLOCATED(SrcRotInitInputTypeData%BladeRootOrientation)) THEN
   END IF
     DstRotInitInputTypeData%BladeRootOrientation = SrcRotInitInputTypeData%BladeRootOrientation
 ENDIF
+    DstRotInitInputTypeData%NacellePosition = SrcRotInitInputTypeData%NacellePosition
     DstRotInitInputTypeData%NacelleOrientation = SrcRotInitInputTypeData%NacelleOrientation
     DstRotInitInputTypeData%AeroProjMod = SrcRotInitInputTypeData%AeroProjMod
  END SUBROUTINE AD_CopyRotInitInputType
@@ -485,6 +487,7 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*3  ! BladeRootOrientation upper/lower bounds for each dimension
       Db_BufSz   = Db_BufSz   + SIZE(InData%BladeRootOrientation)  ! BladeRootOrientation
   END IF
+      Db_BufSz   = Db_BufSz   + SIZE(InData%NacellePosition)  ! NacellePosition
       Db_BufSz   = Db_BufSz   + SIZE(InData%NacelleOrientation)  ! NacelleOrientation
       Int_BufSz  = Int_BufSz  + 1  ! AeroProjMod
   IF ( Re_BufSz  .GT. 0 ) THEN 
@@ -571,6 +574,10 @@ ENDIF
         END DO
       END DO
   END IF
+    DO i1 = LBOUND(InData%NacellePosition,1), UBOUND(InData%NacellePosition,1)
+      DbKiBuf(Db_Xferred) = InData%NacellePosition(i1)
+      Db_Xferred = Db_Xferred + 1
+    END DO
     DO i2 = LBOUND(InData%NacelleOrientation,2), UBOUND(InData%NacelleOrientation,2)
       DO i1 = LBOUND(InData%NacelleOrientation,1), UBOUND(InData%NacelleOrientation,1)
         DbKiBuf(Db_Xferred) = InData%NacelleOrientation(i1,i2)
@@ -680,6 +687,12 @@ ENDIF
         END DO
       END DO
   END IF
+    i1_l = LBOUND(OutData%NacellePosition,1)
+    i1_u = UBOUND(OutData%NacellePosition,1)
+    DO i1 = LBOUND(OutData%NacellePosition,1), UBOUND(OutData%NacellePosition,1)
+      OutData%NacellePosition(i1) = REAL(DbKiBuf(Db_Xferred), R8Ki)
+      Db_Xferred = Db_Xferred + 1
+    END DO
     i1_l = LBOUND(OutData%NacelleOrientation,1)
     i1_u = UBOUND(OutData%NacelleOrientation,1)
     i2_l = LBOUND(OutData%NacelleOrientation,2)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -491,6 +491,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       
       Init%InData_AD%rotors(1)%HubPosition        = ED%y%HubPtMotion%Position(:,1)
       Init%InData_AD%rotors(1)%HubOrientation     = ED%y%HubPtMotion%RefOrientation(:,:,1)
+      Init%InData_AD%rotors(1)%NacellePosition    = ED%y%NacelleMotion%Position(:,1)
       Init%InData_AD%rotors(1)%NacelleOrientation = ED%y%NacelleMotion%RefOrientation(:,:,1)
       
       do k=1,NumBl


### PR DESCRIPTION
This PR **is** ready for merging

**Feature or improvement description**
The AeroDyn 15 nacelle reference position was set to the hub reference position.

The effect of this is likely very small since mesh mapping at the glue code accounts for any location differences, and aero loads on the nacelle from AD15 would be nearly identical calculated at the correct nacelle location or at the hub.  However, buoyancy loads on the nacelle were applied at the hub rather than nacelle location, but mapped to the nacelle in the glue code which would result in an unexpected moment.

**Related issue, if one exists**
#957 

**Impacted areas of the software**
This likely only affects buoyancy loads on the nacelle the MHK feature under development.
