### PR TITLE
Reg_tests python scripts: fix issue where directory returned is empty

### DIFF
--- a/reg_tests/executeAerodynRegressionCase.py
+++ b/reg_tests/executeAerodynRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeBeamdynRegressionCase.py
+++ b/reg_tests/executeBeamdynRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeFASTFarmRegressionCase.py
+++ b/reg_tests/executeFASTFarmRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.sep.join(sys.argv[0].split(os.path.sep)[:-1]) if os.path.sep in sys.argv[0] else "."
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeHydrodynRegressionCase.py
+++ b/reg_tests/executeHydrodynRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeInflowwindPyRegressionCase.py
+++ b/reg_tests/executeInflowwindPyRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.sep.join(sys.argv[0].split(os.path.sep)[:-1]) if os.path.sep in sys.argv[0] else "."
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeInflowwindRegressionCase.py
+++ b/reg_tests/executeInflowwindRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.sep.join(sys.argv[0].split(os.path.sep)[:-1]) if os.path.sep in sys.argv[0] else "."
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeOpenfastAeroAcousticRegressionCase.py
+++ b/reg_tests/executeOpenfastAeroAcousticRegressionCase.py
@@ -25,7 +25,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeOpenfastCppRegressionCase.py
+++ b/reg_tests/executeOpenfastCppRegressionCase.py
@@ -16,7 +16,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeOpenfastRegressionCase.py
+++ b/reg_tests/executeOpenfastRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/executeSubdynRegressionCase.py
+++ b/reg_tests/executeSubdynRegressionCase.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import shutil

--- a/reg_tests/manualRegressionTest.py
+++ b/reg_tests/manualRegressionTest.py
@@ -24,7 +24,7 @@
 
 import os
 import sys
-basepath = os.path.dirname(__file__)
+basepath = os.path.dirname(os.path.abspath(__file__))
 sys.path.insert(0, os.path.sep.join([basepath, "lib"]))
 import argparse
 import subprocess


### PR DESCRIPTION
**Feature or improvement description**
When the `basepath` string is empty, we had been adding "/lib" to the path instead of "./lib", which then causes the scripts to fail to find the library files they need. 

**Impacted areas of the software**
regression testing using python scripts from the directory where they are located (and using `python manualRegressionTest.py` instead of  `python ./manualRegressionTest.py`)

**Test results, if applicable**
This should not change any test results.
