### PR TITLE
[BugFix] Doxygen builds failing on rtd, and locally

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -7,7 +7,7 @@ version: 2
 
 formats:
   - htmlzip
-  - pdf
+  # - pdf
   # - epub
 
 python:

--- a/docs/CMakeLists.txt
+++ b/docs/CMakeLists.txt
@@ -29,15 +29,13 @@ else()
     # Add a sphinx-only HTML target to avoid building doxygen while developing documentation
     add_custom_target(sphinx-html
         COMMAND ${SPHINX_EXECUTABLE} -M html
-        "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
-        -c ${CMAKE_CURRENT_SOURCE_DIR})
+        "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
 
     # PDF documentation generation using sphinx -> latex -> pdflatex
     find_package(LATEX COMPONENTS PDFLATEX BIBTEX)
     if (LATEX_FOUND)
         add_custom_target(sphinx-pdf
             COMMAND ${SPHINX_EXECUTABLE} -M latexpdf
-            "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}"
-            -c ${CMAKE_CURRENT_BINARY_DIR})
+            "${CMAKE_CURRENT_SOURCE_DIR}" "${CMAKE_CURRENT_BINARY_DIR}")
     endif()
 endif()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -28,7 +28,7 @@ builddir = sys.argv[-1]
 sourcedir = sys.argv[-2]
 
 # Use this to turn Doxygen on or off
-useDoxygen = True
+useDoxygen = False
 
 # This function was adapted from https://gitlab.kitware.com/cmb/smtk
 # Only run when on readthedocs


### PR DESCRIPTION
This is ready to merge

**Feature or improvement description**
Something in RTD changed in January 2023 causing our documentation to fail if `doxygen` is enabled.  This is due to an issue with the paths to doxygen.  The change occurred sometime after the 3.4.0 release.

- v3.4.0 (main, e8ec53f9c) docs build on Jan 11, https://readthedocs.org/projects/openfast/builds/19142412/ --> pass
- v3.4.0 (main, e8ec53f9c) docs build on Jan 30, https://readthedocs.org/projects/openfast/builds/19322116/ --> fail

Exactly what changed is a bit unknown: looking through the logs for both yielded very little useful information.  A handful of python packages had minor updates, but nothing major that we would expect to change the results.  Also whatever changed also affects local builds (only for updated python packages).

For this fix, `doxygen` has been turned off on RTD (we don't think anyone uses it).  Doxygen is still built locally and should work on most systems still.

**Related issue, if one exists**
#1423 has some additional details

**Impacted areas of the software**
Only the documentation is affected.

**Additional information**
We would like to include this in a bugfix release, 3.4.1

**Test results, if applicable**
none