### PR TITLE
Move AD module reg tests to a standalone job

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -24,6 +24,55 @@ env:
 
 
 jobs:
+
+  regression-tests-aerodyn-driver:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.7'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install numpy Bokeh==1.4
+
+      - name: Setup Workspace
+        run: cmake -E make_directory ${{runner.workspace}}/openfast/build
+      - name: Configure Build
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/openfast/install \
+            -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
+            -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
+            -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
+      - name: Build AeroDyn Driver
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: cmake --build . --target aerodyn_driver -- -j ${{env.NUM_PROCS}}
+
+      - name: Run AeroDyn tests
+        uses: ./.github/actions/tests-module-aerodyn
+        with:
+          test-target: regression
+
+      - name: Failing test artifacts
+        uses: actions/upload-artifact@v2
+        if: failure()
+        with:
+          name: regression-tests-aerodyn-module
+          path: |
+            ${{runner.workspace}}/openfast/build/reg_tests/modules
+
   regression-tests-release:
     runs-on: ubuntu-20.04
     steps:
@@ -62,10 +111,10 @@ jobs:
 
       - name: Run SubDyn tests
         uses: ./.github/actions/tests-module-subdyn
-      - name: Run AeroDyn tests
-        uses: ./.github/actions/tests-module-aerodyn
-        with:
-          test-target: regression
+      # - name: Run AeroDyn tests
+      #   uses: ./.github/actions/tests-module-aerodyn
+      #   with:
+      #     test-target: regression
       - name: Run HydroDyn tests
         uses: ./.github/actions/tests-module-hydrodyn
       - name: Run InflowWind tests
@@ -151,10 +200,10 @@ jobs:
 
       - name: Run SubDyn tests
         uses: ./.github/actions/tests-module-subdyn
-      - name: Run AeroDyn tests
-        uses: ./.github/actions/tests-module-aerodyn
-        with:
-          test-target: regression
+      # - name: Run AeroDyn tests
+      #   uses: ./.github/actions/tests-module-aerodyn
+      #   with:
+      #     test-target: regression
       - name: Run HydroDyn tests
         uses: ./.github/actions/tests-module-hydrodyn
       - name: Run InflowWind tests


### PR DESCRIPTION
**Feature or improvement description**
Since the AeroDyn driver tests are failing and we haven't been able to identify the issue, this temporary workaround allows the other regression tests to continue running while isolation the AeroDyn specific tests.

**Related issue, if one exists**
#841 

**Impacted areas of the software**
AeroDyn regression test portion of the automated tests

**Additional supporting information**
This is temporary until the AeroDyn bug is fixed.