### PR TITLE
Include stdexcept in FastLibAPI driver

### DIFF
--- a/glue-codes/openfast/src/FastLibAPI.cpp
+++ b/glue-codes/openfast/src/FastLibAPI.cpp
@@ -5,6 +5,7 @@
 #include <iostream>
 #include <math.h>
 #include <cstring>
+#include <stdexcept>
 
 
 FastLibAPI::FastLibAPI(std::string input_file):


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This fixes a build issue in the FastLibAPI C++ driver. In some C++ installations, `runtime_error` is not included in `std`.

**Related issue, if one exists**
Not in an issue but I stole this from https://github.com/luwang00/openfast/commit/3f8b14d0f9717ae7c8b3372a254c798fb907affb

**Impacted areas of the software**
FastLibAPI C++ driver. This is primarily used to test the FAST Library, so it should have minimal impact aside from compiling.