### PR TITLE
Minor error handling and code cleanup

### DIFF
--- a/modules/aerodyn/src/FVW.f90
+++ b/modules/aerodyn/src/FVW.f90
@@ -533,8 +533,8 @@ subroutine FVW_ToString(p,m)
    type(FVW_ParameterType), intent(in)       :: p !< Parameters
    type(FVW_MiscVarType),      intent(inout) :: m !< Misc
    if (DEV_VERSION) then
-      print*,'-----------------------------------------------------------------------------------------'
-      if(.false.) print*,m%nNW ! unused var for now
+      call WrScr('-----------------------------------------------------------------------------------------')
+      if(.false.) call WrScr(num2lstr(m%nNW)) ! unused var for now
    endif
 end subroutine FVW_ToString
 
@@ -990,6 +990,7 @@ contains
 end subroutine FVW_CalcContStateDeriv
 
 
+!------------------------------------------------------------------------------------------------
 !> Interpolate states to the current time
 !! For now: linear interpolation, two states, with t1<t2
 subroutine FVW_ContStates_Interp(t, states, times, p, m, x, ErrStat, ErrMsg )
@@ -1358,6 +1359,7 @@ subroutine FVW_CalcConstrStateResidual( t, u, p, x, xd, z_guess, OtherState, m, 
 end subroutine FVW_CalcConstrStateResidual
 
 
+!----------------------------------------------------------------------------------------------------------------------------------
 subroutine CalcOutputForAD(t, u, p, x, y, m, ErrStat, ErrMsg)
    real(DbKi),                      intent(in   )  :: t           !< Current simulation time in seconds
    type(FVW_InputType),             intent(in   )  :: u           !< Inputs at Time t
@@ -1450,6 +1452,7 @@ subroutine FVW_CalcOutput(t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg)
 
 end subroutine FVW_CalcOutput
 
+!------------------------------------------------------------------------------------------------
 !> Write to  vtk_fvw folder at fps requested
 subroutine WriteVTKOutputs(t, force, u, p, x, z, y, m, ErrStat, ErrMsg)
    real(DbKi),                      intent(in   )  :: t       !< Current simulation time in seconds
@@ -1600,6 +1603,7 @@ contains
    end function Failed
 end subroutine  UA_Init_Wrapper
 
+!------------------------------------------------------------------------------------------------
 !> Compute necessary inputs for UA at a given time step, stored in m%u_UA
 !!  Inputs are AoA, U, Re, 
 !!  See equivalent version in BEMT, and SetInputs_for_UA in BEMT
@@ -1612,8 +1616,8 @@ subroutine CalculateInputsAndOtherStatesForUA(InputIndex, u, p, x, xd, z, OtherS
    type(FVW_ConstraintStateType),      intent(in   ) :: z          ! Constraint states at given time step
    type(FVW_OtherStateType),           intent(inout) :: OtherState ! Other states at given time step
    type(FVW_MiscVarType), target,      intent(inout) :: m          ! Misc/optimization variables
-   integer(IntKi),                  intent(  out)  :: ErrStat     !< Error status of the operation
-   character(*),                    intent(  out)  :: ErrMsg      !< Error message if ErrStat /= ErrID_None
+   integer(IntKi),                     intent(  out) :: ErrStat    !< Error status of the operation
+   character(*),                       intent(  out) :: ErrMsg     !< Error message if ErrStat /= ErrID_None
    ! Local
    type(UA_InputType), pointer     :: u_UA ! Alias to shorten notations
    integer(IntKi)                                    :: i,iW
@@ -1658,7 +1662,7 @@ subroutine CalculateInputsAndOtherStatesForUA(InputIndex, u, p, x, xd, z, OtherS
    end do ! iW nWings
 end subroutine CalculateInputsAndOtherStatesForUA
 
-
+!------------------------------------------------------------------------------------------------
 subroutine UA_UpdateState_Wrapper(AFInfo, t, n, uTimes, p, x, xd, OtherState, m, ErrStat, ErrMsg )
    use FVW_VortexTools, only: interpextrap_cp2node
    use UnsteadyAero, only: UA_UpdateStates
@@ -1704,7 +1708,7 @@ contains
       NodeText = '(nd:'//trim(num2lstr(i))//' bld:'//trim(num2lstr(j))//')'
    end function NodeText
 end subroutine UA_UpdateState_Wrapper
-
+!------------------------------------------------------------------------------------------------
 !> Set dynamic gamma based on dynamic stall states
 !! NOTE: We use Vind_LL computed in CalculateInputsAndOtherStatesForUA
 subroutine UA_SetGammaDyn(t, u, p, x, xd, OtherState, m, AFInfo, z, ErrStat, ErrMsg)

--- a/modules/aerodyn/src/FVW_BiotSavart.f90
+++ b/modules/aerodyn/src/FVW_BiotSavart.f90
@@ -103,7 +103,7 @@ end subroutine ui_seg_11
 !! The function can compute the velocity on part of the segments and part of the control points.
 !! This feature is useful if some parallelization is used, while common storage vectors are used.
 subroutine ui_seg(iCPStart, iCPEnd, CPs, &
-      iSegStart, iSegEnd, nSegTot, nSegPTot, SegPoints, SegConnct, SegGamma,  &
+      iSegStart, iSegEnd, SegPoints, SegConnct, SegGamma,  &
       RegFunction, RegParam, Uind_out)
    real(ReKi), dimension(:,:),     intent(in)    :: CPs         !< Control points (3 x nCPs++)
    integer(IntKi),                 intent(in)    :: iCPStart    !< Index where we start in Control points array
@@ -113,8 +113,6 @@ subroutine ui_seg(iCPStart, iCPEnd, CPs, &
    real(ReKi), dimension(:),       intent(in)    :: SegGamma    !< Segment circulation (nSegTot)
    integer(IntKi),                 intent(in)    :: iSegStart   !< Index in SegConnct, and SegGamma where we start
    integer(IntKi),                 intent(in)    :: iSegEnd     !< Index in SegConnct, and SegGamma where we end
-   integer(IntKi),                 intent(in)    :: nSegTot     !< Total number of segments
-   integer(IntKi),                 intent(in)    :: nSegPTot    !< Total number of segment points
    integer(IntKi),                 intent(in)    :: RegFunction !< Regularization model
    real(ReKi), dimension(:),       intent(in)    :: RegParam    !< Regularization parameter (nSegTot)
    real(ReKi), dimension(:,:)    , intent(inout) :: Uind_out    !< Induced velocity vector - Side effects!!! (3 x nCPs++)

--- a/modules/aerodyn/src/FVW_IO.f90
+++ b/modules/aerodyn/src/FVW_IO.f90
@@ -313,6 +313,12 @@ function is_numeric(string, x)
    character(len=12) :: fmt
    x = 0.0_reki
    n=len_trim(string)
+   
+   if (n==0) then ! blank lines shouldn't be valid numbers
+      is_numeric = .false.
+      return
+   end if
+   
    write(fmt,'("(F",I0,".0)")') n
    read(string,fmt,iostat=e) x
    is_numeric = e == 0
@@ -327,6 +333,12 @@ function is_int(string, x)
    character(len=12) :: fmt
    x = 0
    n=len_trim(string)
+   
+   if (n==0) then ! blank lines shouldn't be valid integers
+      is_int = .false.
+      return
+   end if
+   
    write(fmt,'("(I",I0,")")') n
    read(string,fmt,iostat=e) x
    is_int = e == 0

--- a/modules/aerodyn/src/FVW_IO.f90
+++ b/modules/aerodyn/src/FVW_IO.f90
@@ -249,7 +249,7 @@ CONTAINS
       GridOut%name =StrArray(1) 
       ! Type
       if (.not. is_int    (StrArray(2), GridOut%type  ) ) then
-         ErrMsg2=trim(ErrMsg2)//achar(13)//achar(10)//'GridType needs to be an integer.'
+         ErrMsg2=trim(ErrMsg2)//NewLine//'GridType needs to be an integer.'
          return
       endif
       ! tStart
@@ -258,7 +258,7 @@ CONTAINS
          GridOut%tStart  = 0.0_ReKi
       else
          if (.not. is_numeric(StrArray(3), GridOut%tStart) ) then 
-            ErrMsg2=trim(ErrMsg2)//achar(13)//achar(10)//'TStart needs to be numeric or "default".'
+            ErrMsg2=trim(ErrMsg2)//NewLine//'TStart needs to be numeric or "default".'
             return
          endif
       endif
@@ -268,7 +268,7 @@ CONTAINS
          GridOut%tEnd  = 99999.0_ReKi ! TODO
       else
          if (.not. is_numeric(StrArray(4), GridOut%tEnd) ) then
-            ErrMsg2=trim(ErrMsg2)//achar(13)//achar(10)//'TEnd needs to be numeric or "default".'
+            ErrMsg2=trim(ErrMsg2)//NewLine//'TEnd needs to be numeric or "default".'
             return
          endif
       endif
@@ -280,7 +280,7 @@ CONTAINS
          GridOut%DTout  = p%DTaero
       else
          if (.not. is_numeric(StrArray(5), GridOut%DTout) ) then
-            ErrMsg2=trim(ErrMsg2)//achar(13)//achar(10)//'DTout needs to be numeric, "default" or "all".'
+            ErrMsg2=trim(ErrMsg2)//NewLine//'DTout needs to be numeric, "default" or "all".'
             return
          endif
       endif

--- a/modules/aerodyn/src/FVW_Subs.f90
+++ b/modules/aerodyn/src/FVW_Subs.f90
@@ -1174,7 +1174,7 @@ subroutine InducedVelocitiesAll_Calc(CPs, nCPs, Uind, p, Sgmt, Part, Tree, ErrSt
    ErrMsg =''
 
    if (p%VelocityMethod==idVelocityBasic) then
-      call ui_seg( 1, nCPs, CPs, 1, Sgmt%nAct, Sgmt%nAct, Sgmt%nActP, Sgmt%Points, Sgmt%Connct, Sgmt%Gamma, Sgmt%RegFunction, Sgmt%Epsilon, Uind)
+      call ui_seg( 1, nCPs, CPs, 1, Sgmt%nAct, Sgmt%Points, Sgmt%Connct, Sgmt%Gamma, Sgmt%RegFunction, Sgmt%Epsilon, Uind)
 
    elseif (p%VelocityMethod==idVelocityTree) then
       ! Tree has already been grown with InducedVelocitiesAll_Init
@@ -1375,7 +1375,7 @@ subroutine LiftingLineInducedVelocities(p, x, InductionAtCP, iDepthStart, m, Err
       if (DEV_VERSION) then
          print'(A,I0,A,I0,A,I0)','Induction -  nSeg:',nSeg,' - nSegP:',nSegP, ' - nCPs:',nCPs
       endif
-      call ui_seg( 1, nCPs, CPs, 1, nSeg, nSeg, nSegP, m%Sgmt%Points, m%Sgmt%Connct, m%Sgmt%Gamma, m%Sgmt%RegFunction, m%Sgmt%Epsilon, Uind)
+      call ui_seg( 1, nCPs, CPs, 1, nSeg, m%Sgmt%Points, m%Sgmt%Connct, m%Sgmt%Gamma, m%Sgmt%RegFunction, m%Sgmt%Epsilon, Uind)
       call UnPackLiftingLineVelocities()
 
       deallocate(Uind)

--- a/modules/aerodyn/src/FVW_Tests.f90
+++ b/modules/aerodyn/src/FVW_Tests.f90
@@ -266,7 +266,7 @@ contains
             ! Method 1
             Uind_out =0.0_ReKi
             call ui_seg(1, 1, CPs, &
-                  1, 1, nSegTot, nSegPTot, SegPoints, SegConnct, SegGamma,  &
+                  1, 1, SegPoints, SegConnct, SegGamma,  &
                   RegFunction, RegParam, Uind_out)
             ! Method 2
             call ui_seg_11(CP-P1, CP-P2, SegGamma1, RegFunction, RegParam1, U1)
@@ -306,7 +306,7 @@ contains
             ! Method 1
             Uind_out =0.0_ReKi
             call ui_seg(1, 1, CPs, &
-                  1, 2, nSegTot, nSegPTot, SegPoints, SegConnct, SegGamma,  &
+                  1, 2, SegPoints, SegConnct, SegGamma,  &
                   RegFunction, RegParam, Uind_out)
             ! Method 2
             call ui_seg_11(CP-P1, CP-P2, SegGamma1, RegFunction, RegParam1, U1)
@@ -542,7 +542,7 @@ contains
       call SegmentsToPart(SegPoints, SegConnct, SegGamma, SegEpsilon, 1, nSegTot, nPartPerSeg, PartPoints, PartAlpha, PartEpsilon, iHeadP)
 
       Uind1 =0.0_ReKi; Uind2 =0.0_ReKi;
-      call ui_seg(1, nCPsTot, CPs, 1, nSegTot, nSegTot, nSegPTot, SegPoints, SegConnct, SegGamma, RegFunctionSeg, SegEpsilon, Uind1)
+      call ui_seg(1, nCPsTot, CPs, 1, nSegTot, SegPoints, SegConnct, SegGamma, RegFunctionSeg, SegEpsilon, Uind1)
       call ui_part_nograd(CPs,PartPoints, PartAlpha, RegFunctionPart, PartEpsilon, Uind2, nCPsTot, nPart)
       call test_almost_equal(testname,'Uind 10 part/sgmt no reg', Uind1, Uind2, 1e-3_ReKi, .true.,.true.)
       call dealloc()
@@ -558,7 +558,7 @@ contains
       call SegmentsToPart(SegPoints, SegConnct, SegGamma, SegEpsilon, 1, nSegTot, nPartPerSeg, PartPoints, PartAlpha, PartEpsilon, iHeadP)
 
       Uind1 =0.0_ReKi; Uind2 =0.0_ReKi;
-      call ui_seg(1, nCPsTot, CPs, 1, nSegTot, nSegTot, nSegPTot, SegPoints, SegConnct, SegGamma, RegFunctionSeg, SegEpsilon, Uind1)
+      call ui_seg(1, nCPsTot, CPs, 1, nSegTot, SegPoints, SegConnct, SegGamma, RegFunctionSeg, SegEpsilon, Uind1)
       call ui_part_nograd(CPs,PartPoints, PartAlpha, RegFunctionPart, PartEpsilon, Uind2, nCPsTot, nPart)
       call test_almost_equal(testname,'Uind 2 part/sgmt noreg', Uind1, Uind2, 3e-1_ReKi, .true.,.true.)
       call dealloc()
@@ -576,7 +576,7 @@ contains
       call SegmentsToPart(SegPoints, SegConnct, SegGamma, SegEpsilon, 1, nSegTot, nPartPerSeg, PartPoints, PartAlpha, PartEpsilon, iHeadP)
 
       Uind1 =0.0_ReKi; Uind2 =0.0_ReKi;
-      call ui_seg(1, nCPsTot, CPs, 1, nSegTot, nSegTot, nSegPTot, SegPoints, SegConnct, SegGamma, RegFunctionSeg, SegEpsilon, Uind1)
+      call ui_seg(1, nCPsTot, CPs, 1, nSegTot, SegPoints, SegConnct, SegGamma, RegFunctionSeg, SegEpsilon, Uind1)
       call ui_part_nograd(CPs,PartPoints, PartAlpha, RegFunctionPart, PartEpsilon, Uind2, nCPsTot, nPart)
       !print'(A,10F7.3)','Uind1',Uind1(1,:)
       !print'(A,10F7.3)','Uind2',Uind2(1,:)
@@ -681,7 +681,7 @@ contains
       SegEpsilon=100.0_ReKi
       SmoothModel=0 ! No smooth
       CALL ui_seg(1, 1, CPs, &
-      1, nC1, nC1, nP1, SegPoints, SegConnct, SegGamma,   &
+      1, nC1, SegPoints, SegConnct, SegGamma,   &
       SmoothModel, SegEpsilon, Uind)
       !print*,'Uind',Uind
 

--- a/modules/aerodyn/src/FVW_VTK.f90
+++ b/modules/aerodyn/src/FVW_VTK.f90
@@ -1,6 +1,6 @@
 module FVW_VTK
     !use PrecisionMod, only: ReKi
-    use NWTC_Library, only: ReKi, GetNewUnit
+    use NWTC_Library, only: ReKi, GetNewUnit, NewLine
     implicit none
 !     character(8), parameter :: RFMT='F14.5'
     !character(8), parameter :: RFMT='E24.15E3'
@@ -21,8 +21,6 @@ module FVW_VTK
       real(ReKi),dimension(3,3) :: T_g2b
       real(ReKi),dimension(3)   :: PO_g
    END TYPE FVW_VTK_Misc
-
-    character(1), parameter :: NL = char(10) ! New Line character
 
     interface vtk_dataset_structured_grid; module procedure &
             vtk_dataset_structured_grid_flat, &
@@ -103,9 +101,9 @@ contains
             endif
             if (iostatvar == 0) then
                 if (mvtk%bBinary) then
-                    write(mvtk%vtk_unit)'# vtk DataFile Version 3.0'//NL
-                    write(mvtk%vtk_unit)trim(label)//NL
-                    write(mvtk%vtk_unit)'BINARY'//NL
+                    write(mvtk%vtk_unit)'# vtk DataFile Version 3.0'//NewLine
+                    write(mvtk%vtk_unit)trim(label)//NewLine
+                    write(mvtk%vtk_unit)'BINARY'//NewLine
                 else
                     write(mvtk%vtk_unit,'(a)') '# vtk DataFile Version 2.0'
                     write(mvtk%vtk_unit,'(a)') trim(label)
@@ -147,9 +145,9 @@ contains
         if ( mvtk%bFileOpen ) then
             mvtk%nPoints=size(Points,2)
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'DATASET POLYDATA'//NL
+                write(mvtk%vtk_unit)'DATASET POLYDATA'//NewLine
                 write(mvtk%buffer,'(A,I0,A)') 'POINTS ', mvtk%nPoints ,' double'
-                write(mvtk%vtk_unit)trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit)trim(mvtk%buffer)//NewLine
                 if (bladeFrame)  then
                     do i=1,mvtk%nPoints
                         write(mvtk%vtk_unit)matmul(mvtk%T_g2b,Points(1:3,i)-mvtk%PO_g)
@@ -159,7 +157,7 @@ contains
                         write(mvtk%vtk_unit)Points(1:3,i)
                     enddo
                 endif
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A)') 'DATASET POLYDATA'
                 write(mvtk%vtk_unit,'(A,I0,A)') 'POINTS ', mvtk%nPoints ,' double'
@@ -188,11 +186,11 @@ contains
             mvtk%nData=size(L,2)
             if (mvtk%bBinary) then
                 write(mvtk%buffer,'(A,I0,A,I0)')'LINES ',mvtk%nData,' ',3*mvtk%nData
-                write(mvtk%vtk_unit)trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit)trim(mvtk%buffer)//NewLine
                 do i=1,mvtk%nData
                     write(mvtk%vtk_unit)2,L(1:2,i)
                 enddo
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,I0,A,I0)')'LINES ',mvtk%nData,' ',3*mvtk%nData
                 do i=1,mvtk%nData
@@ -211,11 +209,11 @@ contains
             mvtk%nData=size(Q,2)
             if (mvtk%bBinary) then
                 write(mvtk%buffer,'(A,I0,A,I0)')'POLYGONS ',mvtk%nData,' ',5*mvtk%nData
-                write(mvtk%vtk_unit)trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit)trim(mvtk%buffer)//NewLine
                 do i=1,mvtk%nData
                     write(mvtk%vtk_unit)4,Q(1:4,i)
                 enddo
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,I0,A,I0)') 'POLYGONS ', mvtk%nData,' ',5*mvtk%nData
                 do i=1,mvtk%nData
@@ -236,21 +234,21 @@ contains
         if ( mvtk%bFileOpen ) then
             mvtk%nPoints=size(v1)*size(v2)*size(v3)
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit) 'DATASET RECTILINEAR_GRID'//NL
+                write(mvtk%vtk_unit) 'DATASET RECTILINEAR_GRID'//NewLine
                 write(mvtk%buffer,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', size(v1),' ',size(v2),' ',size(v3)
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%buffer,'(A,I0,A)') 'X_COORDINATES ', size(v1), ' double'
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%vtk_unit)v1
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
                 write(mvtk%buffer,'(A,I0,A)') 'Y_COORDINATES ', size(v2), ' double'
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%vtk_unit)v2
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
                 write(mvtk%buffer,'(A,I0,A)') 'Z_COORDINATES ', size(v3), ' double'
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%vtk_unit)v3
-                !write(mvtk%vtk_unit)NL
+                !write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A)') 'DATASET RECTILINEAR_GRID'
                 write(mvtk%vtk_unit,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', size(v1),' ',size(v2),' ',size(v3)
@@ -274,13 +272,13 @@ contains
         if ( mvtk%bFileOpen ) then
             mvtk%nPoints=n(1)*n(2)*n(3)
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit) 'DATASET STRUCTURED_POINTS'//NL
+                write(mvtk%vtk_unit) 'DATASET STRUCTURED_POINTS'//NewLine
                 write(mvtk%buffer,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ',n(1),' ',n(2),' ',n(3)
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%buffer,'(A,3F16.8)') 'ORIGIN ', x0
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%buffer,'(A,3F16.8)') 'SPACING ', dx
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
             else
                 write(mvtk%vtk_unit,'(A)') 'DATASET STRUCTURED_POINTS'
                 write(mvtk%vtk_unit,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', n(1),' ',n(2),' ',n(3)
@@ -302,13 +300,13 @@ contains
         if ( mvtk%bFileOpen ) then
             mvtk%nPoints=n1*n2*n3
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit) 'DATASET STRUCTURED_GRID'//NL
+                write(mvtk%vtk_unit) 'DATASET STRUCTURED_GRID'//NewLine
                 write(mvtk%buffer,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', n1,' ',n2,' ',n3
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%buffer,'(A,I0,A)') 'POINTS ', mvtk%nPoints, ' double'
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A)') 'DATASET STRUCTURED_GRID'
                 write(mvtk%vtk_unit,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', n1,' ',n2,' ',n3
@@ -328,13 +326,13 @@ contains
         if ( mvtk%bFileOpen ) then
             mvtk%nPoints=n1*n2*n3
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit) 'DATASET STRUCTURED_GRID'//NL
+                write(mvtk%vtk_unit) 'DATASET STRUCTURED_GRID'//NewLine
                 write(mvtk%buffer,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', n1,' ',n2,' ',n3
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%buffer,'(A,I0,A)') 'POINTS ', mvtk%nPoints, ' double'
-                write(mvtk%vtk_unit) trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit) trim(mvtk%buffer)//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A)') 'DATASET STRUCTURED_GRID'
                 write(mvtk%vtk_unit,'(A,I0,A,I0,A,I0)') 'DIMENSIONS ', n1,' ',n2,' ',n3
@@ -355,7 +353,7 @@ contains
         if ( mvtk%bFileOpen ) then
             if(mvtk%bBinary) then
                 write(mvtk%buffer,'(A,I0)')'POINT_DATA ',mvtk%nPoints
-                write(mvtk%vtk_unit)trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit)trim(mvtk%buffer)//NewLine
             else
                 write(mvtk%vtk_unit,'(A,I0)') 'POINT_DATA ', mvtk%nPoints
             endif
@@ -369,10 +367,10 @@ contains
 
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double'//NL
-                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NL
+                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double'//NewLine
+                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'SCALARS ', sname, ' double'
                 write(mvtk%vtk_unit,'(A)') 'LOOKUP_TABLE default'
@@ -388,10 +386,10 @@ contains
 
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double'//NL
-                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NL
+                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double'//NewLine
+                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'SCALARS ', sname, ' double'
                 write(mvtk%vtk_unit,'(A)') 'LOOKUP_TABLE default'
@@ -407,10 +405,10 @@ contains
 
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double'//NL
-                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NL
+                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double'//NewLine
+                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'SCALARS ', sname, ' double'
                 write(mvtk%vtk_unit,'(A)') 'LOOKUP_TABLE default'
@@ -426,9 +424,9 @@ contains
         type(FVW_VTK_Misc),intent(inout) :: mvtk
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NL
+                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'VECTORS ', sname, ' double'
                 write(mvtk%vtk_unit,'(3'//RFMT//')')D
@@ -442,9 +440,9 @@ contains
         type(FVW_VTK_Misc),intent(inout) :: mvtk
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NL
+                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'VECTORS ', sname, ' double'
                 write(mvtk%vtk_unit,'(3'//RFMT//')')D
@@ -458,9 +456,9 @@ contains
         type(FVW_VTK_Misc),intent(inout) :: mvtk
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NL
+                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'VECTORS ', sname, ' double'
                 write(mvtk%vtk_unit,'(3'//RFMT//')')D
@@ -477,7 +475,7 @@ contains
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
                 write(mvtk%buffer,'(A,I0)')'CELL_DATA ',mvtk%nData
-                write(mvtk%vtk_unit)trim(mvtk%buffer)//NL
+                write(mvtk%vtk_unit)trim(mvtk%buffer)//NewLine
             else
                 write(mvtk%vtk_unit,'(A,I0)') 'CELL_DATA ', mvtk%nData
             endif
@@ -491,10 +489,10 @@ contains
 
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double 1'//NL
-                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NL
+                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double 1'//NewLine
+                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,fmt='(A,A,A)') 'SCALARS ', sname, ' double'
                 write(mvtk%vtk_unit,'(A)') 'LOOKUP_TABLE default'
@@ -510,10 +508,10 @@ contains
 
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double 1'//NL
-                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NL
+                write(mvtk%vtk_unit)'SCALARS '//trim(sname)//' double 1'//NewLine
+                write(mvtk%vtk_unit)'LOOKUP_TABLE default'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,fmt='(A,A,A)') 'SCALARS ', sname, ' double'
                 write(mvtk%vtk_unit,'(A)') 'LOOKUP_TABLE default'
@@ -529,9 +527,9 @@ contains
         type(FVW_VTK_Misc),intent(inout) :: mvtk
         if ( mvtk%bFileOpen ) then
             if (mvtk%bBinary) then
-                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NL
+                write(mvtk%vtk_unit)'VECTORS '//trim(sname)//' double'//NewLine
                 write(mvtk%vtk_unit)D
-                write(mvtk%vtk_unit)NL
+                write(mvtk%vtk_unit)NewLine
             else
                 write(mvtk%vtk_unit,'(A,A,A)') 'VECTORS ', sname, ' double'
                 write(mvtk%vtk_unit,'(3'//RFMT//')')D

--- a/modules/extptfm/src/ExtPtfm_MCKF_IO.f90
+++ b/modules/extptfm/src/ExtPtfm_MCKF_IO.f90
@@ -297,7 +297,7 @@ contains
         ! If a selected output channel is not available by this module set ErrStat = ErrID_Warn.
         p%OutParam(I)%Units = "INVALID"
         p%OutParam(I)%Indx = 0
-        WarnMsg=trim(WarnMsg)//TRIM(p%OutParam(I)%Name)//" is not an available output channel."//CHAR(10)
+        WarnMsg=trim(WarnMsg)//TRIM(p%OutParam(I)%Name)//" is not an available output channel."//NewLine
 !         call SetErrStat(ErrID_Warn, TRIM(p%OutParam(I)%Name)//" is not an available output channel.",ErrStat,ErrMsg,'ExtPtfm_SetOutParam')
 !         write(*,*)TRIM(p%OutParam(I)%Name)//" is not an available output channel."
     end subroutine

--- a/modules/nwtc-library/src/SysIVF.f90
+++ b/modules/nwtc-library/src/SysIVF.f90
@@ -61,7 +61,7 @@ MODULE SysSubs
    INTEGER, PARAMETER            :: CU          = 7                                 ! The I/O unit for the console.  Unit 6 causes ADAMS to crash.
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
    LOGICAL, PARAMETER            :: KBInputOK   = .TRUE.                            ! A flag to tell the program that keyboard input is allowed in the environment.
-   CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
+   CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]; Note: NewLine change to ACHAR(10) here on Windows to fix issues with C/Fortran interoperability using WrScr
    CHARACTER(*),  PARAMETER      :: OS_Desc     = 'Intel Visual Fortran for Windows'! Description of the language/OS
    CHARACTER( 1), PARAMETER      :: PathSep     = '\'                               ! The path separator.
    CHARACTER( 1), PARAMETER      :: SwChar      = '/'                               ! The switch character for command-line options.

--- a/modules/nwtc-library/src/SysMatlabWindows.f90
+++ b/modules/nwtc-library/src/SysMatlabWindows.f90
@@ -55,7 +55,7 @@ MODULE SysSubs
 
    LOGICAL, PARAMETER            :: KBInputOK   = .FALSE.                           ! A flag to tell the program that keyboard input is allowed in the environment.
 
-   CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]
+   CHARACTER(*),  PARAMETER      :: NewLine     = ACHAR(10)                         ! The delimiter for New Lines [ Windows is CHAR(13)//CHAR(10); MAC is CHAR(13); Unix is CHAR(10) {CHAR(13)=\r is a line feed, CHAR(10)=\n is a new line}]; Note: NewLine change to ACHAR(10) here on Windows to fix issues with C/Fortran interoperability using WrScr
    CHARACTER(*),  PARAMETER      :: OS_Desc     = 'Intel Visual Fortran for Windows/Matlab' ! Description of the language/OS
    CHARACTER( 1), PARAMETER      :: PathSep     = '\'                               ! The path separator.
    CHARACTER( 1), PARAMETER      :: SwChar      = '/'                               ! The switch character for command-line options.

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -3310,7 +3310,7 @@ SUBROUTINE OutModes(Init, p, m, InitInput, CBparams, Modes, Omega, Omega_Gy, Err
       FileName = TRIM(Init%RootName)//'.CBmodes.json'
       ! Write Nodes/Connectivity/ElementProperties
       call WriteJSONCommon(FileName, Init, p, m, InitInput, 'Modes', UnSum, ErrStat2, ErrMsg2); if(Failed()) return
-      write(UnSum, '(A)', advance='no') ','//char(13)//achar(10) 
+      write(UnSum, '(A)', advance='no') ','//NewLine 
       write(UnSum, '(A)') '"Modes": ['
 
       ! --- Guyan Modes
@@ -3331,7 +3331,7 @@ SUBROUTINE OutModes(Init, p, m, InitInput, CBparams, Modes, Omega, Omega_Gy, Err
       enddo
 
       ! --- CB Modes
-      if (p%nDOFM>0) write(UnSum, '(A)', advance='no')','//achar(13)//achar(10) 
+      if (p%nDOFM>0) write(UnSum, '(A)', advance='no')','//NewLine 
       do i = 1, p%nDOFM
          U_red              = 0.0_ReKi
          U_red(p%ID__L)     = CBparams%PhiL(:,i)
@@ -3358,7 +3358,7 @@ SUBROUTINE OutModes(Init, p, m, InitInput, CBparams, Modes, Omega, Omega_Gy, Err
       CALL WrScr('   Exporting FEM modes to JSON')
       FileName = TRIM(Init%RootName)//'.FEMmodes.json'
       call WriteJSONCommon(FileName, Init, p, m, InitInput, 'Modes', UnSum, ErrStat2, ErrMsg2); if(Failed()) return
-      write(UnSum, '(A)', advance='no') ','//char(13)//achar(10) 
+      write(UnSum, '(A)', advance='no') ','//NewLine
       write(UnSum, '(A)') '"Modes": ['
       nModes = min(size(Modes,2), 30) ! TODO potentially a parameter
       do i = 1, nModes
@@ -3403,7 +3403,7 @@ contains
       endif
       call yaml_write_array(UnSum, '"Displ"', NodesDisp, ReFmt, ErrStat2, ErrMsg2, json=.true.);  
       write(UnSum, '(A)', advance='no')'}'
-      if (iMode<nModes) write(UnSum, '(A)', advance='no')','//achar(13)//achar(10) 
+      if (iMode<nModes) write(UnSum, '(A)', advance='no')','//NewLine 
    END SUBROUTINE WriteOneMode
 
    LOGICAL FUNCTION Failed()
@@ -3463,17 +3463,17 @@ SUBROUTINE WriteJSONCommon(FileName, Init, p, m, InitInput, FileKind, UnSum, Err
       Connectivity(i,1) = p%Elems(i,2)-1 ! Node 1
       Connectivity(i,2) = p%Elems(i,3)-1 ! Node 2
    enddo
-   call yaml_write_array(UnSum, '"Connectivity"', Connectivity, 'I0', ErrStat2, ErrMsg2, json=.true.); write(UnSum, '(A)', advance='no')','//achar(13)//achar(10) 
+   call yaml_write_array(UnSum, '"Connectivity"', Connectivity, 'I0', ErrStat2, ErrMsg2, json=.true.); write(UnSum, '(A)', advance='no')','//NewLine 
    if(allocated(Connectivity)) deallocate(Connectivity)
 
    ! --- Nodes
-   call yaml_write_array(UnSum, '"Nodes"', Init%Nodes(:,2:4), ReFmt, ErrStat2, ErrMsg2, json=.true.);  write(UnSum, '(A)', advance='no')','//achar(13)//achar(10) 
+   call yaml_write_array(UnSum, '"Nodes"', Init%Nodes(:,2:4), ReFmt, ErrStat2, ErrMsg2, json=.true.);  write(UnSum, '(A)', advance='no')','//NewLine 
 
    ! --- Elem props
    write(UnSum, '(A)') '"ElemProps": ['
    do i = 1, size(p%ElemProps)
       write(UnSum, '(A,I0,A,F8.4,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1),'}'
-      if (i<size(p%ElemProps)) write(UnSum, '(A)', advance='no')','//achar(13)//achar(10) 
+      if (i<size(p%ElemProps)) write(UnSum, '(A)', advance='no')','//NewLine 
    enddo
    write(UnSum, '(A)') ']'
 


### PR DESCRIPTION
**Feature or improvement description**
This PR makes a few minor changes to the source code:
- all hard-coded `CHAR(10)` and `CHAR(13)` line ending character strings are replaced with the NWTC Library parameter `NewLine`.
- FVW error handling has been modified so that blank values are not considered valid numbers
- unused subroutine parameters for FVW's `ui_seg` routine have been removed

**Impacted areas of the software**
- Some OLAF or SubDyn output files
- OLAF error messages if a line doesn't contain enough columns

**Test results, if applicable**
This does not change any test results. 


