### PR TITLE
Fix HydroDyn Jacobian outputs when LinOutJac is True

### DIFF
--- a/modules/hydrodyn/src/HydroDyn.f90
+++ b/modules/hydrodyn/src/HydroDyn.f90
@@ -2579,8 +2579,6 @@ SUBROUTINE HD_JacobianPInput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrM
       ! For the case where either RdtnMod=0 and ExtcnMod=0 and hence %SS_Rdtn data or %SS_Exctn data is not valid then we do not have states, so simply return
       ! The key here is to never allocate the dXdu and related state Jacobian arrays because then the glue-code will behave properly
       
-      if ( p%totalStates == 0 ) return
-   
       ! Calculate the partial derivative of the continuous state functions (X) with respect to the inputs (u) here:
 
       ! allocate dXdu if necessary
@@ -2753,8 +2751,6 @@ SUBROUTINE HD_JacobianPContState( t, u, p, x, xd, z, OtherState, y, m, ErrStat, 
    ErrStat = ErrID_None
    ErrMsg  = ''
 
-   if ( p%totalStates == 0 ) return
-   
    ! Calculate the partial derivative of the output functions (Y) with respect to the continuous states (x) here:
    
       


### PR DESCRIPTION
This pull request is ready to be merged

**Related issue, if one exists**
See #1046 

**Impacted areas of the software**
HydroDyn

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
I've run the code with or without this change, and the state matrices are the same, no issues in the glue code. 
The code change fixes #1046. 


