### PR TITLE
Use #ifdef to suppress QuKi when compiling with DOUBLE_PRECISION=OFF

### DIFF
--- a/modules/nwtc-library/src/JSON.f90
+++ b/modules/nwtc-library/src/JSON.f90
@@ -18,7 +18,10 @@
 !
 !**********************************************************************************************************************************
 module JSON
-   use Precision, only: IntKi, SiKi, R8Ki, QuKi
+   use Precision, only: IntKi, SiKi, R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
+   use Precision, only: QuKi
+#endif
    use NWTC_Base, only: ErrID_None, ErrID_Fatal
    use NWTC_IO, only: num2lstr
 
@@ -29,7 +32,9 @@ module JSON
       module procedure json_write_array2R4  ! Two dimension array of SiKi
       module procedure json_write_array2I   ! Two dimension array of IntKi
       module procedure json_write_array2R8  ! Two dimension array of R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
       module procedure json_write_array2R16 ! Two dimension array of QuKi
+#endif
    end interface
 
    private
@@ -168,6 +173,7 @@ subroutine json_write_array2R8(fid, key, A, VarFmt, ErrStat, ErrMsg, AllFmt)
    end if
 end subroutine json_write_array2R8
 
+#ifdef OPENFAST_DOUBLE_PRECISION
 subroutine json_write_array2R16(fid, key, A, VarFmt, ErrStat, ErrMsg, AllFmt)
    integer(IntKi),             intent(in   ) :: fid     !< File Unit
    character(len=*),           intent(in   ) :: key     !< Array name
@@ -210,6 +216,6 @@ subroutine json_write_array2R16(fid, key, A, VarFmt, ErrStat, ErrMsg, AllFmt)
       ErrMsg  = 'Error writing array '//trim(key)//' to JSON file'
    end if
 end subroutine json_write_array2R16
-
+#endif
 
 end module JSON

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -103,23 +103,23 @@ MODULE NWTC_IO
       MODULE PROCEDURE AllLAry2
       MODULE PROCEDURE AllLAry3
    !   MODULE PROCEDURE AllLAry4                               Not yet coded.
-
       MODULE PROCEDURE AllR4Ary1       ! 1-dimensional array of SiKi reals
-      MODULE PROCEDURE AllR8Ary1       ! 1-dimensional array of R8Ki reals
-      MODULE PROCEDURE AllR16Ary1      ! 1-dimensional array of QuKi reals
       MODULE PROCEDURE AllR4Ary2       ! 2-dimensional array of SiKi reals
-      MODULE PROCEDURE AllR8Ary2       ! 2-dimensional array of R8Ki reals
-      MODULE PROCEDURE AllR16Ary2      ! 2-dimensional array of QuKi reals
-
       MODULE PROCEDURE AllR4Ary3       ! 3-dimensional array of SiKi reals
-      MODULE PROCEDURE AllR8Ary3       ! 3-dimensional array of R8Ki reals
-      MODULE PROCEDURE AllR16Ary3      ! 3-dimensional array of QuKi reals
       MODULE PROCEDURE AllR4Ary4       ! 4-dimensional array of SiKi reals
-      MODULE PROCEDURE AllR8Ary4       ! 4-dimensional array of R8Ki reals
-      MODULE PROCEDURE AllR16Ary4      ! 4-dimensional array of QuKi reals
       MODULE PROCEDURE AllR4Ary5       ! 5-dimensional array of SiKi reals
+      MODULE PROCEDURE AllR8Ary1       ! 1-dimensional array of R8Ki reals      
+      MODULE PROCEDURE AllR8Ary2       ! 2-dimensional array of R8Ki reals
+      MODULE PROCEDURE AllR8Ary3       ! 3-dimensional array of R8Ki reals
+      MODULE PROCEDURE AllR8Ary4       ! 4-dimensional array of R8Ki reals
       MODULE PROCEDURE AllR8Ary5       ! 5-dimensional array of R8Ki reals
+#ifdef OPENFAST_DOUBLE_PRECISION
+      MODULE PROCEDURE AllR16Ary1      ! 1-dimensional array of QuKi reals
+      MODULE PROCEDURE AllR16Ary2      ! 2-dimensional array of QuKi reals
+      MODULE PROCEDURE AllR16Ary3      ! 3-dimensional array of QuKi reals
+      MODULE PROCEDURE AllR16Ary4      ! 4-dimensional array of QuKi reals
       MODULE PROCEDURE AllR16Ary5      ! 5-dimensional array of QuKi reals
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::allipary1
@@ -130,7 +130,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE AllRPAry2
       MODULE PROCEDURE AllR4PAry3
       MODULE PROCEDURE AllR8PAry3
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE AllR16PAry3
+#endif
 !      MODULE PROCEDURE AllRPAry4   !not yet coded
    END INTERFACE
 
@@ -141,7 +143,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE ParseLoVar                                             ! Parses an LOGICAL from a string.
       MODULE PROCEDURE ParseSiVar                                             ! Parses a single-precision REAL from a string.
       MODULE PROCEDURE ParseR8Var                                             ! Parses a double-precision REAL from a string.
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ParseQuVar                                             ! Parses a quad-precision REAL from a string.
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::parsechvarwdefault
@@ -151,7 +155,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE ParseLoVarWDefault                                     ! Parses an LOGICAL from a string, potentially sets to a default value if "Default" is parsed.
       MODULE PROCEDURE ParseSiVarWDefault                                     ! Parses a single-precision REAL from a string, potentially sets to a default value if "Default" is parsed.
       MODULE PROCEDURE ParseR8VarWDefault                                     ! Parses a double-precision REAL from a string, potentially sets to a default value if "Default" is parsed.
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ParseQuVarWDefault                                     ! Parses a quad-precision REAL from a string, potentially sets to a default value if "Default" is parsed.
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::parsedbary
@@ -160,7 +166,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE ParseLoAry                                             ! Parse an array of LOGICAL values.
       MODULE PROCEDURE ParseSiAry                                             ! Parse an array of single-precision REAL values.
       MODULE PROCEDURE ParseR8Ary                                             ! Parse an array of double-precision REAL values.
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ParseQuAry                                             ! Parse an array of quad-precision REAL values.
+#endif
       MODULE PROCEDURE ParseChAry
    END INTERFACE
 
@@ -168,7 +176,9 @@ MODULE NWTC_IO
    INTERFACE CheckRealVar
       MODULE PROCEDURE CheckR4Var     ! 4-byte real
       MODULE PROCEDURE CheckR8Var     ! 8-byte real
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE CheckR16Var    ! 16-byte real
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_io::readcvar
@@ -178,7 +188,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE ReadLVar
       MODULE PROCEDURE ReadR4Var     ! 4-byte real
       MODULE PROCEDURE ReadR8Var     ! 8-byte real
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ReadR16Var    ! 16-byte real
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::readivarwdefault
@@ -188,7 +200,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE ReadLVarWDefault      ! Logical
       MODULE PROCEDURE ReadR4VarWDefault     ! 4-byte real
       MODULE PROCEDURE ReadR8VarWDefault     ! 8-byte real
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ReadR16VarWDefault    ! 16-byte real
+#endif
       MODULE PROCEDURE ReadIAryWDefault
    END INTERFACE
    
@@ -203,8 +217,10 @@ MODULE NWTC_IO
       MODULE PROCEDURE ReadR4AryFromStr
       MODULE PROCEDURE ReadR8Ary  ! read array of 8-byte reals
       MODULE PROCEDURE ReadR8AryFromStr
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ReadR16Ary ! read array of 16-byte reals
       MODULE PROCEDURE ReadR16AryFromStr
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::readcarylines   
@@ -212,7 +228,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE ReadCAryLines
       MODULE PROCEDURE ReadR4AryLines
       MODULE PROCEDURE ReadR8AryLines
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE ReadR16AryLines
+#endif
 !     MODULE PROCEDURE ReadIAryLines         ! Not coded yet
 !     MODULE PROCEDURE ReadLAryLines         ! Not coded yet
    END INTERFACE
@@ -223,7 +241,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE B8Ki2LStr       ! 8 byte integers
       MODULE PROCEDURE R2LStr4         ! 4-byte  reals
       MODULE PROCEDURE R2LStr8         ! 8-byte  reals
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE R2LStr16        ! 16-byte reals
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::dispnvd0
@@ -239,8 +259,10 @@ MODULE NWTC_IO
       MODULE PROCEDURE WrMatrix2R4     ! Two dimension matrix of SiKi
       MODULE PROCEDURE WrMatrix1R8     ! Single dimension matrix (Ary) of R8Ki
       MODULE PROCEDURE WrMatrix2R8     ! Two dimension matrix of R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE WrMatrix1R16    ! Single dimension matrix (Ary) of QuKi
       MODULE PROCEDURE WrMatrix2R16    ! Two dimension matrix of QuKi
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_io::wrpartialmatrix1r8
@@ -254,7 +276,9 @@ MODULE NWTC_IO
       MODULE PROCEDURE WrIAryFileNR
       MODULE PROCEDURE WrR4AryFileNR
       MODULE PROCEDURE WrR8AryFileNR
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE WrR16AryFileNR
+#endif
    END INTERFACE
 
 CONTAINS
@@ -796,6 +820,7 @@ CONTAINS
    END SUBROUTINE AllR8PAry3
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AllR16PAry3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg ) 
 
 
@@ -831,6 +856,7 @@ CONTAINS
    Ary = 0
    RETURN
    END SUBROUTINE AllR16PAry3
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllLAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
@@ -1004,6 +1030,7 @@ CONTAINS
    END SUBROUTINE AllR8Ary1
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AllR16Ary1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
 
 
@@ -1037,6 +1064,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE AllR16Ary1
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
@@ -1115,6 +1143,7 @@ CONTAINS
    END SUBROUTINE AllR8Ary2
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AllR16Ary2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
 
 
@@ -1150,6 +1179,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE AllR16Ary2
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
@@ -1226,6 +1256,7 @@ CONTAINS
    END SUBROUTINE AllR8Ary3
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AllR16Ary3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
 
 
@@ -1261,6 +1292,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE AllR16Ary3
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary4 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, Descr, ErrStat, ErrMsg )
@@ -1339,6 +1371,7 @@ CONTAINS
    END SUBROUTINE AllR8Ary4
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AllR16Ary4 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, Descr, ErrStat, ErrMsg )
 
 
@@ -1375,6 +1408,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE AllR16Ary4
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary5 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, AryDim5, Descr, ErrStat, ErrMsg )
@@ -1459,6 +1493,7 @@ CONTAINS
    END SUBROUTINE AllR8Ary5
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AllR16Ary5 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, AryDim5, Descr, ErrStat, ErrMsg )
 
 
@@ -1498,7 +1533,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE AllR16Ary5
-
+#endif
 !=======================================================================
 !> This subroutine checks the data to be parsed to make sure it finds
 !! the expected variable name and an associated value.
@@ -1769,6 +1804,7 @@ SUBROUTINE CheckR8Var( RealVar, RealDesc, ErrStat, ErrMsg )
 END SUBROUTINE CheckR8Var
 !=======================================================================
 !> \copydoc nwtc_io::checkr4var
+#ifdef OPENFAST_DOUBLE_PRECISION
 SUBROUTINE CheckR16Var( RealVar, RealDesc, ErrStat, ErrMsg )
 
    REAL(QuKi),  INTENT(IN)            :: RealVar                               !< Real value to check
@@ -1785,6 +1821,7 @@ SUBROUTINE CheckR16Var( RealVar, RealDesc, ErrStat, ErrMsg )
    END IF
    
 END SUBROUTINE CheckR16Var
+#endif
 !=======================================================================
 !> This routine converts all the text in a string to upper case.
    SUBROUTINE Conv2UC ( Str )
@@ -3577,6 +3614,7 @@ END SUBROUTINE CheckR16Var
 !> This subroutine parses the specified line of text for AryLen REAL values.
 !! Generate an error message if the value is the wrong type.
 !! Use ParseAry (nwtc_io::parseary) instead of directly calling a specific routine in the generic interface.   
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE ParseQuAry ( FileInfo, LineNum, AryName, Ary, AryLen, ErrStat, ErrMsg, UnEc )
 
          ! Arguments declarations.
@@ -3756,6 +3794,7 @@ END SUBROUTINE CheckR16Var
       
       RETURN
    END SUBROUTINE ParseQuVarWDefault
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::parsedbary
    SUBROUTINE ParseInAry ( FileInfo, LineNum, AryName, Ary, AryLen, ErrStat, ErrMsg, UnEc )
@@ -4980,6 +5019,7 @@ END SUBROUTINE CheckR16Var
    END FUNCTION R2LStr8
 !=======================================================================
 !> \copydoc nwtc_io::int2lstr
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION R2LStr16 ( Num, Fmt_in )
 
       ! This function converts a 16-byte floating point number to
@@ -5021,6 +5061,7 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END FUNCTION R2LStr16
+#endif
 !======================================================================
 !> This routine reads a AryLen values separated by whitespace (or other Fortran record delimiters such as commas) 
 !!  into an array (either on same line or multiple lines).
@@ -6601,6 +6642,7 @@ END SUBROUTINE CheckR16Var
    END SUBROUTINE ReadR8AryFromStr
 !=======================================================================
 !> \copydoc nwtc_io::readcary
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE ReadR16Ary ( UnIn, Fil, Ary, AryLen, AryName, AryDescr, ErrStat, ErrMsg, UnEc )
 
 
@@ -6694,6 +6736,7 @@ END SUBROUTINE CheckR16Var
    END IF
    RETURN
    END SUBROUTINE ReadR16AryFromStr
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::readcarylines   
    SUBROUTINE ReadR4AryLines ( UnIn, Fil, Ary, AryLen, AryName, AryDescr, ErrStat, ErrMsg, UnEc )
@@ -6790,6 +6833,7 @@ END SUBROUTINE CheckR16Var
    END SUBROUTINE ReadR8AryLines
 !=======================================================================
 !> \copydoc nwtc_io::readcarylines   
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE ReadR16AryLines ( UnIn, Fil, Ary, AryLen, AryName, AryDescr, ErrStat, ErrMsg, UnEc )
 
 
@@ -6837,6 +6881,7 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE ReadR16AryLines
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::readcvar
 !! WARNING: this routine limits the size of the number being read to 30 characters   
@@ -7034,6 +7079,7 @@ END SUBROUTINE CheckR16Var
 !=======================================================================
 !> \copydoc nwtc_io::readcvar
 !! WARNING: this routine limits the size of the number being read to 30 characters   
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE ReadR16Var ( UnIn, Fil, Var, VarName, VarDescr, ErrStat, ErrMsg, UnEc )
 
 
@@ -7132,6 +7178,7 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE ReadR16VarWDefault
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::readr4varwdefault
    SUBROUTINE ReadIAryWDefault ( UnIn, Fil, Var, AryLen, VarName, VarDescr, VarDefault, ErrStat, ErrMsg, UnEc )
@@ -8020,6 +8067,7 @@ END SUBROUTINE CheckR16Var
    END SUBROUTINE WrMatrix1R8
 !=======================================================================
 !> \copydoc nwtc_io::wrmatrix1r4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE WrMatrix1R16( A, Un, ReFmt, MatName )
    
       REAL(QuKi),             INTENT(IN) :: A(:)
@@ -8048,6 +8096,7 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE WrMatrix1R16
+#endif
 !=======================================================================
 !> \copydoc nwtc_io::wrmatrix1r4
    SUBROUTINE WrMatrix2R4( A, Un, ReFmt, MatName )
@@ -8122,6 +8171,7 @@ END SUBROUTINE CheckR16Var
    END SUBROUTINE WrMatrix2R8
 !=======================================================================  
 !> \copydoc nwtc_io::wrmatrix1r4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE WrMatrix2R16( A, Un, ReFmt, MatName )
    
       REAL(QuKi),             INTENT(IN) :: A(:,:)
@@ -8156,6 +8206,7 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE WrMatrix2R16
+#endif
 !=======================================================================  
 !> Based on nwtc_io::wrmatrix, this routine writes a matrix to an already-open text file. It allows
 !! the user to omit rows and columns of A in the the file.
@@ -8490,6 +8541,7 @@ END SUBROUTINE CheckR16Var
    END SUBROUTINE WrR8AryFileNR
 !=======================================================================
 !> \copydoc nwtc_io::wrr4aryfilenr
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE WrR16AryFileNR ( Unit, Ary, Fmt, ErrStat, ErrMsg  )
 
       ! Argument declarations.
@@ -8528,6 +8580,7 @@ END SUBROUTINE CheckR16Var
 
    RETURN
    END SUBROUTINE WrR16AryFileNR
+#endif
 !=======================================================================
 !> This routine writes out a string to the screen.
    RECURSIVE SUBROUTINE WrScr ( InStr )

--- a/modules/nwtc-library/src/NWTC_Num.f90
+++ b/modules/nwtc-library/src/NWTC_Num.f90
@@ -69,11 +69,15 @@ MODULE NWTC_Num
 
    REAL(SiKi)                                :: Pi_R4                         !< Ratio of a circle's circumference to its diameter in 4-byte precision
    REAL(R8Ki)                                :: Pi_R8                         !< Ratio of a circle's circumference to its diameter in 8-byte precision
+#ifdef OPENFAST_DOUBLE_PRECISION
    REAL(QuKi)                                :: Pi_R16                        !< Ratio of a circle's circumference to its diameter in 16-byte precision
+#endif
 
    REAL(SiKi)                                :: TwoPi_R4                      !< 2*pi in 4-byte precision
    REAL(R8Ki)                                :: TwoPi_R8                      !< 2*pi in 8-byte precision
+#ifdef OPENFAST_DOUBLE_PRECISION
    REAL(QuKi)                                :: TwoPi_R16                     !< 2*pi in 16-byte precision
+#endif
    
    ! constants for kernel smoothing
    INTEGER, PARAMETER :: kernelType_EPANECHINIKOV = 1
@@ -96,14 +100,18 @@ MODULE NWTC_Num
    INTERFACE EqualRealNos
       MODULE PROCEDURE EqualRealNos4
       MODULE PROCEDURE EqualRealNos8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE EqualRealNos16
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::eulerconstructr4()
    INTERFACE EulerConstruct
       MODULE PROCEDURE EulerConstructR4
       MODULE PROCEDURE EulerConstructR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE EulerConstructR16
+#endif
    END INTERFACE
 
    INTERFACE EulerConstructZYX
@@ -114,7 +122,9 @@ MODULE NWTC_Num
    INTERFACE EulerExtract
       MODULE PROCEDURE EulerExtractR4
       MODULE PROCEDURE EulerExtractR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE EulerExtractR16
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::taitbryanyxzextractr4()
@@ -122,20 +132,26 @@ MODULE NWTC_Num
    INTERFACE TaitBryanYXZExtract
       MODULE PROCEDURE TaitBryanYXZExtractR4
       MODULE PROCEDURE TaitBryanYXZExtractR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE TaitBryanYXZExtractR16
+#endif
    END INTERFACE
    
    INTERFACE TaitBryanYXZConstruct
       MODULE PROCEDURE TaitBryanYXZConstructR4
       MODULE PROCEDURE TaitBryanYXZConstructR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE TaitBryanYXZConstructR16
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::outerproductr4
    INTERFACE OuterProduct
       MODULE PROCEDURE OuterProductR4
       MODULE PROCEDURE OuterProductR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE OuterProductR16
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::cross_productr4()
@@ -144,7 +160,9 @@ MODULE NWTC_Num
       MODULE PROCEDURE Cross_ProductR4R8
       MODULE PROCEDURE Cross_ProductR8
       MODULE PROCEDURE Cross_ProductR8R4
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE Cross_ProductR16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::smllrottransd()
@@ -164,21 +182,27 @@ MODULE NWTC_Num
    INTERFACE Zero2TwoPi
       MODULE PROCEDURE Zero2TwoPiR4
       MODULE PROCEDURE Zero2TwoPiR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE Zero2TwoPiR16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::twonormr4
    INTERFACE TwoNorm
       MODULE PROCEDURE TwoNormR4
       MODULE PROCEDURE TwoNormR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE TwoNormR16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::tracer4
    INTERFACE trace
       MODULE PROCEDURE traceR4
       MODULE PROCEDURE traceR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE traceR16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::dcm_expd
@@ -217,18 +241,24 @@ MODULE NWTC_Num
    INTERFACE InterpStp
       MODULE PROCEDURE InterpStpComp4
       MODULE PROCEDURE InterpStpComp8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE InterpStpComp16
+#endif
       MODULE PROCEDURE InterpStpReal4
       MODULE PROCEDURE InterpStpReal4_8
       MODULE PROCEDURE InterpStpReal8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE InterpStpReal16
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::interparrayr4
    INTERFACE InterpArray
       MODULE PROCEDURE InterpArrayR4
       MODULE PROCEDURE InterpArrayR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE InterpArrayR16
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::interpwrappedstpreal4
@@ -236,51 +266,69 @@ MODULE NWTC_Num
       MODULE PROCEDURE InterpWrappedStpReal4
       MODULE PROCEDURE InterpWrappedStpReal4_8
       MODULE PROCEDURE InterpWrappedStpReal8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE InterpWrappedStpReal16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::locatestpr4
    INTERFACE LocateStp
       MODULE PROCEDURE LocateStpR4
       MODULE PROCEDURE LocateStpR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE LocateStpR16
+#endif
    END INTERFACE
 
    !> \copydoc nwtc_num::skewsymmatr4
    INTERFACE SkewSymMat
       MODULE PROCEDURE SkewSymMatR4
       MODULE PROCEDURE SkewSymMatR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE SkewSymMatR16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::angle_extrapinterp2_r4
    INTERFACE Angles_ExtrapInterp
       MODULE PROCEDURE Angles_ExtrapInterp1_R4
       MODULE PROCEDURE Angles_ExtrapInterp1_R8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE Angles_ExtrapInterp1_R16
+#endif
       MODULE PROCEDURE Angles_ExtrapInterp1_R4R
       MODULE PROCEDURE Angles_ExtrapInterp1_R8R
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE Angles_ExtrapInterp1_R16R
+#endif
       MODULE PROCEDURE Angles_ExtrapInterp2_R4
       MODULE PROCEDURE Angles_ExtrapInterp2_R8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE Angles_ExtrapInterp2_R16
+#endif
       MODULE PROCEDURE Angles_ExtrapInterp2_R4R
       MODULE PROCEDURE Angles_ExtrapInterp2_R8R
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE Angles_ExtrapInterp2_R16R
+#endif
    END INTERFACE
 
       !> \copydoc nwtc_num::addorsub2pi_r4
    INTERFACE AddOrSub2Pi
       MODULE PROCEDURE AddOrSub2Pi_R4
       MODULE PROCEDURE AddOrSub2Pi_R8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE AddOrSub2Pi_R16
+#endif
    END INTERFACE
    
       !> \copydoc nwtc_num::mpi2pi_r4
    INTERFACE MPi2Pi
       MODULE PROCEDURE MPi2Pi_R4
       MODULE PROCEDURE MPi2Pi_R8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE MPi2Pi_R16
+#endif
    END INTERFACE
    
 CONTAINS
@@ -356,6 +404,7 @@ CONTAINS
    END SUBROUTINE AddOrSub2Pi_R8
 !=======================================================================
 !> \copydoc nwtc_num::addorsub2pi_r4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE AddOrSub2Pi_R16 ( OldAngle, NewAngle )
 
       ! Argument declarations:
@@ -384,6 +433,7 @@ CONTAINS
 
    RETURN
    END SUBROUTINE AddOrSub2Pi_R16
+#endif
 !=======================================================================
    FUNCTION BlendCosine( x, LowerBound, UpperBound ) RESULT(S)
    
@@ -620,6 +670,7 @@ CONTAINS
    END FUNCTION Cross_ProductR8R4
 !=======================================================================
 !> \copydoc nwtc_num::cross_productr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION Cross_ProductR16(Vector1, Vector2) result(CProd)
 
       ! Argument declarations.
@@ -638,6 +689,7 @@ CONTAINS
 
    RETURN
    END FUNCTION Cross_ProductR16
+#endif
 !=======================================================================
 !> This routine calculates the parameters needed to compute a irregularly-spaced natural cubic spline.
 !! Natural cubic splines are used in that the curvature at the end points is zero.
@@ -1756,6 +1808,7 @@ CONTAINS
    END FUNCTION EqualRealNos8
 !=======================================================================
 !> \copydoc nwtc_num::equalrealnos4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION EqualRealNos16 ( ReNum1, ReNum2 )
 
       ! passed variables
@@ -1788,6 +1841,7 @@ CONTAINS
 
 
    END FUNCTION EqualRealNos16
+#endif
 !=======================================================================
 !> This function creates a rotation matrix, M, from a 1-2-3 rotation
 !! sequence of the 3 Euler angles, \f$\theta_x\f$, \f$\theta_y\f$, and \f$\theta_z\f$, in radians.
@@ -1903,6 +1957,7 @@ CONTAINS
    END FUNCTION EulerConstructR8
 !=======================================================================
 !> \copydoc nwtc_num::eulerconstructr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION EulerConstructR16(theta) result(M)
    
       ! this function creates a rotation matrix, M, from a 1-2-3 rotation
@@ -1952,6 +2007,7 @@ CONTAINS
       M(3,3) =        cx*cy               
    
    END FUNCTION EulerConstructR16
+#endif
 !=======================================================================
 !> if M is a rotation matrix from a 1-2-3 rotation sequence, this function returns 
 !! the 3 Euler angles, \f$\theta_x\f$, \f$\theta_y\f$, and \f$\theta_z\f$ (in radians), that formed 
@@ -2156,6 +2212,7 @@ CONTAINS
    END FUNCTION EulerExtractR8
 !=======================================================================
 !> \copydoc nwtc_num::eulerextractr4 
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION EulerExtractR16(M) result(theta)
    
       ! if M is a rotation matrix from a 1-2-3 rotation sequence, this function returns 
@@ -2250,6 +2307,7 @@ CONTAINS
             
       
    END FUNCTION EulerExtractR16
+#endif
 
 !=======================================================================
 !> 
@@ -3257,6 +3315,7 @@ END FUNCTION FindValidChannelIndx
    END FUNCTION InterpStpComp8
 !=======================================================================
 !> \copydoc nwtc_num::interpstpcomp4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION InterpStpComp16( XVal, XAry, YAry, Ind, AryLen )
 
       ! Function declaration.
@@ -3315,6 +3374,7 @@ END FUNCTION FindValidChannelIndx
 
    RETURN
    END FUNCTION InterpStpComp16
+#endif
 !=======================================================================
 !> \copydoc nwtc_num::interpstpcomp4
    FUNCTION InterpStpReal4( XVal, XAry, YAry, Ind, AryLen )
@@ -3494,6 +3554,7 @@ END FUNCTION FindValidChannelIndx
    END FUNCTION InterpStpReal8 
 !=======================================================================
 !> \copydoc nwtc_num::interpstpcomp4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION InterpStpReal16( XVal, XAry, YAry, Ind, AryLen )
 
       ! Function declaration.
@@ -3550,6 +3611,7 @@ END FUNCTION FindValidChannelIndx
 
    RETURN
    END FUNCTION InterpStpReal16
+#endif
 !=======================================================================
 !> This funtion returns a y-value array that corresponds to an input x-value by interpolating into the arrays.
 !! It uses the passed index as the starting point and does a stepwise interpolation from there. This is
@@ -3926,6 +3988,7 @@ END FUNCTION FindValidChannelIndx
    END FUNCTION InterpWrappedStpReal8
 !=======================================================================
 !> \copydoc nwtc_num::interpwrappedstpreal4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION InterpWrappedStpReal16( XValIn, XAry, YAry, Ind, AryLen )
 
       ! Function declaration.
@@ -3958,6 +4021,7 @@ END FUNCTION FindValidChannelIndx
    
    
    END FUNCTION InterpWrappedStpReal16 
+#endif
 !=======================================================================
 !> This subroutine calculates interpolated values for an array of input values.
 !! The size of the xknown and yknown arrays must match, and the size of the
@@ -4045,6 +4109,7 @@ END FUNCTION FindValidChannelIndx
    END SUBROUTINE InterpArrayR8
 !=======================================================================
 !> \copydoc nwtc_num::interparrayr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE InterpArrayR16( xknown, yknown, xnew, ynew )
       REAL(QuKi), INTENT(IN   ) :: xknown(:)
       REAL(QuKi), INTENT(IN   ) :: yknown(:)
@@ -4084,6 +4149,7 @@ END FUNCTION FindValidChannelIndx
             endif
          end function interp_lin0
    END SUBROUTINE InterpArrayR16
+#endif
 !=======================================================================
 !> This subroutine calculates the iosparametric coordinates, isopc, which is a value between -1 and 1 
 !! (for each dimension of a dataset), indicating where InCoord falls between posLo and posHi.
@@ -4421,6 +4487,7 @@ end subroutine kernelSmoothing
    END SUBROUTINE LocateStpR8
 !=======================================================================
 !> \copydoc nwtc_num::locatestpr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE LocateStpR16( XVal, XAry, Ind, AryLen )
 
       ! Argument declarations.
@@ -4467,6 +4534,7 @@ end subroutine kernelSmoothing
    RETURN
 
    END SUBROUTINE LocateStpR16
+#endif
 !=======================================================================
 !> This routine calculates the mean value of an array.
    FUNCTION Mean ( Ary, AryLen )
@@ -4557,6 +4625,7 @@ end subroutine kernelSmoothing
    END SUBROUTINE MPi2Pi_R8
 !=======================================================================
 !> \copydoc nwtc_num::mpi2pi_r4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE MPi2Pi_R16 ( Angle )
 
                  
@@ -4579,6 +4648,7 @@ end subroutine kernelSmoothing
 
    RETURN
    END SUBROUTINE MPi2Pi_R16
+#endif
 !=======================================================================
 !> This function takes an angle in radians and converts it to 
 !! an angle in degrees in the range [-180,180]
@@ -4650,6 +4720,7 @@ end function Rad2M180to180Deg
    END FUNCTION OuterProductR8   
 !=======================================================================
 !> \copydoc nwtc_num::outerproductr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION OuterProductR16(u,v)
    
    ! this routine calculates the outer product of two vectors
@@ -4669,6 +4740,7 @@ end function Rad2M180to180Deg
    ENDDO
 
    END FUNCTION OuterProductR16 
+#endif
 !=======================================================================
 !> This subroutine perturbs an orientation matrix by a small angle.  Two methods
 !! are used:
@@ -5724,11 +5796,15 @@ end function Rad2M180to180Deg
       Inv2Pi_S  =  0.5_SiKi/Pi_S    ! 1.0_SiKi/TwoPi_S
       Pi_R4   = ACOS( -1.0_SiKi )
       Pi_R8   = ACOS( -1.0_R8Ki )
+#ifdef OPENFAST_DOUBLE_PRECISION
       Pi_R16  = ACOS( -1.0_QuKi )
+#endif
 
       TwoPi_R4  = Pi_R4 *2.0_SiKi
       TwoPi_R8  = Pi_R8 *2.0_R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
       TwoPi_R16 = Pi_R16*2.0_QuKi
+#endif
       
          ! IEEE constants:
       CALL Set_IEEE_Constants( NaN_D, Inf_D, NaN, Inf, NaN_S, Inf_S )
@@ -6411,6 +6487,7 @@ end function Rad2M180to180Deg
    END FUNCTION SkewSymMatR8
 !=======================================================================
 !> \copydoc nwtc_num::skewsymmatr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION SkewSymMatR16 ( x ) RESULT(M)
 
       ! Function arguments
@@ -6432,7 +6509,7 @@ end function Rad2M180to180Deg
    
    RETURN
    END FUNCTION SkewSymMatR16
-
+#endif
 !=======================================================================
 !> If M is a rotation matrix from a 1-2-3 rotation sequence about Y-X-Z, this function returns 
 !! the 3 sequential angles, \f$\theta_y\f$, \f$\theta_x\f$, and \f$\theta_z\f$ (in radians), that formed 
@@ -6718,6 +6795,7 @@ end function Rad2M180to180Deg
    END FUNCTION TaitBryanYXZExtractR8
 
 !> See nwtc_num::taitbryanyxzextractr4 for detailed explanation of algorithm
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION TaitBryanYXZExtractR16(M) result(theta)
    
    
@@ -6795,7 +6873,7 @@ end function Rad2M180to180Deg
 
       
    END FUNCTION TaitBryanYXZExtractR16
-   
+#endif
       FUNCTION TaitBryanYXZConstructR4(theta) result(M)
             ! this function creates a rotation matrix, M, from a 1-2-3 rotation
       ! sequence of the 3 TaitBryan angles, theta_x, theta_y, and theta_z, in radians.
@@ -6893,6 +6971,7 @@ end function Rad2M180to180Deg
    
    END FUNCTION TaitBryanYXZConstructR8
    
+#ifdef OPENFAST_DOUBLE_PRECISION
   FUNCTION TaitBryanYXZConstructR16(theta) result(M)
    
       ! this function creates a rotation matrix, M, from a 1-2-3 rotation
@@ -6941,7 +7020,7 @@ end function Rad2M180to180Deg
       M(3,3) =   cy*cx      
    
    END FUNCTION TaitBryanYXZConstructR16
-
+#endif
 
 !=======================================================================
 !> This routine takes an array of time values such as that returned from
@@ -7001,6 +7080,7 @@ end function Rad2M180to180Deg
    END FUNCTION traceR8
 !=======================================================================
 !> \copydoc nwtc_num::tracer4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION traceR16(A)
          
    REAL(QuKi), INTENT(IN)  :: A(:,:)
@@ -7017,6 +7097,7 @@ end function Rad2M180to180Deg
    end do
    
    END FUNCTION traceR16
+#endif
 !=======================================================================
 !> This function returns the \f$l_2\f$ (Euclidian) norm of a vector, 
 !! \f$v = \left(v_1, v_2, \ldots ,v_n\right)\f$. The \f$l_2\f$-norm is defined as   
@@ -7051,6 +7132,7 @@ end function Rad2M180to180Deg
    END FUNCTION
 !=======================================================================
 !> \copydoc nwtc_num::twonormr4
+#ifdef OPENFAST_DOUBLE_PRECISION
    FUNCTION TwoNormR16(v)
    
       ! this function returns the 2-norm of a vector v
@@ -7063,6 +7145,7 @@ end function Rad2M180to180Deg
       
       
    END FUNCTION
+#endif
 !=======================================================================  
 !> This routine is used to convert Angle to an equivalent value
 !!  in the range \f$[0, 2\pi)\f$. \n
@@ -7118,6 +7201,7 @@ end function Rad2M180to180Deg
    END SUBROUTINE Zero2TwoPiR8   
 !=======================================================================  
 !> \copydoc nwtc_num::zero2twopir4
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE Zero2TwoPiR16 ( Angle )
 
       ! This routine is used to convert Angle to an equivalent value
@@ -7144,6 +7228,7 @@ end function Rad2M180to180Deg
 
    RETURN
    END SUBROUTINE Zero2TwoPiR16
+#endif
 !=======================================================================
    !< This routine extrapolates or interpolates between angles
    SUBROUTINE Angles_ExtrapInterp1_R4(Angle1, Angle2, tin, Angle_out, tin_out )
@@ -7233,6 +7318,7 @@ end function Rad2M180to180Deg
    END SUBROUTINE Angles_ExtrapInterp1_R8
 !=======================================================================  
    !< This routine extrapolates or interpolates between angles
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE Angles_ExtrapInterp1_R16(Angle1, Angle2, tin, Angle_out, tin_out)
        REAL(QuKi),          INTENT(IN   )  :: Angle1 !< Angle at t1 > t2
        REAL(QuKi),          INTENT(IN   )  :: Angle2 !< Angle at t2
@@ -7274,6 +7360,7 @@ end function Rad2M180to180Deg
 !      call MPi2Pi(Angle_out)
 
    END SUBROUTINE Angles_ExtrapInterp1_R16
+#endif
 !=======================================================================
    !< This routine extrapolates or interpolates between angles
    SUBROUTINE Angles_ExtrapInterp1_R4R(Angle1, Angle2, tin, Angle_out, tin_out )
@@ -7363,6 +7450,7 @@ end function Rad2M180to180Deg
    END SUBROUTINE Angles_ExtrapInterp1_R8R
 !=======================================================================  
    !< This routine extrapolates or interpolates between angles
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE Angles_ExtrapInterp1_R16R(Angle1, Angle2, tin, Angle_out, tin_out)
        REAL(QuKi),          INTENT(IN   )  :: Angle1 !< Angle at t1 > t2
        REAL(QuKi),          INTENT(IN   )  :: Angle2 !< Angle at t2
@@ -7404,6 +7492,7 @@ end function Rad2M180to180Deg
 !      call MPi2Pi(Angle_out)
 
    END SUBROUTINE Angles_ExtrapInterp1_R16R
+#endif
 !=======================================================================  
    !< This routine extrapolates or interpolates between angles
    SUBROUTINE Angles_ExtrapInterp2_R4(Angle1, Angle2, Angle3, tin, Angle_out, tin_out )
@@ -7531,6 +7620,7 @@ end function Rad2M180to180Deg
    END SUBROUTINE Angles_ExtrapInterp2_R8
 !=======================================================================  
    !< This routine extrapolates or interpolates between angles
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE Angles_ExtrapInterp2_R16(Angle1, Angle2, Angle3, tin, Angle_out, tin_out )
        REAL(QuKi),          INTENT(IN   )  :: Angle1 !< Angle at t1 > t2 > t3
        REAL(QuKi),          INTENT(IN   )  :: Angle2 !< Angle at t2 > t3
@@ -7591,6 +7681,7 @@ end function Rad2M180to180Deg
 !      call MPi2Pi(Angle_out)
       
    END SUBROUTINE Angles_ExtrapInterp2_R16
+#endif
 !=======================================================================  
    !< This routine extrapolates or interpolates between angles
    SUBROUTINE Angles_ExtrapInterp2_R4R(Angle1, Angle2, Angle3, tin, Angle_out, tin_out )
@@ -7718,6 +7809,7 @@ end function Rad2M180to180Deg
    END SUBROUTINE Angles_ExtrapInterp2_R8R
 !=======================================================================  
    !< This routine extrapolates or interpolates between angles
+#ifdef OPENFAST_DOUBLE_PRECISION
    SUBROUTINE Angles_ExtrapInterp2_R16R(Angle1, Angle2, Angle3, tin, Angle_out, tin_out )
        REAL(QuKi),          INTENT(IN   )  :: Angle1 !< Angle at t1 > t2 > t3
        REAL(QuKi),          INTENT(IN   )  :: Angle2 !< Angle at t2 > t3
@@ -7778,5 +7870,6 @@ end function Rad2M180to180Deg
 !      call MPi2Pi(Angle_out)
       
    END SUBROUTINE Angles_ExtrapInterp2_R16R
+#endif
 !=======================================================================  
 END MODULE NWTC_Num

--- a/modules/nwtc-library/src/NWTC_RandomNumber.f90
+++ b/modules/nwtc-library/src/NWTC_RandomNumber.f90
@@ -35,7 +35,9 @@ INTEGER, PARAMETER        :: LuxLevel       = 3       ! Luxury Level for RanLux 
 INTERFACE UniformRandomNumbers
 MODULE PROCEDURE UniformRandomNumbersR4   ! 4-byte reals
 MODULE PROCEDURE UniformRandomNumbersR8   ! 8-byte reals
+#ifdef OPENFAST_DOUBLE_PRECISION
 MODULE PROCEDURE UniformRandomNumbersR16  ! 16-byte reals
+#endif
 END INTERFACE
 
 CONTAINS
@@ -161,6 +163,7 @@ SUBROUTINE UniformRandomNumbersR8( pRNG_Type, RandomNumbers )
 END SUBROUTINE UniformRandomNumbersR8
 !=======================================================================
 !> \copydoc nwtc_randomnumber::uniformrandomnumbersr4
+#ifdef OPENFAST_DOUBLE_PRECISION
 SUBROUTINE UniformRandomNumbersR16( pRNG_Type, RandomNumbers )
 
    IMPLICIT NONE
@@ -186,5 +189,6 @@ SUBROUTINE UniformRandomNumbersR16( pRNG_Type, RandomNumbers )
    END IF
 
 END SUBROUTINE UniformRandomNumbersR16
+#endif
 
 END MODULE

--- a/modules/nwtc-library/src/SingPrec.f90
+++ b/modules/nwtc-library/src/SingPrec.f90
@@ -40,11 +40,15 @@ INTEGER, PARAMETER              :: B4Ki     = SELECTED_INT_KIND(  9 )           
 INTEGER, PARAMETER              :: B8Ki     = SELECTED_INT_KIND( 18 )           !< Kind for eight-byte whole numbers
 
 #ifdef HAS_FORTRAN2008_FEATURES
+#ifdef OPENFAST_DOUBLE_PRECISION
 INTEGER, PARAMETER              :: QuKi     = real128    !< Kind for 16-byte, floating-point numbers
+#endif
 INTEGER, PARAMETER              :: R8Ki     = real64     !< Kind for eight-byte floating-point numbers
 INTEGER, PARAMETER              :: SiKi     = real32     !< Kind for four-byte, floating-point numbers
 #else
+#ifdef OPENFAST_DOUBLE_PRECISION
 INTEGER, PARAMETER              :: QuKi     = SELECTED_REAL_KIND( 20, 500 )     !< Kind for 16-byte, floating-point numbers
+#endif
 INTEGER, PARAMETER              :: R8Ki     = SELECTED_REAL_KIND( 14, 300 )     !< Kind for eight-byte floating-point numbers
 INTEGER, PARAMETER              :: SiKi     = SELECTED_REAL_KIND(  6,  30 )     !< Kind for four-byte, floating-point numbers
 #endif
@@ -60,7 +64,7 @@ INTEGER, PARAMETER              :: BYTES_IN_QuKi = 16                           
 INTEGER, PARAMETER              :: IntKi          = B4Ki                        !< Default kind for integers
 INTEGER, PARAMETER              :: BYTES_IN_INT   = 4                           !< Number of bytes per IntKi number    - use SIZEOF()
 
-#if !defined (DOUBLE_PRECISION) && !defined (OPENFAST_DOUBLE_PRECISION)
+#ifndef OPENFAST_DOUBLE_PRECISION
 INTEGER, PARAMETER              :: ReKi           = SiKi                        !< Default kind for floating-point numbers
 INTEGER, PARAMETER              :: DbKi           = R8Ki                        !< Default kind for double floating-point numbers
                                                   

--- a/modules/nwtc-library/src/SysGnuLinux.f90
+++ b/modules/nwtc-library/src/SysGnuLinux.f90
@@ -47,14 +47,18 @@ MODULE SysSubs
    INTERFACE NWTC_ERF ! Returns the ERF value of its argument
       MODULE PROCEDURE NWTC_ERFR4
       MODULE PROCEDURE NWTC_ERFR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE NWTC_ERFR16
+#endif
    END INTERFACE
 
    INTERFACE NWTC_gamma ! Returns the gamma value of its argument
          ! note: gamma is part of the F08 standard, but may not be implemented everywhere...
       MODULE PROCEDURE NWTC_gammaR4
       MODULE PROCEDURE NWTC_gammaR8
+#ifdef OPENFAST_DOUBLE_PRECISION
       MODULE PROCEDURE NWTC_gammaR16
+#endif
    END INTERFACE
 
    INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
@@ -131,6 +135,7 @@ FUNCTION NWTC_ERFR8( x )
 
 END FUNCTION NWTC_ERFR8
 !=======================================================================
+#ifdef OPENFAST_DOUBLE_PRECISION
 FUNCTION NWTC_ERFR16( x )
 
    ! Returns the ERF value of its argument. The result has a value equal  
@@ -142,6 +147,7 @@ FUNCTION NWTC_ERFR16( x )
    NWTC_ERFR16 = ERF( x )
 
 END FUNCTION NWTC_ERFR16
+#endif
 !=======================================================================
 FUNCTION NWTC_GammaR4( x )
 
@@ -167,6 +173,7 @@ FUNCTION NWTC_GammaR8( x )
 
 END FUNCTION NWTC_GammaR8
 !=======================================================================
+#ifdef OPENFAST_DOUBLE_PRECISION
 FUNCTION NWTC_GammaR16( x )
 
    ! Returns the gamma value of its argument. The result has a value equal  
@@ -178,6 +185,7 @@ FUNCTION NWTC_GammaR16( x )
    NWTC_GammaR16 = gamma( x )
 
 END FUNCTION NWTC_GammaR16
+#endif
 !=======================================================================
 SUBROUTINE FlushOut ( Unit )
 

--- a/modules/nwtc-library/src/YAML.f90
+++ b/modules/nwtc-library/src/YAML.f90
@@ -18,7 +18,10 @@
 !
 !**********************************************************************************************************************************
 module YAML
-   use Precision, only: IntKi, SiKi, R8Ki, QuKi
+   use Precision, only: IntKi, SiKi, R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
+   use Precision, only: QuKi
+#endif
    use NWTC_Base, only: ErrID_None, ErrID_Fatal
    use NWTC_IO, only: num2lstr
 
@@ -34,8 +37,10 @@ module YAML
       module procedure yaml_write_array1R8  ! Single dimension array (Ary) of R8Ki
       module procedure yaml_write_array2R8  ! Two dimension array of R8Ki
       module procedure yaml_write_array2I   ! Two dimension array of IntKi
+#ifdef OPENFAST_DOUBLE_PRECISION
       module procedure yaml_write_array1R16 ! Single dimension array (Ary) of QuKi
       module procedure yaml_write_array2R16 ! Two dimension array of QuKi
+#endif
    end interface
 
    !> Write list to file
@@ -43,7 +48,9 @@ module YAML
       module procedure yaml_write_listI   ! Single dimension array (Ary) of IntKi
       module procedure yaml_write_listR4  ! Single dimension array (Ary) of SiKi
       module procedure yaml_write_listR8  ! Single dimension array (Ary) of R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
       module procedure yaml_write_listR16 ! Single dimension array (Ary) of QuKi
+#endif
    end interface
    
    !> Write variable to file
@@ -52,7 +59,9 @@ module YAML
       module procedure yaml_write_varI   ! IntKi
       module procedure yaml_write_varR4  ! SiKi
       module procedure yaml_write_varR8  ! R8Ki
+#ifdef OPENFAST_DOUBLE_PRECISION
       module procedure yaml_write_varR16 ! QuKi
+#endif
    end interface
    private
 
@@ -189,6 +198,7 @@ subroutine yaml_write_varR8(fid, key, val, VarFmt, ErrStat, ErrMsg, level, comme
    endif
 end subroutine yaml_write_varR8
 
+#ifdef OPENFAST_DOUBLE_PRECISION
 subroutine yaml_write_varR16(fid, key, val, VarFmt, ErrStat, ErrMsg, level, comment)
    integer(IntKi),             intent(in   ) :: fid     !< File Unit
    character(len=*),           intent(in   ) :: key     !< Variable name
@@ -215,7 +225,7 @@ subroutine yaml_write_varR16(fid, key, val, VarFmt, ErrStat, ErrMsg, level, comm
       ErrMsg  = 'Error writing variable '//trim(key)//' to YAML file'
    endif
 end subroutine yaml_write_varR16
-
+#endif
 
 
 ! --------------------------------------------------------------------------------}
@@ -347,6 +357,7 @@ subroutine yaml_write_listR8(fid, key, A, VarFmt, ErrStat, ErrMsg, level, commen
    end if
 end subroutine yaml_write_listR8
 
+#ifdef OPENFAST_DOUBLE_PRECISION
 subroutine yaml_write_listR16(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comment)
    integer(IntKi),             intent(in   ) :: fid     !< File Unit
    character(len=*),           intent(in   ) :: key     !< list name
@@ -388,6 +399,7 @@ subroutine yaml_write_listR16(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comme
       ErrMsg  = 'Error writing list '//trim(key)//' to YAML file'
    end if
 end subroutine yaml_write_listR16
+#endif
 
 ! --------------------------------------------------------------------------------
 ! --- Write 1D array
@@ -506,6 +518,7 @@ subroutine yaml_write_array1R8(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    end if
 end subroutine yaml_write_array1R8
 
+#ifdef OPENFAST_DOUBLE_PRECISION
 subroutine yaml_write_array1R16(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comment)
    integer(IntKi),             intent(in   ) :: fid     !< File Unit
    character(len=*),           intent(in   ) :: key     !< Array name
@@ -543,7 +556,7 @@ subroutine yaml_write_array1R16(fid, key, A, VarFmt, ErrStat, ErrMsg, level, com
       ErrMsg  = 'Error writing array '//trim(key)//' to YAML file'
    end if
 end subroutine yaml_write_array1R16
-
+#endif
 
 
 ! --------------------------------------------------------------------------------}
@@ -718,6 +731,7 @@ subroutine yaml_write_array2R8(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    end if
 end subroutine yaml_write_array2R8
 
+#ifdef OPENFAST_DOUBLE_PRECISION
 subroutine yaml_write_array2R16(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comment, AllFmt)
    integer(IntKi),             intent(in   ) :: fid     !< File Unit
    character(len=*),           intent(in   ) :: key     !< Array name
@@ -770,6 +784,6 @@ subroutine yaml_write_array2R16(fid, key, A, VarFmt, ErrStat, ErrMsg, level, com
       ErrMsg  = 'Error writing array '//trim(key)//' to YAML file'
    end if
 end subroutine yaml_write_array2R16
-
+#endif
 
 end module YAML


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
This pull request is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
The Flang Fortran compiler used in ROCm does not support the quadruple precision real128 kind. There is a potential for this kind to be removed from the compiler in the future, at which point OpenFAST will fail to build. To prevent this from becoming an issue, this pull request places all uses of QuKi and its associated routines behind `#ifdef OPENFAST_DOUBLE_PRECISION` so compiling with `DOUBLE_PRECISION=OFF` in CMake doesn't use this kind.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
- SingPrec.f90
- NWTC_Num.f90
- NWTC_IO.f90
- YAML.f90
- JSON.f90
- SysGnuLinux.f90

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
This commit does not change the regression test results.

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
