### PR TITLE
FF: additional OpenMP parallelizations in FAST.Farm

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -776,7 +776,7 @@ jobs:
         working-directory: ${{runner.workspace}}/openfast/build
         shell: bash
         run: |
-          set OMP_NUM_THREADS=8
+          set OMP_NUM_THREADS=2
           ctest -VV -L fastfarm -j ${{env.NUM_PROCS}} --verbose
       - name: Failing test artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -776,7 +776,7 @@ jobs:
         working-directory: ${{runner.workspace}}/openfast/build
         shell: bash
         run: |
-          set OMP_NUM_THREADS=4
+          set OMP_NUM_THREADS=8
           ctest -VV -L fastfarm -j ${{env.NUM_PROCS}} --verbose
       - name: Failing test artifacts
         uses: actions/upload-artifact@v3

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -776,7 +776,8 @@ jobs:
         working-directory: ${{runner.workspace}}/openfast/build
         shell: bash
         run: |
-          ctest -VV -L fastfarm -j ${{env.NUM_PROCS}}
+          set OMP_NUM_THREADS=2
+          ctest -VV -L fastfarm -j ${{env.NUM_PROCS}} --verbose
       - name: Failing test artifacts
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -776,7 +776,7 @@ jobs:
         working-directory: ${{runner.workspace}}/openfast/build
         shell: bash
         run: |
-          set OMP_NUM_THREADS=2
+          set OMP_NUM_THREADS=4
           ctest -VV -L fastfarm -j ${{env.NUM_PROCS}} --verbose
       - name: Failing test artifacts
         uses: actions/upload-artifact@v3

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -1696,7 +1696,7 @@ SUBROUTINE Farm_InitFAST( farm, WD_InitInp, AWAE_InitOutput, SC_InitOutput, SC_y
          FWrap_Interval = farm%p%dt_low        ! otherwise FASTWrapper will be called at the regular FAST.Farm time step
       end if
       
-     !OMP PARALLEL DO default(shared) PRIVATE(nt, FWarp_InitOut, FWrap_Interval, ErrStat2, ErrMsg2) schedule(runtime)
+     !$OMP PARALLEL DO default(shared) PRIVATE(nt, FWrap_InitOut, ErrStat2, ErrMsg2) schedule(runtime)
       DO nt = 1,farm%p%NumTurbines
          !+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
          ! initialization can be done in parallel (careful for FWrap_InitInp, though)
@@ -1727,13 +1727,13 @@ SUBROUTINE Farm_InitFAST( farm, WD_InitInp, AWAE_InitOutput, SC_InitOutput, SC_y
          farm%FWrap(nt)%IsInitialized = .true.
          
          if (ErrStat2 >= AbortErrLev) then
-            !OMP CRITICAL  ! Needed to avoid data race on ErrStat and ErrMsg
+            !$OMP CRITICAL  ! Needed to avoid data race on ErrStat and ErrMsg
             CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'T'//trim(num2lstr(nt))//':'//RoutineName)
-            !OMP END CRITICAL
+            !$OMP END CRITICAL
          endif
             
       END DO   
-      !OMP END PARALLEL DO  
+      !$OMP END PARALLEL DO  
 
       if (ErrStat >= AbortErrLev) then
          call cleanup()

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -2188,9 +2188,8 @@ subroutine FARM_UpdateStates(t, n, farm, ErrStat, ErrMsg)
    INTEGER(IntKi)                          :: n_ss                      
    INTEGER(IntKi)                          :: n_FMD   
    REAL(DbKi)                              :: t2                              ! time within the FAST-MoorDyn substepping loop for shared moorings
-   INTEGER(IntKi)                          :: ErrStatWD, ErrStatAWAE, ErrStatMD, ErrStat2 
+   INTEGER(IntKi)                          :: ErrStatAWAE, ErrStatMD, ErrStat2 
    CHARACTER(ErrMsgLen)                    :: ErrMsg2
-   CHARACTER(ErrMsgLen)                    :: ErrMsgWD
    CHARACTER(ErrMsgLen)                    :: ErrMsgAWAE
    CHARACTER(ErrMsgLen)                    :: ErrMsgMD
    INTEGER(IntKi), ALLOCATABLE             :: ErrStatF(:)                     ! Temporary Error status for FAST
@@ -2219,17 +2218,17 @@ subroutine FARM_UpdateStates(t, n, farm, ErrStat, ErrMsg)
       ! 1. CALL WD_US         
   
    !$OMP PARALLEL default(shared)
-   !$OMP do private(nt, errStatWD, errMsgWD) schedule(runtime)
+   !$OMP do private(nt, ErrStat2, ErrMsg2) schedule(runtime)
    DO nt = 1,farm%p%NumTurbines
       
       call WD_UpdateStates( t, n, farm%WD(nt)%u, farm%WD(nt)%p, farm%WD(nt)%x, farm%WD(nt)%xd, farm%WD(nt)%z, &
-                     farm%WD(nt)%OtherSt, farm%WD(nt)%m, ErrStatWD, ErrMsgWD )         
+                     farm%WD(nt)%OtherSt, farm%WD(nt)%m, ErrStat2, ErrMsg2 )         
 
 
       ! Error handling
-      if (errStatWD /= ErrID_None) then
+      if (errStat2 /= ErrID_None) then
          !$OMP CRITICAL  ! Needed to avoid data race on ErrStat and ErrMsg
-         call SetErrStat(ErrStatWD, ErrMsgWD, ErrStat, ErrMsg, 'T'//trim(num2lstr(nt))//':FARM_UpdateStates')
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'T'//trim(num2lstr(nt))//':FARM_UpdateStates')
          !$OMP END CRITICAL
       endif
          
@@ -2259,67 +2258,24 @@ subroutine FARM_UpdateStates(t, n, farm, ErrStat, ErrMsg)
    end do
    
    
+   !#ifdef printthreads
+   !   tm1 = omp_get_wtime()  
+   !   tmSF = 0.0_DbKi 
+   !   tmSM = 0.0_DbKi 
+   !#endif     
    ! Original case: no shared moorings 
    if (farm%p%MooringMod == 0) then     
-      
-      !#ifdef printthreads
-      !   tm1 = omp_get_wtime()  
-      !#endif     
-      !$OMP PARALLEL DO DEFAULT(Shared) Private(nt) !Private(nt,tm2,tm3)
-      DO nt = 1,farm%p%NumTurbines+1
-         if(nt.ne.farm%p%NumTurbines+1) then  
-            !#ifdef printthreads
-            !   tm3 = omp_get_wtime()  
-            !#endif     
-            call FWrap_Increment( t, n, farm%FWrap(nt)%u, farm%FWrap(nt)%p, farm%FWrap(nt)%x, farm%FWrap(nt)%xd, farm%FWrap(nt)%z, &
-                        farm%FWrap(nt)%OtherSt, farm%FWrap(nt)%y, farm%FWrap(nt)%m, ErrStatF(nt), ErrMsgF(nt) )         
-            
-            !#ifdef printthreads
-            !   tm2 = omp_get_wtime() 
-            !   write(*,*)  '    FWrap_Increment for turbine #'//trim(num2lstr(nt))//' using thread #'//trim(num2lstr(omp_get_thread_num()))//' taking '//trim(num2lstr(tm2-tm3))//' seconds'
-            !#endif
 
-         else
-            !#ifdef printthreads
-            !   tm3 = omp_get_wtime()  
-            !#endif    
-            call AWAE_UpdateStates( t, n, farm%AWAE%u, farm%AWAE%p, farm%AWAE%x, farm%AWAE%xd, farm%AWAE%z, &
-                        farm%AWAE%OtherSt, farm%AWAE%m, ErrStatAWAE, ErrMsgAWAE )       
-
-            !#ifdef printthreads
-            !   tm2 = omp_get_wtime() 
-            !   write(*,*)  '    AWAE_UpdateStates using thread #'//trim(num2lstr(omp_get_thread_num()))//' taking '//trim(num2lstr(tm2-tm3))//' seconds'
-            !#endif
-         endif
-         
+      !$OMP PARALLEL DO DEFAULT(Shared) Private(nt)
+      DO nt = 1,farm%p%NumTurbines
+         call FWrap_Increment( t, n, farm%FWrap(nt)%u, farm%FWrap(nt)%p, farm%FWrap(nt)%x, farm%FWrap(nt)%xd, farm%FWrap(nt)%z, &
+                     farm%FWrap(nt)%OtherSt, farm%FWrap(nt)%y, farm%FWrap(nt)%m, ErrStatF(nt), ErrMsgF(nt) )         
       END DO
       !$OMP END PARALLEL DO  
-
-      !#ifdef printthreads   
-      !  tm2 = omp_get_wtime()
-      !  write(*,*) 'Total Farm_US took '//trim(num2lstr(tm2-tm1))//' seconds.'
-      !#endif 
-
    
    ! Farm-level moorings case using MoorDyn
    else if (farm%p%MooringMod == 3) then
       
-      !#ifdef printthreads
-      !   tm1 = omp_get_wtime()  
-      !#endif     
-      
-      ! Set up two parallel sections - one for FAST-MoorDyn steps (FAST portion in parallel for each step), and the other for AWAE.
-      !$OMP PARALLEL SECTIONS DEFAULT(Shared)
-      
-      
-      ! The first section, for looping through FAST and farm-level MoorDyn time steps
-      !$OMP SECTION
-      
-      !#ifdef printthreads
-      !   tm3 = omp_get_wtime()  
-      !   tmSF = 0.0_DbKi 
-      !   tmSM = 0.0_DbKi 
-      !#endif     
       
       ! This is the FAST-MoorDyn farm-level substepping loop        
       do n_ss = 1, farm%p%n_mooring                   ! do n_mooring substeps (number of FAST/FarmMD steps per Farm time step)
@@ -2357,37 +2313,26 @@ subroutine FARM_UpdateStates(t, n, farm, ErrStat, ErrMsg)
    
       !#ifdef printthreads
       !   tm2 = omp_get_wtime() 
-      !   write(*,*)  '    Turbine and support structure simulations with parent thread #'//trim(num2lstr(omp_get_thread_num()))//' taking '//trim(num2lstr(tm2-tm3))//' seconds'
       !   write(*,*)  '       Time on FAST sims: '//trim(num2lstr(tmSF))//' s.  Time on Farm MoorDyn: '//trim(num2lstr(tmSM))//' seconds'
       !#endif
-   
-   
-      ! The second section, for updating AWAE states on a separate thread in parallel with the FAST/MoorDyn time stepping
-      !$OMP SECTION
       
-      !#ifdef printthreads
-      !   tm3 = omp_get_wtime()  
-      !#endif    
-            
-      call AWAE_UpdateStates( t, n, farm%AWAE%u, farm%AWAE%p, farm%AWAE%x, farm%AWAE%xd, farm%AWAE%z, &
-                        farm%AWAE%OtherSt, farm%AWAE%m, ErrStatAWAE, ErrMsgAWAE )       
-     
-      !#ifdef printthreads
-      !   tm2 = omp_get_wtime() 
-      !   write(*,*)  '    AWAE_UpdateStates using thread #'//trim(num2lstr(omp_get_thread_num()))//' taking '//trim(num2lstr(tm2-tm3))//' seconds'
-      !#endif
-     
-     
-      !$OMP END PARALLEL SECTIONS  
-      
-      !#ifdef printthreads   
-      !  tm2 = omp_get_wtime()
-      !  write(*,*) 'Total Farm_US took '//trim(num2lstr(tm2-tm1))//' seconds.'
-      !#endif 
       
    else
       CALL SetErrStat( ErrID_Fatal, 'MooringMod must be 0 or 3.', ErrStat, ErrMsg, RoutineName )
    end if
+   !#ifdef printthreads   
+   !  tm2 = omp_get_wtime()
+   !  write(*,*) 'Total FAST and Moordyn for FF_US took '//trim(num2lstr(tm2-tm1))//' seconds.'
+   !#endif 
+
+   call AWAE_UpdateStates( t, n, farm%AWAE%u, farm%AWAE%p, farm%AWAE%x, farm%AWAE%xd, farm%AWAE%z, &
+                     farm%AWAE%OtherSt, farm%AWAE%m, ErrStatAWAE, ErrMsgAWAE )       
+
+   !#ifdef printthreads   
+   !  tm3 = omp_get_wtime()
+   !  write(*,*) 'AWAE_US took '//trim(num2lstr(tm3-tm2))//' seconds.'
+   !  write(*,*) 'Total Farm_US took '//trim(num2lstr(tm3-tm1))//' seconds.'
+   !#endif 
    
    ! update error messages from FAST's and AWAE's time steps
    DO nt = 1,farm%p%NumTurbines 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -7183,13 +7183,11 @@ END SUBROUTINE CheckR16Var
       ErrMsg  = ""
 
          ! Is this file already open from earlier in the recursion.  That would be bad.
-
+         ! But if it's being read by another thread, we allow it.
       FileName = ThisFile%Filename
       INQUIRE ( FILE=Filename, OPENED=IsOpen )
       IF ( IsOpen )  THEN
-         CALL SetErrStat( ErrID_Fatal, 'Fatal error scanning "'//TRIM( Filename ) &
-                          //'". A file cannot directly or indirectly include itself.', ErrStat, ErrMsg, RoutineName )
-         RETURN
+         CALL SetErrStat( ErrID_Warn, 'The file being read is already opened (maybe by another thread?): "'//TRIM( Filename ), ErrStat, ErrMsg, RoutineName )
       ENDIF
 
 


### PR DESCRIPTION
This pull request ready to be merged

**Feature or improvement description**
- Adds more OpenMP statements in FAST.Farm Subs. 
        - NOTE: parallelizing FWrap_Init (i.e. the step that reads all the OpenFAST input file, can result in the same input files being read by multiple processors. The NWTC_IO had a check that would prevent this, I have removed it). 
        -  Parallelize WD_CalcOutp
        -  Isolate the calls to AWAE_UpdateStates (run after all the OpenFAST Turbine Update states), (small slow down expected because before this step was done in parallel, but separating this calls makes the process cleaner and leaves room for OpenMP Optimization of AWAE_UpdateStates. This shouldn't matter if you have more turbines than cores. )
        - Parallelize the Reading of HighRes boxes in AWAE_UpdatesStates
- Explicitly set the number of threads in the github workflow. Note: I have tested with 2,4, and 8 threads, all seem to work and don't seem to produce overhead from multithreading (but tests have few number of turbines)

**Impacted areas of the software**
Fast.Farm

**Test results, if applicable**
Unchanged
