### PR TITLE
Remove conditional statement for initialization of BEMT variable

### DIFF
--- a/modules/aerodyn/src/BEMT.f90
+++ b/modules/aerodyn/src/BEMT.f90
@@ -291,16 +291,11 @@ subroutine BEMT_InitOtherStates( OtherState, p, errStat, errMsg )
 
    errStat = ErrID_None
    errMsg  = ""
-   
-   
-   if (p%UseInduction) then
-      
-      allocate ( OtherState%ValidPhi( p%numBladeNodes, p%numBlades ), STAT = errStat2 )
-      if ( errStat2 /= 0 ) then
-         call SetErrStat( ErrID_Fatal, 'Error allocating memory for OtherState%ValidPhi.', errStat, errMsg, RoutineName )
-         return
-      end if
-
+     
+   allocate ( OtherState%ValidPhi( p%numBladeNodes, p%numBlades ), STAT = errStat2 )
+   if ( errStat2 /= 0 ) then
+      call SetErrStat( ErrID_Fatal, 'Error allocating memory for OtherState%ValidPhi.', errStat, errMsg, RoutineName )
+      return
    end if
    
    ! values of the OtherStates are initialized in BEMT_ReInit()


### PR DESCRIPTION
This pull request is ready to be merged.

**Bug description**
Pull request #863 assigned a value to the BEMT variable `OtherState%ValidPhi` when `p%UseInduction=False`. However, `OtherState%ValidPhi` was only allocated when `p%UseInduction=True`. This caused a memory fault for cases with `WakeMod=0`. This bug fix removes the conditional statement around the initialization of `OtherState%ValidPhi`.

**Impacted areas of the software**
BEMT/AeroDyn

**Test results, if applicable**
All tests pass.