### PR TITLE
[BugFix] BeamDyn nodal outputs occasionally segfaulted

### DIFF
--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -1062,6 +1062,7 @@ subroutine SetParameters(InitInp, InputFileData, p, ErrStat, ErrMsg)
          if (ErrStat >= AbortErrLev) return
 
       p%NdIndx(1) = 1
+      p%NdIndxInverse(1) = 1
       p%OutNd2NdElem(:,1) = 1 ! note this is an array
       indx = 2
       DO i=1,p%elem_total
@@ -1119,6 +1120,7 @@ subroutine SetParameters(InitInp, InputFileData, p, ErrStat, ErrMsg)
             if (ErrStat >= AbortErrLev) return
          
          p%NdIndx(1) = 1
+         p%NdIndxInverse(1) = 1
          p%OutNd2NdElem(:,1) = 1 ! note this is an array 
          indx = 2   
          DO i=1,p%elem_total


### PR DESCRIPTION
**Ready for merging**

**Feature or improvement description**
BeamDyn would occasionally incur a segmentation fault when nodal outputs were requested. This appeared to happen only with certain Intel compiler version on Windows and was difficult to reproduce reliably.  The root cause was the first entry in `NdIndxInverse` index lookup table not getting set (this index table is used to map the quadrature point node to the correct nodal output channel).  Thus the first index value would be whatever was resident in that memory location and might be a value outside the range of the output nodes which would result in a segmentation fault.

For whatever reason, I could only reproduce this error with some Intel compiles on Windows.  It did not show up on Linux or with the gcc compilers.  Maybe this is due to different memory layout or previous stored values in the particular memory space (hard to tell without spending more time on the issue).

This issue only affected the indexing for the first node, so may in some instances have caused incorrect outputs for the first node nodal outputs to not match the root outputs.

**Related issue, if one exists**
Maybe related: #248 
Noted in forum post: https://forums.nrel.gov/t/sending-rtaeropwr-via-servodyn-to-bladed-style-dll-controller/2043/14

**Impacted areas of the software**
BeamDyn node based outputs are the only bit of code affected.


