### PR TITLE
Add non-rotating hub forces to Bladed Interface

### DIFF
--- a/docs/source/user/servodyn/SrvD--Ex.sum
+++ b/docs/source/user/servodyn/SrvD--Ex.sum
@@ -74,6 +74,9 @@
           95      -->  Reserved (SrvD customization: set to SrvD AirDens parameter)
           96      -->  Reserved (SrvD customization: set to SrvD AvgWindSpeed parameter)
          109      -->  Shaft torque (=hub Mx for clockwise rotor) (Nm) [SrvD input]
+         110      -->  Thrust - Rotating low-speed shaft force x (GL co-ords) (N) [SrvD input]
+         111      -->  Nonrotating low-speed shaft force y (GL co-ords) (N) [SrvD input]
+         112      -->  Nonrotating low-speed shaft force z (GL co-ords) (N) [SrvD input]		 
          117      -->  Controller state [always set to 0]
          120      <--  Airfoil command, blade 1
          121      <--  Airfoil command, blade 2

--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -1812,7 +1812,10 @@ END IF
    y%NcIMURAxs = m%AllOuts(NcIMURAxs)*D2R                  ! Nacelle roll    acceleration (rad/s^2) -- this is in the shaft (tilted) coordinate system, instead of the nacelle (nontilted) coordinate system
    y%NcIMURAys = m%AllOuts(NcIMURAys)*D2R                  ! Nacelle nodding acceleration (rad/s^2)
    y%NcIMURAzs = m%AllOuts(NcIMURAzs)*D2R                  ! Nacelle yaw     acceleration (rad/s^2) -- this is in the shaft (tilted) coordinate system, instead of the nacelle (nontilted) coordinate system
-   
+   y%LSShftFxa = m%AllOuts(LSShftFxa)*1000.                ! Rotating low-speed shaft force x (GL co-ords) (N)
+   y%LSShftFys = m%AllOuts(LSShftFys)*1000.                ! Nonrotating low-speed shaft force y (GL co-ords) (N)
+   y%LSShftFzs = m%AllOuts(LSShftFzs)*1000.                ! Nonrotating low-speed shaft force z (GL co-ords) (N)
+
                
    RETURN
    

--- a/modules/elastodyn/src/ElastoDyn_Registry.txt
+++ b/modules/elastodyn/src/ElastoDyn_Registry.txt
@@ -875,3 +875,6 @@ typedef	^	OutputType	ReKi	NcIMURAxs	-	-	-	"Nacelle inertial measurement unit ang
 typedef	^	OutputType	ReKi	NcIMURAys	-	-	-	"Nacelle inertial measurement unit angular (rotational) acceleration (absolute)"	rad/s^2
 typedef	^	OutputType	ReKi	NcIMURAzs	-	-	-	"Nacelle inertial measurement unit angular (rotational) acceleration (absolute)"	rad/s^2
 typedef	^	OutputType	ReKi	RotPwr	-	-	-	"Rotor power (this is equivalent to the low-speed shaft power)"	W
+typedef	^	OutputType	ReKi	LSShftFxa	-	-	-	"Rotating low-speed shaft force x"	N
+typedef	^	OutputType	ReKi	LSShftFys	-	-	-	"Nonrotating low-speed shaft force y"	N
+typedef	^	OutputType	ReKi	LSShftFzs	-	-	-	"Nonrotating low-speed shaft force z"	N

--- a/modules/elastodyn/src/ElastoDyn_Types.f90
+++ b/modules/elastodyn/src/ElastoDyn_Types.f90
@@ -873,6 +873,9 @@ IMPLICIT NONE
     REAL(ReKi)  :: NcIMURAys      !< Nacelle inertial measurement unit angular (rotational) acceleration (absolute) [rad/s^2]
     REAL(ReKi)  :: NcIMURAzs      !< Nacelle inertial measurement unit angular (rotational) acceleration (absolute) [rad/s^2]
     REAL(ReKi)  :: RotPwr      !< Rotor power (this is equivalent to the low-speed shaft power) [W]
+    REAL(ReKi)  :: LSShftFxa      !< Rotating low-speed shaft force x [N]
+    REAL(ReKi)  :: LSShftFys      !< Nonrotating low-speed shaft force y [N]
+    REAL(ReKi)  :: LSShftFzs      !< Nonrotating low-speed shaft force z [N]
   END TYPE ED_OutputType
 ! =======================
 CONTAINS
@@ -23519,6 +23522,9 @@ ENDIF
     DstOutputData%NcIMURAys = SrcOutputData%NcIMURAys
     DstOutputData%NcIMURAzs = SrcOutputData%NcIMURAzs
     DstOutputData%RotPwr = SrcOutputData%RotPwr
+    DstOutputData%LSShftFxa = SrcOutputData%LSShftFxa
+    DstOutputData%LSShftFys = SrcOutputData%LSShftFys
+    DstOutputData%LSShftFzs = SrcOutputData%LSShftFzs
  END SUBROUTINE ED_CopyOutput
 
  SUBROUTINE ED_DestroyOutput( OutputData, ErrStat, ErrMsg )
@@ -23809,6 +23815,9 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! NcIMURAys
       Re_BufSz   = Re_BufSz   + 1  ! NcIMURAzs
       Re_BufSz   = Re_BufSz   + 1  ! RotPwr
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFxa
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFys
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFzs
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -24221,6 +24230,12 @@ ENDIF
     ReKiBuf(Re_Xferred) = InData%NcIMURAzs
     Re_Xferred = Re_Xferred + 1
     ReKiBuf(Re_Xferred) = InData%RotPwr
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFxa
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFys
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFzs
     Re_Xferred = Re_Xferred + 1
  END SUBROUTINE ED_PackOutput
 
@@ -24773,6 +24788,12 @@ ENDIF
     Re_Xferred = Re_Xferred + 1
     OutData%RotPwr = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFxa = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFys = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFzs = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
  END SUBROUTINE ED_UnPackOutput
 
 
@@ -25205,6 +25226,12 @@ END IF ! check if allocated
   y_out%NcIMURAzs = y1%NcIMURAzs + b * ScaleFactor
   b = -(y1%RotPwr - y2%RotPwr)
   y_out%RotPwr = y1%RotPwr + b * ScaleFactor
+  b = -(y1%LSShftFxa - y2%LSShftFxa)
+  y_out%LSShftFxa = y1%LSShftFxa + b * ScaleFactor
+  b = -(y1%LSShftFys - y2%LSShftFys)
+  y_out%LSShftFys = y1%LSShftFys + b * ScaleFactor
+  b = -(y1%LSShftFzs - y2%LSShftFzs)
+  y_out%LSShftFzs = y1%LSShftFzs + b * ScaleFactor
  END SUBROUTINE ED_Output_ExtrapInterp1
 
 
@@ -25369,6 +25396,15 @@ END IF ! check if allocated
   b = (t(3)**2*(y1%RotPwr - y2%RotPwr) + t(2)**2*(-y1%RotPwr + y3%RotPwr))* scaleFactor
   c = ( (t(2)-t(3))*y1%RotPwr + t(3)*y2%RotPwr - t(2)*y3%RotPwr ) * scaleFactor
   y_out%RotPwr = y1%RotPwr + b  + c * t_out
+  b = (t(3)**2*(y1%LSShftFxa - y2%LSShftFxa) + t(2)**2*(-y1%LSShftFxa + y3%LSShftFxa))* scaleFactor
+  c = ( (t(2)-t(3))*y1%LSShftFxa + t(3)*y2%LSShftFxa - t(2)*y3%LSShftFxa ) * scaleFactor
+  y_out%LSShftFxa = y1%LSShftFxa + b  + c * t_out
+  b = (t(3)**2*(y1%LSShftFys - y2%LSShftFys) + t(2)**2*(-y1%LSShftFys + y3%LSShftFys))* scaleFactor
+  c = ( (t(2)-t(3))*y1%LSShftFys + t(3)*y2%LSShftFys - t(2)*y3%LSShftFys ) * scaleFactor
+  y_out%LSShftFys = y1%LSShftFys + b  + c * t_out
+  b = (t(3)**2*(y1%LSShftFzs - y2%LSShftFzs) + t(2)**2*(-y1%LSShftFzs + y3%LSShftFzs))* scaleFactor
+  c = ( (t(2)-t(3))*y1%LSShftFzs + t(3)*y2%LSShftFzs - t(2)*y3%LSShftFzs ) * scaleFactor
+  y_out%LSShftFzs = y1%LSShftFzs + b  + c * t_out
  END SUBROUTINE ED_Output_ExtrapInterp2
 
 END MODULE ElastoDyn_Types

--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -1019,6 +1019,10 @@ SUBROUTINE SrvD_InputSolve( p_FAST, m_FAST, u_SrvD, y_ED, y_IfW, y_OpFM, y_BD, y
 
    u_SrvD%RotPwr    = y_ED%RotPwr
 
+   u_SrvD%LSShftFxa = y_ED%LSShftFxa
+   u_SrvD%LSShftFys = y_ED%LSShftFys
+   u_SrvD%LSShftFzs = y_ED%LSShftFzs
+
    !   ! ServoDyn inputs from AeroDyn
    !IF ( p_FAST%CompAero == Module_AD ) THEN
    !ELSE

--- a/modules/servodyn/src/BladedInterface.f90
+++ b/modules/servodyn/src/BladedInterface.f90
@@ -603,6 +603,9 @@ subroutine WrLegacyChannelInfoToSummaryFile(u,p,dll_data,UnSum,ErrStat,ErrMsg)
    call WrSumInfoSend(95, 'Reserved (SrvD customization: set to SrvD AirDens parameter)')
    call WrSumInfoSend(96, 'Reserved (SrvD customization: set to SrvD AvgWindSpeed parameter)')
    call WrSumInfoSend(109, 'Shaft torque (=hub Mx for clockwise rotor) (Nm) [SrvD input]')
+   call WrSumInfoSend(110, 'Thrust - Rotating low-speed shaft force x (GL co-ords) (N) [SrvD input]')
+   call WrSumInfoSend(111, 'Nonrotating low-speed shaft force y (GL co-ords) (N) [SrvD input]')
+   call WrSumInfoSend(112, 'Nonrotating low-speed shaft force z (GL co-ords) (N) [SrvD input]')
    call WrSumInfoSend(117, 'Controller state [always set to 0]')
    if (dll_data%DLL_NumTrq>0)  call WrSumInfoSend(R-1,                    'Start of generator speed torque lookup table')
    if (dll_data%DLL_NumTrq>0)  call WrSumInfoSend(R-1+dll_data%DLL_NumTrq,'End   of generator speed torque lookup table')
@@ -1047,6 +1050,9 @@ END IF
 ! Records 107-108 are outputs [see Retrieve_avrSWAP()]
 
    dll_data%avrSWAP(109) = u%LSSTipMxa ! or u%LSShftMxs     !> * Record 109: Shaft torque (=hub Mx for clockwise rotor) (Nm) [SrvD input]
+   dll_data%avrSWAP(110) = u%LSShftFxa                      !> * Record 110: Thrust - Rotating low-speed shaft force x (GL co-ords) (N) [SrvD input]
+   dll_data%avrSWAP(111) = u%LSShftFys                      !> * Record 111: Nonrotating low-speed shaft force y (GL co-ords) (N) [SrvD input]
+   dll_data%avrSWAP(112) = u%LSShftFzs                      !> * Record 112: Nonrotating low-speed shaft force z (GL co-ords) (N) [SrvD input]
    dll_data%avrSWAP(117) = 0                                !> * Record 117: Controller state [always set to 0]
 
    !> * Records \f$R\f$ through \f$R + 2*DLL\_NumTrq - 1\f$: torque-speed look-up table elements.

--- a/modules/servodyn/src/ServoDyn_Registry.txt
+++ b/modules/servodyn/src/ServoDyn_Registry.txt
@@ -223,6 +223,9 @@ typedef	^	BladedDLLType	ReKi	RotPwr	-	-	-	"Rotor power (this is equivalent to th
 typedef	^	BladedDLLType	ReKi	LSSTipMxa	-	-	-	"Rotating low-speed shaft bending moment at the shaft tip (teeter pin for 2-blader, apex of rotation for 3-blader)"	N-m
 typedef	^	BladedDLLType	ReKi	RootMyc	3	-	-	"Out-of-plane moment (i.e., the moment caused by out-of-plane forces) at the blade root for each of the blades (max 3)"	N-m
 typedef	^	BladedDLLType	ReKi	RootMxc	3	-	-	"In-plane moment (i.e., the moment caused by in-plane forces) at the blade root"	N-m
+typedef	^	BladedDLLType	ReKi	LSShftFxa	-	-	-	"Rotating low-speed shaft force x"	N
+typedef	^	BladedDLLType	ReKi	LSShftFys	-	-	-	"Nonrotating low-speed shaft force y"	N
+typedef	^	BladedDLLType	ReKi	LSShftFzs	-	-	-	"Nonrotating low-speed shaft force z"	N
 ## these are PARAMETERS sent to the DLL (THEIR VALUES SHOULD NOT CHANGE DURING SIMULATION):
 typedef	^	BladedDLLType	DbKi	DLL_DT	-	-	-	"interval for calling DLL (integer multiple number of DT)"	s
 typedef	^	BladedDLLType	CHARACTER(1024)	DLL_InFile	-	-	-	"Name of input file used in DLL"	-
@@ -507,6 +510,9 @@ typedef	^	InputType	ReKi	NcIMURAzs	-	-	-	"Nacelle inertial measurement unit angu
 typedef	^	InputType	ReKi	RotPwr	-	-	-	"Rotor power (this is equivalent to the low-speed shaft power)"	W
 typedef	^	InputType	ReKi	HorWindV	-	-	-	"Horizontal hub-height wind velocity magnitude"	m/s
 typedef	^	InputType	ReKi	YawAngle	-	-	2pi	"Estimate of yaw (nacelle + platform)"	radians
+typedef	^	InputType	ReKi	LSShftFxa	-	-	-	"Rotating low-speed shaft force x"	N
+typedef	^	InputType	ReKi	LSShftFys	-	-	-	"Nonrotating low-speed shaft force y"	N
+typedef	^	InputType	ReKi	LSShftFzs	-	-	-	"Nonrotating low-speed shaft force z"	N
 typedef	^	InputType	SiKi	fromSC	{:}	-	-	"A swap array: used to pass turbine specific input data to the DLL controller from the supercontroller"	-
 typedef	^	InputType	SiKi	fromSCglob	{:}	-	-	"A swap array: used to pass global input data to the DLL controller from the supercontroller"	-
 typedef	^	InputType	SiKi	Lidar	{:}	-	-	"A swap array: used to pass input data to the DLL controller from the Lidar"	-

--- a/modules/servodyn/src/ServoDyn_Types.f90
+++ b/modules/servodyn/src/ServoDyn_Types.f90
@@ -236,6 +236,9 @@ IMPLICIT NONE
     REAL(ReKi)  :: LSSTipMxa      !< Rotating low-speed shaft bending moment at the shaft tip (teeter pin for 2-blader, apex of rotation for 3-blader) [N-m]
     REAL(ReKi) , DIMENSION(1:3)  :: RootMyc      !< Out-of-plane moment (i.e., the moment caused by out-of-plane forces) at the blade root for each of the blades (max 3) [N-m]
     REAL(ReKi) , DIMENSION(1:3)  :: RootMxc      !< In-plane moment (i.e., the moment caused by in-plane forces) at the blade root [N-m]
+    REAL(ReKi)  :: LSShftFxa      !< Rotating low-speed shaft force x [N]
+    REAL(ReKi)  :: LSShftFys      !< Nonrotating low-speed shaft force y [N]
+    REAL(ReKi)  :: LSShftFzs      !< Nonrotating low-speed shaft force z [N]
     REAL(DbKi)  :: DLL_DT      !< interval for calling DLL (integer multiple number of DT) [s]
     CHARACTER(1024)  :: DLL_InFile      !< Name of input file used in DLL [-]
     CHARACTER(1024)  :: RootName      !< RootName for writing output files [-]
@@ -513,6 +516,9 @@ IMPLICIT NONE
     REAL(ReKi)  :: RotPwr      !< Rotor power (this is equivalent to the low-speed shaft power) [W]
     REAL(ReKi)  :: HorWindV      !< Horizontal hub-height wind velocity magnitude [m/s]
     REAL(ReKi)  :: YawAngle      !< Estimate of yaw (nacelle + platform) [radians]
+    REAL(ReKi)  :: LSShftFxa      !< Rotating low-speed shaft force x [N]
+    REAL(ReKi)  :: LSShftFys      !< Nonrotating low-speed shaft force y [N]
+    REAL(ReKi)  :: LSShftFzs      !< Nonrotating low-speed shaft force z [N]
     REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: fromSC      !< A swap array: used to pass turbine specific input data to the DLL controller from the supercontroller [-]
     REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: fromSCglob      !< A swap array: used to pass global input data to the DLL controller from the supercontroller [-]
     REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: Lidar      !< A swap array: used to pass input data to the DLL controller from the Lidar [-]
@@ -3479,6 +3485,9 @@ ENDIF
     DstBladedDLLTypeData%LSSTipMxa = SrcBladedDLLTypeData%LSSTipMxa
     DstBladedDLLTypeData%RootMyc = SrcBladedDLLTypeData%RootMyc
     DstBladedDLLTypeData%RootMxc = SrcBladedDLLTypeData%RootMxc
+    DstBladedDLLTypeData%LSShftFxa = SrcBladedDLLTypeData%LSShftFxa
+    DstBladedDLLTypeData%LSShftFys = SrcBladedDLLTypeData%LSShftFys
+    DstBladedDLLTypeData%LSShftFzs = SrcBladedDLLTypeData%LSShftFzs
     DstBladedDLLTypeData%DLL_DT = SrcBladedDLLTypeData%DLL_DT
     DstBladedDLLTypeData%DLL_InFile = SrcBladedDLLTypeData%DLL_InFile
     DstBladedDLLTypeData%RootName = SrcBladedDLLTypeData%RootName
@@ -3911,6 +3920,9 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! LSSTipMxa
       Re_BufSz   = Re_BufSz   + SIZE(InData%RootMyc)  ! RootMyc
       Re_BufSz   = Re_BufSz   + SIZE(InData%RootMxc)  ! RootMxc
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFxa
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFys
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFzs
       Db_BufSz   = Db_BufSz   + 1  ! DLL_DT
       Int_BufSz  = Int_BufSz  + 1*LEN(InData%DLL_InFile)  ! DLL_InFile
       Int_BufSz  = Int_BufSz  + 1*LEN(InData%RootName)  ! RootName
@@ -4240,6 +4252,12 @@ ENDIF
       ReKiBuf(Re_Xferred) = InData%RootMxc(i1)
       Re_Xferred = Re_Xferred + 1
     END DO
+    ReKiBuf(Re_Xferred) = InData%LSShftFxa
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFys
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFzs
+    Re_Xferred = Re_Xferred + 1
     DbKiBuf(Db_Xferred) = InData%DLL_DT
     Db_Xferred = Db_Xferred + 1
     DO I = 1, LEN(InData%DLL_InFile)
@@ -4842,6 +4860,12 @@ ENDIF
       OutData%RootMxc(i1) = ReKiBuf(Re_Xferred)
       Re_Xferred = Re_Xferred + 1
     END DO
+    OutData%LSShftFxa = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFys = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFzs = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
     OutData%DLL_DT = DbKiBuf(Db_Xferred)
     Db_Xferred = Db_Xferred + 1
     DO I = 1, LEN(OutData%DLL_InFile)
@@ -14751,6 +14775,9 @@ ENDIF
     DstInputData%RotPwr = SrcInputData%RotPwr
     DstInputData%HorWindV = SrcInputData%HorWindV
     DstInputData%YawAngle = SrcInputData%YawAngle
+    DstInputData%LSShftFxa = SrcInputData%LSShftFxa
+    DstInputData%LSShftFys = SrcInputData%LSShftFys
+    DstInputData%LSShftFzs = SrcInputData%LSShftFzs
 IF (ALLOCATED(SrcInputData%fromSC)) THEN
   i1_l = LBOUND(SrcInputData%fromSC,1)
   i1_u = UBOUND(SrcInputData%fromSC,1)
@@ -15013,6 +15040,9 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! RotPwr
       Re_BufSz   = Re_BufSz   + 1  ! HorWindV
       Re_BufSz   = Re_BufSz   + 1  ! YawAngle
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFxa
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFys
+      Re_BufSz   = Re_BufSz   + 1  ! LSShftFzs
   Int_BufSz   = Int_BufSz   + 1     ! fromSC allocated yes/no
   IF ( ALLOCATED(InData%fromSC) ) THEN
     Int_BufSz   = Int_BufSz   + 2*1  ! fromSC upper/lower bounds for each dimension
@@ -15307,6 +15337,12 @@ ENDIF
     ReKiBuf(Re_Xferred) = InData%HorWindV
     Re_Xferred = Re_Xferred + 1
     ReKiBuf(Re_Xferred) = InData%YawAngle
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFxa
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFys
+    Re_Xferred = Re_Xferred + 1
+    ReKiBuf(Re_Xferred) = InData%LSShftFzs
     Re_Xferred = Re_Xferred + 1
   IF ( .NOT. ALLOCATED(InData%fromSC) ) THEN
     IntKiBuf( Int_Xferred ) = 0
@@ -15739,6 +15775,12 @@ ENDIF
     OutData%HorWindV = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
     OutData%YawAngle = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFxa = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFys = ReKiBuf(Re_Xferred)
+    Re_Xferred = Re_Xferred + 1
+    OutData%LSShftFzs = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! fromSC not allocated
     Int_Xferred = Int_Xferred + 1
@@ -17409,6 +17451,12 @@ END IF ! check if allocated
   b = -(u1%HorWindV - u2%HorWindV)
   u_out%HorWindV = u1%HorWindV + b * ScaleFactor
   CALL Angles_ExtrapInterp( u1%YawAngle, u2%YawAngle, tin, u_out%YawAngle, tin_out )
+  b = -(u1%LSShftFxa - u2%LSShftFxa)
+  u_out%LSShftFxa = u1%LSShftFxa + b * ScaleFactor
+  b = -(u1%LSShftFys - u2%LSShftFys)
+  u_out%LSShftFys = u1%LSShftFys + b * ScaleFactor
+  b = -(u1%LSShftFzs - u2%LSShftFzs)
+  u_out%LSShftFzs = u1%LSShftFzs + b * ScaleFactor  
 IF (ALLOCATED(u_out%fromSC) .AND. ALLOCATED(u1%fromSC)) THEN
   DO i1 = LBOUND(u_out%fromSC,1),UBOUND(u_out%fromSC,1)
     b = -(u1%fromSC(i1) - u2%fromSC(i1))
@@ -17632,6 +17680,15 @@ END IF ! check if allocated
   c = ( (t(2)-t(3))*u1%HorWindV + t(3)*u2%HorWindV - t(2)*u3%HorWindV ) * scaleFactor
   u_out%HorWindV = u1%HorWindV + b  + c * t_out
   CALL Angles_ExtrapInterp( u1%YawAngle, u2%YawAngle, u3%YawAngle, tin, u_out%YawAngle, tin_out )
+  b = (t(3)**2*(u1%LSShftFxa - u2%LSShftFxa) + t(2)**2*(-u1%LSShftFxa + u3%LSShftFxa))* scaleFactor
+  c = ( (t(2)-t(3))*u1%LSShftFxa + t(3)*u2%LSShftFxa - t(2)*u3%LSShftFxa ) * scaleFactor
+  u_out%LSShftFxa = u1%LSShftFxa + b  + c * t_out
+  b = (t(3)**2*(u1%LSShftFys - u2%LSShftFys) + t(2)**2*(-u1%LSShftFys + u3%LSShftFys))* scaleFactor
+  c = ( (t(2)-t(3))*u1%LSShftFys + t(3)*u2%LSShftFys - t(2)*u3%LSShftFys ) * scaleFactor
+  u_out%LSShftFys = u1%LSShftFys + b  + c * t_out
+  b = (t(3)**2*(u1%LSShftFzs - u2%LSShftFzs) + t(2)**2*(-u1%LSShftFzs + u3%LSShftFzs))* scaleFactor
+  c = ( (t(2)-t(3))*u1%LSShftFzs + t(3)*u2%LSShftFzs - t(2)*u3%LSShftFzs ) * scaleFactor
+  u_out%LSShftFzs = u1%LSShftFzs + b  + c * t_out  
 IF (ALLOCATED(u_out%fromSC) .AND. ALLOCATED(u1%fromSC)) THEN
   DO i1 = LBOUND(u_out%fromSC,1),UBOUND(u_out%fromSC,1)
     b = (t(3)**2*(u1%fromSC(i1) - u2%fromSC(i1)) + t(2)**2*(-u1%fromSC(i1) + u3%fromSC(i1)))* scaleFactor


### PR DESCRIPTION
This pull request adds non-rotating hub forces to the legacy Bladed Interface based on the Bladed documentation.

<!-- Is this pull request ready to be merged?
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
A bladed-style dll might expect non-rotating hub forces at swaparray position 110-112.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
Bladed Interface in ServoDyn

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
No impact on tests expected. Expected is impact on:
- Servodyn Summary file.
- SwapArray handed to the Bladed-style dll.

**Additional supporting information**
<!-- Add any other context about the problem here. -->
Changes are made by TÜV NORD based on bladed documentation.

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
Internal validation show the expected behaviour.