### PR TITLE
AeroDyn/UnsteadyAero_Driver: Fix for bug #1346

### DIFF
--- a/modules/aerodyn/src/UnsteadyAero_Driver.f90
+++ b/modules/aerodyn/src/UnsteadyAero_Driver.f90
@@ -201,9 +201,15 @@ program UnsteadyAero_Driver
    !u(2) = time at n=0  (t= -dt)
    !u(3) = time at n=-1 (t= -2dt) if NumInp > 2
 
-   DO iu = 1, NumInp-1 !u(NumInp) is overwritten in time-sim loop, so no need to init here 
-      call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr)
-   END DO
+   if ( dvrInitInp%SimMod == 1 ) then
+     DO iu = 1, NumInp-1 !u(NumInp) is overwritten in time-sim loop, so no need to init here 
+        call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp)
+     end do
+   else
+      DO iu = 1, NumInp-1 !u(NumInp) is overwritten in time-sim loop, so no need to init here 
+        call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr)
+      END DO
+   end if
    
       ! Set inputs which do not vary with node or time
 
@@ -220,8 +226,12 @@ program UnsteadyAero_Driver
       END DO
   
       ! first value of uTimes/u contain inputs at t+dt
-      call setUAinputs(n+1,  u(1), uTimes(1), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr)
-
+      if ( dvrInitInp%SimMod == 1 ) then
+        call setUAinputs(n+1,  u(1), uTimes(1), dt, dvrInitInp)
+      else
+        call setUAinputs(n+1,  u(1), uTimes(1), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr)
+      end if
+        
       t = uTimes(2)
 
          ! Use existing states to compute the outputs
@@ -283,10 +293,10 @@ program UnsteadyAero_Driver
    real(DbKi),             intent(  out)        :: t
    real(DbKi),             intent(in)           :: dt
    TYPE(UA_Dvr_InitInput), intent(in)           :: dvrInitInp           ! Initialization data for the driver program
-   real(DbKi),             intent(in)           :: timeArr(:)
-   real(ReKi),             intent(in)           :: AOAarr(:)
-   real(ReKi),             intent(in)           :: Uarr(:)
-   real(ReKi),             intent(in)           :: OmegaArr(:)
+   real(DbKi),             intent(in), optional :: timeArr(:)
+   real(ReKi),             intent(in), optional :: AOAarr(:)
+   real(ReKi),             intent(in), optional :: Uarr(:)
+   real(ReKi),             intent(in), optional :: OmegaArr(:)
    integer                                      :: indx
    real(ReKi)                                   :: phase
    real(ReKi)                                   :: d_ref2AC

--- a/modules/aerodyn/src/UnsteadyAero_Driver.f90
+++ b/modules/aerodyn/src/UnsteadyAero_Driver.f90
@@ -185,7 +185,7 @@ program UnsteadyAero_Driver
 !   call WriteAFITables(AFI_Params(1), dvrInitInp%OutRootName)
    
    
-    ! Initialize UnsteadyAero (after AFI)
+      ! Initialize UnsteadyAero (after AFI)
    call UA_Init( InitInData, u(1), p, x, xd, OtherState, y, m, dt, AFI_Params, AFIndx, InitOutData, errStat, errMsg ) 
       call checkError()
 
@@ -202,8 +202,8 @@ program UnsteadyAero_Driver
    !u(3) = time at n=-1 (t= -2dt) if NumInp > 2
 
    DO iu = 1, NumInp-1 !u(NumInp) is overwritten in time-sim loop, so no need to init here 
-     call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr, errStat, errMsg) 
-      call checkError()
+      call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr, errStat, errMsg) 
+         call checkError()
    END DO
    
       ! Set inputs which do not vary with node or time
@@ -222,7 +222,7 @@ program UnsteadyAero_Driver
   
       ! first value of uTimes/u contain inputs at t+dt
       call setUAinputs(n+1,  u(1), uTimes(1), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr, errStat, errMsg) 
-        call checkError()
+         call checkError()
         
       t = uTimes(2)
 
@@ -336,7 +336,7 @@ program UnsteadyAero_Driver
 
       else
          ! check optional variables and allocation status
-          if (any([allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr)])) then
+         if (any([allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr)])) then
              
             indx = min(n,size(timeArr))
             indx = max(1, indx) ! use constant data at initialization
@@ -353,10 +353,10 @@ program UnsteadyAero_Driver
             end if
             u%v_ac(1) = sin(u%alpha)*u%U
             u%v_ac(2) = cos(u%alpha)*u%U
-          else
+         else
             errStat = -1
             errMsg = 'mandatory input arrays are not allocated: timeArr,AOAarr,OmegaArr,Uarr'
-          end if
+         end if
              
       end if
    

--- a/modules/aerodyn/src/UnsteadyAero_Driver.f90
+++ b/modules/aerodyn/src/UnsteadyAero_Driver.f90
@@ -336,7 +336,7 @@ program UnsteadyAero_Driver
 
       else
          ! check optional variables and allocation status
-         if (any([allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr)])) then
+         if (any( (/ allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr) /) )) then
              
             indx = min(n,size(timeArr))
             indx = max(1, indx) ! use constant data at initialization


### PR DESCRIPTION
**This pull request fixes a bug in AeroDyn/UnsteadyAero_Driver:**

bug #1346: If SimMod==1 (reduced frequency model) is used, non-allocated variables are handed over to subroutines with intent(in), which causes a runtime error.

**Feature or improvement description**
Fix for bug #1346, added some if clauses and making some arrays 'optional'.


**Related issue, if one exists**
none

**Impacted areas of the software**
AeroDyn -> UnsteadyAero_Driver.f90


**Additional supporting information**
UnsteadyAero_Driver is only used for stand-alone run of a single airfoil unsteady aerodynamics tests.

