### PR TITLE
Allow up to 99 output planes in FAST.Farm

### DIFF
--- a/docs/source/user/fast.farm/InputFiles.rst
+++ b/docs/source/user/fast.farm/InputFiles.rst
@@ -649,15 +649,14 @@ excluding its file extension, where *<n*\ :sub:`t`\ *>* and
 *<n*\ :sub:`low`\ *>* are as specified in
 :numref:`FF:Input:VTK`, but include leading zeros.
 
-For visualization, FAST.Farm can also output low-resolution disturbed
-(including wakes) wind data output files that are two-dimensional (2D)
-slices of the full low-resolution domain, specified by the following 7
-inputs. Up to nine 2D slices parallel to the *X-Y*, *Y-Z*, and/or *X-Z*
-planes can be output.
+For visualization, FAST.Farm can also output low-resolution disturbed (including
+wakes) wind data output files that are two-dimensional (2D) slices of the full
+low-resolution domain, specified by the following 7 inputs. Up to ninety-nine 2D
+slices parallel to the *X-Y*, *Y-Z*, and/or *X-Z* planes can be output.
 
 -  **NOutDisWindXY** [integer] specifies the number of 2D slices
    parallel to the *X-Y* plane where low-resolution disturbed wind data
-   output files are output (:math:`0` to :math:`9`).
+   output files are output (:math:`0` to :math:`99`).
 
 -  **OutDisWindZ** [m] is a list **NOutDisWindXY** values long of the
    *Z* coordinates of each plane that will be output. These values are
@@ -666,7 +665,7 @@ planes can be output.
 
 -  **NOutDisWindYZ** [integer] specifies the number of 2D slices
    parallel to the *Y-Z* plane where low-resolution disturbed wind data
-   output files are output (:math:`0` to :math:`9`).
+   output files are output (:math:`0` to :math:`99`).
 
 -  **OutDisWindX** [m] is a list **NOutDisWindYZ** values long of the
    *X* coordinates of each plane that will be output. These values are
@@ -675,7 +674,7 @@ planes can be output.
 
 -  **NOutDisWindXZ** [integer] specifies the number of 2D slices
    parallel to the *X-Z* plane where low-resolution disturbed wind data
-   output files are output (:math:`0` to :math:`9`).
+   output files are output (:math:`0` to :math:`99`).
 
 -  **OutDisWindY** [m] is a list **NOutDisWindXZ** values long of the
    *Y* coordinates of each plane that will be output. These values are

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -44,6 +44,7 @@ MODULE FAST_Farm_Subs
 
     
    integer, parameter :: maxOutputPoints = 9
+   integer, parameter :: maxOutputPlanes = 99      ! Allow up to 99 outpt planes
    
    CONTAINS
  
@@ -1139,7 +1140,7 @@ SUBROUTINE Farm_ReadPrimaryFile( InputFile, p, WD_InitInp, AWAE_InitInp, SC_Init
       end if
       
       ! NOutDisWindXY - Number of XY planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low.DisXY.<n_out>.t<n/n_low-out>.vtk (-) [0 to 9]:
-   CALL ReadVar( UnIn, InputFile, AWAE_InitInp%NOutDisWindXY, "NOutDisWindXY", "Number of XY planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low.DisXY.<n_out>.t<n/n_low-out>.vtk (-) [0 to 9]", ErrStat2, ErrMsg2, UnEc)
+   CALL ReadVar( UnIn, InputFile, AWAE_InitInp%NOutDisWindXY, "NOutDisWindXY", "Number of XY planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low.DisXY.<n_out>.t<n/n_low-out>.vtk (-) [0 to 99]", ErrStat2, ErrMsg2, UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       if ( ErrStat >= AbortErrLev ) then
          call cleanup()
@@ -1162,7 +1163,7 @@ SUBROUTINE Farm_ReadPrimaryFile( InputFile, p, WD_InitInp, AWAE_InitInp, SC_Init
       end if
       
       ! NOutDisWindYZ - Number of YZ planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low.DisYZ.<n_out>.t<n/n_low-out>.vtk (-) [0 to 9]:
-   CALL ReadVar( UnIn, InputFile, AWAE_InitInp%NOutDisWindYZ, "NOutDisWindYZ", "Number of YZ planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low.DisYZ.<n_out>.t<n/n_low-out>.vtk (-) [0 to 9]", ErrStat2, ErrMsg2, UnEc)
+   CALL ReadVar( UnIn, InputFile, AWAE_InitInp%NOutDisWindYZ, "NOutDisWindYZ", "Number of YZ planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low.DisYZ.<n_out>.t<n/n_low-out>.vtk (-) [0 to 99]", ErrStat2, ErrMsg2, UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       if ( ErrStat >= AbortErrLev ) then
          call cleanup()
@@ -1185,7 +1186,7 @@ SUBROUTINE Farm_ReadPrimaryFile( InputFile, p, WD_InitInp, AWAE_InitInp, SC_Init
       end if      
       
       ! NOutDisWindXZ - Number of XZ planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low/DisXZ.<n_out>.t<n/n_low-out>.vtk (-) [0 to 9]:
-   CALL ReadVar( UnIn, InputFile, AWAE_InitInp%NOutDisWindXZ, "NOutDisWindXZ", "Number of XZ planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low/DisXZ.<n_out>.t<n/n_low-out>.vtk (-) [0 to 9]", ErrStat2, ErrMsg2, UnEc)
+   CALL ReadVar( UnIn, InputFile, AWAE_InitInp%NOutDisWindXZ, "NOutDisWindXZ", "Number of XZ planes for output of disturbed wind data across the low-resolution domain to <OutFileRoot>.Low/DisXZ.<n_out>.t<n/n_low-out>.vtk (-) [0 to 99]", ErrStat2, ErrMsg2, UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       if ( ErrStat >= AbortErrLev ) then
          call cleanup()
@@ -1545,9 +1546,9 @@ SUBROUTINE Farm_ValidateInput( p, WD_InitInp, AWAE_InitInp, SC_InitInp, ErrStat,
    AWAE_InitInp%WrDisDT =  p%DT_low * n_disDT_dt
    
    
-   if (AWAE_InitInp%NOutDisWindXY < 0 .or. AWAE_InitInp%NOutDisWindXY > maxOutputPoints ) CALL SetErrStat( ErrID_Fatal, 'NOutDisWindXY must be in the range [0, 9].', ErrStat, ErrMsg, RoutineName )
-   if (AWAE_InitInp%NOutDisWindYZ < 0 .or. AWAE_InitInp%NOutDisWindYZ > maxOutputPoints ) CALL SetErrStat( ErrID_Fatal, 'NOutDisWindYZ must be in the range [0, 9].', ErrStat, ErrMsg, RoutineName )
-   if (AWAE_InitInp%NOutDisWindXZ < 0 .or. AWAE_InitInp%NOutDisWindXZ > maxOutputPoints ) CALL SetErrStat( ErrID_Fatal, 'NOutDisWindXZ must be in the range [0, 9].', ErrStat, ErrMsg, RoutineName )
+   if (AWAE_InitInp%NOutDisWindXY < 0 .or. AWAE_InitInp%NOutDisWindXY > maxOutputPlanes ) CALL SetErrStat( ErrID_Fatal, 'NOutDisWindXY must be in the range [0, 99].', ErrStat, ErrMsg, RoutineName )
+   if (AWAE_InitInp%NOutDisWindYZ < 0 .or. AWAE_InitInp%NOutDisWindYZ > maxOutputPlanes ) CALL SetErrStat( ErrID_Fatal, 'NOutDisWindYZ must be in the range [0, 99].', ErrStat, ErrMsg, RoutineName )
+   if (AWAE_InitInp%NOutDisWindXZ < 0 .or. AWAE_InitInp%NOutDisWindXZ > maxOutputPlanes ) CALL SetErrStat( ErrID_Fatal, 'NOutDisWindXZ must be in the range [0, 99].', ErrStat, ErrMsg, RoutineName )
    if (p%NOutDist < 0 .or. p%NOutDist > maxOutputPoints ) then
       CALL SetErrStat( ErrID_Fatal, 'NOutDist must be in the range [0, 9].', ErrStat, ErrMsg, RoutineName )
    else

--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1497,6 +1497,7 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
    character(ErrMsgLen)                         :: errMsg2
    character(*), parameter                      :: RoutineName = 'AWAE_CalcOutput'
    integer(intKi)                               :: n, n_high
+   character(2)                                 :: PlaneNumStr          ! 2 digit number of the output plane
    CHARACTER(1024)                              :: FileName
    INTEGER(IntKi)                               :: Un                   ! unit number of opened file
 
@@ -1534,10 +1535,10 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
 
          ! XY plane slices
       do k = 1,p%NOutDisWindXY
-
+         write(PlaneNumStr, '(i2.2)') k
          call ExtractSlice( XYSlice, p%OutDisWindZ(k), p%Z0_low, p%nZ_low, p%nX_low, p%nY_low, p%dZ_low, m%Vdist_low_full, m%outVizXYPlane(:,:,:,1))
             ! Create the output vtk file with naming <WindFilePath>/Low/DisXY<k>.t<n/p%WrDisSkp1>.vtk
-         FileName = trim(p%OutFileVTKRoot)//".Low.DisXY"//trim(num2lstr(k))//"."//trim(Tstr)//".vtk"
+         FileName = trim(p%OutFileVTKRoot)//".Low.DisXY"//PlaneNumStr//"."//trim(Tstr)//".vtk"
          call WrVTK_SP_header( FileName, "Low resolution, disturbed wind of XY Slice at time = "//trim(num2lstr(t))//" seconds.", Un, ErrStat2, ErrMsg2 )
             call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
             if (ErrStat >= AbortErrLev) return
@@ -1546,12 +1547,12 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
             if (ErrStat >= AbortErrLev) return
       end do
 
-
          ! YZ plane slices
       do k = 1,p%NOutDisWindYZ
+         write(PlaneNumStr, '(i2.2)') k
          call ExtractSlice( YZSlice, p%OutDisWindX(k), p%X0_low, p%nX_low, p%nY_low, p%nZ_low, p%dX_low, m%Vdist_low_full, m%outVizYZPlane(:,:,:,1))
             ! Create the output vtk file with naming <WindFilePath>/Low/DisYZ<k>.t<n/p%WrDisSkp1>.vtk
-         FileName = trim(p%OutFileVTKRoot)//".Low.DisYZ"//trim(num2lstr(k))//"."//trim(Tstr)//".vtk"
+         FileName = trim(p%OutFileVTKRoot)//".Low.DisYZ"//PlaneNumStr//"."//trim(Tstr)//".vtk"
          call WrVTK_SP_header( FileName, "Low resolution, disturbed wind of YZ Slice at time = "//trim(num2lstr(t))//" seconds.", Un, ErrStat2, ErrMsg2 )
             call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
             if (ErrStat >= AbortErrLev) return
@@ -1562,9 +1563,10 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
 
          ! XZ plane slices
       do k = 1,p%NOutDisWindXZ
+         write(PlaneNumStr, '(i2.2)') k
          call ExtractSlice( XZSlice, p%OutDisWindY(k), p%Y0_low, p%nY_low, p%nX_low, p%nZ_low, p%dY_low, m%Vdist_low_full, m%outVizXZPlane(:,:,:,1))
             ! Create the output vtk file with naming <WindFilePath>/Low/DisXZ<k>.t<n/p%WrDisSkp1>.vtk
-         FileName = trim(p%OutFileVTKRoot)//".Low.DisXZ"//trim(num2lstr(k))//"."//trim(Tstr)//".vtk"
+         FileName = trim(p%OutFileVTKRoot)//".Low.DisXZ"//PlaneNumStr//"."//trim(Tstr)//".vtk"
          call WrVTK_SP_header( FileName, "Low resolution, disturbed wind of XZ Slice at time = "//trim(num2lstr(t))//" seconds.", Un, ErrStat2, ErrMsg2 )
             call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
             if (ErrStat >= AbortErrLev) return


### PR DESCRIPTION
This PR is ready for merging

**Feature or improvement description**
Previously we only allowed 9 output planes from the low resolution domain in FAST.Farm.  Users typically want more planes than this, so they've had to rerun the simulation with a different output plane set to get more planes.  This was both time consuming and annoying.

This PR bumps that limit up to 99 planes.  If more are required, it would be relatively trivial to bump this limit up to 999 or more.

**Related issue, if one exists**
None.  Just user complaints directly to me.

**Impacted areas of the software**
FAST.Farm outputs only

**Additional supporting information**
See plot that @rthedin will add below.

**Test results, if applicable**
No test results are changed.  @rthedin is testing with a large turbine array and will report below if it works as expected.