### PR TITLE
BugFix: Checks to populate matrix input to Newman's app were reversed

### DIFF
--- a/modules/hydrodyn/src/WAMIT2.f90
+++ b/modules/hydrodyn/src/WAMIT2.f90
@@ -4221,12 +4221,12 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
                         IF ( EqualRealNos( Data3D%WvDir1(J), Data3D%WvDir2(J) ) .AND. &
                              EqualRealNos( Data3D%WvDir1(K), Data3D%WvDir2(K) ) ) THEN
 
-                              ! Check if not filled
-                           IF ( .NOT. Data3D%DataMask( I, J, K, L )  ) THEN
+                              ! Check if filled
+                              IF ( Data3D%DataMask( I, J, K, L )  ) THEN
 
                                  ! See if the diagonal mirror one (WvDir2,WvDir1) value is not filled,
                                  ! and fill it if empty
-                              IF ( Data3D%DataMask( I, K, J, L )  ) THEN
+                              IF ( .NOT. Data3D%DataMask( I, K, J, L )  ) THEN
                                  Data3D%DataSet ( I, K, J, L ) = Data3D%DataSet( I, J, K, L )
                                  Data3D%DataMask( I, K, J, L ) = .TRUE.
                               ENDIF

--- a/modules/hydrodyn/src/WAMIT2.f90
+++ b/modules/hydrodyn/src/WAMIT2.f90
@@ -4226,10 +4226,10 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
 
                                  ! See if the diagonal mirror one (WvDir2,WvDir1) value is not filled,
                                  ! and fill it if empty
-                              IF ( .NOT. Data3D%DataMask( I, K, J, L )  ) THEN
-                                 Data3D%DataSet ( I, K, J, L ) = Data3D%DataSet( I, J, K, L )
-                                 Data3D%DataMask( I, K, J, L ) = .TRUE.
-                              ENDIF
+                                 IF ( .NOT. Data3D%DataMask( I, K, J, L )  ) THEN
+                                    Data3D%DataSet ( I, K, J, L ) = Data3D%DataSet( I, J, K, L )
+                                    Data3D%DataMask( I, K, J, L ) = .TRUE.
+                                 ENDIF
                            ENDIF
                         ENDIF ! Check that wave directions will pair.
                      ENDIF

--- a/modules/hydrodyn/src/WAMIT2.f90
+++ b/modules/hydrodyn/src/WAMIT2.f90
@@ -4221,15 +4221,15 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
                         IF ( EqualRealNos( Data3D%WvDir1(J), Data3D%WvDir2(J) ) .AND. &
                              EqualRealNos( Data3D%WvDir1(K), Data3D%WvDir2(K) ) ) THEN
 
-                              ! Check if filled
-                              IF ( Data3D%DataMask( I, J, K, L )  ) THEN
+                           ! Check if filled
+                           IF ( Data3D%DataMask( I, J, K, L )  ) THEN
 
                                  ! See if the diagonal mirror one (WvDir2,WvDir1) value is not filled,
                                  ! and fill it if empty
-                                 IF ( .NOT. Data3D%DataMask( I, K, J, L )  ) THEN
-                                    Data3D%DataSet ( I, K, J, L ) = Data3D%DataSet( I, J, K, L )
-                                    Data3D%DataMask( I, K, J, L ) = .TRUE.
-                                 ENDIF
+                              IF ( .NOT. Data3D%DataMask( I, K, J, L )  ) THEN
+                                 Data3D%DataSet ( I, K, J, L ) = Data3D%DataSet( I, J, K, L )
+                                 Data3D%DataMask( I, K, J, L ) = .TRUE.
+                              ENDIF
                            ENDIF
                         ENDIF ! Check that wave directions will pair.
                      ENDIF


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
Only half of the direction pairs of the WAMIT mean drift files are needed to use Newman's approximation, as the other pairs can be obtained by symmetry. However, the checks used to exploit this symmetry and populate the whole matrix were reversed, and this is fixed by this pull request.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
#1096 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
HydroDyn (only when Newman's approximation is used)

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
I may be mistaken, but there are currently no tests using Newman's approximation.

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] MAP_X64.dll
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
