### PR TITLE
Small reorganization and clean up FAST.Farm r-test input files, upload of artifact

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -783,4 +783,4 @@ jobs:
         with:
           name: rtest-FF
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/fastfarm
+            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/fast-farm

--- a/reg_tests/executeFASTFarmRegressionCase.py
+++ b/reg_tests/executeFASTFarmRegressionCase.py
@@ -112,10 +112,12 @@ else:
 if not os.path.isdir(testBuildDirectory):
     rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
+caseName='FAST.Farm' # for ease of comparison
+
 ### Run openfast on the test case
 if not noExec:
     caseInputFile = os.path.join(testBuildDirectory, caseName + ".fstf")
-    returnCode = openfastDrivers.runOpenfastCase(caseInputFile, executable)
+    returnCode = openfastDrivers.runOpenfastCase(caseInputFile, executable, verbose=verbose)
     if returnCode != 0:
         sys.exit(returnCode*10)
     


### PR DESCRIPTION
This pull request is ready to be merged

**Description**
As part of the #931, I've reorganized the r-test of FAST.Farm a bit. To easily compare the test cases, I've renamed (`git mv`) the main file FAST.Farm.fstf, and I'm placing common files (like the ElastoDyn tower) into the 5MW baseline folder. 
I've also introduced "-" before the description of the parameters, as this seem to be common in other input files. 


This pull request also include a small bug fix so that artifacts are uploaded if FAST.Farm runs fails.

I'd like to merge this before #931 to make the comparison easier. 

**Test results**
The tests shouldn't change. 
