### PR TITLE
Seg Fault due to hub model and external inflow

### DIFF
--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -607,6 +607,7 @@ SUBROUTINE AD_InputSolve_IfW( p_FAST, u_AD, y_IfW, y_OpFM, ErrStat, ErrMsg )
       end if
       
       if (u_AD%rotors(1)%NacelleMotion%NNodes > 0) then
+!        for cfd we will lump the hub and nacelle together
          u_AD%rotors(1)%InflowOnNacelle(1) = y_OpFM%u(1)
          u_AD%rotors(1)%InflowOnNacelle(2) = y_OpFM%v(1)
          u_AD%rotors(1)%InflowOnNacelle(3) = y_OpFM%w(1)

--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -607,9 +607,9 @@ SUBROUTINE AD_InputSolve_IfW( p_FAST, u_AD, y_IfW, y_OpFM, ErrStat, ErrMsg )
       end if
       
       if (u_AD%rotors(1)%NacelleMotion%NNodes > 0) then
-         u_AD%rotors(1)%InflowOnNacelle(1) = y_OpFM%u(node)
-         u_AD%rotors(1)%InflowOnNacelle(2) = y_OpFM%v(node)
-         u_AD%rotors(1)%InflowOnNacelle(3) = y_OpFM%w(node)
+         u_AD%rotors(1)%InflowOnNacelle(1) = y_OpFM%u(1)
+         u_AD%rotors(1)%InflowOnNacelle(2) = y_OpFM%v(1)
+         u_AD%rotors(1)%InflowOnNacelle(3) = y_OpFM%w(1)
          node = node + 1
       else
          u_AD%rotors(1)%InflowOnNacelle = 0.0_ReKi


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? --> 
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
The hub index is 1 in most of the code (first entry in the array), but here it is the last one.  I've had segfaults in nalu-wind and amr-wind that both trace back to this line of code when running actuators with the hub turned on.

Interestingly we only see this issue with GCC, and in testing a `RelWithDebugInfo` build of OpenFAST the failures were intermittent as many memory leaks are.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
https://github.com/Exawind/nalu-wind/issues/979

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
Any turbine run using the external inflow and hub model.

**Additional supporting information**
<!-- Add any other context about the problem here. -->
Pinging @andrew-platt @rafmudaf @gantech 

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
I am not an openfast developer and am not aware of the tests. I assume this is just not getting covered in the test suite.  We've had a segfault in the nalu-wind test suite for months now.

https://my.cdash.org/test/60805600

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] MAP_X64.dll
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
