### PR TITLE
BeamDyn driver visualization, and bugfix

### DIFF
--- a/modules/beamdyn/src/Driver_Beam.f90
+++ b/modules/beamdyn/src/Driver_Beam.f90
@@ -100,7 +100,7 @@ PROGRAM BeamDyn_Driver_Program
       ! initialize the BD_InitInput values not in the driver input file
    BD_InitInput%RootName = TRIM(BD_Initinput%InputFile)
    BD_InitInput%RootName = TRIM(RootName)//'.BD'
-   BD_InitInput%RootDisp = 0.d0
+   BD_InitInput%RootDisp = MATMUL(BD_InitInput%GlbPos(:),DvrData%RootRelInit) - BD_InitInput%GlbPos(:)
    BD_InitInput%DynamicSolve = DvrData%DynamicSolve      ! QuasiStatic options handled within the BD code.
 
    t_global = DvrData%t_initial

--- a/modules/beamdyn/src/Driver_Beam.f90
+++ b/modules/beamdyn/src/Driver_Beam.f90
@@ -161,9 +161,17 @@ PROGRAM BeamDyn_Driver_Program
       ! Write VTK reference if requested (ref is (0,0,0)
    if (DvrData%WrVTK > 0) then
       call SetVTKvars()
-      call MeshWrVTKreference( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Output%BldMotion,   trim(DvrData%VTK_OutFileRoot)//'BldMotion', ErrStat, ErrMsg );  call CheckError()
-      call MeshWrVTKreference( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%PointLoad, trim(DvrData%VTK_OutFileRoot)//'PointLoad', ErrStat, ErrMsg );  call CheckError()
-      call MeshWrVTKreference( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%DistrLoad, trim(DvrData%VTK_OutFileRoot)//'DistrLoad', ErrStat, ErrMsg );  call CheckError()
+      call MeshWrVTKreference( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Output%BldMotion,   trim(DvrData%VTK_OutFileRoot)//'_BldMotion', ErrStat, ErrMsg );  call CheckError()
+      call MeshWrVTKreference( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%PointLoad, trim(DvrData%VTK_OutFileRoot)//'_PointLoad', ErrStat, ErrMsg );  call CheckError()
+      call MeshWrVTKreference( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%DistrLoad, trim(DvrData%VTK_OutFileRoot)//'_DistrLoad', ErrStat, ErrMsg );  call CheckError()
+   endif
+      ! Write VTK reference if requested (ref is (0,0,0)
+   if (DvrData%WrVTK == 2) then
+      n_t_vtk = 0
+      call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Output%BldMotion,   trim(DvrData%VTK_OutFileRoot)//'_BldMotion',  n_t_vtk, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
+      call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%PointLoad, trim(DvrData%VTK_OutFileRoot)//'_PointLoad',  n_t_vtk, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
+      call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%DistrLoad, trim(DvrData%VTK_OutFileRoot)//'_DistrLoad',  n_t_vtk, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
+      call CheckError()
    endif
 
 
@@ -219,9 +227,10 @@ PROGRAM BeamDyn_Driver_Program
          ! Write VTK reference if requested (ref is (0,0,0)
       if (DvrData%WrVTK == 2) then
          if ( MOD( n_t_global, DvrData%n_VTKTime ) == 0 ) then
-            call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Output%BldMotion,   trim(DvrData%VTK_OutFileRoot)//'BldMotion', n_t_global, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
-            call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%PointLoad, trim(DvrData%VTK_OutFileRoot)//'PointLoad', n_t_global, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
-            call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%DistrLoad, trim(DvrData%VTK_OutFileRoot)//'DistrLoad', n_t_global, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
+            n_t_vtk = n_t_vtk + 1
+            call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Output%BldMotion,   trim(DvrData%VTK_OutFileRoot)//'_BldMotion', n_t_vtk, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
+            call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%PointLoad, trim(DvrData%VTK_OutFileRoot)//'_PointLoad', n_t_vtk, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
+            call MeshWrVTK( (/0.0_SiKi, 0.0_SiKi, 0.0_SiKi /), BD_Input(1)%DistrLoad, trim(DvrData%VTK_OutFileRoot)//'_DistrLoad', n_t_vtk, .true., ErrStat, ErrMsg, DvrData%VTK_tWidth )
             call CheckError()
          endif
       endif


### PR DESCRIPTION
This PR is ready to merge.

**Feature or improvement description**

- Added VTK outputs from the driver to simplify checking of BD driver results.
- Fixed bug in driver where the `TranslationDisp` was not set during initialization.  This caused the blade root to "jump" at the first timestep if the `GlbRotBladeT0` is set to `F` with a non-identity DCM and a non-zero`GlbPos` vector.  This required really tiny timesteps and led to huge transients.

**Related issue, if one exists**
None.

**Impacted areas of the software**
BeamDyn driver only.  This does not affect anything in the coupling to OF.

**Additional supporting information**
Visualization of blade set to 90 degrees azimuth.  Before the fix of the `TranslationDisp` bug, initialization started with the root at the reference location:
![bd_5MW_dynamic_gravity_Az90--T0](https://user-images.githubusercontent.com/2745453/222255302-6be054ba-374e-43f4-857b-db9dd5b33ad9.png)

After first timestep; note the huge shape change as a result of the sudden jump of the root from (0,0,10) to (0,-10,0):
![bd_5MW_dynamic_gravity_Az90--T1](https://user-images.githubusercontent.com/2745453/222255465-dbcb50f6-28ef-4907-8fef-01794f582896.png)

**Test results, if applicable**
The GlbRotBladeT0 flag in the  bd_5MW_dynamic_gravity_Az90 test case is now set to `False` to test the `TranslationDisp` bug.  The test result is identical to before (as is expected).