### PR TITLE
docs: update rtd to use sphinxcontrib-bibtex v2.0.0 and later

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,6 +67,17 @@ extensions = [
     'sphinxcontrib.bibtex',
     'sphinxcontrib.mermaid',
 ]
+bibtex_bibfiles = [
+    'source/user/aerodyn-aeroacoustics/references.bib',
+    'source/user/aerodyn-olaf/bibliography.bib',
+    'source/user/aerodyn/bibliography.bib',
+    'source/user/beamdyn/references.bib',
+    'source/user/extptfm/bibliography.bib',
+    'source/user/fast.farm/bibliography.bib',
+    'source/user/hydrodyn/references.bib',
+    'source/user/servodyn-stc/StC_Refs.bib',
+    'source/user/subdyn/references_SD.bib'
+]
 
 autodoc_default_flags = [
     'members',

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -3,7 +3,7 @@ docutils==0.16
 Pygments>=2.2
 pyparsing>=2.1
 Sphinx>=1.8.5
-sphinxcontrib-bibtex>=0.3.3,<2.0.0
+sphinxcontrib-bibtex>=2.0.0
 sphinxcontrib-doxylink>=1.3
 sphinxcontrib-mermaid>=0.6
 sphinx_rtd_theme>=0.3

--- a/docs/source/user/aerodyn-aeroacoustics/references.bib
+++ b/docs/source/user/aerodyn-aeroacoustics/references.bib
@@ -1,4 +1,4 @@
-@article{Amiet:1975,
+@article{aa-Amiet:1975,
    author=  {Roy K. Amiet},
    title=   {Acoustic Radiation from an Airfoil in a Turbulent Stream},
    journal= {Journal of Sound and Vibration},
@@ -9,7 +9,7 @@
    doi=     {10.1016/S0022-460X(75)80105-2}
 }
 
-@techreport{Bortolotti:2019,
+@techreport{aa-Bortolotti:2019,
    author=        {Pietro Bortolotti and Helena Canet Tarres and Katherine Dykes and Karl Merz and Latha Sethuraman and David Verelst and Frederik Zahle},
    year=          {2019},
    title=         {Systems Engineering in Wind Energy - WP2.1 Reference Wind Turbines},
@@ -17,7 +17,7 @@
    URL=           {https://www.nrel.gov/docs/fy19osti/73492.pdf}
 }
 
-@techreport{Brooks:1989,
+@techreport{aa-Brooks:1989,
    author=     {Thomas F. Brooks and  D. Stuart Pope and Michael A. Marcolini},
    year=       {1989},
    title=      {Airfoil Self-Noise and Prediction},
@@ -26,7 +26,7 @@
    number=     { 1218}
 }
 
-@article{Drela:1987,
+@article{aa-Drela:1987,
    author = {Drela, Mark and Giles, Michael B.},
    title = {Viscous-inviscid analysis of transonic and low Reynolds number airfoils},
    journal = {AIAA Journal},
@@ -37,7 +37,7 @@
    doi = {10.2514/3.9789},
 }
 
-@inproceedings{Guidati:1997,
+@inproceedings{aa-Guidati:1997,
    author = {Gianfranco Guidati and Rainer Bareiss and Siegfried Wagner and Rene Parchen and Gianfranco Guidati and Rainer Bareiss and Siegfried Wagner and Rene Parchen},
    title = {Simulation and measurement of inflow-turbulence noise on airfoils},
    booktitle = {3rd AIAA/CEAS Aeroacoustics Conference},
@@ -46,7 +46,7 @@
 }
 
 
-@article{Lowson:1970,
+@article{aa-Lowson:1970,
    author=        {Martin V. Lowson},
    year=          {1970},
    title=         {Theoretical Analysis of Compressor Noise Evaluation},
@@ -56,7 +56,7 @@
    doi=           {10.1121/1.1911508}
 }
 
-@article{Klein:2018,
+@article{aa-Klein:2018,
    author=        {Levin Klein and Jonas Gude and Florian Wenz and Thorsten Lutz and Ewald Krämer},
    year=          {2018},
    title=         {Advanced Computational Fluid Dynamics (CFD)–Multi-Body Simulation (MBS) Coupling to Assess Low-Frequency Emissions from Wind Turbines},
@@ -66,7 +66,7 @@
    doi=           {10.5194/wes-3-713-2018}
 }
 
-@techreport{MoriartyMigliore:2003,
+@techreport{aa-MoriartyMigliore:2003,
    author=        {Patrick J. Moriarty and Paul G. Migliore},
    year=          {2003},
    title=         {Semi-Empirical Aeroacoustic Noise Prediction Code for Wind Turbines},
@@ -76,7 +76,7 @@
    URL=           {https://www.nrel.gov/docs/fy04osti/34478.pdf}
 }
 
-@inproceedings{MoriartyGuidatiMigliore:2004,
+@inproceedings{aa-MoriartyGuidatiMigliore:2004,
    author = {Patrick Moriarty and Gianfranco Guidati and Paul Migliore},
    title = {Recent Improvement of a Semi-Empirical Aeroacoustic Prediction Code for Wind Turbines},
    booktitle = {10th AIAA/CEAS Aeroacoustics Conference},
@@ -84,7 +84,7 @@
    doi = {10.2514/6.2004-3041}
 }
 
-@inproceedings{MoriartyGuidatiMigliore:2005,
+@inproceedings{aa-MoriartyGuidatiMigliore:2005,
    author = {Patrick Moriarty and Gianfranco Guidati and Paul Migliore},
    title = {Prediction of Turbulent Inflow and Trailing-Edge Noise for Wind Turbines},
    booktitle = {11th AIAA/CEAS Aeroacoustics Conference},
@@ -92,7 +92,7 @@
    doi = {10.2514/6.2005-2881}
 }
 
-@techreport{MoriartyHansen:2005,
+@techreport{aa-MoriartyHansen:2005,
    author=        {Patrick J. Moriarty and A. C. Hansen},
    year=          {2005},
    title=         {AeroDyn Theory Manual},
@@ -102,7 +102,7 @@
    URL=           {https://www.nrel.gov/docs/fy05osti/36881.pdf}
 }
 
-@techreport{Moriarty:2005,
+@techreport{aa-Moriarty:2005,
    author=        { Patrick J. Moriarty},
    year=          {2005},
    title=         {NAFNoise User's Guide},
@@ -111,13 +111,13 @@
    URL=           {https://github.com/NREL/NAFNoise/blob/master/NAFNoise.pdf}
 }
 
-@misc{xfoil:699,
+@misc{aa-xfoil:699,
    author=  {Mark Drela},
    title=   {{XF}oil, release 6.99},
    url=     {https://web.mit.edu/drela/Public/web/xfoil/}
 }
 
-@misc{openfast:2019,
+@misc{aa-openfast:2019,
    title= {Open{FAST}, dev branch},
    year= {2019},
    publisher= {GitHub},
@@ -125,7 +125,7 @@
    url=  {https://github.com/OpenFAST/openfast}
 }
 
-@techreport{Parchen:1998,
+@techreport{aa-Parchen:1998,
    author=        {René R. Parchen},
    year=          {1998},
    title=         {Progress Report {DRAW}: A Prediction Scheme for Trailing Edge Noise Based on Detailed Boundary Layer Characteristics},
@@ -133,7 +133,7 @@
 }
 
 
-@inproceedings{Paterson:1976,
+@inproceedings{aa-Paterson:1976,
    author = {R. Paterson and R. Amiet},
    title = {Acoustic radiation and surface pressure characteristics of an airfoil due to incident turbulence},
    booktitle = {3rd Aeroacoustics Conference},
@@ -144,7 +144,7 @@
    doi = {10.2514/6.1976-571}
 }
 
-@article{Sucameli:2018,
+@article{aa-Sucameli:2018,
 	doi = {10.1088/1742-6596/1037/2/022038},
 	year = 2018,
 	month = {jun},
@@ -158,7 +158,7 @@
 }
 
 
-@techreport{Viterna:1981,
+@techreport{aa-Viterna:1981,
    author=        {Larry A. Viterna},
    year=          {1981},
    title=         {Method for Predicting Impulsive Noise Generated by Wind Turbine Rotors},
@@ -169,7 +169,7 @@
 
 
 
-@article{Zhu:2005,
+@article{aa-Zhu:2005,
    author=     {Wei J. Zhu and Nicolai Heilskov and Wen Zhong Shen},
    year=       {2005},
    title=      {Modeling of Aerodynamically Generated Noise From Wind Turbines},

--- a/docs/source/user/aerodyn-aeroacoustics/refs.rst
+++ b/docs/source/user/aerodyn-aeroacoustics/refs.rst
@@ -5,6 +5,5 @@
 
 .. bibliography:: references.bib
    :labelprefix: aa-
-   :keyprefix: aa-
 
 

--- a/docs/source/user/aerodyn-olaf/bibliography.bib
+++ b/docs/source/user/aerodyn-olaf/bibliography.bib
@@ -1,4 +1,4 @@
-@article{Larsen08_1,
+@article{olaf-Larsen08_1,
   title=    {Wake Meander: A Pragmatic Approach},
   author=   {G. C. Larsen and H. A. Madsen and K. Thomsen and et al.},
   journal=  {Wind Energy},
@@ -9,7 +9,7 @@
   doi =     {http://onlinelibrary.wiley.com/doi/10.1002/we.267/epdf}
 }
 
-@inproceedings{Bagai94_1,
+@inproceedings{olaf-Bagai94_1,
   author= {A. Bagai and J. G. Leishman},
   title= {Rotor Free-Wake Modeling using a Pseudo-Implicit Technique Including Comparisons with Experimental Data},
   booktitle= {50th Annual Forum of the American Helicopter Society},
@@ -17,14 +17,14 @@
   address= {Washington, D.C.}
 }
 
-@article{Quon18_1,
+@article{olaf-Quon18_1,
   title=    {Comparison of Wake Characterization Methods for Large-Eddy Simulations of a Rotor in Stratified Flow},
   author=   {E. Quon and M. Churchfield and J. Jonkman},
   journal=  {Computers & Fluids},
   year=     {2018}
 }
 
-@article{Martinez17_1,
+@article{olaf-Martinez17_1,
   title=    {Optimal Smoothing Length Scale for Actuator Line Models of Wind Turbine Blades Based on Gaussian Body Force Distribution},
   author=   {L. A. Martinez-Tossas and M. J. Churchfield and C. Meneveau},
   journal=  {Wind Energy},
@@ -35,7 +35,7 @@
   doi =     {http://onlinelibrary.wiley.com/doi/10.1002/we.2081/epdf}
 }
 
-@article{Vatistas91_1,
+@article{olaf-Vatistas91_1,
 	Author = {G. H. Vatistas and V. Koezel and W. C. Mih},
     Title = {A Simpler Model for Concentrated Vortices},
 	Journal = {Experiments in Fluids},
@@ -44,14 +44,14 @@
 	Pages = {73-76},
 	Year = {1991}}
 
-@article{Quon19_1,
+@article{olaf-Quon19_1,
   title=    {Comparison of Wake Characterization Methods for Large-Eddy Simulations of a Rotor in Stratified Flow},
   author=   {E. Quon and M. Churchfield and J. Jonkman},
   journal=  {Computers \& Fluids},
   year=     {2019 (Forthcoming)}
 }
 
-@inproceedings{Jonkman18_1,
+@inproceedings{olaf-Jonkman18_1,
   title=    {Validation of FAST.Farm Against Large-Eddy Simulations},
   author=   {J. Jonkman and P. Doubrawa and N. Hamilton and et al.},
   series=   {TORQUE 2018},
@@ -62,7 +62,7 @@
   address=  {Milano, Italy}
 }
 
-@Book{Hansen08_1,
+@Book{olaf-Hansen08_1,
   author = {M. O. L. Hansen},
   title = {Aerodynamics of Wind Turbines},
   publisher = {Earthscan},
@@ -70,7 +70,7 @@
   address = {London; Sterling, VA}
 }
 
-@techreport{Weissinger47_1,
+@techreport{olaf-Weissinger47_1,
   Author = {J. Weissinger},
   Title = {The Lift Distribution of Swept-Back Wings},
   Institution = {NACA},
@@ -79,7 +79,7 @@
   Year = {1947}
 }
 
-@techreport{Jonkman13_1,
+@techreport{olaf-Jonkman13_1,
   Author = {J. Jonkman},
   Title = {The New Modularization Framework for the FAST Wind Turbine CAE Tool},
   Institution = {National Renewable Energy Laboratory},
@@ -88,7 +88,7 @@
   Year = {2013}
 }
 
-@techreport{Jonkman15_1,
+@techreport{olaf-Jonkman15_1,
   Author = {J. Jonkman and M. A. Sprague and B. J. Jonkman},
   Title = {FAST Modular Framework for Wind Turbine Simulation: New Algorithms and Numerical Examples},
   Institution = {National Renewable Energy Laboratory},
@@ -97,7 +97,7 @@
   Year = {2015}
 }
 
-@phdthesis{Gupta06_1,
+@phdthesis{olaf-Gupta06_1,
 	Author = {S. Gupta},
     Title = {Development of a Time-Accurate Viscous Lagrangian Vortex Wake Model for Wind Turbine Applications},
 	School = {Univeristy of Maryland},
@@ -106,7 +106,7 @@
 	Year = {2006}
 }
 
-@phdthesis{Scully75_1,
+@phdthesis{olaf-Scully75_1,
 	Author = {M. P. Scully},
     Title = {Computation of Helicopter Rotor Wake Geometry and Its Influence on Rotor Harmonic Airloads},
 	School = {Massachusetts Institute of Technology},
@@ -116,7 +116,7 @@
 }
 
   
-@phdthesis{Ribera07_1,
+@phdthesis{olaf-Ribera07_1,
 	Author = {M. Ribera},
     Title = {Helicopter Flight Dynamics Simulation with a Time-Accurate Free-Vortex Wake Model},
 	School = {University of Maryland},
@@ -124,7 +124,7 @@
 	Type = {PhD thesis},
 	Year = {2007}}
 
-@inproceedings{Doubrawa18_1,
+@inproceedings{olaf-Doubrawa18_1,
   author=   {P. Doubrawa and J. Annoni and J. Jonkman and et al.},
   title=    {Optimization-Based Calibration of FAST.Farm Parameters Against SOWFA},
   booktitle={AIAA SciTech Forum},
@@ -137,7 +137,7 @@
   doi =     {https://arc.aiaa.org/doi/pdf/10.2514/6.2018-0512}
 }
 
-@inproceedings{Shaler19_1,
+@inproceedings{olaf-Shaler19_1,
   title=    {FAST.Farm Response of Varying Wind Inflow Techniques},
   author=   {K. Shaler and J. Jonkman and P. Doubrawa and N. Hamilton},
   booktitle={AIAA SciTech Forum},
@@ -150,7 +150,7 @@
   doi =     {https://arc.aiaa.org/doi/pdf/10.2514/6.2019-2086}
 }
 
-@inproceedings{Jonkman17_1,
+@inproceedings{olaf-Jonkman17_1,
   title=    {Development of FAST.Farm: A New MultiPhysics Engineering Tool for Wind-Farm Design and Analysis},
   author=   {J. Jonkman and J. Annoni and G. Hayman and B. Jonkman and A. purkayastha},
   booktitle={AIAA SciTech Forum},
@@ -163,7 +163,7 @@
   doi =     {http://arc.aiaa.org/doi/pdf/10.2514/6.2017-0454}
 }
 
-@inproceedings{Churchfield15_1,
+@inproceedings{olaf-Churchfield15_1,
   title=    {A Comparison of the Dynamic Wake Meandering Model, Large-Eddy Simulations, and Field Data at the Egmond aan Zee Offshore Wind Plant},
   author=   {M. J. Churchfield and P. J. Moriarty and Y. Hao and et al.},
   booktitle={AIAA SciTech Forum},
@@ -176,7 +176,7 @@
   doi =     {http://dx.doi.org/10.2514/6.2015-0724}
 }
 
-@inproceedings{Churchfield12_1,
+@inproceedings{olaf-Churchfield12_1,
   title=    {A Large-Eddy Simulation of Wind-Plant Aerodynamics},
   author=   {M. J. Churchfield and P. J. Moriarty and L. A. Martinez and et al.},
   series=   {50th AIAA Aerospace Sciences Meeting},
@@ -188,7 +188,7 @@
   doi =     {http://dx.doi.org/10.2514/6.2012-537}
 }
 
-@techreport{Jonkman09_1,
+@techreport{olaf-Jonkman09_1,
   title=    {Definition of a 5-MW Reference Wind Turbine for Offshore System Development},
   author=   {Jonkman, J. and Butterfield, S. and Musial, W. and Scott, G.},
   number=   {NREL/TP-500-38060},
@@ -198,7 +198,7 @@
   year=     {2009}
 }
 
-@techreport{TurbSim_1,
+@techreport{olaf-TurbSim_1,
   title=    {TurbSim User's Guide v2.00.00},
   author=   {Jonkman, B.},
   number=   {NREL/TP-xxxx-xxxxx},
@@ -208,7 +208,7 @@
   year=     {2014}
 }
 
-@techreport{IEC_1,
+@techreport{olaf-IEC_1,
   title=    {Wind Turbines - Part 1: Design Requirements},
   author=   {IEC 61400-1},
   number=   {3rd edition},
@@ -218,7 +218,7 @@
   year=     {2006}
 }
 
-@techreport{Simms01_1,
+@techreport{olaf-Simms01_1,
   title=    {NREL Unsteady Aerodynamics Experiment in the NASA-Ames Wind Tunnel: A Comparison of Predictions to Measurements},
   author=   {Simms, D. and Schreck, S. and Hand, M. and Fingersh, L.J.},
   number=   {NREL/TP-500-29494},
@@ -228,7 +228,7 @@
   year=     {2001}
 }
 
-@techreport{Jonkman18_2,
+@techreport{olaf-Jonkman18_2,
   title=    {FAST.Farm User's Guide and Theory Manual},
   author=   {J. M. Jonkman},
   number=   {NREL/TP-xxxx-xxxxx},
@@ -238,14 +238,14 @@
   year=     {2018}
 }
 
-@misc{FAST,
+@misc{olaf-FAST,
 title = {OpenFAST Documentation},
 month = {November},
 year = {2017},
 url = {http://openfast.readthedocs.io/en/main/}
 }
 
-@misc{SAMWICH,
+@misc{olaf-SAMWICH,
   author = {E. Quon},
   title = {SAMWICH Wake-Tracking Toolbox},
   publisher = {GitHub},
@@ -254,7 +254,7 @@ url = {http://openfast.readthedocs.io/en/main/}
   year= {2017}
 }
 
-@phdthesis{Krista12_1,
+@phdthesis{olaf-Krista12_1,
 	Author = {K. Kecskemety},
     Title = {Assessing the Influence of Wake Dynamics on the Performance and Aeroelastic Behavior of Wind Turbines},
 	School = {Ohio State University},
@@ -262,21 +262,21 @@ url = {http://openfast.readthedocs.io/en/main/}
 	Type = {PhD thesis},
 	Year = {2012}}
 	
-@book{Leishman_book,
+@book{olaf-Leishman_book,
 	Author = {J. Leishman},
 	Title = {Principles of Helicopter Aerodynamics},
 	Publisher = {Cambridge Univ. Press},
 	Address = {Cambridge, MA},
 	Year = {2006}}
 	
-@book{Rankine58_1,
+@book{olaf-Rankine58_1,
 	Author = {W. J. M. Rankine},
 	Title = {Manual of Applied Mechanics},
 	Publisher = {Griffen Co.},
 	Address = {London},
 	Year = {1858}}
 	
-@article{Leishman02_1,
+@article{olaf-Leishman02_1,
 	Author = {J. G. Leishman and M. J. Bhagwat and A. Bagai},
     Title = {Free-Vortex Filament Methods for the Analysis of Helicopter Rotor Wakes},
 	Journal = {Journal of Aircraft},
@@ -285,14 +285,14 @@ url = {http://openfast.readthedocs.io/en/main/}
 	Pages = {759-775},
 	Year = {2002}}
 	
-@inproceedings{Ananthan02_1,
+@inproceedings{olaf-Ananthan02_1,
 	Author = {S. Ananthan and J. G. Leishman and M. Ramasamy},
     Title = {The Role of Filament Stretching in  the Free-Vortex Modeling of Rotor Wakes},
 	booktitle = {58th Annual Forum and Technology Display of the American Helicopter Society International},
     year = {2002},
     address = {Montreal, Canada}}
 	
-@article{Gupta05_1,
+@article{olaf-Gupta05_1,
 	Author = {S. Gupta and J. G. Leishman},
     Title = {Free-Vortex Filament Methods for the Analysis of Helicopter Rotor Wakes},
 	Journal = {Journal of Aircraft},
@@ -301,7 +301,7 @@ url = {http://openfast.readthedocs.io/en/main/}
 	Pages = {759-775},
 	Year = {2002}}
 	
-@techreport{Wiser17_1,
+@techreport{olaf-Wiser17_1,
   title=    {2016 Wind Technologies Market Report},
   author=   {R. Wiser and M. Bolinger},
   number=   {DOE/GO-102917-5033},
@@ -311,7 +311,7 @@ url = {http://openfast.readthedocs.io/en/main/}
   year=     {2017},
   doi = {10.2172/1393638}}
 
-@phdthesis{Shaler19_2,
+@phdthesis{olaf-Shaler19_2,
 	Author = {K. Shaler},
     Title = {Wake Interaction Modeling Using A Parallelized Free Vortex Wake Model},
 	School = {Ohio State University},
@@ -319,7 +319,7 @@ url = {http://openfast.readthedocs.io/en/main/}
 	Type = {PhD thesis},
 	Year = {2020}}
 	
-@phdthesis{Abedi16_1,
+@phdthesis{olaf-Abedi16_1,
 	Author = {H. Abedi},
     Title = {Development of Vortex Filament Method for Wind Power Aerodynamics},
 	School = {Chalmers University of Technology},
@@ -328,7 +328,7 @@ url = {http://openfast.readthedocs.io/en/main/}
 	Year = {2016}}
 	
 	
-@techreport{Johnson19_1,	
+@techreport{olaf-Johnson19_1,	
 	Author={N. Johnson and P. Bortolotti and K. Dykes and et al.},
    Title={Investigation of Innovative Rotor Concepts for the Big Adaptive Rotor Project},
    institution={National Renewable Energy Laboratory},
@@ -336,7 +336,7 @@ url = {http://openfast.readthedocs.io/en/main/}
    Year=2019
    }
 
-@techreport{Sprague15_1,
+@techreport{olaf-Sprague15_1,
     title={FAST Modular Framework for Wind Turbine Simulation: New Algorithms and Numerical Examples},
     author={Michael A. Sprague and Jason M. Jonkman and Bonnie J. Jonkman},
     institution={National Renewable Energy Laboratory},
@@ -344,7 +344,7 @@ url = {http://openfast.readthedocs.io/en/main/}
     year={2015}
 }
 
-@article{Miras17_1,
+@article{olaf-Miras17_1,
     author = {M. Sessarego and N. Ramos Garc{\'i}a and J. N. S{\o}rensen and W. Z. Shen},
     title = {Development of an aeroelastic code based on three-dimensional viscous-inviscid method for wind turbine computations},
     year = {2017},
@@ -355,7 +355,7 @@ url = {http://openfast.readthedocs.io/en/main/}
     number = {7},
 }
 
-@article{Bagai93_1,
+@article{olaf-Bagai93_1,
     author = {A. Bagai and J. G. Leishman},
     title = {Flow Visualization of Compressible Vortex Structures Using Density Gradient Techniques},
     year = {1993},
@@ -365,20 +365,20 @@ url = {http://openfast.readthedocs.io/en/main/}
     number = {6}
 }
 
-@phdthesis{Papadakis14_1,
+@phdthesis{olaf-Papadakis14_1,
     author = {G. Papadakis},
     title = {Development of a hybrid compressible vortex particle method and application to external problems including helicopter flows},
     school = {National Technical University of Athens},
     year = {2014},
 }
-@article{Voutsinas06_1,
+@article{olaf-Voutsinas06_1,
   author = {S. G. Voutsinas},
   title = {Vortex methods in aeronautics: how to make things work},
   journal = {International Journal of Computational Fluid Dynamics},
   year = {2006},
 }
 
-@article{Rosenhead31_1,
+@article{olaf-Rosenhead31_1,
   author = {L. Rosenhead},
   title = {The Formation of Vortices from a Surface of Discontinuity},
   journal = {Proceedings of the Royal Society of London. Series A, Containing Papers of a Mathematical and Physical Character},
@@ -391,7 +391,7 @@ url = {http://openfast.readthedocs.io/en/main/}
   publisher = {The Royal Society},
 }
 
-@article{Winckelmans93_1,
+@article{olaf-Winckelmans93_1,
   author = {G. S. Winckelmans and A. Leonard},
   title = {Contributions to vortex particle methods for the computation of 3-dimensional incompressible unsteady flows},
   publisher = {Academic Press Inc. JNL-Comp Subscriptions},
@@ -403,7 +403,7 @@ url = {http://openfast.readthedocs.io/en/main/}
   issn = {00219991, 10902716}
 }
 
-@article{Branlard15_1,
+@article{olaf-Branlard15_1,
 author  = {E. Branlard and G. Papadakis and M. Gaunaa and G. Winckelmans and T. J. Larsen},
 title   = {Aeroelastic large eddy simulations using vortex methods: unfrozen turbulent and sheared inflow},
 journal = {Journal of Physics: Conference Series (Online)},
@@ -413,7 +413,7 @@ volume  = {625},
 issn    = {1742-6596},
 }
 
-@book{Branlard17_1,
+@book{olaf-Branlard17_1,
     author = {E. Branlard},
     title = {Wind Turbine Aerodynamics and Vorticity-Based Methods: Fundamentals and Recent Applications},
     year = {2017},
@@ -422,7 +422,7 @@ issn    = {1742-6596},
     isbn={ 978-3-319-55163-0}
 }
 
-@TECHREPORT{Garrel03_1,
+@TECHREPORT{olaf-Garrel03_1,
     author = {A. van Garrel},
     title = {Development of a Wind Turbine Aerodynamics Simulation Module},
     institution = {ECN},
@@ -430,7 +430,7 @@ issn    = {1742-6596},
     number = {ECN-C--03-079}
 }
 
-@TECHREPORT{Kerwin:lecturenotes,
+@TECHREPORT{olaf-Kerwin:lecturenotes,
   author = {J. Kerwin},
   title = {Lecture Notes Hydrofoil and propellers},
   institution = {M.I.T.},

--- a/docs/source/user/aerodyn-olaf/zrefs.rst
+++ b/docs/source/user/aerodyn-olaf/zrefs.rst
@@ -5,6 +5,5 @@
 
 .. bibliography:: bibliography.bib
    :labelprefix: olaf-
-   :keyprefix: olaf-
 
 

--- a/docs/source/user/aerodyn/bibliography.bib
+++ b/docs/source/user/aerodyn/bibliography.bib
@@ -1,5 +1,5 @@
 
-@TECHREPORT{AeroDyn:manual,
+@TECHREPORT{ad-AeroDyn:manual,
     title       = {AeroDyn Theory Manual},
     author      = {P. J. Moriarty and A. Craig Hansen},
     institution = {National Renewable Energy Laboratory},
@@ -8,7 +8,7 @@
     note        = {NREL/EL-500-36881}
 }
 
-@TECHREPORT{AeroDyn:manualUnsteady,
+@TECHREPORT{ad-AeroDyn:manualUnsteady,
     title  = {The Unsteady Aerodynamics Module for FAST 8},
     author = {R. Damiani and G. Hayman},
     year   = 2019,
@@ -16,7 +16,7 @@
     note        = {NREL/TP-5000-66347}
 }
 
-@book{Branlard:book,
+@book{ad-Branlard:book,
     author = {E. Branlard},
     title = {Wind Turbine Aerodynamics and Vorticity-Based Methods: Fundamentals and Recent Applications},
     year = {2017},
@@ -26,7 +26,7 @@
 }
 
 
-@article{Hansen:book,
+@article{ad-Hansen:book,
     author = {Hansen, M. O. L. and S{\o}rensen, J. N. and Voutsinas, S. and S{\o}rensen, N. and Madsen, H. Aa.},
     doi = {10.1016/j.paerosci.2006.10.002},
     journal = {Progress in Aerospace Sciences},
@@ -38,7 +38,7 @@
 }
 
 
-@article{Ning:2014,
+@article{ad-Ning:2014,
     author = {Ning, S. Andrew},
     title = {A simple solution method for the blade element momentum equations with guaranteed convergence},
     journal = {Wind Energy},
@@ -51,7 +51,7 @@
 }
 
 
-@techreport{Hansen:2004,
+@techreport{ad-Hansen:2004,
   title = {A Beddoes-Leishman type dynamic stall model in state-space and indicial formulations},
   author = {Hansen, M.H. and Gaunaa, Mac and Aagaard Madsen, Helge},
   year = {2004},
@@ -62,7 +62,7 @@
 }
 
 
-@article{Oye:1991,
+@article{ad-Oye:1991,
     author = {S. {\O}ye},
     title = {Dynamic stall, simulated as a time lag of separation},
     year = {1991},
@@ -70,7 +70,7 @@
     publisher={ETSU-N-118, Harwell Laboratory, UK}
 }
 
-@article{LeishmanBeddoes:1989,
+@article{ad-LeishmanBeddoes:1989,
     author = {J. G. Leishman and T.S. Beddoes},
     title = {A semi-empirical model for dynamic stall},
     year = {1989},
@@ -80,7 +80,7 @@
     pages={p3-17}
 }
 
-@techreport{Murray:2011,
+@techreport{ad-Murray:2011,
   title={The development of CACTUS : a wind and marine turbine performance simulation code.},
   author={J. Murray and M. Barone},
   year={2011},

--- a/docs/source/user/aerodyn/zrefs.rst
+++ b/docs/source/user/aerodyn/zrefs.rst
@@ -5,6 +5,5 @@
 
 .. bibliography:: bibliography.bib
    :labelprefix: ad-
-   :keyprefix: ad-
 
 

--- a/docs/source/user/extptfm/bibliography.bib
+++ b/docs/source/user/extptfm/bibliography.bib
@@ -1,4 +1,4 @@
-@article{Branlard:2020superelement,
+@article{ep-Branlard:2020superelement,
 	doi = {10.1088/1742-6596/1452/1/012033},
 	url = {https://doi.org/10.1088/1742-6596/1452/1/012033},
 	year = 2020,
@@ -11,7 +11,7 @@
 	journal = {Journal of Physics: Conference Series}
 }
 
-@article{CraigBampton:1968,
+@article{ep-CraigBampton:1968,
     author={Craig, R. and Bampton, M.},
     title={{Coupling of Substructures for Dynamic Analysis}},
     journal={AIAA Journal},
@@ -21,7 +21,7 @@
     pages={1313-1319}
 }
 
-@article{Guyan:1965,
+@article{ep-Guyan:1965,
     author={Guyan, R.},
     year=1965,
     title={Reduction of Stiffness and Mass Matrices},

--- a/docs/source/user/extptfm/zrefs.rst
+++ b/docs/source/user/extptfm/zrefs.rst
@@ -5,4 +5,3 @@
 
 .. bibliography:: bibliography.bib
    :labelprefix: ep-
-   :keyprefix: ep-

--- a/docs/source/user/fast.farm/bibliography.bib
+++ b/docs/source/user/fast.farm/bibliography.bib
@@ -1,4 +1,4 @@
-@article{Larsen08_1,
+@article{ff-Larsen08_1,
   title=    {Wake Meander: A Pragmatic Approach},
   author=   {G. C. Larsen and et al.},
   journal=  {Wind Energy},
@@ -9,7 +9,7 @@
   doi =     {http://onlinelibrary.wiley.com/doi/10.1002/we.267/epdf}
 }
 
-@article{Larsen13_1,
+@article{ff-Larsen13_1,
   title=    {Validation of the Dynamic Wake Meander Model for Loads and Power Production in the Egmond aan Zee Wind Farm},
   author=   {T. J. Larsen and et al.},
   journal=  {Wind Energy},
@@ -21,7 +21,7 @@
   doi =     {http://onlinelibrary.wiley.com/doi/10.1002/we.1563/epdf}
 }
 
-@article{Martinez21_1,
+@article{ff-Martinez21_1,
   title=    {Wind Turbine Wakes: High-Thrust Coefficient},
   author=   {L. A. Martinez-Tossas},
   journal=  {Wind Energy},
@@ -30,7 +30,7 @@
   note  =   {Publication pending}
 }
 
-@article{Gebraad16_1,
+@article{ff-Gebraad16_1,
   title=    {Wind Plant Power Optimization Through Yaw Control Using a Parametric Model for Wake Effects – a CFD Simulation Study},
   author=   {P. M. O. Gebraad and et al.},
   journal=  {Wind Energy},
@@ -42,14 +42,14 @@
   doi =     {http://onlinelibrary.wiley.com/doi/10.1002/we.1822/epdf}
 }
 
-@article{Quon18_1,
+@article{ff-Quon18_1,
   title=    {Comparison of Wake Characterization Methods for Large-Eddy Simulations of a Rotor in Stratified Flow},
   author=   {E. Quon and et al.},
   journal=  {Computers & Fluids},
   year=     {2018}
 }
 
-@article{Martinez17_1,
+@article{ff-Martinez17_1,
   title=    {Optimal Smoothing Length Scale for Actuator Line Models of Wind Turbine Blades Based on Gaussian Body Force Distribution},
   author=   {L. A. Martinez-Tossas and et al.},
   journal=  {Wind Energy},
@@ -60,7 +60,7 @@
   doi =     {http://onlinelibrary.wiley.com/doi/10.1002/we.2081/epdf}
 }
 
-@phdthesis{Keck13_1,
+@phdthesis{ff-Keck13_1,
 	Author = {R.-E. Keck and et al.},
     Title = {A Consistent Turbulence Formulation for the Dynamic Wake Meandering Model in the Atmospheric Boundary Layer},
 	School = {DTU},
@@ -68,7 +68,7 @@
 	Type = {Phd thesis},
 	Year = {2013}}
 	
-@phdthesis{Hao16_1,
+@phdthesis{ff-Hao16_1,
 	Author = {Y. Hao},
     Title = {Wind Farm Wake Modeling and Analysis of Wake Impacts in a Wind Farm},
 	School = {University of Massachusetts},
@@ -76,7 +76,7 @@
 	Type = {Phd thesis},
 	Year = {2016}}
 
-@article{Ainslie88_1,
+@article{ff-Ainslie88_1,
   title=    {Calculating the Flowfield in the Wake of Wind Turbines},
   author=   {J. F. Ainslie},
   journal=  {Journal of Wind Engineering and Industrial Aerodynamics},
@@ -87,7 +87,7 @@
   doi =     {https://doi.org/10.1016/0167-6105(88)90037-2}
 }
 
-@article{Crank96_1,
+@article{ff-Crank96_1,
   title=    {A Practical Method for Numerical Evaluation of Solutions of Partial Differencial Equations of the Heat-Conduction Type},
   author=   {J. Crank and P. Nicolson},
   journal=  {Advances in Computaional Mathematics},
@@ -96,7 +96,7 @@
   year=     {1996}
 }
 
-@techreport{Thomas49_1,
+@techreport{ff-Thomas49_1,
   title=    {Elliptic Problems in Linear Difference Equations Over a Network},
   author=   {L. H. Thomas},
   institution={Watson Science Computer Laboratory},
@@ -104,7 +104,7 @@
   year=     {1949}
 }
 
-@article{Madsen10_1,
+@article{ff-Madsen10_1,
   title=    {Calibration and Validation of the Dynamic Wake Meandering Model for Implementation in an Aeroelastic Code},
   author=   {H. A. Madsen and et al.},
   journal=  {Journal of Solar Energy Engineering},
@@ -116,7 +116,7 @@
   doi =     {https://doi.org/10.1115/1.4002555}
 }
 
-@article{Shaler19_2,
+@article{ff-Shaler19_2,
   title=    {Effects of Inflow Spatiotemporal Discretization on Wake Meandering and Turbine Structural Response Using FAST.Farm},
   author=   {K. Shaler and et al.},
   journal=  {Journal of Physics: Conference Series},
@@ -126,14 +126,14 @@
   doi = {10.1088/1742-6596/1256/1/012023}
 }
 
-@article{Quon19_1,
+@article{ff-Quon19_1,
   title=    {Comparison of Wake Characterization Methods for Large-Eddy Simulations of a Rotor in Stratified Flow},
   author=   {E. Quon and et al.},
   journal=  {Computers \& Fluids},
   year=     {2019 (Forthcoming)}
 }
 
-@inproceedings{Jonkman18_1,
+@inproceedings{ff-Jonkman18_1,
   title=    {Validation of FAST.Farm Against Large-Eddy Simulations},
   author=   {J. Jonkman and et al.},
   series=   {TORQUE 2018},
@@ -145,7 +145,7 @@
   address=  {Milano, Italy}
 }
 
-@inproceedings{Doubrawa18_1,
+@inproceedings{ff-Doubrawa18_1,
   title=    {Optimization-Based Calibration of FAST.Farm Parameters Against SOWFA},
   author=   {P. Doubrawa and et al.},
   series=   {36th Wind Energy Symposium},
@@ -158,7 +158,7 @@
   doi =     {https://arc.aiaa.org/doi/pdf/10.2514/6.2018-0512}
 }
 
-@inproceedings{Madsen16_1,
+@inproceedings{ff-Madsen16_1,
   title=    {Wake Flow Characteristics at High Wind Speed.},
   author=   {H. A. Madsen and et al.},
   series=   {34th Wind Energy Symposium},
@@ -169,13 +169,13 @@
   doi =     {http://dx.doi.org/10.2514/6.2016-1522.}
 }
 
-@misc{SOWFA,
+@misc{ff-SOWFA,
   title = {SOWFA},
   howpublished = {\url{https://nwtc.nrel.gov/SOWFA}},
   note = {Accessed: 2019-10-05}
 }
 
-@inproceedings{Jonkman13_1,
+@inproceedings{ff-Jonkman13_1,
   title=    {The New Modularization Framework for the FAST wind Turbine CAE Tool},
   author=   {J. Jonkman},
   series=   {51st AIAA Aerospace Sciences Meeting},
@@ -185,7 +185,7 @@
   address=  {Dallas, TX}
 }
 
-@inproceedings{Sprague15_1,
+@inproceedings{ff-Sprague15_1,
   title=    {FAST Modular Wind Turbine CAE Tool: Nonmatching Spatial and Temporal Meshes},
   author=   {M. A. Sprague and et al.},
   series=   {50th AIAA Aerospace Sciences Meeting},
@@ -198,7 +198,7 @@
   DOI=      {http://arc.aiaa.org/doi/pdf/10.2514/6.2014-0520}
 }
 
-@inproceedings{Sprague14_1,
+@inproceedings{ff-Sprague14_1,
   title=    {FAST Modular Framework for Wind Turbine Simulation: New Algorithms and Numerical Examples},
   author=   {M. A. Sprague and et al.},
   series=   {51th AIAA Aerospace Sciences Meeting},
@@ -208,7 +208,7 @@
   address=  {Kissimmee, FL},
   DOI=      {http://arc.aiaa.org/doi/pdf/10.2514/6.2014-0520}
 }
-@inproceedings{Shaler19_1,
+@inproceedings{ff-Shaler19_1,
   title=    {FAST.Farm Response of Varying Wind Inflow Techniques},
   author=   {K. Shaler and et al.},
   series=   {37th Wind Energy Symposium},
@@ -219,7 +219,7 @@
   doi =     {https://arc.aiaa.org/doi/pdf/10.2514/6.2019-2086}
 }
 
-@inproceedings{Jonkman17_1,
+@inproceedings{ff-Jonkman17_1,
   title=    {Development of FAST.Farm: A New MultiPhysics Engineering Tool for Wind-Farm Design and Analysis},
   author=   {J. Jonkman and et al.},
   series=   {35th Wind Energy Symposium},
@@ -232,7 +232,7 @@
   doi =     {http://arc.aiaa.org/doi/pdf/10.2514/6.2017-0454}
 }
 
-@inproceedings{Katic86_1,
+@inproceedings{ff-Katic86_1,
   title=    {A Simple Model for Cluster Efficiency},
   author=   {I. Kati\`{c} and et al.},
   series=   {European Wind Energy Association Conference and Exhibition},
@@ -241,7 +241,7 @@
   address=  {Rome, Italy}
 }
 
-@inproceedings{Churchfield15_1,
+@inproceedings{ff-Churchfield15_1,
   title=    {A Comparison of the Dynamic Wake Meandering Model, Large-Eddy Simulations, and Field Data at the Egmond aan Zee Offshore Wind Plant},
   author=   {M. J. Churchfield and et al.},
   series=   {33rd Wind Energy Symposium},
@@ -252,7 +252,7 @@
   doi =     {http://dx.doi.org/10.2514/6.2015-0724}
 }
 
-@inproceedings{Hao14_1,
+@inproceedings{ff-Hao14_1,
   title=    {Implementing the Dynamic Wake Meandering Model in the NWTC Design Codes},
   author=   {Y. Hao and et al.},
   series=   {32nd Wind Energy Symposium},
@@ -265,7 +265,7 @@
   doi =     {http://dx.doi.org/10.2514/6.2014-1089}
 }
 
-@inproceedings{Churchfield12_1,
+@inproceedings{ff-Churchfield12_1,
   title=    {A Large-Eddy Simulation of Wind-Plant Aerodynamics},
   author=   {M. J. Churchfield and et al.},
   series=   {50th AIAA Aerospace Sciences Meeting},
@@ -279,7 +279,7 @@
 }
 
 
-@techreport{Jonkman09_1,
+@techreport{ff-Jonkman09_1,
   title=    {Definition of a 5-MW Reference Wind Turbine for Offshore System Development},
   author=   {J. Jonkman and et al.},
   number=   {NREL/TP-500-38060},
@@ -289,7 +289,7 @@
   year=     {2009}
 }
 
-@techreport{Buhl05_1,
+@techreport{ff-Buhl05_1,
   title=    {A New Empirical Relationship Between Thrust Coefficient and Induction Factor for the Turbulent Windmill State},
   author=   {M. L. Buhl, Jr.},
   number=   {NREL/TP-500-36834},
@@ -299,7 +299,7 @@
   year=     {2005}
 }
 
-@techreport{TurbSim_1,
+@techreport{ff-TurbSim_1,
   title=    {TurbSim User's Guide v2.00.00},
   author=   {B. Jonkman},
   number=   {NREL/TP-xxxx-xxxxx},
@@ -309,7 +309,7 @@
   year=     {2014}
 }
 
-@techreport{IEC_1,
+@techreport{ff-IEC_1,
   title=    {Wind Turbines - Part 1: Design Requirements},
   author=   {IEC 61400-1},
   number=   {3rd edition},
@@ -319,7 +319,7 @@
   year=     {2006}
 }
 
-@techreport{Simms01_1,
+@techreport{ff-Simms01_1,
   title=    {NREL Unsteady Aerodynamics Experiment in the NASA-Ames Wind Tunnel: A Comparison of Predictions to Measurements},
   author=   {D. Simms and et al.},
   number=   {NREL/TP-500-29494},
@@ -329,7 +329,7 @@
   year=     {2001}
 }
 
-@techreport{Jonkman18_2,
+@techreport{ff-Jonkman18_2,
   title=    {FAST.Farm User's Guide and Theory Manual},
   author=   {J. M. Jonkman},
   number=   {NREL/TP-xxxx-xxxxx},
@@ -339,14 +339,14 @@
   year=     {2018}
 }
 
-@misc{FAST,
+@misc{ff-FAST,
 title = {OpenFAST Documentation},
 month = {November},
 year = {2017},
 url = {http://openfast.readthedocs.io/en/master/}
 }
 
-@misc{SAMWICH,
+@misc{ff-SAMWICH,
   author = {E. Quon},
   title = {SAMWICH Wake-Tracking Toolbox},
   publisher = {GitHub},
@@ -355,7 +355,7 @@ url = {http://openfast.readthedocs.io/en/master/}
   year= {2017}
 }
 
-@book{Smith06_1,
+@book{ff-Smith06_1,
     author = {S. W. Smith},
     title = {The Scientist and Engineer's Guide to Digital Signal Processing},
     year = {2006},

--- a/docs/source/user/fast.farm/zrefs.rst
+++ b/docs/source/user/fast.farm/zrefs.rst
@@ -5,6 +5,5 @@
 
 .. bibliography:: bibliography.bib
    :labelprefix: ff-
-   :keyprefix: ff-
 
 

--- a/docs/source/user/servodyn-stc/StC_Refs.bib
+++ b/docs/source/user/servodyn-stc/StC_Refs.bib
@@ -1,4 +1,4 @@
-@inproceedings{namik_active_2013,
+@inproceedings{stc-namik_active_2013,
 	title = {Active structural control with actuator dynamics on a floating wind turbine},
 	url = {http://arc.aiaa.org/doi/pdf/10.2514/6.2013-455},
 	booktitle = {Proceedings of the 51st {AIAA} {Aerospace} {Sciences} {Meeting}},
@@ -8,7 +8,7 @@
 }
 %%	urldate = {2015-03-31},
 
-@article{lackner_passive_2011,
+@article{stc-lackner_passive_2011,
 	title = {Passive structural control of offshore wind turbines},
 	volume = {14},
 	url = {http://onlinelibrary.wiley.com/doi/10.1002/we.426/full},
@@ -20,7 +20,7 @@
 }
 %%	urldate = {2015-03-31},
 
-@article{stewart_optimization_2013,
+@article{stc-stewart_optimization_2013,
 	title = {Optimization of a passive tuned mass damper for reducing loads in offshore wind turbines},
 	volume = {21},
 	number = {4},
@@ -30,7 +30,7 @@
 	pages = {1090--1104}
 }
 
-@article{stewart_impact_2014,
+@article{stc-stewart_impact_2014,
 	title = {The impact of passive tuned mass dampers and wind–wave misalignment on offshore wind turbine loads},
 	volume = {73},
 	url = {http://www.sciencedirect.com/science/article/pii/S0141029614002673},
@@ -41,7 +41,7 @@
 }
 %%	urldate = {2015-03-31},
 
-@article{stewart_effect_2011,
+@article{stc-stewart_effect_2011,
 	title = {The effect of actuator dynamics on active structural control of offshore wind turbines},
 	volume = {33},
 	url = {http://www.sciencedirect.com/science/article/pii/S0141029611000915},
@@ -53,7 +53,7 @@
 }
 %%	urldate = {2015-03-31},
 
-@article{lackner_structural_2011,
+@article{stc-lackner_structural_2011,
 	title = {Structural control of floating wind turbines},
 	volume = {21},
 	url = {http://www.sciencedirect.com/science/article/pii/S0957415810002072},

--- a/docs/source/user/servodyn-stc/zrefs.rst
+++ b/docs/source/user/servodyn-stc/zrefs.rst
@@ -5,6 +5,3 @@
 
 .. bibliography:: StC_Refs.bib
    :labelprefix: stc-
-   :keyprefix: stc-
-
-


### PR DESCRIPTION
This PR is ready to merge.

**Summary**
I had locked the `sphinxcontrib-bibtex` version to < 2.0.0 when I ran into issues with multiple bibliographies that we use (one per module).  This was increasingly becoming a problem as python 3.8 and later would like to use a newer version.

**Solution**
The `conf.py` was updated to include a `bibtex_bibfiles` variable.  However, the new version of `sphinxcontrib-bibtex` is more thorough in checking for repeated bibtex entries, and complained about a few duplicated entries (checked across all bib files).  This required hardcoding of the `keyprefix` values into each modules .bib file instead of using sphinx to insert them.  The rendering is therefore identical to the previous behavior, but will now compile correctly with the newer package.

See https://ap-openfast.readthedocs.io/en/f-docs-bibtex2.0.0/source/user/fast.farm/zrefs.html (duplicated entries first appeared in the fast.farm docs).