### PR TITLE
 FF: update of guidelines for Curled wake dr and DT_low

### DIFF
--- a/docs/source/user/fast.farm/FFarmTheory.rst
+++ b/docs/source/user/fast.farm/FFarmTheory.rst
@@ -581,9 +581,11 @@ The wake will adopt a "curled" shape in skewed inflow.
 This corresponds to model 2 with curled-wake vortices of zero intensities, leading to an axi-symmetric wake.
 Swirl effects can be included in this formulation.
 
+Because the Curl and Cartesian implementations rely on a first-order forward sheme, the implementation is less robust that the Polar implementation. 
+An approximate stability criterion for the curled-wake model is given in Equation 20 of the following `paper <https://doi.org/10.5194/wes-6-555-2021>`__). This criterion was adapted to provide the guidelines on **dr** and **DT_Low** given in :numref:`FF:ModGuidance`.
 
-The curled-wake model implementation is described in the following reference:
-`<https://onlinelibrary.wiley.com/doi/10.1002/we.2785>`__
+
+The curled-wake model implementation is described in the following `reference <https://onlinelibrary.wiley.com/doi/10.1002/we.2785>`__.
 
 **The rest of this documentation concerns the Polar fomulation**.
 

--- a/docs/source/user/fast.farm/InputFiles.rst
+++ b/docs/source/user/fast.farm/InputFiles.rst
@@ -243,6 +243,11 @@ low-resolution ambient wind calculation, as well as the global
 called every **DT_Low** seconds, although OpenFAST and its modules may
 choose to use a time step that is an integer multiple smaller than or
 equal to **DT_Low**.
+When **Wake_Mod=2,3**, the stability of the algorithm will depend on the choice 
+of **dr** and **DT_Low**.
+(typically  :math:`\textbf{DT_Low}  \gtrapprox 2 \textbf{dr}/V_\text{Hub}`, 
+see :numref:`FF:ModGuidance`)
+
 
 **DT_High** [sec] sets the time step of the high-resolution ambient wind
 data calculation and must be an integer multiple smaller than or equal
@@ -389,17 +394,18 @@ Three wake formulations are available (see :numref:`FF:Theory` for more details)
 
 **Mod_Wake** [switch] is used to switch between wake formulations.
 There are three options available:
-1) Polar [**Mod_Wake=1**] (default). 
-The wake is axi-symmetric, defined on a polar grid, 
+1) Polar [**Mod_Wake=1**] (default); 
+the wake is axi-symmetric, defined on a polar grid, 
 solved using an implicit Crank-Nicolson scheme,
 satisfying both the momentum and mass conservation laws under a shear layer approximation.
-2) Curled-wake model [**Mod_Wake=2**]. 
-The wake is defined on a Cartesian grid, 
+2) Curled-wake model [**Mod_Wake=2**];
+the wake is defined on a Cartesian grid, 
 the effect of curled wake vorticies in skewed inflow is accounted for by introducing cross-flow velocities, the momentum conservation is solved using a first-order forward Euler scheme, 
 mass conservation is not enforced, the effect of wake swirl may be accounted for.
 The wake will adopt a "curled" shape in skewed inflow.
-3) Cartesian [**Mod_Wake=3**]
-This corresponds to model 2 with curled-wake vortices of zero intensities, leading to an axi-symmetric wake.
+3) Cartesian [**Mod_Wake=3**]; corresponds to model 2 with curled-wake vortices of zero intensities, leading to an axi-symmetric wake.
+
+When Wake_Mod=2,3, the stability of the algorithm will depend on the choice of **dr** and **DT_Low** (see the guidelines (see the guidelines given in :numref:`FF:ModGuidance`).
 
 
 
@@ -411,6 +417,8 @@ The wake planes are defined by the following parameters:
    FAST.Farm sufficiently resolves the wake deficit within each plane.
    When a cartesian grid is used (**Mod_Wake=2 or 2**), **dr** represents the 
    spacing in the y and z direction of the plane.
+   When **Wake_Mod=2,3**, the stability of the algorithm will depend on the choice 
+   of **dr** and **DT_Low** (see the guidelines given in :numref:`FF:ModGuidance`).
 
 -  **NumRadii** [integer] (:math:`N_r`) sets the number of radii. To
    ensure the wake deficits are accurately computed by FAST.Farm,
@@ -448,7 +456,7 @@ where
 :math:`a_\text{avg}` is the average axial induction factor across the rotor disk.
 If the DEFAULT keyword is specified in place of a numerical value, **f_c** is set to :math:`12.5/R_\text{est}` Hz
 which corresponds to :math:`U=10` m/s, :math:`a=1/3` in the equation above, and 
-where the estimated rotor radius is obtained as: :math:`R_text{est} = (dr * NumRadii) / 3`.
+where the estimated rotor radius is obtained as: :math:`R_\text{est} = (dr * NumRadii) / 3`.
 Changing the grid resolution will change the estimated radius, therefore it is recommended to set a numerical 
 value for **f_c** directly instead of using DEFAULT. 
 If numerical issues occur, you may attempt to lower the value of **f_c** to introduce more filtering of high frequencies.

--- a/docs/source/user/fast.farm/InputFiles.rst
+++ b/docs/source/user/fast.farm/InputFiles.rst
@@ -245,7 +245,7 @@ choose to use a time step that is an integer multiple smaller than or
 equal to **DT_Low**.
 When **Wake_Mod=2,3**, the stability of the algorithm will depend on the choice 
 of **dr** and **DT_Low**.
-(typically  :math:`\textbf{DT_Low}  \gtrapprox 2 \textbf{dr}/V_\text{Hub}`, 
+(typically  :math:`\textbf{DT_Low}  \lessapprox \textbf{dr}/(2V_\text{Hub})`, 
 see :numref:`FF:ModGuidance`)
 
 

--- a/docs/source/user/fast.farm/ModelGuidance.rst
+++ b/docs/source/user/fast.farm/ModelGuidance.rst
@@ -516,7 +516,7 @@ time steps. Note that :math:`D^\text{Wake}` can be approximated as
 When **Wake_Mod=2,3**, for numerical stability, it is recommended to set the time step with a value that (approximately) satisfies the following guideline (see Equation 20 of the following `paper <https://doi.org/10.5194/wes-6-555-2021>`__):
 
    .. math::
-      \textbf{DT_Low}  \gtrapprox \frac{2 \textbf{dr }}{V_\text{Hub}}
+      \textbf{DT_Low}  \lessapprox \frac{\textbf{dr}}{2 V_\text{Hub}}
 
 
 Spatial discretization convergence was assessed in the same manner as
@@ -821,7 +821,7 @@ parameters:
 When **Wake_Mod=2,3**, for numerical stability, it is recommended to set the spacing with a value that (approximately) satisfies the following guideline (see Equation 20 of the following `paper <https://doi.org/10.5194/wes-6-555-2021>`__):
 
    .. math::
-      \textbf{dr}  \ltrapprox \frac{D}{20}
+      \textbf{dr}  \ltrapprox \frac{D}{10}
 
 
 

--- a/docs/source/user/fast.farm/ModelGuidance.rst
+++ b/docs/source/user/fast.farm/ModelGuidance.rst
@@ -513,6 +513,12 @@ frequency of wake meandering should be resolved by at least :math:`10`
 time steps. Note that :math:`D^\text{Wake}` can be approximated as
 :math:`D^\text{Rotor}` in this calculation.
 
+When **Wake_Mod=2,3**, for numerical stability, it is recommended to set the time step with a value that (approximately) satisfies the following guideline (see Equation 20 of the following `paper <https://doi.org/10.5194/wes-6-555-2021>`__):
+
+   .. math::
+      \textbf{DT_Low}  \gtrapprox \frac{2 \textbf{dr }}{V_\text{Hub}}
+
+
 Spatial discretization convergence was assessed in the same manner as
 temporal discretization. Minimal sensitivity to spatial discretization
 was found for the low-resolution domain in the range of spatial
@@ -812,6 +818,13 @@ parameters:
    .. math::
       \textbf{dr} \le c_\text{max}
 
+When **Wake_Mod=2,3**, for numerical stability, it is recommended to set the spacing with a value that (approximately) satisfies the following guideline (see Equation 20 of the following `paper <https://doi.org/10.5194/wes-6-555-2021>`__):
+
+   .. math::
+      \textbf{dr}  \ltrapprox \frac{D}{20}
+
+
+
 -  **NumRadii** -- To ensure the wake deficits are accurately computed by
    FAST.Farm, **NumRadii** should be set so that the diameter of each
    wake plane, 2(**NumRadii**\ -1)\ **dr**, is large relative to the rotor
@@ -819,6 +832,8 @@ parameters:
 
    .. math::
       \textbf{NumRadii} \ge \frac{3D^{Rotor}}{2\ \textbf{dr}}+1
+
+
 
 -  **NumPlanes** -- To ensure the wake deficits are accurately captured by
    FAST.Farm, **NumPlanes** should be set so that the wake planes


### PR DESCRIPTION
Adding guidelines for the choice of *dr* and *dt_low* when using the curled wake model. 

@tonyinme 

Co-authored-by: Martinez <tonyinme@gmail.com>