### PR TITLE
AeroDyn/UnsteadyAero_Driver: Fix for bug #1346

### DIFF
--- a/modules/aerodyn/src/UnsteadyAero_Driver.f90
+++ b/modules/aerodyn/src/UnsteadyAero_Driver.f90
@@ -185,7 +185,7 @@ program UnsteadyAero_Driver
 !   call WriteAFITables(AFI_Params(1), dvrInitInp%OutRootName)
    
    
-    ! Initialize UnsteadyAero (after AFI)
+      ! Initialize UnsteadyAero (after AFI)
    call UA_Init( InitInData, u(1), p, x, xd, OtherState, y, m, dt, AFI_Params, AFIndx, InitOutData, errStat, errMsg ) 
       call checkError()
 
@@ -202,7 +202,8 @@ program UnsteadyAero_Driver
    !u(3) = time at n=-1 (t= -2dt) if NumInp > 2
 
    DO iu = 1, NumInp-1 !u(NumInp) is overwritten in time-sim loop, so no need to init here 
-      call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr)
+      call setUAinputs(2-iu,  u(iu), uTimes(iu), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr, errStat, errMsg) 
+         call checkError()
    END DO
    
       ! Set inputs which do not vary with node or time
@@ -220,8 +221,9 @@ program UnsteadyAero_Driver
       END DO
   
       ! first value of uTimes/u contain inputs at t+dt
-      call setUAinputs(n+1,  u(1), uTimes(1), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr)
-
+      call setUAinputs(n+1,  u(1), uTimes(1), dt, dvrInitInp, timeArr, AOAarr, Uarr, OmegaArr, errStat, errMsg) 
+         call checkError()
+        
       t = uTimes(2)
 
          ! Use existing states to compute the outputs
@@ -276,24 +278,26 @@ program UnsteadyAero_Driver
       
    end subroutine checkError
    !----------------------------------------------------------------------------------------------------  
-   subroutine setUAinputs(n,u,t,dt,dvrInitInp,timeArr,AOAarr,Uarr,OmegaArr)
+   subroutine setUAinputs(n,u,t,dt,dvrInitInp,timeArr,AOAarr,Uarr,OmegaArr,errStat,errMsg)
    
-   integer,                intent(in)           :: n
-   type(UA_InputType),     intent(inout)        :: u            ! System inputs
-   real(DbKi),             intent(  out)        :: t
-   real(DbKi),             intent(in)           :: dt
-   TYPE(UA_Dvr_InitInput), intent(in)           :: dvrInitInp           ! Initialization data for the driver program
-   real(DbKi),             intent(in)           :: timeArr(:)
-   real(ReKi),             intent(in)           :: AOAarr(:)
-   real(ReKi),             intent(in)           :: Uarr(:)
-   real(ReKi),             intent(in)           :: OmegaArr(:)
-   integer                                      :: indx
-   real(ReKi)                                   :: phase
-   real(ReKi)                                   :: d_ref2AC
-   real(ReKi)                                   :: alpha_ref
-   real(ReKi)                                   :: U_ref
-   real(ReKi)                                   :: v_ref(2)
-   real(ReKi)                                   :: v_34(2)
+   integer,                intent(in)              :: n
+   type(UA_InputType),     intent(inout)           :: u            ! System inputs
+   real(DbKi),             intent(  out)           :: t
+   real(DbKi),             intent(in)              :: dt
+   TYPE(UA_Dvr_InitInput), intent(in)              :: dvrInitInp           ! Initialization data for the driver program
+   real(DbKi),             intent(in), allocatable :: timeArr(:)
+   real(ReKi),             intent(in), allocatable :: AOAarr(:)
+   real(ReKi),             intent(in), allocatable :: Uarr(:)
+   real(ReKi),             intent(in), allocatable :: OmegaArr(:)
+   integer,                intent(out)             :: errStat
+   character(len=*),       intent(out)             :: errMsg
+   integer                                         :: indx
+   real(ReKi)                                      :: phase
+   real(ReKi)                                      :: d_ref2AC
+   real(ReKi)                                      :: alpha_ref
+   real(ReKi)                                      :: U_ref
+   real(ReKi)                                      :: v_ref(2)
+   real(ReKi)                                      :: v_34(2)
    logical, parameter :: OscillationAtMidChord=.true.  ! for legacy, use false
    logical, parameter :: VelocityAt34         =.true.  ! for legacy, use false
 
@@ -331,21 +335,29 @@ program UnsteadyAero_Driver
 
 
       else
-         indx = min(n,size(timeArr))
-         indx = max(1, indx) ! use constant data at initialization
+         ! check optional variables and allocation status
+         if (any( (/ allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr) /) )) then
+             
+            indx = min(n,size(timeArr))
+            indx = max(1, indx) ! use constant data at initialization
          
-         ! Load timestep data from the time-series inputs which were previous read from input file
-         t       = timeArr(indx)
-         u%alpha = AOAarr(indx)*pi/180.0   ! This needs to be in radians
-         u%omega = OmegaArr(indx)
-         u%U     = Uarr(indx)
-         if (n> size(timeArr)) then
-            t = t + dt*(n - size(timeArr) ) ! update for NumInp>1;
-         elseif (n < 1) then
-            t = (n-1)*dt
+            ! Load timestep data from the time-series inputs which were previous read from input file
+            t       = timeArr(indx)
+            u%alpha = AOAarr(indx)*pi/180.0   ! This needs to be in radians
+            u%omega = OmegaArr(indx)
+            u%U     = Uarr(indx)
+            if (n> size(timeArr)) then
+              t = t + dt*(n - size(timeArr) ) ! update for NumInp>1;
+            elseif (n < 1) then
+              t = (n-1)*dt
+            end if
+            u%v_ac(1) = sin(u%alpha)*u%U
+            u%v_ac(2) = cos(u%alpha)*u%U
+         else
+            errStat = -1
+            errMsg = 'mandatory input arrays are not allocated: timeArr,AOAarr,OmegaArr,Uarr'
          end if
-         u%v_ac(1) = sin(u%alpha)*u%U
-         u%v_ac(2) = cos(u%alpha)*u%U
+             
       end if
    
    end subroutine setUAinputs

--- a/modules/aerodyn/src/UnsteadyAero_Driver.f90
+++ b/modules/aerodyn/src/UnsteadyAero_Driver.f90
@@ -301,6 +301,10 @@ program UnsteadyAero_Driver
    logical, parameter :: OscillationAtMidChord=.true.  ! for legacy, use false
    logical, parameter :: VelocityAt34         =.true.  ! for legacy, use false
 
+      ! Initialize error handling variables
+      ErrMsg  = ''
+      ErrStat = ErrID_None
+
       u%UserProp = 0
       u%Re       = dvrInitInp%Re
    
@@ -336,7 +340,7 @@ program UnsteadyAero_Driver
 
       else
          ! check optional variables and allocation status
-         if (any( (/ allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr) /) )) then
+         if (all( (/ allocated(timeArr),allocated(AOAarr),allocated(OmegaArr),allocated(Uarr) /) )) then
              
             indx = min(n,size(timeArr))
             indx = max(1, indx) ! use constant data at initialization
@@ -354,7 +358,7 @@ program UnsteadyAero_Driver
             u%v_ac(1) = sin(u%alpha)*u%U
             u%v_ac(2) = cos(u%alpha)*u%U
          else
-            errStat = -1
+            errStat = ErrID_Fatal
             errMsg = 'mandatory input arrays are not allocated: timeArr,AOAarr,OmegaArr,Uarr'
          end if
              


### PR DESCRIPTION
**This pull request fixes a bug in AeroDyn/UnsteadyAero_Driver:**

bug https://github.com/OpenFAST/openfast/issues/1346: If SimMod==1 (reduced frequency model) is used, non-allocated variables are handed over to subroutines with intent(in), which causes a runtime error.

**Feature or improvement description**
Fix for bug https://github.com/OpenFAST/openfast/issues/1346, added some if clauses and making some arrays 'optional'.

**Related issue, if one exists**
#1346 

**Impacted areas of the software**
AeroDyn -> UnsteadyAero_Driver.f90

**Additional supporting information**
UnsteadyAero_Driver is only used for stand-alone run of a single airfoil unsteady aerodynamics tests.



*This PR was originally #1347, but there was a mixup on our end with the merge.  I have recreated this with the merge commit to main and the original text from #1347.  Many thanks to @RiekJ for your contribution and patience with our mixup*