### PR TITLE
HD: increase max length of line read from kinematics files

### DIFF
--- a/modules/hydrodyn/src/UserWaves.f90
+++ b/modules/hydrodyn/src/UserWaves.f90
@@ -944,7 +944,7 @@ CONTAINS
       CHARACTER(*), INTENT(OUT) :: s(n)     !< Fields
       LOGICAL                   :: OK
       ! Local var
-      CHARACTER(2048)           :: TextLine          !< One line of text read from the file
+      CHARACTER(65536)          :: TextLine          !< One line of text read from the file
       OK=.TRUE.
 
       ! Read line


### PR DESCRIPTION
This PR is ready for merging

**Description**
If a user has a complex hydrodynamics model with lots of nodes and attempts to use `WaveMod==6`, the reading of the wave kinetic files may fail because there are more than 2048 characters on a line (see issue #1229).  I increased the size of the temporary character array used to an absurdly large value (2^16 characters) so that this will no longer be a problem with more than ~100 nodes.

**Test cases**
No test cases are affected by this PR.

closes #1229 