### PR TITLE
MAP: small fix based on MAP 1.3

### DIFF
--- a/modules/map/src/makefile
+++ b/modules/map/src/makefile
@@ -31,6 +31,7 @@ ifeq ($(OS),Windows_NT)
   CFLAGS    = $(BITS) -g -std=c99 -DMAP_DLL_EXPORTS -DCMINPACK_NO_DLL  -DNDEBUG -D_WINDOWS -D_USRDLL -D_MINGW
   LDFLAGS   = $(BITS) -g -shared -Wl,--export-all-symbols
   LIB_FLAGS :=
+  CC_TOOLS  = gcc
 else
   PLATFORM = $(shell uname -s)
   DEL_CMD   = rm -rf

--- a/modules/map/src/mapapi.c
+++ b/modules/map/src/mapapi.c
@@ -358,7 +358,7 @@ MAP_EXTERNCALL void map_offset_vessel(MAP_OtherStateType_t* other_type, MAP_Inpu
 
   /* define transformation matrix */
   R[0][0] = cpsi*cthe;    R[0][1] = cpsi*sthe*sphi - spsi*cphi;   R[0][2] = cpsi*sthe*cphi + spsi*sphi;
-  R[1][0] = spsi*cthe;    R[1][1] = sphi*sthe*sphi + cpsi*cphi;   R[1][2] = spsi*sthe*cphi - cpsi*sphi;
+  R[1][0] = spsi*cthe;    R[1][1] = sphi*sthe*spsi + cpsi*cphi;   R[1][2] = spsi*sthe*cphi - cpsi*sphi;
   R[2][0] = -sthe;        R[2][1] = cthe*sphi;                    R[2][2] = cthe*cphi;
 
   for (i=0 ; i<u_size ; i++) { 

--- a/modules/map/src/mapinit.c
+++ b/modules/map/src/mapinit.c
@@ -2433,19 +2433,19 @@ MAP_ERROR_CODE set_output_list(Domain* domain, MAP_InitOutputType_t* io_type, ch
     };
 
     if (line_iter->options.azimuth_flag) {
-      success = push_variable_to_output_list(y_list, line_num, &line_iter->psi, "psi", "[m]");
+      success = push_variable_to_output_list(y_list, line_num, &line_iter->psi, "psi", "[rad]");
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.altitude_flag) {
-      success = push_variable_to_output_list(y_list, line_num, &line_iter->alpha, "alpha", "[m]");
+      success = push_variable_to_output_list(y_list, line_num, &line_iter->alpha, "alpha", "[rad]");
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.altitude_anchor_flag) {
-      success = push_variable_to_output_list(y_list, line_num, &line_iter->alpha_at_anchor, "alpha_a", "[m]");
+      success = push_variable_to_output_list(y_list, line_num, &line_iter->alpha_at_anchor, "alpha_a", "[rad]");
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
@@ -2797,8 +2797,8 @@ MAP_ERROR_CODE print_help_to_screen()
   printf("      -v_anch,       --Vertical force at anchor (does NOT include applied forces) [N]\n");
   printf("      -tension_fair, --Line force-magnitude at fairlead (include applied loads) [N]\n");
   printf("      -tension_anch, --Line force-magnitude at anchor (include applied loads) [N]\n");
-  printf("      -azimuth,      --Line lateral offset angle global X axis [deg]\n");
-  printf("      -altitude,     --Line inclination angle relative to global XY plane at fairlead [deg]\n");
+  printf("      -azimuth,      --Line lateral offset angle global X axis [rad]\n");
+  printf("      -altitude,     --Line inclination angle relative to global XY plane at fairlead [rad]\n");
   printf("      -lay_length,   --Length of line on seabed [m]\n");
   printf("      -line_tension, -- \n");
   printf("    Model features:\n");


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
Fix a bug in the transformation matrix used in the C interface, together with some unit definitions, and makefile for windows. 

**Impacted areas of the software**
MAP only, but the changes do not affect the coupling to openfast, only some of the C-library calls. I saw these changes when comparing with version 1.3 of MAP from https://bitbucket.org/mmasciola/map-plus-plus/src/master/ 

I double check the transformation matrix change, for successive Z-Y-X rotations it should indeed be: 
![image](https://user-images.githubusercontent.com/1318316/158491623-df199fc6-179f-4796-bf52-b45ec0e079ae.png)




