### PR TITLE
Docs: update manual regression testing syntax for Windows

### DIFF
--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -85,17 +85,15 @@ executing with the help option:
 
     >>>$ python manualRegressionTest.py -h
     usage: manualRegressionTest.py [-h] [-p [Plotting-Flag]] [-n [No-Execution]]
-                                [-v [Verbose-Flag]] [-case [Case-Name]]
-                                OpenFAST System-Name Compiler-Id Test-Tolerance
+                                [-v [Verbose-Flag]] [-case [Case-Name]] [-module [Module-Name]]
+                                Executable-Name Relative-Tolerance Absolute-Tolerance
 
-    Executes OpenFAST and a regression test for a single test case.
+    Executes OpenFAST or driver and a regression test for a single test case.
 
     positional arguments:
-    OpenFAST              path to the OpenFAST executable
-    System-Name           current system's name: [Darwin,Linux,Windows]
-    Compiler-Id           compiler's id: [Intel,GNU]
-    Test-Tolerance        tolerance defining pass or failure in the regression
-                            test
+    Executable-Name       path to the executable
+    Relative-Tolerance    Relative tolerance to allow the solution to deviate; expressed as order of magnitudes less than baseline.
+    Absolute-Tolerance    Absolute tolerance to allow small values to pass; expressed as order of magnitudes less than baseline.
 
     optional arguments:
     -h, --help            show this help message and exit
@@ -106,6 +104,8 @@ executing with the help option:
     -v [Verbose-Flag], -verbose [Verbose-Flag]
                             bool to include verbose system output
     -case [Case-Name]     single case name to execute
+    -module [Module-Name], -mod [Module-Name]
+                            name of module to execute
 
 .. note::
 
@@ -351,17 +351,15 @@ included Python driver.
     cd reg_tests
     python manualRegressionTest.py -h
     # usage: manualRegressionTest.py [-h] [-p [Plotting-Flag]] [-n [No-Execution]]
-    #                                [-v [Verbose-Flag]] [-case [Case-Name]]
-    #                                OpenFAST System-Name Compiler-Id Test-Tolerance
+    #                                [-v [Verbose-Flag]] [-case [Case-Name]] [-module [Module-Name]]
+    #                                Executable-Name Relative-Tolerance Absolute-Tolerance
     # 
-    # Executes OpenFAST and a regression test for a single test case.
+    # Executes OpenFAST or driver and a regression test for a single test case.
     # 
     # positional arguments:
-    #   OpenFAST              path to the OpenFAST executable
-    #   System-Name           current system's name: [Darwin,Linux,Windows]
-    #   Compiler-Id           compiler's id: [Intel,GNU]
-    #   Test-Tolerance        tolerance defining pass or failure in the regression
-    #                         test
+    # Executable-Name       path to the executable
+    # Relative-Tolerance    Relative tolerance to allow the solution to deviate; expressed as order of magnitudes less than baseline.
+    # Absolute-Tolerance    Absolute tolerance to allow small values to pass; expressed as order of magnitudes less than baseline.
     # 
     # optional arguments:
     #   -h, --help            show this help message and exit
@@ -372,12 +370,10 @@ included Python driver.
     #   -v [Verbose-Flag], -verbose [Verbose-Flag]
     #                         bool to include verbose system output
     #   -case [Case-Name]     single case name to execute
+    #   -module [Module-Name], -mod [Module-Name]
+    #                         name of module to execute
 
-    python manualRegressionTest.py \
-        ..\build\bin\openfast_x64_Double.exe \
-        Windows \
-        Intel \
-        1e-5
+    python manualRegressionTest.py ..\build\bin\openfast_x64_Double.exe 2.0 1.9
 
 .. _reg_test_windows:
 

--- a/docs/source/testing/regression_test.rst
+++ b/docs/source/testing/regression_test.rst
@@ -68,7 +68,7 @@ The following packages are required for regression testing:
 - Python 3.7+
 - Numpy
 - CMake and CTest (Optional)
-- Bokeh 1.4 (Optional)
+- Bokeh 2.4+ (Optional)
 
 .. _python_driver:
 

--- a/docs/source/testing/regression_test_windows.rst
+++ b/docs/source/testing/regression_test_windows.rst
@@ -84,7 +84,7 @@ Windows with Visual Studio regression test
  
     b) Change your working directory to ``openfast\reg_tests``
 
-    c) Type: ``python manualRegressionTest.py ..\build\bin\openfast_x64_Double.exe 1e-5 1e-6`` 
+    c) Type: ``python manualRegressionTest.py ..\build\bin\openfast_x64_Double.exe 2.0 1.9`` 
          You should see this: ``executing AWT_YFix_WSt``
 
     d) The tests will continue to execute one-by-one until you finally see something like this:

--- a/docs/source/testing/regression_test_windows.rst
+++ b/docs/source/testing/regression_test_windows.rst
@@ -84,7 +84,7 @@ Windows with Visual Studio regression test
  
     b) Change your working directory to ``openfast\reg_tests``
 
-    c) Type: ``python manualRegressionTest.py ..\build\bin\openfast_x64_Double.exe Windows Intel 1e-5`` 
+    c) Type: ``python manualRegressionTest.py ..\build\bin\openfast_x64_Double.exe 1e-5 1e-6`` 
          You should see this: ``executing AWT_YFix_WSt``
 
     d) The tests will continue to execute one-by-one until you finally see something like this:

--- a/reg_tests/README.md
+++ b/reg_tests/README.md
@@ -10,7 +10,7 @@ Dependencies required to run the regression test suite are
 - Python 3.7+
 - Numpy
 - CMake and CTest
-- Bokeh 1.4 (optional)
+- Bokeh 2.4+ (optional)
 
 ## Execution
 The automated regression test runs CTest and can be executed by running either of the commands `make test` or `ctest` from the build directory. If the entire OpenFAST package is to be built, CMake will configure CTest to find the new binary at `openfast/build/glue-codes/openfast/openfast`. However, if the intention is to build only the test suite, the OpenFAST binary should be specified in the CMake configuration under the `CTEST_OPENFAST_EXECUTABLE` flag. There is also a corresponding `CTEST_[MODULE]_NAME` flag for each module that is included in the regression test.


### PR DESCRIPTION
This is a minor documentation update that is ready for merging.

**Feature or improvement description**
The directions in the documentation for manually running regression tests on Windows were not updated after changes to the testing architecture (probably v3.2.0 or thereabouts).

**Related issue, if one exists**
https://forums.nrel.gov/t/manualregressiontest-with-windows-visual-studio-regression-test/4431

**Impacted areas of the software**
No impacts on the software itself.
