### PR TITLE
Bug Fix: OLAF: particles are NaN when vortex segments have zero length

### DIFF
--- a/modules/aerodyn/src/FVW.f90
+++ b/modules/aerodyn/src/FVW.f90
@@ -784,7 +784,7 @@ subroutine FVW_UpdateStates( t, n, u, utimes, p, x, xd, z, OtherState, AFInfo, m
    call CleanUp()
 
    if (DEV_VERSION) then
-      if(have_nan(p, m, x, u, 'End Update ')) then
+      if(have_nan(p, m, x, z, u, 'End Update ')) then
          STOP
       endif
    endif
@@ -909,11 +909,14 @@ subroutine FVW_CalcContStateDeriv( t, u, p, x, xd, z, OtherState, m, dxdt, ErrSt
       enddo
 
       if (DEV_VERSION) then
-         !call print_mean_4d( m%W(iW)%Vind_NW(:,:, 1:m%nNW+1,:), 'Mean induced vel. NW')
-         !if (nFWEff>0) then
-         !   call print_mean_4d( m%W(iW)%Vind_FW(:,:, 1:nFWEff ,:), 'Mean induced vel. FW')
-         !endif
-         !print'(A25,3F12.4)','MeanFW (non free)',VmeanFW
+         do iW=1,p%nWings
+            call print_mean_3d( m%W(iW)%Vind_NW(:,:, 1:m%nNW+1), 'Mean induced vel. NW')
+            if (nFWEff>0) then
+               call print_mean_3d( m%W(iW)%Vind_FW(:,:, 1:nFWEff), 'Mean induced vel. FW')
+            endif
+         enddo
+         print'(A25,3F12.4)','MeanNW           ',VmeanNW
+         print'(A25,3F12.4)','MeanFW (non free)',VmeanFW
          !call print_mean_4d( m%Vwnd_NW(:,:, 1:m%nNW+1,:), 'Mean wind vel.    NW')
          !call print_mean_4d( m%Vwnd_FW(:,:, 1:nFWEff+1,:), 'Mean wind vel. FWEff')
          !call print_mean_4d( m%Vwnd_FW(:,:, (p%nFWFree+1):m%nFW+1,:), 'Mean wind vel.    FWNF')

--- a/modules/aerodyn/src/FVW.f90
+++ b/modules/aerodyn/src/FVW.f90
@@ -1069,6 +1069,9 @@ subroutine FVW_Euler1( t, u, p, x, xd, z, OtherState, m, ErrStat, ErrMsg )
    if (DEV_VERSION) then
       do iW = 1, p%nWings
          ! Additional checks
+         ! Find points that are the same
+         call find_equal_points(x%W(iW)%r_NW  (1:3, 1:p%W(iW)%nSpan+1, 1:m%nNW+1), 'r_NW After conv'//trim(num2lstr(iW)))
+
          if (any(m%dxdt%W(iW)%r_NW(1:3, 1:p%W(iW)%nSpan+1, 1:m%nNW+1)<-999)) then
             print*,'FVW_Euler1: Attempting to convect NW with a wrong velocity'
             STOP

--- a/modules/aerodyn/src/FVW_Subs.f90
+++ b/modules/aerodyn/src/FVW_Subs.f90
@@ -452,48 +452,51 @@ subroutine print_x_NW_FW(p, m, x, label)
 endsubroutine
 
 !> Debug function to figure out if data have nan
-logical function have_nan(p, m, x, u, label)
+logical function have_nan(p, m, x, z, u, label)
    type(FVW_ParameterType),         intent(in) :: p !< Parameters
    type(FVW_MiscVarType),           intent(in) :: m !< Initial misc/optimization variables
    type(FVW_ContinuousStateType),   intent(in) :: x !< Continuous states
+   type(FVW_ConstraintStateType),   intent(in) :: z !< ConstrStates
    type(FVW_InputType),             intent(in) :: u(:) !< Input states
    character(len=*),                intent(in) :: label !< label for print
    integer :: iW
    have_nan=.False.
    do iW = 1,size(p%W)
       if (any(isnan(x%W(iW)%r_NW))) then
-         print*,trim(label),'NaN in W(iW)%r_NW'
+         print*,trim(label),'NaN in W(iW)%r_NW'//trim(num2lstr(iW))
          have_nan=.True.
       endif
       if (any(isnan(x%W(iW)%r_FW))) then
-         print*,trim(label),'NaN in W(iW)%r_FW'
+         print*,trim(label),'NaN in W(iW)%r_FW'//trim(num2lstr(iW))
          have_nan=.True.
       endif
       if (any(isnan(x%W(iW)%Gamma_NW))) then
-         print*,trim(label),'NaN in G_NW'
+         print*,trim(label),'NaN in G_NW'//trim(num2lstr(iW))
          have_nan=.True.
       endif
       if (any(isnan(x%W(iW)%Gamma_FW))) then
-         print*,trim(label),'NaN in G_FW'
+         print*,trim(label),'NaN in G_FW'//trim(num2lstr(iW))
          have_nan=.True.
       endif
       if (any(isnan(x%W(iW)%Eps_NW))) then
-         print*,trim(label),'NaN in G_FW'
+         print*,trim(label),'NaN in G_FW'//trim(num2lstr(iW))
          have_nan=.True.
       endif
       if (any(isnan(x%W(iW)%Eps_FW))) then
-         print*,trim(label),'NaN in G_FW'
+         print*,trim(label),'NaN in G_FW'//trim(num2lstr(iW))
+         have_nan=.True.
+      endif
+      if (any(isnan(z%W(iW)%Gamma_LL))) then
+         print*,trim(label),'NaN in G_LL'//trim(num2lstr(iW))
          have_nan=.True.
       endif
    enddo
-   if (any(isnan(u(1)%V_wind))) then
-      print*,trim(label),'NaN in Vwind1'
-      have_nan=.True.
-   endif
-   if (any(isnan(u(2)%V_wind))) then
-      print*,trim(label),'NaN in Vwind2'
-      have_nan=.True.
-   endif
+   do iW=1,size(u)
+      if (any(isnan(u(iW)%V_wind))) then
+         print*,trim(label),'NaN in Vwind'//trim(num2lstr(iW))
+         have_nan=.True.
+      endif
+   enddo
 endfunction
 
 

--- a/modules/aerodyn/src/FVW_VortexTools.f90
+++ b/modules/aerodyn/src/FVW_VortexTools.f90
@@ -17,6 +17,8 @@ module FVW_VortexTools
    integer,parameter :: M1_010 = 3
    integer,parameter :: M1_001 = 4
 
+   logical,parameter :: DEV_VERSION_VT = .FALSE.
+
    !> 
    type T_Part
       real(ReKi), dimension(:,:), pointer :: P           =>null() 
@@ -402,7 +404,17 @@ contains
           P2 = SegPoints(1:3,SegConnct(2,iSeg))
           DP = P2-P1
           SegLen  = sqrt(DP(1)**2 + DP(2)**2 + DP(3)**2)
-          SegDir  = DP/SegLen                     ! Unit vector along segment direction
+          if (SegLen>0) then
+             SegDir  = DP/SegLen                     ! Unit vector along segment direction
+          else
+             ! For now we set direction to zero. Part. Intensity will be zero. Multiple zero part may be created at P1
+             ! In the future we should skip the creation of the particles all together
+             SegDir  = 0
+             if (DEV_VERSION_VT) then
+                ! TODO this requires attention and a bug fix
+                print*,'OLAF: encountered a segment of zero length'
+             endif
+          endif
           PartInt = DP*SegGamma(iSeg)/nPartPerSeg ! alpha = Gamma.L/n = omega.dV [m^3/s]
           PartEps = SegEpsilon(iSeg)                   ! TODO this might need tuning depending on RegFunction and n_new
           PartLen = SegLen/nPartPerSeg

--- a/reg_tests/lib/rtestlib.py
+++ b/reg_tests/lib/rtestlib.py
@@ -60,7 +60,7 @@ def validateExeOrExit(path):
     if not int(permissionsMask)%2 == 1:
         exitWithError("Error: executable at {} does not have proper permissions.".format(path))
 
-def copyTree(src, dst, excludeExt=[], renameDict={}, renameExtDict={}, includeExt=None):
+def copyTree(src, dst, excludeExt=None, renameDict=None, renameExtDict=None, includeExt=None):
     """ 
     Copy a directory to another one, overwritting files if necessary.
     copy_tree from distutils and copytree from shutil fail on Windows (in particular on git files)
@@ -72,9 +72,22 @@ def copyTree(src, dst, excludeExt=[], renameDict={}, renameExtDict={}, includeEx
      - renameDict: dictionary used to rename files (the key is replaced by the value)
      - renameExt: dictionary used to rename extensions (the key is replaced by the value)
     """
+    from time import sleep
+    # Default arguments
+    if excludeExt is None:
+        excludeExt=[]
+    if renameDict is None:
+        renameDict ={}
+    if renameExtDict is None:
+        renameExtDict ={}
+    # Local functions
     def forceMergeFlatDir(srcDir, dstDir):
         if not os.path.exists(dstDir):
-            os.makedirs(dstDir)
+            try:
+                os.makedirs(dstDir)
+            except FileExistsError:
+                sleep(0.1)
+                pass
         for item in os.listdir(srcDir):
             srcFile = os.path.join(srcDir, item)
             dstFile = os.path.join(dstDir, item)
@@ -113,7 +126,11 @@ def copyTree(src, dst, excludeExt=[], renameDict={}, renameExtDict={}, includeEx
         d = os.path.join(dst, item)
         if os.path.isfile(s):
             if not os.path.exists(dst):
-                os.makedirs(dst)
+                try:
+                    os.makedirs(dst)
+                except FileExistsError:
+                    sleep(0.1)
+                    pass
             forceCopyFile(s,d)
         if os.path.isdir(s):
             isRecursive = not isAFlatDir(s)


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
When vortex segments had zero length, the creation of particles created NaN particles. The code now handles this. 
The pull request includes small improvements and additional checks when DEV_VERSION is .True. 
The important change is on this line: https://github.com/OpenFAST/openfast/compare/dev...ebranlard:openfast:f/olaf-fix?expand=1#diff-db1adcb1fe71081ac4cf249196c11ed2f720f6e90f3047d2253bced9c7fda42eR399

**Related issue, if one exists**
#1273 

**Impacted areas of the software**
AeroDyn/OLAF (typically under turbulent conditions and in single precision). 


**Test results, if applicable**
Test results are not changed. The case where zero filament occurred was a turbulent case from a model that cannot be shared. The error is difficult to reproduce. 

