### PR TITLE
Update git-module urls

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "reg_tests/r-test"]
 	path = reg_tests/r-test
-	url = https://github.com/OpenFAST/r-test.git
+	url = git@github.com:/OpenFAST/r-test.git
 [submodule "unit_tests/pfunit"]
 	path = unit_tests/pfunit
-	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git
+	url = git@github.com:/Goddard-Fortran-Ecosystem/pFUnit.git


### PR DESCRIPTION
**Feature or improvement description**
This pull request changes the method by which the git-submodules are cloned. They are currently using https but this changes it to ssh. For most people interacting with the repository, there will be no change. However, for anyone who wants to make changes to the r-test or pfunit git-submodules from within the OpenFAST repository, GitHub no longer allows to push to a remote with https so this change allows that.

**Related issue, if one exists**
None

**Impacted areas of the software**
pfunit and r-test submodule git infrastructure