### PR TITLE
Improve GitHub templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,3 +1,9 @@
+---
+name: Bug report
+about: Report a bug to help us improve
+title: 'Bug report'
+labels: "Type: Bug"
+---
 
 <?
 NOTE: Is your issue a bug or a usage question?

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,3 @@
----
-name: Bug report
-about: Report a bug to help us improve
-title: 'Bug report'
-labels: "Type: Bug"
----
 
 <?
 Is this pull request ready to be merged?


### PR DESCRIPTION
# Improves the Issues and Pull Request templates

This pull request adds more info in the GH Issues template. Specifically, guidance on what should be posted as an issue is added, a template declaration from the user that they've done due diligence in searching for the answer, and info on formatting the post are included.

**Related issue, if one exists**
Many issues posted contain information redundant in other issues. Also, many posts contain screenshots of text making it impossible for other users to search for these error messages. 

**Impacted areas of the software**
GitHub Issues and Pull Request template

**Additional supporting information**
Any feedback or suggested from @ebranlard @andrew-platt @bjonkman are welcome! This is intended to help bridge the gap between OpenFAST developers and the community.

**Test results, if applicable**
I cannot verify that it will format as intended until it is merged, but I did render it in VS Code markdown
