### PR TITLE
hd: add NBodyMod regression tests

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -358,6 +358,10 @@ hd_regression("hd_5MW_OC3Spar_DLL_WTurb_WavesIrr"           "hydrodyn;offshore")
 hd_regression("hd_5MW_OC4Semi_WSt_WavesWN"                  "hydrodyn;offshore")
 hd_regression("hd_5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti"    "hydrodyn;offshore")
 hd_regression("hd_TaperCylinderPitchMoment"                 "hydrodyn;offshore")
+hd_regression("hd_NBodyMod1"                                "hydrodyn;offshore")
+hd_regression("hd_NBodyMod2"                                "hydrodyn;offshore")
+hd_regression("hd_NBodyMod3"                                "hydrodyn;offshore")
+
 
 # Py-HydroDyn regression tests
 py_hd_regression("py_hd_5MW_OC4Semi_WSt_WavesWN"            "hydrodyn;offshore;python")

--- a/reg_tests/executeHydrodynRegressionCase.py
+++ b/reg_tests/executeHydrodynRegressionCase.py
@@ -37,7 +37,7 @@ import pass_fail
 from errorPlotting import exportCaseSummary
 
 ##### Main program
-excludeExt=['.out','.outb','.ech','.yaml','.sum','.log']
+excludeExt=['.out','.outb','.ech','.yaml','.sum','.log','.rst']
 
 ### Store the python executable for future python calls
 pythonCommand = sys.executable
@@ -92,13 +92,7 @@ if not os.path.isdir(inputsDirectory):
 # create the local output directory if it does not already exist
 # and initialize it with input files for all test cases
 if not os.path.isdir(testBuildDirectory):
-    os.makedirs(testBuildDirectory)
-    for file in glob.glob(os.path.join(inputsDirectory,"hd_*inp")):
-        filename = file.split(os.path.sep)[-1]
-        shutil.copy(os.path.join(inputsDirectory,filename), os.path.join(testBuildDirectory,filename))
-    for file in glob.glob(os.path.join(inputsDirectory,"*dat")):
-        filename = file.split(os.path.sep)[-1]
-        shutil.copy(os.path.join(inputsDirectory,filename), os.path.join(testBuildDirectory,filename))
+    rtl.copyTree(inputsDirectory, testBuildDirectory, excludeExt=excludeExt)
 
 dirToCopy = os.path.join("glue-codes","openfast","5MW_Baseline","HydroData")
 buildDirectoryGlue = os.path.join(buildDirectory,os.pardir,os.pardir,dirToCopy)


### PR DESCRIPTION
This is ready for merging.

**Feature or improvement description**
Flexible platform capability was added to OpenFAST v2.6.0 in HydroDyn.  This included a new flag `NBodyMod` with three methods of handling multiple potential flow (WAMIT) bodies.  No test cases were added at that time.

This was a set of test cases developed by @mattEhall some time ago.

**Related issue, if one exists**
#1480 fixed a bug in `NBodyMod = 1`

**Impacted areas of the software**
Testing of HydroDyn `NBodyMod` options only

**Test results, if applicable**
New test cases have been added.  These are based on the OC4Semi test case, but treat the floating platform as 4 separate bodies (center column, and 3 corner columns):

- `NBodyMod1` -- a single set  of WAMIT files includes coupling terms between each body (PtfmRefxt/yt/zt/ztRot should match XBODY(1)/(2)/(3)/(4) in WAMIT and NBody should match NBODY in WAMIT)
- `NBodyMod2` -- 4 separate WAMIT bodies neglecting couplings between each body and NBODY=1 with XBODY=0 in WAMIT (PtfmRefxt/yt/zt/ztRot may differ from XBODY(1)/(2)/(3)/(4) in WAMIT)
- `NBodyMod3` -- 4 separate WAMIT bodies neglecting couplings between each body and NBODY=1 with XBODY=/0 in WAMIT (PtfmRefxt/yt/zt/ztRot should match XBODY(1)/(2)/(3)/(4) in WAMIT)
