### PR TITLE
BugFix: Fix typo in DLLEXPORT attributes for IfW C interface

### DIFF
--- a/modules/inflowwind/src/IfW_C_Binding.f90
+++ b/modules/inflowwind/src/IfW_C_Binding.f90
@@ -76,8 +76,8 @@ end subroutine SetErr
 SUBROUTINE IfW_C_Init(InputFileString_C, InputFileStringLength_C, InputUniformString_C, InputUniformStringLength_C, NumWindPts_C, DT_C, NumChannels_C, OutputChannelNames_C, OutputChannelUnits_C, ErrStat_C, ErrMsg_C) BIND (C, NAME='IfW_C_Init')
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
-!DEC$ ATTRIBUTES DLLEXPORT :: IfW_Init_c
-!GCC$ ATTRIBUTES DLLEXPORT :: IfW_Init_c
+!DEC$ ATTRIBUTES DLLEXPORT :: IfW_C_Init
+!GCC$ ATTRIBUTES DLLEXPORT :: IfW_C_Init
 #endif
     TYPE(C_PTR)                                    , INTENT(IN   )   :: InputFileString_C
     INTEGER(C_INT)                                 , INTENT(IN   )   :: InputFileStringLength_C
@@ -181,8 +181,8 @@ END SUBROUTINE IfW_C_Init
 SUBROUTINE IfW_C_CalcOutput(Time_C,Positions_C,Velocities_C,OutputChannelValues_C,ErrStat_C,ErrMsg_C) BIND (C, NAME='IfW_C_CalcOutput')
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
-!DEC$ ATTRIBUTES DLLEXPORT :: IfW_CalcOutput_c
-!GCC$ ATTRIBUTES DLLEXPORT :: IfW_CalcOutput_c
+!DEC$ ATTRIBUTES DLLEXPORT :: IfW_C_CalcOutput
+!GCC$ ATTRIBUTES DLLEXPORT :: IfW_C_CalcOutput
 #endif
    REAL(C_DOUBLE)                , INTENT(IN   )      :: Time_C
    REAL(C_FLOAT)                 , INTENT(IN   )      :: Positions_C(3*InitInp%NumWindPoints)
@@ -234,8 +234,8 @@ END SUBROUTINE IfW_C_CalcOutput
 SUBROUTINE IfW_C_End(ErrStat_C,ErrMsg_C) BIND (C, NAME='IfW_C_End')
    IMPLICIT NONE
 #ifndef IMPLICIT_DLLEXPORT
-!DEC$ ATTRIBUTES DLLEXPORT :: IfW_End_c
-!GCC$ ATTRIBUTES DLLEXPORT :: IfW_End_c
+!DEC$ ATTRIBUTES DLLEXPORT :: IfW_C_End
+!GCC$ ATTRIBUTES DLLEXPORT :: IfW_C_End
 #endif
    INTEGER(C_INT)                , INTENT(  OUT)      :: ErrStat_C
    CHARACTER(KIND=C_CHAR)        , INTENT(  OUT)      :: ErrMsg_C(ErrMsgLen_C)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

Compilation fix under Windows + GCC  (IfW_C_Binding.f90)
The DLLEXPORT attribute in the compiler directives must match the subroutine names, otherwise the compiler throws an error

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. --> 
Pull request https://github.com/OpenFAST/openfast/pull/720 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] MAP_X64.dll
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
