### PR TITLE
NWTC_IO: nullifying DLL (on restart)  if not present when packing

### DIFF
--- a/modules/nwtc-library/src/NWTC_Base.f90
+++ b/modules/nwtc-library/src/NWTC_Base.f90
@@ -65,7 +65,7 @@ MODULE NWTC_Base
    
    TYPE DLL_Type 
 
-      INTEGER(C_INTPTR_T)       :: FileAddr                                        !< The address of file FileName.         (RETURN value from LoadLibrary ) [Windows]
+      INTEGER(C_INTPTR_T)       :: FileAddr  = INT(0,C_INTPTR_T)                   !< The address of file FileName.         (RETURN value from LoadLibrary ) [Windows]
       TYPE(C_PTR)               :: FileAddrX = C_NULL_PTR                          !< The address of file FileName.         (RETURN value from dlopen ) [Linux]
       TYPE(C_FUNPTR)            :: ProcAddr(NWTC_MAX_DLL_PROC)  = C_NULL_FUNPTR    !< The address of procedure ProcName.    (RETURN value from GetProcAddress or dlsym) [initialized to Null for pack/unpack]
 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2080,6 +2080,11 @@ END SUBROUTINE CheckR16Var
       
       IF ( IntKiBuf(1) == 1 .AND. LEN_TRIM(OutData%FileName) > 0 .AND. LEN_TRIM(OutData%ProcName(1)) > 0 ) THEN
          CALL LoadDynamicLib( OutData, ErrStat, ErrMsg )
+      else
+         ! Nullifying
+         OutData%FileAddr  = INT(0,C_INTPTR_T)
+         OutData%FileAddrX = C_NULL_PTR
+         OutData%ProcAddr  = C_NULL_FUNPTR
       END IF
       
    END SUBROUTINE DLLTypeUnPack   


### PR DESCRIPTION
This pull request ready to be merged

**Feature or improvement description**
When doing "restarts" using a checkpoint (I've tested it when using the -VTKLin option), OpenFAST exits with the error that that "the Orca Flex library could not be freed", even though Orca Flex was not used at all before or after the restart. 

I'm using Windows, and gfortran 10.3. The check whether a library is freed (in `SysGnuWin`) is:(see [here](https://github.com/OpenFAST/openfast/blob/dev/modules/nwtc-library/src/SysGnuWin.f90#L524))
```fortran
   IF ( DLL%FileAddr == INT(0,C_INTPTR_T) ) RETURN   
```

I've added nullifications of the C DLL pointers when "unpacking" a DLL_Type. I think that's a good idea to do so no matter what. 

I think it could also be safe to add a initializer for the datatype ([here](https://github.com/OpenFAST/openfast/blob/dev/modules/nwtc-library/src/NWTC_Base.f90#L68) )
```fortran
      INTEGER(C_INTPTR_T)  :: FileAddr    = INT(0,C_INTPTR_T)
```


@bjonkman let me know your thoughts. 






**Impacted areas of the software**
NWTC_IO

**Test results, if applicable**
No change, this is a restart, which I'm not sure we are testing. 
