### PR TITLE
S-Function build errors

### DIFF
--- a/glue-codes/simulink/src/FAST_SFunc.c
+++ b/glue-codes/simulink/src/FAST_SFunc.c
@@ -203,7 +203,7 @@ static void mdlInitializeSizes(SimStruct *S)
        FAST_AllocateTurbines(&nTurbines, &ErrStat, ErrMsg);
        if (checkError(S)) return;
 
-       FAST_Sizes(&iTurb, InputFileName, &AbortErrLev, &NumOutputs, &dt, &ErrStat, ErrMsg, ChannelNames, &TMax, InitInputAry);
+       FAST_Sizes(&iTurb, InputFileName, &AbortErrLev, &NumOutputs, &TMax, &dt, &ErrStat, ErrMsg, ChannelNames, &TMax, InitInputAry);
        n_t_global = -1;
        if (checkError(S)) return;
 

--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -26,7 +26,7 @@ EXTERNAL_ROUTINE void FAST_OpFM_Step(int * iTurb, int *ErrStat, char *ErrMsg);
 EXTERNAL_ROUTINE void FAST_HubPosition(int * iTurb, float * absolute_position, float * rotation_veocity, double * orientation_dcm, int *ErrStat, char *ErrMsg);
 
 EXTERNAL_ROUTINE void FAST_Restart(int * iTurb, const char *CheckpointRootName, int *AbortErrLev, int * NumOuts, double * dt, int * n_t_global, int *ErrStat, char *ErrMsg);
-EXTERNAL_ROUTINE void FAST_Sizes(int * iTurb, const char *InputFileName, int *AbortErrLev, int * NumOuts, double * dt, double * tmax, int *ErrStat, char *ErrMsg, char *ChannelNames, double *TMax = NULL, double *InitInputAry = NULL);
+EXTERNAL_ROUTINE void FAST_Sizes(int * iTurb, const char *InputFileName, int *AbortErrLev, int * NumOuts, double * dt, double * tmax, int *ErrStat, char *ErrMsg, char *ChannelNames, double *TMax, double *InitInputAry);
 EXTERNAL_ROUTINE void FAST_Start(int * iTurb, int *NumInputs_c, int *NumOutputs_c, double *InputAry, double *OutputAry, int *ErrStat, char *ErrMsg);
 EXTERNAL_ROUTINE void FAST_Update(int * iTurb, int *NumInputs_c, int *NumOutputs_c, double *InputAry, double *OutputAry, bool *EndSimulationEarly, int *ErrStat, char *ErrMsg);
 EXTERNAL_ROUTINE void FAST_End(int * iTurb, bool * stopThisProgram);


### PR DESCRIPTION
The Simulink S-Function in OpenFAST v3.2.0 does not build. These are the changes I made to get it to build.

I have no idea if this will cause issues with other code that also uses `FAST_Library.h`

Here are the error message from the build:
.\..\..\modules\openfast-library\src\FAST_Library.h(29): error C2143: syntax error: missing ')' before '='
..\..\..\modules\openfast-library\src\FAST_Library.h(29): error C2072: 'FAST_Sizes': initialization of a function
..\..\..\modules\openfast-library\src\FAST_Library.h(29): error C2059: syntax error: 'type'
C:\<omitted path>\openfast\glue-codes\simulink\src\FAST_SFunc.c(206): error C2198:
'FAST_Sizes': too few arguments for call

