### PR TITLE
SD: SumPrint line in input file had name of SSSum

### DIFF
--- a/docs/source/user/subdyn/input_files.rst
+++ b/docs/source/user/subdyn/input_files.rst
@@ -602,7 +602,7 @@ Output: Summary and Outfile
 In this section of the input file, the user sets flags and switches for
 the desired output behavior.
 
-Specifying **SDSum** = TRUE causes SubDyn to generate a summary file
+Specifying **SumPrint** = TRUE causes SubDyn to generate a summary file
 with name **OutRootName**.SD.sum*. **OutRootName** is either
 specified in the SUBDYN section of the driver input file when running
 SubDyn in stand-alone mode, or in the FAST input file when running a

--- a/docs/source/user/subdyn/output_files.rst
+++ b/docs/source/user/subdyn/output_files.rst
@@ -27,7 +27,7 @@ Summary File
 ------------
 
 SubDyn generates a summary file with the naming convention,
-**OutRootName.SD.sum** if the **SDSum** parameter is set to TRUE.
+**OutRootName.SD.sum** if the **SumPrint** parameter is set to TRUE.
 This file summarizes key information about the substructure model,
 including:
 

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -1260,7 +1260,7 @@ IF (Check( Init%nCMass < 0     , 'NCMass must be >=0')) return
 
 !---------------------------- OUTPUT: SUMMARY & OUTFILE ------------------------------
 CALL ReadCom (UnIn, SDInputFile,               'OUTPUT'                                            ,ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
-CALL ReadLVar(UnIn, SDInputFile, Init%SSSum  , 'SSSum'  , 'Summary File Logic Variable'            ,ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
+CALL ReadLVar(UnIn, SDInputFile, Init%SSSum  , 'SumPrint'  , 'Summary File Logic Variable'            ,ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
 ! --- Reading OutCBModes and OutFEM Modes (temporary backward compatibility if missing)
 !CALL ReadIVar( UnIn, SDInputFile, p%OutCBModes  , 'OutCBModes'  , 'Output of CB Modes'  , ErrStat2 , ErrMsg2 , UnEc ); if(Failed()) return
 read(UnIn,'(A)',iostat=ErrStat2) Line


### PR DESCRIPTION
If there was a file parsing error in JOINT ADDITIONAL CONCENTRATED MASSES section, the `SumPrint` line in the input file could have a read error.  This results in an error printed to the screen about `SSSum` not found -- but the input files all say `SumPrint`.

Another option instead of changing this is to update all the SD input files to have `SSSum`.  However, this would be nonstandard with the rest of our input files

This is ready for merging.

Issue reported by @shashankNREL