### PR TITLE
GitHub Workflow: adding build-all-debug-single to check type errors 

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -31,7 +31,6 @@ jobs:
   build-all-debug:
     # Tests compiling in debug mode.
     # Also compiles the Registry and generates new types files.
-    # TODO: NOT ENABLED Single precision compile checks that the precision types are correctly set.
     # Debug more speeds up the build.
     runs-on: ubuntu-20.04
     steps:
@@ -75,6 +74,38 @@ jobs:
         with:
           path: ${{runner.workspace}}
           key: build-all-debug-${{ github.sha }}
+
+  build-all-debug-single:
+    # Tests compiling in debug mode with single precision.
+    # This workspace is not used by any other subtests, it checks type errors of the type ReKi/R8Ki
+    # Debug speeds up the build.
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+        with:
+          submodules: recursive
+      - name: Setup workspace
+        run: cmake -E make_directory ${{runner.workspace}}/openfast/build
+      - name: Configure build
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/openfast/install \
+            -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
+            -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
+            -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DCMAKE_BUILD_TYPE:STRING=DEBUG \
+            -DBUILD_SHARED_LIBS:BOOL=OFF \
+            -DVARIABLE_TRACKING=OFF \
+            -DDOUBLE_PRECISION:BOOL=OFF \
+            ${GITHUB_WORKSPACE}
+            # -DDOUBLE_PRECISION=OFF \
+      - name: Build all
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake --build . --target all -- -j ${{env.NUM_PROCS}}
+
 
 
   build-drivers-release:


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
This additional workflow compiles the code in single&debug, to catch type errors that may not be captured in double precision (e.g. ReKi/R8Ki). 

**Impacted areas of the software**
Github workflow

