### PR TITLE
GetNewUnit: increase allowed number of open files to 16384

### DIFF
--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2207,7 +2207,11 @@ END SUBROUTINE CheckR16Var
    INTEGER                                :: Un                                           ! Unit number
    LOGICAL                                :: Opened                                       ! Flag indicating whether or not a file is opened.
    INTEGER(IntKi), PARAMETER              :: StartUnit = 10                               ! Starting unit number to check (numbers less than 10 reserved)
-   INTEGER(IntKi), PARAMETER              :: MaxUnit   = 99                               ! The maximum unit number available (or 10 less than the number of files you want to have open at a time)
+   ! NOTE: maximum unit numbers in fortran 90 and later is 2**31-1.  However, there are limits within the OS.
+   !     macos -- 256  (change with ulimit -n)
+   !     linux -- 1024 (change with ulimit -n)
+   !     windows -- 512 (not sure how to change -- ADP)
+   INTEGER(IntKi), PARAMETER              :: MaxUnit   = 1024                             ! The maximum unit number available (or 10 less than the number of files you want to have open at a time)
    CHARACTER(ErrMsgLen)                   :: Msg                                          ! Temporary error message
 
 


### PR DESCRIPTION
Ready for merging

**Feature or improvement description**
When running large FAST.Farm simulations with more than 90 turbines, the simulation will fail when 89 files are open simultaneously.  This PR bumps the limit up to more acceptable values for modern compilers and linux cluster applications.

As of GCC 4.5 (older than gcc 6 which is the oldest we support) and Intel from ~2009 (or possibly earlier), the maximum allowed unit number is 2**31-1. We are setting this to 16384, which is the limit on Eagle.

However, the OS may impose a limit:
- macos -- 256 (change with ulimit -n)
- linux -- 1024 typically (change with ulimit -n -- may require elevated permissions on clusters)
- windows -- probably 255 (no clue how to change)

**Impacted areas of the software**
This will really only affect really large simulations with FAST.Farm where ~100 or more turbines are in use.

**Additional supporting information**
During testing of large wind farms (150+ turbines) using FAST.Farm with AeroDisk and Simple-ElestoDyn (SED), it was found that the artificially low constraint of 99 unit numbers prevented any simulation with more than 89 turbines from running.

**Possible compilications**

- This has not been tested with `mingw`.  However, a brief search showed that `mingw` using gcc > 4.5 should be handle this without issue. We don't really support compilers before gcc 6.4, so this should not be an issue.
- The OS itself may impose a lower limit.  This will be up to the operator to solve (setting `ulimit -n` on mac/linux for example).