### PR TITLE
Simulink: add documentation of inputs to FAST_Library.h

### DIFF
--- a/glue-codes/simulink/README.md
+++ b/glue-codes/simulink/README.md
@@ -1,0 +1,5 @@
+OpenFAST expects a set of channels passed from Simulink to the library.  The number channels may change between OpenFAST releases.
+
+For list of control channels, see comments at end of source file modules/openfast-library/src/FAST_Library.h 
+
+The examples included here inclue all the channels listed in the FAST_Library.h file.

--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -54,6 +54,16 @@ EXTERNAL_ROUTINE void FAST_CreateCheckpoint(int * iTurb, const char *CheckpointR
 #define MAXInitINPUTS 53
 
 #define NumFixedInputs  2 + 2 + MAXIMUM_BLADES + 1 + MAXIMUM_AFCTRL + MAXIMUM_CABLE_DELTAL + MAXIMUM_CABLE_DELTALDOT
-
+/* Fixed inputs list:
+    1       Generator Torque (N-m)
+    2       Electrical Power (W)
+    3       Yaw pos (rad)
+    4       Yaw rate (rad/s)
+    5-7     Blade 1-3 pitch angle (rad)
+    8       High speed shaft brake fraction (-)
+    9-11    Blade 1-3 Airfoil control (-)
+    12-31   Cable control channel 1-20 DeltaL (m)
+    32-51   Cable control channel 1-20 DeltaLDot (m/s)
+*/
 
 #endif


### PR DESCRIPTION
This is ready for merging

**Feature or improvement description**
The change to the Simulink inputs was not documented well in the 3.1.0 release.  This PR adds a current list of inputs to FAST_Library.h and a readme in the `glue-codes/simulink` directory pointing to where this can be found

**Related issue, if one exists**
#1163 

**Impacted areas of the software**
This is documentation only (comment lines were added within the code).

**Additional supporting information**
It took me longer than expected to figure out what the channel list should be even though I wrote the code.  So I added it here so I can more easily find it in future development, and can point Simulink users and other developers to it.  This could be added to readthedocs, but we don't currently have any info there for the Simulink interface.