### PR TITLE
Fix Time-Step Delay in Super Controller within FAST.Farm

### DIFF
--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -2202,9 +2202,18 @@ subroutine FARM_CalcOutput(t, farm, ErrStat, ErrMsg)
 
    call Transfer_WD_to_AWAE(farm)
    
+   if ( farm%p%UseSC ) then
+
+         !--------------------
+         ! 3a. Transfer y_F to u_SC, at n+1
+      do nt = 1,farm%p%NumTurbines
+
+         farm%SC%uInputs%toSC( (nt-1)*farm%SC%p%NumCtrl2SC + 1 : nt*farm%SC%p%NumCtrl2SC ) = farm%FWrap(nt)%y%toSC    
+
+      end do
+
       !--------------------
       ! 2. call SC_CO and transfer y_SC to u_F, at n+1 
-   if ( farm%p%UseSC ) then
       call SC_CalcOutput(t, farm%SC%uInputs, farm%SC%p, farm%SC%x, farm%SC%xd, farm%SC%z, &
                            farm%SC%OtherState, farm%SC%y, farm%SC%m, ErrStat2, ErrMsg2 ) 
       
@@ -2212,9 +2221,6 @@ subroutine FARM_CalcOutput(t, farm, ErrStat, ErrMsg)
             
          farm%FWrap(nt)%u%fromSCglob  = farm%SC%y%fromSCglob
          farm%FWrap(nt)%u%fromSC      = farm%SC%y%fromSC( (nt-1)*farm%SC%p%NumSC2Ctrl + 1 : nt*farm%SC%p%NumSC2Ctrl )
-         !--------------------
-         ! 3a. Transfer y_F to u_SC, at n+1
-         farm%SC%uInputs%toSC( (nt-1)*farm%SC%p%NumCtrl2SC + 1 : nt*farm%SC%p%NumCtrl2SC ) = farm%FWrap(nt)%y%toSC
          
       end do
       


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
The transfer within FAST.Farm of `to_SC`, which is an output from OpenFAST and an input to the super controller, previously happened after the call to the super controller `CalcOutput`, which caused a one time-step delay. This change moves the transfer before the call to super controller `CalcOutput` to eliminate the delay. The original implementation correctly followed the FAST.Farm glue code implementation plan, but it is unclear why the plan was written this way. The FAST.Farm user documentation in readthedocs is already consistent with this change, so, the implementation and user documentation are now consistent.  

**Related issue, if one exists**
This issue was discussed in Dec '21 on our forum: https://forums.nrel.gov/t/super-controller-link-with-turbine-controller/2587/19.

**Impacted areas of the software**
FAST.Farm glue code

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
The super controller is not currently tested.