### PR TITLE
Fix MAP linearization operating point

### DIFF
--- a/modules/map/src/lineroutines.h
+++ b/modules/map/src/lineroutines.h
@@ -96,6 +96,7 @@ MAP_ERROR_CODE increment_the_dof_by_delta(MAP_InputType_t* u_type, const Vessel*
 MAP_ERROR_CODE increment_psi_dof_by_delta(MAP_InputType_t* u_type, const Vessel* vessel, const double delta, const int size);
 
 
+MAP_ERROR_CODE f_op_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterType_t* p_type, MAP_InputType_t* u_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, Fd* force, int size, char* map_msg, MAP_ERROR_CODE* ierr);
 MAP_ERROR_CODE fd_x_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterType_t* p_type, MAP_InputType_t* u_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, Fd* force, const double epsilon, const int size, const double* original_pos, char* map_msg, MAP_ERROR_CODE* ierr);
 MAP_ERROR_CODE fd_y_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterType_t* p_type, MAP_InputType_t* u_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, Fd* force, const double epsilon, const int size, const double* original_pos, char* map_msg, MAP_ERROR_CODE* ierr);
 MAP_ERROR_CODE fd_z_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterType_t* p_type, MAP_InputType_t* u_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, Fd* force, const double epsilon, const int size, const double* original_pos, char* map_msg, MAP_ERROR_CODE* ierr);
@@ -103,6 +104,7 @@ MAP_ERROR_CODE fd_phi_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterTy
 MAP_ERROR_CODE fd_the_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterType_t* p_type, MAP_InputType_t* u_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, Fd* force, const double epsilon, const int size, const double* original_x, const double* original_y, const double* original_z, char* map_msg, MAP_ERROR_CODE* ierr);
 MAP_ERROR_CODE fd_psi_sequence(MAP_OtherStateType_t* other_type, MAP_ParameterType_t* p_type, MAP_InputType_t* u_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, Fd* force, const double epsilon, const int size, const double* original_x, const double* original_y, const double* original_z, char* map_msg, MAP_ERROR_CODE* ierr);
 MAP_ERROR_CODE calculate_stiffness(double* K, Fd* force, const double delta, const int size);
+MAP_ERROR_CODE calculate_sumforce (double* F, Fd* force, const int size);
 
 /**
  * sets cable excursions (l and h) and reference frame psi rotation

--- a/modules/map/src/map.f90
+++ b/modules/map/src/map.f90
@@ -1403,6 +1403,9 @@ SUBROUTINE MAP_JacobianPInput( t, u, p, x, xd, z, OtherState, y, ErrStat, ErrMsg
    end if
    call cleanup()
    
+   ! Calling CalcOutput at operating point to ensure that "y" does not have the values of y_m (MAP specific issue)
+   call map_CalcOutput( t, u, p, x, xd, z, OtherState, y, ErrStat2, ErrMsg2 ) 
+      call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName) ! we shouldn't have any errors about allocating memory here so I'm not going to return-on-error until later  
 contains
    subroutine cleanup()
       call map_DestroyOutput(       y_p, ErrStat2, ErrMsg2 )

--- a/modules/map/src/mapapi.c
+++ b/modules/map/src/mapapi.c
@@ -378,6 +378,73 @@ MAP_EXTERNCALL void map_offset_vessel(MAP_OtherStateType_t* other_type, MAP_Inpu
 };
 
 
+/*  Return summed force (rigid body force at point (0,0,0)) based on current operating point displacements
+ *  Computed at the displaced vessel position
+ */
+MAP_EXTERNCALL double* map_f_op(MAP_InputType_t* u_type, MAP_ParameterType_t* p_type, MAP_OtherStateType_t* other_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, MAP_ERROR_CODE* ierr, char* map_msg)
+{
+  MAP_ERROR_CODE success = MAP_SAFE;
+  const int n = u_type->x_Len;
+  const int SIX = 6;
+  int i = 0;
+  Fd force;
+  double* F;
+ 
+  map_reset_universal_error(map_msg, ierr);
+
+  /* Summed force */
+  F = malloc(SIX*sizeof(double));
+  for (i=0 ; i<SIX ; i++) {
+    F[i] = 0.0;
+  };
+
+  /* All n forces */
+  force.fx = malloc(n*sizeof(double));
+  force.fy = malloc(n*sizeof(double));
+  force.fz = malloc(n*sizeof(double));
+  force.mx = malloc(n*sizeof(double));
+  force.my = malloc(n*sizeof(double));
+  force.mz = malloc(n*sizeof(double));  
+  
+  /* initialize stuff allocated above to zero */
+  for (i=0 ; i<n ; i++) {
+    force.fx[i] = 0.0;
+    force.fy[i] = 0.0;
+    force.fz[i] = 0.0;
+    force.mx[i] = 0.0;
+    force.my[i] = 0.0;
+    force.mz[i] = 0.0;
+  };
+    
+  MAP_BEGIN_ERROR_LOG; 
+  
+  /* Compute operating point force (required to transfer matrix to a different point */
+  success = f_op_sequence(other_type, p_type, u_type, y_type, z_type, &force, n, map_msg, ierr); CHECKERRQ(MAP_FATAL_62);
+  
+  /* Sum force */
+  success = calculate_sumforce(F, &force, n); CHECKERRQ(MAP_FATAL_64);
+
+  MAP_END_ERROR_LOG; 
+
+  MAPFREE(force.fx);
+  MAPFREE(force.fy);
+  MAPFREE(force.fz);
+  MAPFREE(force.mx);
+  MAPFREE(force.my);
+  MAPFREE(force.mz);
+   
+  return F;
+};
+
+MAP_EXTERNCALL void map_free_f_op(double* array)
+{
+  MAPFREE(array);
+};
+
+
+
+// NOTE: The matrix returned is the transposed of a stiffness matrix!
+// Computed at the displaced vessel position
 MAP_EXTERNCALL double** map_linearize_matrix(MAP_InputType_t* u_type, MAP_ParameterType_t* p_type, MAP_OtherStateType_t* other_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, double epsilon, MAP_ERROR_CODE* ierr, char* map_msg)
 {
   double* x_original = NULL;
@@ -440,6 +507,7 @@ MAP_EXTERNCALL double** map_linearize_matrix(MAP_InputType_t* u_type, MAP_Parame
     z_original[k] = u_type->z[k];      
   };
   
+  /* Compute (transpose of) stiffness matrix by perturbing component by component */
   for (i=0 ; i<SIX ; i++) { /* down, force direction changes */
     success = reset_force_to_zero(force.fx, force.fy, force.fz, force.mx, force.my, force.mz, n);
     if (i==0) {        

--- a/modules/map/src/mapapi.h
+++ b/modules/map/src/mapapi.h
@@ -206,6 +206,16 @@ MAP_EXTERNCALL double** map_linearize_matrix(MAP_InputType_t* u_type, MAP_Parame
  */
 MAP_EXTERNCALL void map_free_linearize_matrix(double** array);
 
+/**
+ * lib.map_f_op.argtypes = [MapInput_Type, MapData_Type, MapOutnput_Type, c_double, c_char_p, POINTER(c_int)]        
+ */
+MAP_EXTERNCALL double* map_f_op(MAP_InputType_t* u_type, MAP_ParameterType_t* p_type, MAP_OtherStateType_t* other_type, MAP_OutputType_t* y_type, MAP_ConstraintStateType_t* z_type, MAP_ERROR_CODE* ierr, char* map_msg);
+
+/**
+ * lib.map_free_f_op.argtypes = [POINTER(c_double)]
+ */
+MAP_EXTERNCALL void map_free_f_op(double* array);
+
 
 /**
  * @brief     Initializes the MAP model and allocates memory. Inconsistencies with the input file is reported here. 


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
This pull request contains two features:
- Fix #1165: the operating point loads written to the "lin" files were wrong. They are now fixed by calling `MAP_CalcOutput` at the end of the routine `MAP_JacobianPInputs`. 
- Add the routine routine `map_f_op` to the MAP API to be able to return the summed loads at (0,0,0). These summed loads are required to be able to translate the stiffness matrix returned by MAP (at the point (0,0,0)) to a different point, such as the platform reference point. C or python wrapper of MAP can access this feature. 

**Related issue, if one exists**
#1165

**Impacted areas of the software**
MAP

