### PR TITLE
hd: fix NBody>1 & NBodyMod=1 WAMIT2 bug

### DIFF
--- a/modules/hydrodyn/src/WAMIT2.f90
+++ b/modules/hydrodyn/src/WAMIT2.f90
@@ -729,7 +729,7 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
 
          !----------------------------------------------------------------------
          !> 6. Set zero values for unused outputs.  This is mostly so that the
-         !!    compiler does not complain.
+         !!    compiler does not complain.  Also set misc vars
          !----------------------------------------------------------------------
       x%DummyContState           = 0.0_SiKi
       xd%DummyDiscState          = 0.0_SiKi
@@ -737,6 +737,8 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
       CALL AllocAry( m%LastIndWave, p%NBody, 'm%LastIndWave', ErrStatTmp, ErrMsgTmp)
       CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName)
       m%LastIndWave              = 1_IntKi
+      call AllocAry(m%F_Waves2, 6*p%NBody, 'm%F_Waves2', ErrStatTmp, ErrMsgTmp)
+      CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName)
 
       OtherState%DummyOtherState = 0
 
@@ -4024,7 +4026,7 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
 
          ! Now that we know how many frequencies and wave directions there are, we can allocate the array
          ! for saving the sorted data.
-      ALLOCATE( Data3D%DataSet( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6 ),  STAT=ErrStatTmp )
+      ALLOCATE( Data3D%DataSet( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6*Data3D%NumBodies ),  STAT=ErrStatTmp )
       IF (ErrStatTmp /= 0) CALL SetErrStat(ErrID_Fatal,'Cannot allocate array Data3D%DataSet to store '// &
                               'the sorted 3D 2nd order WAMIT data.',  ErrStat,ErrMsg,RoutineName)
       IF ( ErrStat >= AbortErrLev ) THEN
@@ -4038,7 +4040,7 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
       ENDIF
 
          ! Allocate the logical array for storing the mask for which points are valid. Set to .FALSE.
-      ALLOCATE( Data3D%DataMask( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6 ),  STAT=ErrStatTmp )
+      ALLOCATE( Data3D%DataMask( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6*Data3D%NumBodies ),  STAT=ErrStatTmp )
       IF (ErrStatTmp /= 0) CALL SetErrStat(ErrID_Fatal,'Cannot allocate array Data3D%DataMask to store '// &
                               'the sorted 3D 2nd order WAMIT data.',  ErrStat,ErrMsg,RoutineName)
       IF ( ErrStat >= AbortErrLev ) THEN
@@ -4130,6 +4132,21 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
 
             ! Find which force component this belongs to
          TmpCoord(4) = NINT(RawData3D(I,4))
+            ! Check that it is a valid force component
+         if (TmpCoord(4) < 1 .or. TmpCoord(4) > 6*Data3D%NumBodies) then
+            CALL SetErrStat( ErrID_Fatal, ' Line '//TRIM(Num2Lstr(NumHeaderLines+I))//' of '//TRIM(Filename3D)// &
+                           ' contains force component '//TRIM(Num2LStr(TmpCoord(4)))//' which is outside the expected force '// &
+                           ' range of 1 to '//TRIM(Num2Lstr(6*Data3D%NumBodies))//' for a '//TRIM(Num2LStr(Data3D%NumBodies))// &
+                           ' body system.', ErrStat, ErrMsg, RoutineName)
+            IF (ALLOCATED(RawData3D))        DEALLOCATE(RawData3D,STAT=ErrStatTmp)
+            IF (ALLOCATED(RawData3DTmp))     DEALLOCATE(RawData3DTmp,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpRealArr))       DEALLOCATE(TmpRealArr,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpDataRow))       DEALLOCATE(TmpDataRow,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpWvFreq1))       DEALLOCATE(TmpWvFreq1,STAT=ErrStatTmp)
+            CALL CleanUp
+            RETURN
+         endif
+
 
 
             !> The data from the WAMIT file is non-dimensional, so we need to dimensionalize it here.  This
@@ -4164,7 +4181,8 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
                                     REAL(InitInp%RhoXg * InitInp%WAMITULEN**K * RawData3D(I,8)               ,SiKi)) ) THEN
                CALL SetErrStat( ErrID_Fatal, ' Line '//TRIM(Num2Lstr(NumHeaderLines+I))//' of '//TRIM(Filename3D)// &
                         ' contains different values for the real and imaginary part (columns 7 and 8) than was '// &
-                        'given earlier in the file for the same values of wave frequency and wave direction.', &
+                        'given earlier in the file for the same values of wave frequency and wave direction '// &
+                        '(force dimension = '//TRIM(Num2LStr(TmpCoord(4)))//').', &
                         ErrStat, ErrMsg, RoutineName )
                IF (ALLOCATED(TmpRealArr))       DEALLOCATE(TmpRealArr,STAT=ErrStatTmp)
                IF (ALLOCATED(RawData3D))        DEALLOCATE(RawData3D,STAT=ErrStatTmp)
@@ -4860,7 +4878,7 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
 
          ! Now that we know how many frequencies and wave directions there are, we can allocate the array
          ! for saving the sorted data.
-      ALLOCATE( Data4D%DataSet( Data4D%NumWvFreq1, Data4D%NumWvFreq2, Data4D%NumWvDir1, Data4D%NumWvDir2, 6 ),  STAT=ErrStatTmp )
+      ALLOCATE( Data4D%DataSet( Data4D%NumWvFreq1, Data4D%NumWvFreq2, Data4D%NumWvDir1, Data4D%NumWvDir2, 6*Data4D%NumBodies ),  STAT=ErrStatTmp )
       IF (ErrStatTmp /= 0) CALL SetErrStat(ErrID_Fatal,'Cannot allocate array Data4D%DataSet to store '// &
                               'the sorted 4D 2nd order WAMIT data.',  ErrStat,ErrMsg,RoutineName)
       IF ( ErrStat >= AbortErrLev ) THEN
@@ -4875,7 +4893,7 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
       ENDIF
 
          ! Allocate the logical array for storing the mask for which points are valid. Set to .FALSE.
-      ALLOCATE( Data4D%DataMask( Data4D%NumWvFreq1, Data4D%NumWvFreq2, Data4D%NumWvDir1, Data4D%NumWvDir2, 6 ),  STAT=ErrStatTmp )
+      ALLOCATE( Data4D%DataMask( Data4D%NumWvFreq1, Data4D%NumWvFreq2, Data4D%NumWvDir1, Data4D%NumWvDir2, 6*Data4D%NumBodies ),  STAT=ErrStatTmp )
       IF (ErrStatTmp /= 0) CALL SetErrStat(ErrID_Fatal,'Cannot allocate array Data4D%DataMask to store '// &
                               'the sorted 4D 2nd order WAMIT data.',  ErrStat,ErrMsg,RoutineName)
       IF ( ErrStat >= AbortErrLev ) THEN
@@ -4988,6 +5006,21 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
 
             ! Find which force component this belongs to
          TmpCoord(5) = NINT(RawData4D(I,5))
+            ! Check that it is a valid force component
+         if (TmpCoord(5) < 1 .or. TmpCoord(5) > 6*Data4D%NumBodies) then
+            CALL SetErrStat( ErrID_Fatal, ' Line '//TRIM(Num2Lstr(NumHeaderLines+I))//' of '//TRIM(Filename4D)// &
+                           ' contains force component '//TRIM(Num2LStr(TmpCoord(5)))//' which is outside the expected force '// &
+                           ' range of 1 to '//TRIM(Num2Lstr(6*Data4D%NumBodies))//' for a '//TRIM(Num2LStr(Data4D%NumBodies))// &
+                           ' body system.', ErrStat, ErrMsg, RoutineName)
+            IF (ALLOCATED(RawData4D))        DEALLOCATE(RawData4D,STAT=ErrStatTmp)
+            IF (ALLOCATED(RawData4DTmp))     DEALLOCATE(RawData4DTmp,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpRealArr))       DEALLOCATE(TmpRealArr,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpDataRow))       DEALLOCATE(TmpDataRow,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpWvFreq1))       DEALLOCATE(TmpWvFreq1,STAT=ErrStatTmp)
+            IF (ALLOCATED(TmpWvFreq2))       DEALLOCATE(TmpWvFreq2,STAT=ErrStatTmp)
+            CALL CleanUp
+            RETURN
+         endif
 
 
             !> The data from the WAMIT file is non-dimensional, so we need to dimensionalize it here.  This
@@ -5022,7 +5055,8 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
                                      REAL(InitInp%RhoXg * InitInp%WAMITULEN**K * RawData4D(I,9)                            ,SiKi))) THEN
                CALL SetErrStat( ErrID_Fatal, ' Line '//TRIM(Num2Lstr(NumHeaderLines+I))//' of '//TRIM(Filename4D)// &
                         ' contains different values for the real and imaginary part (columns 8 and 9) than was '// &
-                        'given earlier in the file for the same values of wave frequency and wave direction.', &
+                        'given earlier in the file for the same values of wave frequency and wave direction '// &
+                        '(force dimension = '//TRIM(Num2LStr(TmpCoord(5)))//').', &
                         ErrStat, ErrMsg, RoutineName )
                IF (ALLOCATED(RawData4D))        DEALLOCATE(RawData4D,STAT=ErrStatTmp)
                IF (ALLOCATED(RawData4DTmp))     DEALLOCATE(RawData4DTmp,STAT=ErrStatTmp)
@@ -6014,10 +6048,10 @@ SUBROUTINE Copy_InitData4Dto3D( Data4D, Data3D, ErrStat, ErrMsg )
 
 
       ! Now allocate the storage arrays
-   ALLOCATE( Data3D%DataSet( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6 ),  STAT=ErrStatTmp )
+   ALLOCATE( Data3D%DataSet( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6*Data3D%NumBodies ),  STAT=ErrStatTmp )
    IF (ErrStatTmp /= 0) CALL SetErrStat(ErrID_Fatal,'Cannot allocate array Data3D%DataSet to store '// &
                            'the 3D 2nd order WAMIT data.',  ErrStat,ErrMsg,RoutineName)
-   ALLOCATE( Data3D%DataMask( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6 ),  STAT=ErrStatTmp )
+   ALLOCATE( Data3D%DataMask( Data3D%NumWvFreq1, Data3D%NumWvDir1, Data3D%NumWvDir2, 6*Data3D%NumBodies ),  STAT=ErrStatTmp )
    IF (ErrStatTmp /= 0) CALL SetErrStat(ErrID_Fatal,'Cannot allocate array Data3D%DataMask to store '// &
                            'the information on the 3D 2nd order WAMIT data.',  ErrStat,ErrMsg,RoutineName)
    CALL AllocAry( Data3D%WvFreq1, Data3D%NumWvFreq1, 'Data3D WvFreq array', ErrStatTmp, ErrMsgTmp )

--- a/modules/hydrodyn/src/WAMIT2.txt
+++ b/modules/hydrodyn/src/WAMIT2.txt
@@ -89,7 +89,7 @@ typedef   ^                OtherStateType      IntKi                 DummyOtherS
 # Define any data that are used only for efficiency purposes (these variables are not associated with time):
 #   e.g. indices for searching in an array, large arrays that are local variables in any routine called multiple times, etc.
 typedef     ^                 MiscVarType       INTEGER              LastIndWave       :        -        -        "Index for last interpolation step of 2nd order forces"   -
-typedef     ^                 ^                 ReKi                 F_Waves2          {6}      -        -        "2nd order force from this timestep"   -
+typedef     ^                 ^                 ReKi                 F_Waves2          {:}      -        -        "2nd order force from this timestep"   -
 
 
 

--- a/modules/hydrodyn/src/WAMIT2_Types.f90
+++ b/modules/hydrodyn/src/WAMIT2_Types.f90
@@ -105,7 +105,7 @@ IMPLICIT NONE
 ! =========  WAMIT2_MiscVarType  =======
   TYPE, PUBLIC :: WAMIT2_MiscVarType
     INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: LastIndWave      !< Index for last interpolation step of 2nd order forces [-]
-    REAL(ReKi) , DIMENSION(1:6)  :: F_Waves2      !< 2nd order force from this timestep [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: F_Waves2      !< 2nd order force from this timestep [-]
   END TYPE WAMIT2_MiscVarType
 ! =======================
 ! =========  WAMIT2_ParameterType  =======
@@ -1570,7 +1570,18 @@ IF (ALLOCATED(SrcMiscData%LastIndWave)) THEN
   END IF
     DstMiscData%LastIndWave = SrcMiscData%LastIndWave
 ENDIF
+IF (ALLOCATED(SrcMiscData%F_Waves2)) THEN
+  i1_l = LBOUND(SrcMiscData%F_Waves2,1)
+  i1_u = UBOUND(SrcMiscData%F_Waves2,1)
+  IF (.NOT. ALLOCATED(DstMiscData%F_Waves2)) THEN 
+    ALLOCATE(DstMiscData%F_Waves2(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%F_Waves2.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
     DstMiscData%F_Waves2 = SrcMiscData%F_Waves2
+ENDIF
  END SUBROUTINE WAMIT2_CopyMisc
 
  SUBROUTINE WAMIT2_DestroyMisc( MiscData, ErrStat, ErrMsg, DEALLOCATEpointers )
@@ -1596,6 +1607,9 @@ ENDIF
   
 IF (ALLOCATED(MiscData%LastIndWave)) THEN
   DEALLOCATE(MiscData%LastIndWave)
+ENDIF
+IF (ALLOCATED(MiscData%F_Waves2)) THEN
+  DEALLOCATE(MiscData%F_Waves2)
 ENDIF
  END SUBROUTINE WAMIT2_DestroyMisc
 
@@ -1639,7 +1653,11 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*1  ! LastIndWave upper/lower bounds for each dimension
       Int_BufSz  = Int_BufSz  + SIZE(InData%LastIndWave)  ! LastIndWave
   END IF
+  Int_BufSz   = Int_BufSz   + 1     ! F_Waves2 allocated yes/no
+  IF ( ALLOCATED(InData%F_Waves2) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! F_Waves2 upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%F_Waves2)  ! F_Waves2
+  END IF
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -1682,10 +1700,21 @@ ENDIF
         Int_Xferred = Int_Xferred + 1
       END DO
   END IF
-    DO i1 = LBOUND(InData%F_Waves2,1), UBOUND(InData%F_Waves2,1)
-      ReKiBuf(Re_Xferred) = InData%F_Waves2(i1)
-      Re_Xferred = Re_Xferred + 1
-    END DO
+  IF ( .NOT. ALLOCATED(InData%F_Waves2) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%F_Waves2,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%F_Waves2,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%F_Waves2,1), UBOUND(InData%F_Waves2,1)
+        ReKiBuf(Re_Xferred) = InData%F_Waves2(i1)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
  END SUBROUTINE WAMIT2_PackMisc
 
  SUBROUTINE WAMIT2_UnPackMisc( ReKiBuf, DbKiBuf, IntKiBuf, Outdata, ErrStat, ErrMsg )
@@ -1733,12 +1762,24 @@ ENDIF
         Int_Xferred = Int_Xferred + 1
       END DO
   END IF
-    i1_l = LBOUND(OutData%F_Waves2,1)
-    i1_u = UBOUND(OutData%F_Waves2,1)
-    DO i1 = LBOUND(OutData%F_Waves2,1), UBOUND(OutData%F_Waves2,1)
-      OutData%F_Waves2(i1) = ReKiBuf(Re_Xferred)
-      Re_Xferred = Re_Xferred + 1
-    END DO
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! F_Waves2 not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%F_Waves2)) DEALLOCATE(OutData%F_Waves2)
+    ALLOCATE(OutData%F_Waves2(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%F_Waves2.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%F_Waves2,1), UBOUND(OutData%F_Waves2,1)
+        OutData%F_Waves2(i1) = ReKiBuf(Re_Xferred)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
  END SUBROUTINE WAMIT2_UnPackMisc
 
  SUBROUTINE WAMIT2_CopyParam( SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg )


### PR DESCRIPTION
This is ready for merging.

**Feature or improvement description**
An outside user reported issues with a multibody potential flow HydroDyn model with a .12d input file.  We traced this to some arrays in WAMIT2 were not initialized to the correct dimensions for multiple WAMIT bodies in the second order files.

**Related issue, if one exists**
None

**Impacted areas of the software**
HydroDyn 2nd order potential flow only (WAMIT2)

**Additional supporting information**
This bug was introduced in v2.5.0 when flexible multibody hydrodynamics was introduced.

**Test results, if applicable**
We have no publicly sharable models available that demonstrate this issue.