### PR TITLE
[BugFix] ServoDyn StC control signal channels were not zeroed properly

### DIFF
--- a/modules/servodyn/src/ServoDyn.f90
+++ b/modules/servodyn/src/ServoDyn.f90
@@ -6429,6 +6429,10 @@ subroutine StC_SetDLLinputs(p,m,MeasDisp,MeasVel,ErrStat,ErrMsg,InitResize)
    ErrStat = ErrID_None
    ErrMsg  = ""
 
+      ! Since we do averaging of these signal
+   if (allocated(MeasDisp))   MeasDisp = 0.0_SiKi
+   if (allocated(MeasVel))    MeasVel  = 0.0_SiKi
+
       ! Only proceed if we have have StC controls with the extended swap and legacy interface
    if ((p%NumStC_Control <= 0) .or. (.not. p%EXavrSWAP))    return
    if (.not. allocated(MeasDisp) .or. .not. allocated(MeasVel)) then


### PR DESCRIPTION
This PR *is* ready for merging

**Feature or improvement description**
The Structural controls (tuned mass dampers, etc) in ServoDyn can be controlled through the DLL interface.  However, the displacement and velocity values sent to the DLL were not zeroed out properly before sending.  This resulted in the controller receiving the incorrect value for the displacements and velocities.O.

**Related issue, if one exists**
None

**Impacted areas of the software**
ServoDyn StC, only when used with the DLL ( `StC_CMODE=5` )

**Additional supporting information**
Alan W. found this issue while testing the StCs for use in WEIS.

**Test results, if applicable**
None of the current tests use this feature yet.