### PR TITLE
Add `regression_tests` to the ALL target.

### DIFF
--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -188,7 +188,7 @@ add_custom_target(
 )
 
 add_custom_target(
-  regression_test_module_drivers
+  regression_test_module_drivers ALL
   DEPENDS
     aerodyn_driver
     beamdyn_driver

--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -181,7 +181,7 @@ add_custom_target(
 )
 
 add_custom_target(
-  regression_tests
+  regression_tests ALL
   DEPENDS
     openfast
     regression_test_controllers


### PR DESCRIPTION
Fixes issue #1325

**Feature or improvement description**
When `BUILD_TESTING` is enabled, a user would generally expect that a `make install` command would include everything for the regression testing.  This PR adds the `regression_tests` target to the `ALL` target in the CMake build system.

**Related issue, if one exists**
#1325

**Impacted areas of the software**
This only affects the cmake build system when testing is enabled.