### PR TITLE
Bug/bd conv

### DIFF
--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -5438,6 +5438,10 @@ SUBROUTINE BD_InitAcc( u, p, x, m, qdotdot, ErrStat, ErrMsg )
       ! Calculate Quadrature point values needed
    CALL BD_QuadraturePointData( p, x, m )     ! Calculate QP values uuu, uup, RR0, kappa, E1
 
+      ! Reset QP values
+   CALL BD_QPData_mEta_rho(p, m)
+   CALL BD_QPDataVelocity(p, x, m)
+
       ! set misc vars, particularly m%RHS
    CALL BD_CalcForceAcc( u, p, m, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -276,6 +276,7 @@ of_regression("5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti"  "openfast;elastodyn;aerod
 of_regression("5MW_OC3Spar_DLL_WTurb_WavesIrr"         "openfast;elastodyn;aerodyn15;servodyn;hydrodyn;map;offshore")
 of_regression("5MW_OC4Semi_WSt_WavesWN"                "openfast;elastodyn;aerodyn15;servodyn;hydrodyn;moordyn;offshore")
 of_regression("5MW_Land_BD_DLL_WTurb"                  "openfast;beamdyn;aerodyn15;servodyn")
+of_regression("5MW_Land_BD_Init"                       "openfast;beamdyn;aerodyn15;servodyn")
 of_regression("5MW_OC4Jckt_ExtPtfm"                    "openfast;elastodyn;extptfm")
 of_regression("HelicalWake_OLAF"                       "openfast;aerodyn15;olaf")
 of_regression("EllipticalWing_OLAF"                    "openfast;aerodyn15;olaf")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
This pull request is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
This pull request resolves an issue where the BeamDyn driver results were different from OpenFAST results. Specifically, OpenFAST failed to converge during initial correction steps whereas the driver succeeded because it didn't perform corrections. It was possible to make OpenFAST converge by specifying a smaller time step which is why the issue wasn't apparent. During the initial correction steps, the `MiscVars` variable `vvv` wasn't being reset between steps which caused velocity errors to accumulate and the solution to diverge. This was corrected by re-initializing `m%vvv` in `BD_InitAcc` which is only called during these initial correction steps.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
- BeamDyn
- Regression Tests: `5MW_Land_BD_DLL_WTurb`

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
The `5MW_Land_BD_DLL_WTurb` regression test results were updated because they were slightly different at the beginning of the simulation. A new test case, `5MW_Land_BD_Init` was added to demonstrate that the model converges at a larger time step. 

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
