### PR TITLE
Reg-test scripts modification to help avoid race condition and cleanup of caselist

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -254,7 +254,7 @@ of_fastlib_regression("AWT_YFree_WSt"                    "fastlib;elastodyn;aero
 
 # OpenFAST Python API test
 of_regression_py("5MW_Land_DLL_WTurb_py"                     "openfast;fastlib;python;elastodyn;aerodyn15;servodyn")
-of_regression_py("5MW_ITIBarge_DLL_WTurb_WavesIrr_py"        "openfast;fastlib;python;elastodyn;aerodyn14;servodyn;hydrodyn;map;offshore")
+#of_regression_py("5MW_ITIBarge_DLL_WTurb_WavesIrr_py"        "openfast;fastlib;python;elastodyn;aerodyn14;servodyn;hydrodyn;map;offshore")
 of_regression_py("5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti_py"  "openfast;fastlib;python;elastodyn;aerodyn15;servodyn;hydrodyn;map;offshore")
 of_regression_py("5MW_OC3Spar_DLL_WTurb_WavesIrr_py"         "openfast;fastlib;python;elastodyn;aerodyn15;servodyn;hydrodyn;map;offshore")
 of_regression_py("5MW_OC4Semi_WSt_WavesWN_py"                "openfast;fastlib;python;elastodyn;aerodyn15;servodyn;hydrodyn;moordyn;offshore")
@@ -304,9 +304,9 @@ bd_regression("bd_static_twisted_with_k1"   "beamdyn;static")
 
 # HydroDyn regression tests
 hd_regression("hd_OC3tripod_offshore_fixedbottom_wavesirr"  "hydrodyn;offshore")
-hd_regression("hd_5MW_ITIBarge_DLL_WTurb_WavesIrr"          "hydrodyn;offshore")
+#hd_regression("hd_5MW_ITIBarge_DLL_WTurb_WavesIrr"          "hydrodyn;offshore")
 hd_regression("hd_5MW_OC3Spar_DLL_WTurb_WavesIrr"           "hydrodyn;offshore")
-hd_regression("hd_5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth"      "hydrodyn;offshore")
+#hd_regression("hd_5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth"      "hydrodyn;offshore")
 hd_regression("hd_5MW_OC4Semi_WSt_WavesWN"                  "hydrodyn;offshore")
 hd_regression("hd_5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti"    "hydrodyn;offshore")
 hd_regression("hd_TaperCylinderPitchMoment"                 "hydrodyn;offshore")

--- a/reg_tests/executeFASTFarmRegressionCase.py
+++ b/reg_tests/executeFASTFarmRegressionCase.py
@@ -36,13 +36,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Helper functions
-def ignoreBaselineItems(directory, contents):
-    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
-    caught = []
-    for c in contents:
-        if c in itemFilter:
-            caught.append(c)
-    return tuple(caught)
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 ##### Main program
 
@@ -101,7 +95,7 @@ if not os.path.isdir(inputsDirectory):
 dst = os.path.join(buildDirectory, "5MW_Baseline")
 src = os.path.join(moduleDirectory, "5MW_Baseline")
 if not os.path.isdir(dst):
-    shutil.copytree(src, dst)
+    rtl.copyTree(src, dst, excludeExt=excludeExt)
 else:
     names = os.listdir(src)
     for name in names:
@@ -111,12 +105,12 @@ else:
         dstname = os.path.join(dst, name)
         if os.path.isdir(srcname):
             if not os.path.isdir(dstname):
-                shutil.copytree(srcname, dstname)
+                rtl.copyTree(srcname, dstname, excludeExt=excludeExt)
         else:
             shutil.copy2(srcname, dstname)
 
 if not os.path.isdir(testBuildDirectory):
-    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 ### Run openfast on the test case
 if not noExec:

--- a/reg_tests/executeHydrodynRegressionCase.py
+++ b/reg_tests/executeHydrodynRegressionCase.py
@@ -37,6 +37,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Main program
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 ### Store the python executable for future python calls
 pythonCommand = sys.executable
@@ -103,7 +104,7 @@ dirToCopy = os.path.join("glue-codes","openfast","5MW_Baseline","HydroData")
 buildDirectoryGlue = os.path.join(buildDirectory,os.pardir,os.pardir,dirToCopy)
 if not os.path.isdir(buildDirectoryGlue):
     src = os.path.join(rtest,dirToCopy)
-    shutil.copytree(src, buildDirectoryGlue)
+    rtl.copyTree(src, buildDirectoryGlue, excludeExt=excludeExt)
     
 ### Run HydroDyn on the test case
 if not noExec:

--- a/reg_tests/executeOpenfastAeroAcousticRegressionCase.py
+++ b/reg_tests/executeOpenfastAeroAcousticRegressionCase.py
@@ -37,13 +37,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Helper functions
-def ignoreBaselineItems(directory, contents):
-    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
-    caught = []
-    for c in contents:
-        if c in itemFilter:
-            caught.append(c)
-    return tuple(caught)
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 ##### Main program
 
@@ -102,7 +96,7 @@ if not os.path.isdir(inputsDirectory):
 # create the local output directory if it does not already exist
 # and initialize it with input files for all test cases
 if not os.path.isdir(testBuildDirectory):
-    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 ### Run openfast on the test case
 if not noExec:

--- a/reg_tests/executeOpenfastCppRegressionCase.py
+++ b/reg_tests/executeOpenfastCppRegressionCase.py
@@ -28,13 +28,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Helper functions
-def ignoreBaselineItems(directory, contents):
-    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
-    caught = []
-    for c in contents:
-        if c in itemFilter:
-            caught.append(c)
-    return tuple(caught)
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 ##### Main program
 
@@ -92,7 +86,7 @@ if not os.path.isdir(inputsDirectory):
 dst = os.path.join(buildDirectory, "5MW_Baseline")
 src = os.path.join(openfast_gluecode_directory, "5MW_Baseline")
 if not os.path.isdir(dst):
-    shutil.copytree(src, dst)
+    rtl.copyTree(src, dst, excludeExt=excludeExt)
 else:
     names = os.listdir(src)
     for name in names:
@@ -102,12 +96,12 @@ else:
         dstname = os.path.join(dst, name)
         if os.path.isdir(srcname):
             if not os.path.isdir(dstname):
-                shutil.copytree(srcname, dstname)
+                rtl.copyTree(srcname, dstname, excludeExt=excludeExt)
         else:
             shutil.copy2(srcname, dstname)
 
 if not os.path.isdir(testBuildDirectory):
-    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 ### Run openfast on the test case
 if not noExec:

--- a/reg_tests/executeOpenfastCppRegressionCase.py
+++ b/reg_tests/executeOpenfastCppRegressionCase.py
@@ -28,7 +28,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Helper functions
-excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
+excludeExt=['.out','.outb','.ech','.sum','.log']
 
 ##### Main program
 

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -36,13 +36,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Helper functions
-def ignoreBaselineItems(directory, contents):
-    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
-    caught = []
-    for c in contents:
-        if c in itemFilter:
-            caught.append(c)
-    return tuple(caught)
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 def file_line_count(filename):
     file_handle = open(filename, 'r')
@@ -117,13 +111,13 @@ if not os.path.isdir(inputsDirectory):
 for data in ["Ideal_Beam", "WP_Baseline"]:
     dataDir = os.path.join(buildDirectory, data)
     if not os.path.isdir(dataDir):
-        shutil.copytree(os.path.join(moduleDirectory, data), dataDir)
+        rtl.copyTree(os.path.join(moduleDirectory, data), dataDir, excludeExt=excludeExt)
 
 # Special copy for the 5MW_Baseline folder because the Windows python-only workflow may have already created data in the subfolder ServoData
 dst = os.path.join(buildDirectory, "5MW_Baseline")
 src = os.path.join(moduleDirectory, "5MW_Baseline")
 if not os.path.isdir(dst):
-    shutil.copytree(src, dst)
+    rtl.copyTree(src, dst, excludeExt=excludeExt)
 else:
     names = os.listdir(src)
     for name in names:
@@ -133,12 +127,12 @@ else:
         dstname = os.path.join(dst, name)
         if os.path.isdir(srcname):
             if not os.path.isdir(dstname):
-                shutil.copytree(srcname, dstname)
+                rtl.copyTree(srcname, dstname, excludeExt=excludeExt)
         else:
             shutil.copy2(srcname, dstname)
 
 if not os.path.isdir(testBuildDirectory):
-    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 ### Run openfast on the test case
 if not noExec:

--- a/reg_tests/executeOpenfastRegressionCase.py
+++ b/reg_tests/executeOpenfastRegressionCase.py
@@ -36,13 +36,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Helper functions
-def ignoreBaselineItems(directory, contents):
-    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
-    caught = []
-    for c in contents:
-        if c in itemFilter:
-            caught.append(c)
-    return tuple(caught)
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 ##### Main program
 
@@ -102,13 +96,13 @@ if not os.path.isdir(inputsDirectory):
 for data in ["AOC", "AWT27", "SWRT", "UAE_VI", "WP_Baseline"]:
     dataDir = os.path.join(buildDirectory, data)
     if not os.path.isdir(dataDir):
-        shutil.copytree(os.path.join(moduleDirectory, data), dataDir)
+        rtl.copyTree(os.path.join(moduleDirectory, data), dataDir, excludeExt=excludeExt)
 
 # Special copy for the 5MW_Baseline folder because the Windows python-only workflow may have already created data in the subfolder ServoData
 dst = os.path.join(buildDirectory, "5MW_Baseline")
 src = os.path.join(moduleDirectory, "5MW_Baseline")
 if not os.path.isdir(dst):
-    shutil.copytree(src, dst)
+    rtl.copyTree(src, dst, excludeExt=excludeExt)
 else:
     names = os.listdir(src)
     for name in names:
@@ -118,12 +112,12 @@ else:
         dstname = os.path.join(dst, name)
         if os.path.isdir(srcname):
             if not os.path.isdir(dstname):
-                shutil.copytree(srcname, dstname)
+                rtl.copyTree(srcname, dstname, excludeExt=excludeExt)
         else:
             shutil.copy2(srcname, dstname)
 
 if not os.path.isdir(testBuildDirectory):
-    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 ### Run openfast on the test case
 if not noExec:

--- a/reg_tests/executePythonRegressionCase.py
+++ b/reg_tests/executePythonRegressionCase.py
@@ -40,13 +40,7 @@ from errorPlotting import exportCaseSummary
 import openfast_library
 
 ##### Helper functions
-def ignoreBaselineItems(directory, contents):
-    itemFilter = ['linux-intel', 'linux-gnu', 'macos-gnu', 'windows-intel']
-    caught = []
-    for c in contents:
-        if c in itemFilter:
-            caught.append(c)
-    return tuple(caught)
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
 
 ##### Main program
 
@@ -104,13 +98,13 @@ if not os.path.isdir(inputsDirectory):
 for data in ["AOC", "AWT27", "SWRT", "UAE_VI", "WP_Baseline"]:
     dataDir = os.path.join(buildDirectory, data)
     if not os.path.isdir(dataDir):
-        shutil.copytree(os.path.join(moduleDirectory, data), dataDir)
+        rtl.copyTree(os.path.join(moduleDirectory, data), dataDir, excludeExt=excludeExt)
 
 # Special copy for the 5MW_Baseline folder because the Windows python-only workflow may have already created data in the subfolder ServoData
 dst = os.path.join(buildDirectory, "5MW_Baseline")
 src = os.path.join(moduleDirectory, "5MW_Baseline")
 if not os.path.isdir(dst):
-    shutil.copytree(src, dst)
+    rtl.copyTree(src, dst, excludeExt=excludeExt)
 else:
     names = os.listdir(src)
     for name in names:
@@ -120,12 +114,12 @@ else:
         dstname = os.path.join(dst, name)
         if os.path.isdir(srcname):
             if not os.path.isdir(dstname):
-                shutil.copytree(srcname, dstname)
+                rtl.copyTree(srcname, dstname, excludeExt=excludeExt)
         else:
             shutil.copy2(srcname, dstname)
 
 if not os.path.isdir(testBuildDirectory):
-    shutil.copytree(inputsDirectory, testBuildDirectory, ignore=ignoreBaselineItems)
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 ### Run openfast on the test case
 if not noExec:


### PR DESCRIPTION
This PR is ready to be merged

**Feature or improvement description**
As discussed in PR #1199, there is a frequent issue with race conditions when copying test case inputs over to the regression testing location.  This is caused by the `shutil.copytree` command that errors out if there are pre-existing files.  To get around this issue, the `rtl.copyTree` command is now used.  

Additionally, three test cases are dropped from the python interface testing and HydroDyn module testing.  These cases are equivalent to ones that had been dropped from main OpenFAST test case list as they do not agree sufficiently between platforms for the new testing methodology (likely due to numerical issues in HydroDyn).  These cases include:
- Python interface test:
    - `5MW_ITIBarge_DLL_WTurb_WavesIrr_py`
- HydroDyn module tests:
    - `hd_5MW_ITIBarge_DLL_WTurb_WavesIrr`
    - `hd_5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth`

**Related issue, if one exists**
See comment https://github.com/OpenFAST/openfast/pull/1199#issuecomment-1233158938 and following discussion in PR #1199 for context on the `rtl.copyTree`.
The dropped cases should have been dropped with PR #1217.


**Impacted areas of the software**
This only affects the running of test cases.

**Test results, if applicable**
See above.