### PR TITLE
B/lin doc corrections 3.2.0

### DIFF
--- a/docs/source/user/api_change.rst
+++ b/docs/source/user/api_change.rst
@@ -19,8 +19,17 @@ None
 
 OpenFAST v3.1.0 to OpenFAST v3.2.0
 ----------------------------------
+
 ============================================= ==== =============== ========================================================================================================================================================================================================
-Removed in OpenFAST dev
+Added in OpenFAST v3.2.0 
+---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
+Module                                        Line  Flag Name        Example Value
+============================================= ==== =============== ========================================================================================================================================================================================================
+TurbSim                                       13   WrHAWCFF         False      WrHAWCFF          - Output full-field time-series data in HAWC form?  (Generates RootName-u.bin, RootName-v.bin, RootName-w.bin, RootName.hawc)
+============================================= ==== =============== ========================================================================================================================================================================================================
+
+============================================= ==== =============== ========================================================================================================================================================================================================
+Removed in OpenFAST v3.2.0 
 ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Module                                        Line  Flag Name        Example Value
 ============================================= ==== =============== ========================================================================================================================================================================================================
@@ -58,7 +67,6 @@ OpenFAST                                      28   Patm            103500     Pa
 OpenFAST                                      29   Pvap            1700       Pvap              - Vapour pressure of working fluid (Pa) [used only for an MHK turbine cavitation check]
 OpenFAST                                      30   WtrDpth         50         WtrDpth           - Water depth (m)
 OpenFAST                                      31   MSL2SWL         0          MSL2SWL           - Offset between still-water level and mean sea level (m) [positive upward]
-TurbSim                                       13   WrHAWCFF        False      WrHAWCFF          - Output full-field time-series data in HAWC form?  (Generates RootName-u.bin, RootName-v.bin, RootName-w.bin, RootName.hawc)
 AeroDyn 15                                    40   UAStartRad      0.25       UAStartRad        - Starting radius for dynamic stall (fraction of rotor radius) [used only when AFAeroMod=2; if line is missing UAStartRad=0]
 AeroDyn 15                                    41   UAEndRad        0.95       UAEndRad          - Ending radius for dynamic stall (fraction of rotor radius) [used only when AFAeroMod=2; if line is missing UAEndRad=1]
 AeroDyn driver                                34   Twr2Shft        3.09343    Twr2Shft          - Vertical distance from the tower-top to the rotor shaft (m)

--- a/docs/source/user/fast.farm/index.rst
+++ b/docs/source/user/fast.farm/index.rst
@@ -2,8 +2,7 @@
 FAST.Farm User's Guide and Theory Manual
 ========================================
 
-This document offers a quick reference guide for the FAST.Farm driver for
-OpenFAST. The FAST.Farm implementation plan is also available for download:
+The FAST.Farm implementation plan is also available for download:
 :download:`FAST.Farm Development Plan <../../../OtherSupporting/FAST.Farm_Plan_Rev25.doc>`.
 
 The documentation here was derived from the FAST.Farm User's Guide and Theory Manual by Jason

--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -5482,7 +5482,7 @@ SUBROUTINE Perturb_u( p, n, perturb_sign, u, du )
    CASE ( 1) !Module/Mesh/Field: u%TowerMotion%TranslationDisp = 1;
       u%TowerMotion%TranslationDisp( fieldIndx,node) = u%TowerMotion%TranslationDisp( fieldIndx,node) + du * perturb_sign
    CASE ( 2) !Module/Mesh/Field: u%TowerMotion%Orientation = 2;
-      CALL PerturbOrientationMatrix( u%TowerMotion%Orientation(:,:,node), du * perturb_sign, fieldIndx )
+      CALL PerturbOrientationMatrix( u%TowerMotion%Orientation(:,:,node), du * perturb_sign, fieldIndx, UseSmlAngle=.true )
    CASE ( 3) !Module/Mesh/Field: u%TowerMotion%TranslationVel = 3;
       u%TowerMotion%TranslationVel( fieldIndx,node ) = u%TowerMotion%TranslationVel( fieldIndx,node) + du * perturb_sign
       

--- a/modules/servodyn/src/ServoDyn.f90
+++ b/modules/servodyn/src/ServoDyn.f90
@@ -3300,7 +3300,7 @@ subroutine SrvD_Perturb_u( p, n, perturb_sign, u, du )
       case (13) ! TranslationDisp = 1;
          u%TStCMotionMesh(instance)%TranslationDisp(fieldIndx,1) = u%TStCMotionMesh(instance)%TranslationDisp(fieldIndx,1) + du * perturb_sign
       case (14) ! Orientation     = 2;
-         CALL PerturbOrientationMatrix( u%TStCMotionMesh(instance)%Orientation(:,:,1), du * perturb_sign, fieldIndx )
+         CALL PerturbOrientationMatrix( u%TStCMotionMesh(instance)%Orientation(:,:,1), du * perturb_sign, fieldIndx, UseSmlAngle=.true )
       case (15) ! TranslationVel  = 3;
          u%TStCMotionMesh(instance)%TranslationVel( fieldIndx,1) = u%TStCMotionMesh(instance)%TranslationVel( fieldIndx,1) + du * perturb_sign
       case (16) ! RotationVel     = 4;
@@ -3314,7 +3314,7 @@ subroutine SrvD_Perturb_u( p, n, perturb_sign, u, du )
       case (19) ! TranslationDisp = 1;
          u%SStCMotionMesh(instance)%TranslationDisp(fieldIndx,1) = u%SStCMotionMesh(instance)%TranslationDisp(fieldIndx,1) + du * perturb_sign
       case (20) ! Orientation     = 2;
-         CALL PerturbOrientationMatrix( u%SStCMotionMesh(instance)%Orientation(:,:,1), du * perturb_sign, fieldIndx )
+         CALL PerturbOrientationMatrix( u%SStCMotionMesh(instance)%Orientation(:,:,1), du * perturb_sign, fieldIndx, UseSmlAngle=.true )
       case (21) ! TranslationVel  = 3;
          u%SStCMotionMesh(instance)%TranslationVel( fieldIndx,1) = u%SStCMotionMesh(instance)%TranslationVel( fieldIndx,1) + du * perturb_sign
       case (22) ! RotationVel     = 4;


### PR DESCRIPTION
This is ready to merge.

This PR contains a few requested corrections for the 3.2.0 release in review https://github.com/OpenFAST/openfast/pull/1175#pullrequestreview-1036570929


Corrections include
- Correction to angle perturbation for TStC and SStC to use small angle (this now matches the implementation plan for linearization)
- Correction to angle perturbation for tower in AD15 to use small angle (this now matches the implementation plan for linearization)
- Typo in `api_change.rst`
- relocate TurbSim entry in `api_change.rst`
- removal of incorrect line of text in FAST.Farm documentation in `fast.farm/index.rst`

**Tests**
I don't believe any regression test results will be affected.  

The change in the angular perturbations to use small angle assumptions instead of large angles has a very small effect in the resulting DCM (small angle method is slightly more accurate near 0, so we use it when we know angles remain small).  So the DCM produced using the small angle method will be very slightly different than the large angle forumaltion, but the difference is very small.  The effect of this on the linearization of the AD15 tower becomes negligible since the angular perturbation of tower nodes in AD15 has little effect in the aero loads.  Similarly the structural controls (StCs) are not very sensitive to small angular changes, so the minor difference in the DCM will have no impact on the linearization results.


