### PR TITLE
AeroDyn: Improved coning and prebend modeling in future BEM 

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -284,7 +284,7 @@ subroutine AD_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitOut
       if (Failed()) return;
       NumBlades(iR)          = InitInp%rotors(iR)%NumBlades
       p%rotors(iR)%NumBlades = InitInp%rotors(iR)%NumBlades
-      AeroProjMod(iR)        = InitInp%rotors(iR)%AeroProjMod
+      AeroProjMod(iR)        = InitInp%rotors(iR)%AeroProjMod ! NOTE: we allow this to be overwritten
       if (nRotors > 1) then
          p%rotors(iR)%RootName  = TRIM(InitInp%RootName)//'.AD.R'//trim(num2lstr(iR))
       else
@@ -314,6 +314,21 @@ subroutine AD_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitOut
    CALL ParsePrimaryFileInfo( PriPath, InitInp, InitInp%InputFile, p%RootName, NumBlades, interval, FileInfo_In, InputFileData, UnEcho, ErrStat2, ErrMsg2 )
       if (Failed()) return;
 
+   ! Temporary HACK, for WakeMod=10, 11 or 12 use AeroProjMod 2 (will trigger PolarBEM)
+   if (InputFileData%WakeMod==10) then
+      call WrScr('   WARNING: WakeMod=10 is a temporary hack. Using new projection method with WakeMod=0.')
+      InputFileData%WakeMod = 0
+      AeroProjMod(:) = 2
+   elseif (InputFileData%WakeMod==11) then
+      call WrScr('   WARNING: WakeMod=11 is a temporary hack. Using new projection method with WakeMod=1.')
+      InputFileData%WakeMod = 1
+      AeroProjMod(:) = 2
+   elseif (InputFileData%WakeMod==12) then
+      call WrScr('   WARNING: WakeMod=12 is a temporary hack. Using new projection method with WakeMod=2.')
+      InputFileData%WakeMod = 2
+      AeroProjMod(:) = 2
+   endif
+
       ! -----------------------------------------------------------------
       ! Read the AeroDyn blade files, or copy from passed input
 !FIXME: add handling for passing of blade files and other types of files.
@@ -336,7 +351,9 @@ subroutine AD_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitOut
       ! set the rest of the parameters
    p%SkewMod = InputFileData%SkewMod
    do iR = 1, nRotors
-      p%rotors(iR)%AeroProjMod = InitInp%rotors(iR)%AeroProjMod
+      !p%rotors(iR)%AeroProjMod = InitInp%rotors(iR)%AeroProjMod
+      p%rotors(iR)%AeroProjMod = AeroProjMod(iR)
+      p%rotors(iR)%AeroBEM_Mod = InitInp%rotors(iR)%AeroBEM_Mod
       call SetParameters( InitInp, InputFileData, InputFileData%rotors(iR), p%rotors(iR), p, ErrStat2, ErrMsg2 )
       if (Failed()) return;
    enddo
@@ -550,6 +567,9 @@ subroutine AD_ReInit(p, x, xd, z, OtherState, m, Interval, ErrStat, ErrMsg )
                call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
          end if
       enddo
+   else
+      ErrStat = ErrID_Fatal
+      ErrMsg = 'AD_ReInit: Cannot reinitialize AeroDyn with OLAF'
    end if
 
       
@@ -1025,7 +1045,7 @@ subroutine Init_u( u, p, p_AD, InputFileData, InitInp, errStat, errMsg )
       
    u%InflowOnBlade = 0.0_ReKi
    u%UserProp      = 0.0_ReKi
-   u%InflowOnHub = 0.0_ReKi
+   u%InflowOnHub   = 0.0_ReKi
    u%InflowOnNacelle = 0.0_ReKi
    u%InflowOnTailFin = 0.0_ReKi
    
@@ -2483,9 +2503,9 @@ subroutine SetInputsForBEMT(p, u, m, indx, errStat, errMsg)
    real(ReKi)                              :: numer, denom, ratio, signOfAngle ! helper variables for calculating u%chi0  
    real(ReKi)                              :: tilt, yaw
    real(ReKi)                              :: SkewVec(3), tmp_skewVec(3), x_hat_wind(3), tmpD(3), tmpW(3)
-!   real(R8Ki)                              :: windCrossDisk(3)
-!   real(R8Ki)                              :: windCrossDiskMag
-!   real(R8Ki)                              :: x_vec(3), y_vec(3), z_vec(3)
+   real(R8Ki)                              :: windCrossDisk(3)
+   real(R8Ki)                              :: windCrossDiskMag
+   real(R8Ki)                              :: x_vec(3), y_vec(3), z_vec(3)
    real(R8Ki)                              :: elemPosRelToHub(3,p%NUMBLNDS)
    real(R8Ki)                              :: elemPosRotorProj(3,p%NUMBLNDS)
    real(R8Ki)                              :: dr(3), dz(3)
@@ -2498,29 +2518,15 @@ subroutine SetInputsForBEMT(p, u, m, indx, errStat, errMsg)
       ! Get disk average values and orientations
    call DiskAvgValues(p, u, m, x_hat_disk, y_hat_disk, z_hat_disk, Azimuth) ! also sets m%V_diskAvg, m%V_dot_x
 
-   if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist) then
-      call GeomWithoutSweepPitchTwist(p,u,x_hat_disk,m,ErrStat=ErrStat,ErrMsg=ErrMsg,thetaBladeNds=thetaBladeNds)
-   elseif (p%AeroProjMod==APM_LiftingLine) then
-      ! TODO we might want to do something different here
-      call GeomWithoutSweepPitchTwist(p,u,x_hat_disk,m,ErrStat=ErrStat,ErrMsg=ErrMsg,thetaBladeNds=thetaBladeNds)
-   elseif (p%AeroProjMod==APM_BEM_Polar) then 
-       !pass
-       !call GeomWithoutSweepPitchTwist(p,u, x_hat_disk, m, ErrStat=ErrStat,ErrMsg=ErrMsg, thetaBladeNds=m%BEMT_u(indx)%theta, toeBladeNds=m%BEMT_u(indx)%toeAngle) ! sets m%orientationAnnulus, m%Curve, m%hub_theta_x_root, m%AllOuts( BPitch(  k) )
-   else
-      call WrScr('AeroProjMod not supported - should never happen')
-      STOP
-   endif
-
-   if (ErrStat >= AbortErrLev) return
-
    ! Velocity in disk normal
-   m%BEMT_u(indx)%V0 = m%AvgDiskVel
+   m%BEMT_u(indx)%V0 = m%AvgDiskVelDist    ! Note: used for SkewWake Cont
    m%BEMT_u(indx)%x_hat_disk = x_hat_disk
    if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist .or. p%AeroProjMod==APM_LiftingLine) then
-      ! NOTE: OpenFAST: Contains translational velocity!!!  m%V_dot_x  = dot_product( m%V_diskAvg, x_hat_disk )
-      m%BEMT_u(indx)%Un_disk  = dot_product( m%V_diskAvg, x_hat_disk )
+      ! NOTE: m%V_diskAvg contains translational velocity and disturbed wind
+      m%BEMT_u(indx)%Un_disk  = dot_product( m%V_diskAvg, x_hat_disk )  ! NOTE: used for DBEMT only
    elseif (p%AeroProjMod==APM_BEM_Polar) then     
-      m%BEMT_u(indx)%Un_disk  = dot_product( m%AvgDiskVel, x_hat_disk )
+      ! NOTE: m%AvgDiskVel contains undisturbed wind only
+      m%BEMT_u(indx)%Un_disk  = dot_product( m%AvgDiskVel, x_hat_disk ) ! NOTE: used for DBEMT only
    endif
 
    ! Calculate Yaw and Tilt for use in xVelCorr
@@ -2542,8 +2548,8 @@ subroutine SetInputsForBEMT(p, u, m, indx, errStat, errMsg)
    tmpW = x_hat_wind
    tmpW(2) = 0.0
    tilt  = acos(max(-1.0_ReKi,min(1.0_ReKi,dot_product(tmpD,tmpW)/(twonorm(tmpD)*TwoNorm(tmpW))))) 
-   tmp_skewVec = cross_product(tmpD,tmpW)
-   tilt = sign(tilt,-tmp_skewVec(2))
+   tmp_skewVec = cross_product(tmpW,tmpD)
+   tilt = sign(tilt,tmp_skewVec(2))
    m%tilt = tilt
      
    ! "Angular velocity of rotor" rad/s
@@ -2555,58 +2561,96 @@ subroutine SetInputsForBEMT(p, u, m, indx, errStat, errMsg)
       m%BEMT_u(indx)%chi0 = 0.0_ReKi
    else
          ! make sure we don't have numerical issues that make the ratio outside +/-1
-      tmp_sz_y = min(  1.0_ReKi, m%V_dot_x / denom )
-      tmp_sz_y = max( -1.0_ReKi, tmp_sz_y )
+      numer = m%V_dot_x
+      ratio = numer / denom
+      m%BEMT_u(indx)%chi0 = acos( max( min( ratio, 1.0_ReKi ), -1.0_ReKi ) )
       
-      m%BEMT_u(indx)%chi0 = acos( tmp_sz_y )
-      
-   end if
-   
-   ! "Azimuth angle" rad
-   m%bemt_u(indx)%psi = Azimuth
+      SkewVec = cross_product( m%V_diskAvg, x_hat_disk )
+      ! NOTE: chi0 is used only as cos(chi0), tan(chi0)**2, or abs(chi0), so the sign calculated here is only for output purposes
+      ! Depending on yaw and/or tilt, z and/or y component of the cross product above will dicatate the sign of chi0.
+      ! Pending Test: What happens when y or z are of similar magnitude
+      if (abs(SkewVec(2))>abs(SkewVec(3))) then
+        signofAngle = sign(1.0_ReKi,SkewVec(2))
+      else
+        signofAngle = sign(1.0_ReKi,SkewVec(3))
+      endif
 
-   ! Local radius (and orientation)
+      if (p%AeroBEM_Mod /= BEMMod_2D) then
+         m%BEMT_u(indx)%chi0 = sign( m%BEMT_u(indx)%chi0, signOfAngle )
+      endif
+   end if
+
+
+   !..........................
+   !  Compute skew azimuth angle
+   !..........................
    if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist .or. p%AeroProjMod==APM_LiftingLine) then
 
-      ! "Radial distance from center-of-rotation to node" m
+      m%BEMT_u(indx)%psi = Azimuth
+   elseif (p%AeroProjMod==APM_BEM_Polar) then
+
       do k=1,p%NumBlades
+         ! Determine current azimuth angle and pitch axis vector of blade k
+         call Calculate_MeshOrientation_Rel2Hub(u%BladeRootMotion(k), u%HubMotion, x_hat_disk, orientationBladeAzimuth)
+         
+         ! Extract azimuth angle for blade k
+         ! NOTE: EB, this might need improvements (express wrt hub, also deal with case hubRad=0). This is likely not psi_skew. 
+         theta = -EulerExtract( transpose(orientationBladeAzimuth(:,:,1)) )
+         m%BEMT_u(indx)%psi(k) = theta(1)
+      end do !k=blades
+         
+      ! Find the most-downwind azimuth angle needed by the skewed wake correction model
+      windCrossDisk = cross_product( x_hat_wind, x_hat_disk )
+      windCrossDiskMag = TwoNorm( windCrossDisk )
+      if (windCrossDiskMag <= 0.01_ReKi) then
+         m%BEMT_u(indx)%psiSkewOffset = PiBy2
+      else
+         ! Assemble blade azimuth unit vectors and orientation matrix
+         z_vec = windCrossDisk / windCrossDiskMag
+         x_vec = x_hat_disk
+         y_vec = cross_product( z_vec, x_vec )
+         orientation(1,:) = x_vec
+         orientation(2,:) = y_vec
+         orientation(3,:) = z_vec
+         ! Extract azimuth angle for most down-wind blade orientation
+         theta = -EulerExtract( transpose(orientation) )
+         m%BEMT_u(indx)%psiSkewOffset = theta(1)+PiBy2  ! cross-product of wind vector and rotor axis will lead downwind blade azimuth by 90 degrees
+      end if
+
+
+   else
+      call WrScr('AeroProjMod not supported - should never happen')
+      STOP
+   endif
+   
+   !..........................
+   ! Compute pitch and blade azimuth (stored in misc)
+   !..........................
+   call StorePitchAndAzimuth(p, u, m, ErrStat2, ErrMsg2); call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+   if (ErrStat >= AbortErrLev) return
+
+   !..........................
+   ! Set main geometry parameters (orientatioAnnulus, Curve, rLocal)
+   !..........................
+   if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist .or. p%AeroProjMod==APM_LiftingLine) then
+
+      ! orientationAnnulus and curve
+      if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist) then
+         call Calculate_MeshOrientation_NoSweepPitchTwist(p, u, m, ErrStat=ErrStat, ErrMsg=ErrMsg, thetaBladeNds=thetaBladeNds)
+      else
+         call Calculate_MeshOrientation_LiftingLine(p, u, m, ErrStat=ErrStat, ErrMsg=ErrMsg, thetaBladeNds=thetaBladeNds)
+      endif
+
+      ! local radius (normalized distance from rotor centerline)
+      do k=1,p%NumBlades
+         call Calculate_MeshOrientation_Rel2Hub(u%BladeMotion(k), u%HubMotion, x_hat_disk, elemPosRelToHub_save=elemPosRelToHub, elemPosRotorProj_save=elemPosRotorProj)
          do j=1,p%NumBlNds    
-            ! displaced position of the jth node in the kth blade relative to the hub:
-            tmp =  u%BladeMotion(k)%Position(:,j) + u%BladeMotion(k)%TranslationDisp(:,j) &
-                 - u%HubMotion%Position(:,1)      - u%HubMotion%TranslationDisp(:,1)       
-            ! local radius (normalized distance from rotor centerline)
-            tmp_sz_y = dot_product( tmp, y_hat_disk )**2
-            tmp_sz   = dot_product( tmp, z_hat_disk )**2
-            m%BEMT_u(indx)%rLocal(j,k) = sqrt( tmp_sz + tmp_sz_y )      
+            m%BEMT_u(indx)%rLocal(j,k) = TwoNorm( elemPosRotorProj(:,j) )
          end do !j=nodes      
       end do !k=blades  
       
   elseif (p%AeroProjMod==APM_BEM_Polar) then
       do k=1,p%NumBlades
-      
-         ! Determine current azimuth angle and pitch axis vector of blade k
-         call Calculate_MeshOrientation_Rel2Hub(u%BladeRootMotion(k), u%HubMotion, x_hat_disk, orientationBladeAzimuth)
-         
-         ! Extract azimuth angle for blade k
-         theta = -EulerExtract( transpose(orientationBladeAzimuth(:,:,1)) )
-         m%BEMT_u(indx)%psi(k) = theta(1)
-         
-         !.........................
-         ! Values for output and/or FAST.Farm
-         !.........................
-         ! construct system equivalent to u%BladeRootMotion(k)%Orientation, but without the blade-pitch angle:
-         orientation = matmul( u%BladeRootMotion(k)%Orientation(:,:,1), transpose( u%HubMotion%Orientation(:,:,1) ) )
-         theta = EulerExtract( orientation ) !hub_theta_root(k)
-         ! theta(1) = Azimuth, theta(2) = cant+precone+rotorTilt, theta(3) = pitch+twist
-         
-         if (k<=size(m%hub_theta_x_root)) then
-            m%hub_theta_x_root(k) = theta(1)   ! save this value for FAST.Farm
-         end if
-
-         ! Get orientation of blade root with pitch set to zero
-         if (k<=size(BPitch)) then
-            m%AllOuts( BPitch(k) ) = -theta(3)*R2D ! save this value of pitch for potential output
-         end if
          
          ! Determine current azimuth angle and pitch axis vector of blade k, element j
          call Calculate_MeshOrientation_Rel2Hub(u%BladeMotion(k), u%HubMotion, x_hat_disk, m%orientationAnnulus(:,:,:,k), elemPosRelToHub_save=elemPosRelToHub, elemPosRotorProj_save=elemPosRotorProj)
@@ -2640,18 +2684,13 @@ subroutine SetInputsForBEMT(p, u, m, indx, errStat, errMsg)
    !..........................
    ! local blade angles
    !..........................
-  !!! if !GeomWithoutSweepPitchTwist is called in this routine, use the commented-out lines instead of the calculations in this section
-  !!! ! whole array operations (values calculated in GeomWithoutSweepPitchTwist):
-  !!! m%BEMT_u(indx)%cantAngle = m%Curve ! cant angle (including aeroelastic deformation)
-  !!!!m%BEMT_u(indx)%theta     =  ! twist (including pitch and aeroelastic deformation)
-  !!!!m%BEMT_u(indx)%toeAngle  =  ! toe angle
    if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist .or. p%AeroProjMod==APM_LiftingLine) then
      ! Theta
       do k=1,p%NumBlades
          do j=1,p%NumBlNds         
             m%BEMT_u(indx)%theta(j,k) = thetaBladeNds(j,k) ! local pitch + twist (aerodyanmic + elastic) angle of the jth node in the kth blade
 
-            ! NOTE: curve computed by GeomWithoutSweepPitchTwist
+            ! NOTE: curve computed by Calculate_MeshOrientation_*
             m%BEMT_u(indx)%toeAngle(j,k)  = 0.0_ReKi
             m%BEMT_u(indx)%cantAngle(j,k) = 0.0_ReKi
          end do !j=nodes
@@ -2681,11 +2720,13 @@ subroutine SetInputsForBEMT(p, u, m, indx, errStat, errMsg)
    !..........................
    do k=1,p%NumBlades
       do j=1,p%NumBlNds         
+         ! Velocity in "p" or "w" system (depending) on AeroProjMod
          tmp   = m%DisturbedInflow(:,j,k) - u%BladeMotion(k)%TranslationVel(:,j) ! rel_V(j)_Blade(k)
          m%BEMT_u(indx)%Vx(j,k) = dot_product( tmp, m%orientationAnnulus(1,:,j,k) ) ! normal component (normal to the plane, not chord) of the inflow velocity of the jth node in the kth blade
          m%BEMT_u(indx)%Vy(j,k) = dot_product( tmp, m%orientationAnnulus(2,:,j,k) ) !+ TwoNorm(m%DisturbedInflow(:,j,k))*(sin()*sin(tilt)*)! tangential component (tangential to the plane, not chord) of the inflow velocity of the jth node in the kth blade
          m%BEMT_u(indx)%Vz(j,k) = dot_product( tmp, m%orientationAnnulus(3,:,j,k) ) ! radial component (tangential to the plane, not chord) of the inflow velocity of the jth node in the kth blade
 
+         ! NOTE: We'll likely remove that:
          m%BEMT_u(indx)%xVelCorr(j,k) = TwoNorm(m%DisturbedInflow(:,j,k))*(             sin(yaw)*sin(-m%BEMT_u(indx)%cantAngle(j,k))*sin(m%BEMT_u(indx)%psi(k)) &
                                                                             + sin(tilt)*cos(yaw)*sin(-m%BEMT_u(indx)%cantAngle(j,k))*cos(m%BEMT_u(indx)%psi(k)) ) !m%BEMT_u(indx)%Vy(j,k)*sin(-theta(2))*sin(m%BEMT_u(indx)%psi(k))
       end do !j=nodes
@@ -2736,38 +2777,38 @@ subroutine DiskAvgValues(p, u, m, x_hat_disk, y_hat_disk, z_hat_disk, Azimuth)
    real(R8Ki), optional,    intent(  out)  :: Azimuth(p%NumBlades)
    real(ReKi)                              :: z_hat(3)
    real(ReKi)                              :: tmp(3)
+   real(ReKi)                              :: V_elast_diskAvg(3)
    real(ReKi)                              :: tmp_sz, tmp_sz_y
    integer(intKi)                          :: j                      ! loop counter for nodes
    integer(intKi)                          :: k                      ! loop counter for blades
 
-   ! calculate disk-averaged undisturbed wind
+   ! calculate disk-averaged velocities
    m%AvgDiskVel = 0.0_ReKi
+   m%AvgDiskVelDist = 0.0_ReKi ! TODO potentially get rid of that in the future
    do k=1,p%NumBlades
       do j=1,p%NumBlNds
-         m%AvgDiskVel = m%AvgDiskVel + m%DisturbedInflow(:,j,k)
+         m%AvgDiskVelDist = m%AvgDiskVelDist + m%DisturbedInflow(:,j,k)
+         m%AvgDiskVel = m%AvgDiskVel + u%InflowOnBlade(:,j,k)
       end do
    end do
+   m%AvgDiskVelDist = m%AvgDiskVelDist / real( p%NumBlades * p%NumBlNds, ReKi )
    m%AvgDiskVel = m%AvgDiskVel / real( p%NumBlades * p%NumBlNds, ReKi )
 
-      ! calculate disk-averaged relative wind speed, V_DiskAvg
-   m%V_diskAvg = 0.0_ReKi
+      ! calculate disk-averaged elastic velocity
+   V_elast_diskAvg = 0.0_ReKi
    do k=1,p%NumBlades
       do j=1,p%NumBlNds
-   !      !tmp = m%DisturbedInflow(:,j,k) - u%BladeMotion(k)%TranslationVel(:,j)
-   !      !tmp = u%InflowOnBlade(:,j,k) - u%BladeMotion(k)%TranslationVel(:,j)
-   !      !m%V_diskAvg = m%V_diskAvg + tmp
-         m%V_diskAvg = m%V_diskAvg + u%BladeMotion(k)%TranslationVel(:,j)
+         V_elast_diskAvg = V_elast_diskAvg + u%BladeMotion(k)%TranslationVel(:,j)
       end do
    end do
-   m%V_diskAvg = m%V_diskAvg / real( p%NumBlades * p%NumBlNds, ReKi )
+   V_elast_diskAvg = V_elast_diskAvg / real( p%NumBlades * p%NumBlNds, ReKi )
 
-   m%V_diskAvg = m%AvgDiskVel - m%V_diskAvg   
+      ! calculate disk-averaged relative wind speed, V_DiskAvg
+   m%V_diskAvg = m%AvgDiskVelDist - V_elast_diskAvg 
    
    
       ! orientation vectors:
    x_hat_disk = u%HubMotion%Orientation(1,:,1) !actually also x_hat_hub
-!  x_hat_disk = x_hat_disk / TwoNorm( x_hat_disk )  ! not necessary since Orientation(1,:,1) is already unit length
-   
 
    m%V_dot_x  = dot_product( m%V_diskAvg, x_hat_disk )
    
@@ -2800,6 +2841,39 @@ subroutine DiskAvgValues(p, u, m, x_hat_disk, y_hat_disk, z_hat_disk, Azimuth)
    end if
    
 end subroutine DiskAvgValues
+!----------------------------------------------------------------------------------------------------------------------------------
+subroutine StorePitchAndAzimuth(p, u, m, ErrStat,ErrMsg)
+   type(RotParameterType),  intent(in   )  :: p                               !< AD parameters
+   type(RotInputType),      intent(in   )  :: u                               !< AD Inputs at Time
+   type(RotMiscVarType),    intent(inout)  :: m                               !< Misc/optimization variables
+   integer(IntKi),          intent(  out)  :: ErrStat                         !< Error status of the operation
+   character(*),            intent(  out)  :: ErrMsg                          !< Error message if ErrStat /= ErrID_None
+   real(R8Ki)                              :: theta(3)
+   real(R8Ki)                              :: orientation(3,3)
+   integer(intKi)                          :: k                      ! loop counter for blades
+   integer(intKi)                          :: ErrStat2
+   character(ErrMsgLen)                    :: ErrMsg2
+   character(*), parameter                 :: RoutineName = 'StorePitchAndAzimuth'
+
+   ErrStat = ErrID_None
+   ErrMsg  = ""
+
+   ! theta, "Twist angle (includes all sources of twist)" rad
+   do k=1,p%NumBlades
+      ! orientation = rotation from hub 2 bl
+      ! orientation = matmul( u%BladeRootMotion(k)%Orientation(:,:,1), transpose( u%HubMotion%Orientation(:,:,1) ) )
+      call LAPACK_gemm( 'n', 't', 1.0_R8Ki, u%BladeRootMotion(k)%Orientation(:,:,1), u%HubMotion%Orientation(:,:,1), 0.0_R8Ki, orientation, errStat2, errMsg2)
+         call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+      theta = EulerExtract( orientation ) !hub_theta_root(k)
+      if (k<=size(BPitch)) then
+         m%AllOuts( BPitch(  k) ) = -theta(3)*R2D ! save this value of pitch for potential output
+      endif
+      if (k<=size(m%hub_theta_x_root)) then
+          m%hub_theta_x_root(k) = theta(1)   ! save this value for FAST.Farm (Azimuth wrt hub motion)
+      end if
+   enddo
+
+endsubroutine StorePitchAndAzimuth
 !----------------------------------------------------------------------------------------------------------------------------------
 subroutine Calculate_MeshOrientation_Rel2Hub(Mesh1, HubMotion, x_hat_disk, orientationAnnulus, elemPosRelToHub_save, elemPosRotorProj_save)
    TYPE(MeshType),             intent(in)  :: Mesh1          !< either BladeMotion or BladeRootMotion mesh
@@ -2848,19 +2922,23 @@ subroutine Calculate_MeshOrientation_Rel2Hub(Mesh1, HubMotion, x_hat_disk, orien
       if (present(elemPosRelToHub_save) ) elemPosRelToHub_save( :,j) = elemPosRelToHub
       if (present(elemPosRotorProj_save)) elemPosRotorProj_save(:,j) = elemPosRotorProj
    end do
+
+   ! orientation = matmul( Mesh1(k)%Orientation(:,:,j), transpose( orientationAnnulus(:,:,j) ) )
+   ! theta = EulerExtract( orientation )
+   ! ! Get toe angle
+   ! toeAngle(j) = theta(1)
+   ! ! cant angle (including aeroelastic deformation)
+   ! cantAngle(j) = theta(2)
+   ! Curve(j) = theta(2)
+   ! ! twist (including pitch and aeroelastic deformation)
+   ! thetaNds(j) = -theta(3)
       
 end subroutine Calculate_MeshOrientation_Rel2Hub
 !----------------------------------------------------------------------------------------------------------------------------------
-! GeomWithoutSweepPitchTwist sets these variables:
-!   m%orientationAnnulus
-!   m%Curve
-!   m%hub_theta_x_root
-!   m%AllOuts( BPitch(  k) )
-!   thetaBladeNds (optional)
-subroutine GeomWithoutSweepPitchTwist(p,u,x_hat_disk,m,thetaBladeNds,toeBladeNds,ErrStat,ErrMsg)
+! Calculate_MeshOrientation_NoSweepPitchTwist sets orientationAnnulus, Curve and potential Blades nodes angles
+subroutine Calculate_MeshOrientation_NoSweepPitchTwist(p, u, m, thetaBladeNds, toeBladeNds, ErrStat, ErrMsg)
    type(RotParameterType),  intent(in   )  :: p                               !< AD parameters
    type(RotInputType),      intent(in   )  :: u                               !< AD Inputs at Time
-   real(R8Ki),              intent(in   )  :: x_hat_disk(3)
    type(RotMiscVarType),    intent(inout)  :: m                               !< Misc/optimization variables
    real(R8Ki), optional,    intent(  out)  :: thetaBladeNds(p%NumBlNds,p%NumBlades)
    real(R8Ki), optional,    intent(  out)  :: toeBladeNds(p%NumBlNds,p%NumBlades)
@@ -2874,107 +2952,78 @@ subroutine GeomWithoutSweepPitchTwist(p,u,x_hat_disk,m,thetaBladeNds,toeBladeNds
    integer(intKi)                          :: k                      ! loop counter for blades
    integer(intKi)                          :: ErrStat2
    character(ErrMsgLen)                    :: ErrMsg2
-   character(*), parameter                 :: RoutineName = 'GeomWithoutSweepPitchTwist'
+   character(*), parameter                 :: RoutineName = 'Calculate_MeshOrientation_NoSweepPitchTwist'
 
    ErrStat = ErrID_None
    ErrMsg  = ""
 
-   if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist) then
-   
-         ! theta, "Twist angle (includes all sources of twist)" rad
-         ! Vx, "Local axial velocity at node" m/s
-         ! Vy, "Local tangential velocity at node" m/s
-      do k=1,p%NumBlades
-            ! construct system equivalent to u%BladeRootMotion(k)%Orientation, but without the blade-pitch angle:
-         ! orientation = rotation from hub 2 bl
-         call LAPACK_gemm( 'n', 't', 1.0_R8Ki, u%BladeRootMotion(k)%Orientation(:,:,1), u%HubMotion%Orientation(:,:,1), 0.0_R8Ki, orientation, errStat2, errMsg2)
+   do k=1,p%NumBlades
+      ! orientation = rotation from hub 2 bl
+      call LAPACK_gemm( 'n', 't', 1.0_R8Ki, u%BladeRootMotion(k)%Orientation(:,:,1), u%HubMotion%Orientation(:,:,1), 0.0_R8Ki, orientation, errStat2, errMsg2)
+         call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+      theta = EulerExtract( orientation ) !hub_theta_root(k)
+      theta(3) = 0.0_ReKi
+
+      ! construct system equivalent to u%BladeRootMotion(k)%Orientation, but without the blade-pitch angle:
+      orientation = EulerConstruct( theta ) ! rotation from hub 2 non-pitched blade
+      orientation_nopitch = matmul( orientation, u%HubMotion%Orientation(:,:,1) ) ! withoutPitch_theta_Root(k) ! rotation from global 2 non-pitched blade
+
+      do j=1,p%NumBlNds
+
+            ! form coordinate system equivalent to u%BladeMotion(k)%Orientation(:,:,j) but without live sweep (due to in-plane
+            ! deflection), blade-pitch and twist (aerodynamic + elastic) angles:
+
+         ! orientation = matmul( u%BladeMotion(k)%Orientation(:,:,j), transpose(orientation_nopitch) )
+         ! orientation = rotation from non pitched blade 2 balde section
+         call LAPACK_gemm( 'n', 't', 1.0_R8Ki, u%BladeMotion(k)%Orientation(:,:,j), orientation_nopitch, 0.0_R8Ki, orientation, errStat2, errMsg2)
             call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
-         theta = EulerExtract( orientation ) !hub_theta_root(k)
-         if (k<=3) then
-            m%AllOuts( BPitch(  k) ) = -theta(3)*R2D ! save this value of pitch for potential output
-         endif
+         theta = EulerExtract( orientation ) !root(k)WithoutPitch_theta(j)_blade(k)
+
+         m%Curve(      j,k) =  theta(2)  ! save value for possible output later
+         if (present(thetaBladeNds)) thetaBladeNds(j,k) = -theta(3) ! local pitch + twist (aerodyanmic + elastic) angle of the jth node in the kth blade
+         if (present(toeBladeNds  )) toeBladeNds(  j,k) =  theta(1)
+
+         theta(1) = 0.0_ReKi
          theta(3) = 0.0_ReKi
-         if (k<=size(m%hub_theta_x_root)) then
-             m%hub_theta_x_root(k) = theta(1)   ! save this value for FAST.Farm
-         end if
+         m%orientationAnnulus(:,:,j,k) = matmul( EulerConstruct( theta ), orientation_nopitch ) ! WithoutSweepPitch+Twist_theta(j)_Blade(k)
 
-         orientation = EulerConstruct( theta ) ! rotation from hub 2 non-pitched blade
-         orientation_nopitch = matmul( orientation, u%HubMotion%Orientation(:,:,1) ) ! withoutPitch_theta_Root(k) ! rotation from global 2 non-pitched blade
-
-         do j=1,p%NumBlNds
-
-               ! form coordinate system equivalent to u%BladeMotion(k)%Orientation(:,:,j) but without live sweep (due to in-plane
-               ! deflection), blade-pitch and twist (aerodynamic + elastic) angles:
-
-            ! orientation = matmul( u%BladeMotion(k)%Orientation(:,:,j), transpose(orientation_nopitch) )
-            ! orientation = rotation from non pitched blade 2 balde section
-            call LAPACK_gemm( 'n', 't', 1.0_R8Ki, u%BladeMotion(k)%Orientation(:,:,j), orientation_nopitch, 0.0_R8Ki, orientation, errStat2, errMsg2)
-               call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
-            theta = EulerExtract( orientation ) !root(k)WithoutPitch_theta(j)_blade(k)
-
-            m%Curve(      j,k) =  theta(2)  ! save value for possible output later
-            if (present(thetaBladeNds)) thetaBladeNds(j,k) = -theta(3) ! local pitch + twist (aerodyanmic + elastic) angle of the jth node in the kth blade
-            if (present(toeBladeNds  )) toeBladeNds(  j,k) =  theta(1)
-
-            theta(1) = 0.0_ReKi
-            theta(3) = 0.0_ReKi
-            m%orientationAnnulus(:,:,j,k) = matmul( EulerConstruct( theta ), orientation_nopitch ) ! WithoutSweepPitch+Twist_theta(j)_Blade(k)
-
-         end do !j=nodes
-      end do !k=blades
-      
-   else if (p%AeroProjMod==APM_LiftingLine) then
+      end do !j=nodes
+   end do !k=blades
+end subroutine Calculate_MeshOrientation_NoSweepPitchTwist
+!----------------------------------------------------------------------------------------------------------------------------------
+subroutine Calculate_MeshOrientation_LiftingLine(p, u, m, thetaBladeNds, toeBladeNds, ErrStat, ErrMsg)
+   type(RotParameterType),  intent(in   )  :: p                               !< AD parameters
+   type(RotInputType),      intent(in   )  :: u                               !< AD Inputs at Time
+   type(RotMiscVarType),    intent(inout)  :: m                               !< Misc/optimization variables
+   real(R8Ki), optional,    intent(  out)  :: thetaBladeNds(p%NumBlNds,p%NumBlades)
+   real(R8Ki), optional,    intent(  out)  :: toeBladeNds(p%NumBlNds,p%NumBlades)
+   integer(IntKi),          intent(  out)  :: ErrStat                         !< Error status of the operation
+   character(*),            intent(  out)  :: ErrMsg                          !< Error message if ErrStat /= ErrID_None
+   real(R8Ki)                              :: theta(3)
+   real(R8Ki)                              :: orientation(3,3)
+   integer(intKi)                          :: j                      ! loop counter for nodes
+   integer(intKi)                          :: k                      ! loop counter for blades
+   integer(intKi)                          :: ErrStat2
+   character(ErrMsgLen)                    :: ErrMsg2
+   character(*), parameter                 :: RoutineName = 'Calculate_MeshOrientation_LiftingLine'
+   ErrStat = ErrID_None
+   ErrMsg  = ""
    
-      do k=1,p%NumBlades
-        ! construct system equivalent to u%BladeRootMotion(k)%Orientation, but without the blade-pitch angle:
-        !orientation = matmul( u%BladeRootMotion(k)%Orientation(:,:,1), transpose( u%HubMotion%Orientation(:,:,1) ) ) : equivalent, without taking the transpose:
-         call LAPACK_gemm( 'n', 't', 1.0_R8Ki, u%BladeRootMotion(k)%Orientation(:,:,1), u%HubMotion%Orientation(:,:,1), 0.0_R8Ki, orientation, errStat2, errMsg2)
-            call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
-         theta = EulerExtract( orientation ) !hub_theta_root(k)
-       ! theta(1) = Azimuth, theta(2) = cant+precone+rotorTilt, theta(3) = pitch+twist
-         
-         if (k<=size(BPitch)) then
-            m%AllOuts( BPitch(  k) ) = -theta(3)*R2D ! save this value of pitch for potential output
-         endif
-
-         if (k<=size(m%hub_theta_x_root)) then
-            m%hub_theta_x_root(k) = theta(1)   ! save this value for FAST.Farm
-         end if
-      end do
-      
-            
-      !.........................
-      ! Set orientation Annulus:
-      !.........................
-      
-      do k=1,p%NumBlades
-         call Calculate_MeshOrientation_Rel2Hub(u%BladeMotion(k), u%HubMotion, x_hat_disk, m%orientationAnnulus(:,:,:,k))
-
-         ! NOTE: important for AeroProjMod=APM_LiftingLine we use BladeMotion Orientation directly for annulus
-         ! otherwise ad_EllipticalWingInf_OLAF fails. Might need double checking...
-         do j=1,p%NumBlNds
-            m%orientationAnnulus(:,:,j,k) = u%BladeMotion(k)%Orientation(:,:,j)
-         enddo
+   do k=1,p%NumBlades
+      do j=1,p%NumBlNds
+         m%orientationAnnulus(:,:,j,k) = u%BladeMotion(k)%Orientation(:,:,j)
       enddo
-      
-      !.........................
-      ! Set Curve and possibly thetaBladeNds:
-      !.........................
-      do k=1,p%NumBlades
-         do j=1,p%NumBlNds
-            orientation = matmul( u%BladeMotion(k)%Orientation(:,:,j), transpose( m%orientationAnnulus(:,:,j,k) ) )
-            theta = EulerExtract( orientation )
-            m%Curve(      j,k) =  theta(2)
-            if (present(thetaBladeNds)) thetaBladeNds(j,k) = -theta(3)
-            if (present(toeBladeNds  )) toeBladeNds(  j,k) =  theta(1)
-         enddo
+   
+      do j=1,p%NumBlNds
+         orientation = matmul( u%BladeMotion(k)%Orientation(:,:,j), transpose( m%orientationAnnulus(:,:,j,k) ) )
+         theta = EulerExtract( orientation )
+         m%Curve(      j,k) =  theta(2) ! TODO
+         if (present(thetaBladeNds)) thetaBladeNds(j,k) = -theta(3)
+         if (present(toeBladeNds  )) toeBladeNds(  j,k) =  theta(1)
       enddo
+   end do !k=blades
       
-   else
-      ErrStat = ErrID_Fatal
-      ErrMsg ='GeomWithoutSweepPitchTwist: AeroProjMod not supported '//trim(num2lstr(p%AeroProjMod))
-   endif
-end subroutine GeomWithoutSweepPitchTwist
+end subroutine Calculate_MeshOrientation_LiftingLine
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This subroutine sets m%FVW_u(indx).
 subroutine SetInputsForFVW(p, u, m, errStat, errMsg)
@@ -3005,7 +3054,12 @@ subroutine SetInputsForFVW(p, u, m, errStat, errMsg)
          ! Get disk average values and orientations
          ! NOTE: needed because it sets m%V_diskAvg and m%V_dot_x, needed by CalcOutput..
          call DiskAvgValues(p%rotors(iR), u(tIndx)%rotors(iR), m%rotors(iR), x_hat_disk) ! also sets m%V_diskAvg and m%V_dot_x
-         call GeomWithoutSweepPitchTwist(p%rotors(iR),u(tIndx)%rotors(iR), x_hat_disk, m%rotors(iR), thetaBladeNds,ErrStat=ErrStat2,ErrMsg=ErrMsg2) ! also sets m%orientationAnnulus, m%Curve, m%hub_theta_x_root, m%AllOuts( BPitch(  k) )
+         if (p%rotors(iR)%AeroProjMod==APM_BEM_NoSweepPitchTwist) then
+            call Calculate_MeshOrientation_NoSweepPitchTwist(p%rotors(iR),u(tIndx)%rotors(iR),  m%rotors(iR), thetaBladeNds,ErrStat=ErrStat2,ErrMsg=ErrMsg2) ! sets m%orientationAnnulus, m%Curve
+         else if (p%rotors(iR)%AeroProjMod==APM_LiftingLine) then
+            call Calculate_MeshOrientation_LiftingLine      (p%rotors(iR),u(tIndx)%rotors(iR), m%rotors(iR), thetaBladeNds,ErrStat=ErrStat2,ErrMsg=ErrMsg2) ! sets m%orientationAnnulus, m%Curve
+         endif
+         call StorePitchAndAzimuth(p%rotors(iR), u(tIndx)%rotors(iR), m%rotors(iR), ErrStat2, ErrMsg2)
          call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
          if (ErrStat >= AbortErrLev) return
 
@@ -3158,11 +3212,18 @@ subroutine SetOutputsFromBEMT( p, u, m, y )
          m%My(j,k) = moment(2)
          m%Mz(j,k) = moment(3)            
          
+         
+         if (p%BEMT%BEM_Mod==BEMMod_2D) then
             ! note: because force and moment are 1-d arrays, I'm calculating the transpose of the force and moment outputs
             !       so that I don't have to take the transpose of orientationAnnulus(:,:,j,k)
-         y%BladeLoad(k)%Force(:,j)  = matmul( force,  m%orientationAnnulus(:,:,j,k) )  ! force per unit length of the jth node in the kth blade
-         y%BladeLoad(k)%Moment(:,j) = matmul( moment, m%orientationAnnulus(:,:,j,k) )  ! moment per unit length of the jth node in the kth blade
+            y%BladeLoad(k)%Force(:,j)  = matmul( force,  m%orientationAnnulus(:,:,j,k) )  ! force per unit length of the jth node in the kth blade
+            y%BladeLoad(k)%Moment(:,j) = matmul( moment, m%orientationAnnulus(:,:,j,k) )  ! moment per unit length of the jth node in the kth blade
          
+         else
+	        ! Transfer loads from the airfoil frame to the blade frame
+	        y%BladeLoad(k)%Force(:,j)  = matmul( forceAirfoil,  u%BladeMotion(k)%Orientation(:,:,j) )  ! force per unit length of the jth node in the kth blade 
+	        y%BladeLoad(k)%Moment(:,j) = matmul( momentAirfoil, u%BladeMotion(k)%Orientation(:,:,j) )  ! moment per unit length of the jth node in the kth blade 
+	     endif
       end do !j=nodes
    end do !k=blades
    
@@ -3957,14 +4018,22 @@ SUBROUTINE Init_BEMTmodule( InputFileData, RotInputFileData, u_AD, u, p, p_AD, x
    InitInp%MomentumCorr  = .FALSE. ! TODO EB
    InitInp%SumPrint      = InputFileData%SumPrint
    InitInp%RootName      = p%RootName
-   if (p%AeroProjMod == APM_BEM_NoSweepPitchTwist) then
-      InitInp%BEM_Mod    = BEMMod_2D
-   else if (p%AeroProjMod == APM_BEM_Polar) then
-      InitInp%BEM_Mod    = BEMMod_3D
-   else
-      InitInp%BEM_Mod    = -1
-      call SetErrStat(ErrID_Fatal, "AeroProjMod needs to be 0 or 2 when used with BEM", ErrStat, ErrMsg, RoutineName)   
+   InitInp%BEM_Mod       = p%AeroBEM_Mod
+
+
+   if (p%AeroBEM_Mod==-1) then
+      !call WrSCr('WARNING: AeroDyn: BEM_Mod is -1, using default BEM_Mod based on projection')
+      if (p%AeroProjMod == APM_BEM_NoSweepPitchTwist) then
+         InitInp%BEM_Mod    = BEMMod_2D
+      else if (p%AeroProjMod == APM_BEM_Polar) then
+         InitInp%BEM_Mod    = BEMMod_3D
+      else
+         InitInp%BEM_Mod    = -1
+         call SetErrStat(ErrID_Fatal, "AeroProjMod needs to be 1 or 2 when used with BEM", ErrStat, ErrMsg, RoutineName)   
+      endif
    endif
+   p%AeroBEM_Mod = InitInp%BEM_Mod ! Very important, for consistency
+   !call WrScr('   AeroDyn: projMod: '//trim(num2lstr(p%AeroProjMod))//', BEM_Mod:'//trim(num2lstr(InitInp%BEM_Mod)))
       ! remove the ".AD" from the RootName
    k = len_trim(InitInp%RootName)
    if (k>3) then
@@ -4083,6 +4152,7 @@ SUBROUTINE Init_OLAF( InputFileData, u_AD, u, p, x, xd, z, OtherState, m, ErrSta
                   ! displaced position of the jth node in the kth blade relative to the hub:
             tmp =  u_AD%rotors(iR)%BladeMotion(iB)%Position(:,j)  - u_AD%rotors(iR)%HubMotion%Position(:,1)
                ! local radius (normalized distance from rotor centerline)
+               ! NOTE: rLocal is not necessary a good distance for VAWT
             tmp_sz_y = dot_product( tmp, y_hat_disk )**2
             tmp_sz   = dot_product( tmp, z_hat_disk )**2
             rLocal(j) = sqrt( tmp_sz + tmp_sz_y )

--- a/modules/aerodyn/src/AeroDyn_Driver_Registry.txt
+++ b/modules/aerodyn/src/AeroDyn_Driver_Registry.txt
@@ -111,7 +111,8 @@ typedef   ^                         ^            TwrData                 twr    
 typedef   ^                         ^            IntKi                   numBlades        -      -     -   "" -
 typedef   ^                         ^            logical                 basicHAWTFormat  -      -     -   "If true simply input HubRad/Pitch/Overhang/Cone, otherwise all turbine inputs" -
 typedef   ^                         ^            logical                 hasTower         -      -     -   "" -
-typedef   ^                         ^            IntKi                   projMod  -      -     -   "If true simply input HubRad/Pitch/Overhang/Cone, otherwise all turbine inputs" -
+typedef   ^                         ^            IntKi                   projMod          -      -     -   "If true simply input HubRad/Pitch/Overhang/Cone, otherwise all turbine inputs" -
+typedef   ^                         ^            IntKi                   BEM_Mod          -      -     -   "Switch for different BEM implementations" -
 typedef   ^                         ^            logical                 HAWTprojection   -      -     -   "" -
 typedef   ^                         ^            IntKi                   motionType       -      -     -   "" -
 typedef   ^                         ^            ReKi                    motion           ::     -     -   "" "-"

--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -195,7 +195,7 @@ subroutine Dvr_InitCase(iCase, dvr, ADI, FED, errStat, errMsg )
    else
       ! Should never happen
    endif
-   dvr%numSteps = ceiling(dvr%tMax/dvr%dt)
+   dvr%numSteps = ceiling(dvr%tMax/dvr%dt) ! TODO I believe we need a plus one here
 
    ! Validate the inputs
    call ValidateInputs(dvr, errStat2, errMsg2) ; if(Failed()) return     
@@ -429,10 +429,15 @@ subroutine Init_ADI_ForDriver(iCase, ADI, dvr, FED, dt, errStat, errMsg)
    else
       ! UA does not like changes of dt between cases
       if ( .not. EqualRealNos(ADI%p%AD%DT, dt) ) then
-         call WrScr('Info: dt is changing between cases, AeroDyn will be re-initialized')
-         call ADI_End( ADI%u(1:1), ADI%p, ADI%x, ADI%xd, ADI%z, ADI%OtherState, ADI%y, ADI%m, errStat2, errMsg2); call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'Init_ADI_ForDriver'); if(Failed()) return
-         !call AD_Dvr_DestroyAeroDyn_Data   (AD     , errStat2, errMsg2); call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call WrScr('[INFO] dt is changing between cases, AeroDyn will be re-initialized')
          needInit=.true.
+      endif
+      if (ADI%p%AD%WakeMod == WakeMod_FVW) then
+         call WrScr('[INFO] OLAF is used, AeroDyn will be re-initialized')
+         needInit=.true.
+      endif
+      if (needInit) then
+         call ADI_End( ADI%u(1:1), ADI%p, ADI%x, ADI%xd, ADI%z, ADI%OtherState, ADI%y, ADI%m, errStat2, errMsg2); call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'Init_ADI_ForDriver'); if(Failed()) return
       endif
    endif
 
@@ -484,7 +489,8 @@ subroutine Init_ADI_ForDriver(iCase, ADI, dvr, FED, dt, errStat, errMsg)
          else
             InitInp%AD%rotors(iWT)%AeroProjMod = wt%projMod
          endif
-         !call WrScr('>>> Using projection method '//trim(num2lstr(InitInp%AD%rotors(iWT)%AeroProjMod)))
+         InitInp%AD%rotors(iWT)%AeroBEM_Mod = wt%BEM_Mod
+         !call WrScr('   Driver:  projMod: '//trim(num2lstr(InitInp%AD%rotors(iWT)%AeroProjMod))//', BEM_Mod:'//trim(num2lstr(InitInp%AD%rotors(iWT)%AeroBEM_Mod)))
          InitInp%AD%rotors(iWT)%HubPosition    = y_ED%HubPtMotion%Position(:,1)
          InitInp%AD%rotors(iWT)%HubOrientation = y_ED%HubPtMotion%RefOrientation(:,:,1)
          InitInp%AD%rotors(iWT)%NacellePosition    = y_ED%NacelleMotion%Position(:,1)
@@ -503,6 +509,7 @@ subroutine Init_ADI_ForDriver(iCase, ADI, dvr, FED, dt, errStat, errMsg)
       endif
    else
       ! --- Reinit
+      ! TODO change rootname, but that's a parameter..
       call ADI_ReInit(ADI%p, ADI%x, ADI%xd, ADI%z, ADI%OtherState, ADI%m, dt, errStat2, errMsg2); if(Failed()) return
    endif
 
@@ -973,8 +980,9 @@ subroutine Dvr_ReadInputFile(fileName, dvr, errStat, errMsg )
       call ParseVar(FileInfo_In, CurLine, 'ProjMod'//sWT    , wt%projMod       , errStat2, errMsg2, unEc);
       if (errStat2==ErrID_Fatal) then
          wt%projMod = -1
+         wt%BEM_Mod = -1
       else
-         call WrScr('>>> ProjMod is present in AeroDyn driver input file. ProjMod: '//trim(num2lstr(wt%projMod)))
+         call ParseVar(FileInfo_In, CurLine, 'BEM_Mod'//sWT    , wt%BEM_Mod     , errStat2, errMsg2, unEc); if(Failed()) return
       endif
       call ParseVar(FileInfo_In, CurLine, 'BasicHAWTFormat'//sWT    , wt%basicHAWTFormat       , errStat2, errMsg2, unEc); if(Failed()) return
 

--- a/modules/aerodyn/src/AeroDyn_Driver_Types.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Types.f90
@@ -144,6 +144,7 @@ IMPLICIT NONE
     LOGICAL  :: basicHAWTFormat      !< If true simply input HubRad/Pitch/Overhang/Cone, otherwise all turbine inputs [-]
     LOGICAL  :: hasTower      !<  [-]
     INTEGER(IntKi)  :: projMod      !< If true simply input HubRad/Pitch/Overhang/Cone, otherwise all turbine inputs [-]
+    INTEGER(IntKi)  :: BEM_Mod      !< Switch for different BEM implementations [-]
     LOGICAL  :: HAWTprojection      !<  [-]
     INTEGER(IntKi)  :: motionType      !<  [-]
     REAL(ReKi) , DIMENSION(:,:), ALLOCATABLE  :: motion      !<  [-]
@@ -2395,6 +2396,7 @@ ENDIF
     DstWTDataData%basicHAWTFormat = SrcWTDataData%basicHAWTFormat
     DstWTDataData%hasTower = SrcWTDataData%hasTower
     DstWTDataData%projMod = SrcWTDataData%projMod
+    DstWTDataData%BEM_Mod = SrcWTDataData%BEM_Mod
     DstWTDataData%HAWTprojection = SrcWTDataData%HAWTprojection
     DstWTDataData%motionType = SrcWTDataData%motionType
 IF (ALLOCATED(SrcWTDataData%motion)) THEN
@@ -2690,6 +2692,7 @@ ENDIF
       Int_BufSz  = Int_BufSz  + 1  ! basicHAWTFormat
       Int_BufSz  = Int_BufSz  + 1  ! hasTower
       Int_BufSz  = Int_BufSz  + 1  ! projMod
+      Int_BufSz  = Int_BufSz  + 1  ! BEM_Mod
       Int_BufSz  = Int_BufSz  + 1  ! HAWTprojection
       Int_BufSz  = Int_BufSz  + 1  ! motionType
   Int_BufSz   = Int_BufSz   + 1     ! motion allocated yes/no
@@ -3004,6 +3007,8 @@ ENDIF
     IntKiBuf(Int_Xferred) = TRANSFER(InData%hasTower, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = InData%projMod
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = InData%BEM_Mod
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = TRANSFER(InData%HAWTprojection, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
@@ -3472,6 +3477,8 @@ ENDIF
     OutData%hasTower = TRANSFER(IntKiBuf(Int_Xferred), OutData%hasTower)
     Int_Xferred = Int_Xferred + 1
     OutData%projMod = IntKiBuf(Int_Xferred)
+    Int_Xferred = Int_Xferred + 1
+    OutData%BEM_Mod = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1
     OutData%HAWTprojection = TRANSFER(IntKiBuf(Int_Xferred), OutData%HAWTprojection)
     Int_Xferred = Int_Xferred + 1

--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -2098,11 +2098,6 @@ subroutine calcCantAngle(f, xi,stencilSize,n,cantAngle)
     real(ReKi)                  :: cx(stencilSize), cf(stencilSize), xiIn(stencilSize)
     real(ReKi)                  :: fIn(stencilSize), cPrime(n), fPrime(n), xiAbs(n)
     real(ReKi), intent(inout)   :: cantAngle(n)
-     
-    !dimension       :: f(n),xi(n), sortInd(n), cx(stencilSize),cf(stencilSize), xiIn(stencilSize)
-    !dimension       :: cantAngle(n), fIn(stencilSize), cPrime(n), fPrime(n), indexIn(stencilSize), xiAbs(n)
-    
-
     
     do i = 1,size(xi)
         

--- a/modules/aerodyn/src/AeroDyn_Inflow.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow.f90
@@ -4,10 +4,10 @@ module AeroDyn_Inflow
    use NWTC_Library
    use AeroDyn_Inflow_Types
    use AeroDyn_Types
-   use AeroDyn, only: AD_Init, AD_ReInit, AD_CalcOutput, AD_UpdateStates
+   use AeroDyn, only: AD_Init, AD_ReInit, AD_CalcOutput, AD_UpdateStates, AD_End
    use AeroDyn, only: AD_NumWindPoints, AD_GetExternalWind, AD_SetExternalWindPositions
    use AeroDyn_IO, only: AD_SetVTKSurface
-   use InflowWind, only: InflowWind_Init, InflowWind_CalcOutput
+   use InflowWind, only: InflowWind_Init, InflowWind_CalcOutput, InflowWind_End
 
    implicit none
 
@@ -167,6 +167,10 @@ subroutine ADI_End( u, p, x, xd, z, OtherState, y, m, errStat, errMsg )
    integer(IntKi) :: i
    errStat = ErrID_None
    errMsg  = ""
+
+   ! End modules
+   call AD_End(u(1)%AD, p%AD, x%AD, xd%AD, z%AD, OtherState%AD, y%AD, m%AD, ErrStat, ErrMsg)
+   call InflowWind_End(m%IW%u, m%IW%p, m%IW%x, m%IW%xd, m%IW%z, m%IW%OtherSt, m%IW%y, m%IW%m, ErrStat, ErrMsg)
 
    ! Destroy the input data:
    !if (allocated(u)) then
@@ -472,12 +476,16 @@ subroutine ADI_CalcOutput_IW(t, u_IfW, IW, errStat, errMsg)
       call InflowWind_CalcOutput(t, u_IfW, IW%p, IW%x, IW%xd, IW%z, IW%OtherSt, IW%y, IW%m, errStat2, errMsg2)
       call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'ADI_CalcOutput_IW') 
    else
+      !$OMP PARALLEL DEFAULT(SHARED)
+      !$OMP DO PRIVATE(j,z) schedule(runtime)
       do j=1,size(u_IfW%PositionXYZ,2)
          z = u_IfW%PositionXYZ(3,j)
          IW%y%VelocityUVW(1,j) = IW%HWindSpeed*(z/IW%RefHt)**IW%PLExp
          IW%y%VelocityUVW(2,j) = 0.0_ReKi !V
          IW%y%VelocityUVW(3,j) = 0.0_ReKi !W      
       end do 
+      !$OMP END DO 
+      !$OMP END PARALLEL
    endif
 end subroutine ADI_CalcOutput_IW
 !----------------------------------------------------------------------------------------------------------------------------------

--- a/modules/aerodyn/src/AeroDyn_Registry.txt
+++ b/modules/aerodyn/src/AeroDyn_Registry.txt
@@ -83,6 +83,7 @@ typedef	^	RotInitInputType	R8Ki	BladeRootOrientation	{:}{:}{:}	-	-	"DCM referenc
 typedef	^	RotInitInputType	R8Ki	NacellePosition	{3}	-	-	"X-Y-Z reference position of nacelle"	m
 typedef	^	RotInitInputType	R8Ki	NacelleOrientation	{3}{3}	-	-	"DCM reference orientation of nacelle"	-
 typedef	^	RotInitInputType	IntKi	AeroProjMod   	-	1	-	"Flag to switch between different projection models"	-
+typedef	^	RotInitInputType	IntKi	AeroBEM_Mod   	-      -1	-	"Flag to switch between different BEM Model"	-
 
 typedef	^	InitInputType	RotInitInputType rotors	{:}	-	-	"Init Input Types for rotors"	-
 typedef	^	InitInputType	CHARACTER(1024)	InputFile	-	-	-	"Name of the input file"	-
@@ -302,7 +303,8 @@ typedef	^	RotMiscVarType	MeshType	TwrBuoyLoadPoint	-	-	-	"point mesh for lumped 
 typedef	^	RotMiscVarType	MeshType	TwrBuoyLoad	-	-	-	"line mesh for per unit length buoyant tower loads"	-
 typedef	^	RotMiscVarType	MeshMapType	T_P_2_T_L	-	-	-	"mapping data structure to map buoyant tower point loads (m%TwrBuoyLoadPoint) to buoyant tower line loads (m%TwrBuoyLoad)"
 typedef	^	RotMiscVarType	Logical	FirstWarn_TowerStrike	-	-	-	"flag to avoid printing tower strike multiple times" -
-typedef	^	RotMiscVarType	ReKi	AvgDiskVel	{3}	-	-	"disk-averaged U,V,W"	m/s
+typedef	^	RotMiscVarType	ReKi	AvgDiskVel	{3}	-	-	"disk-averaged U,V,W (undisturbed)"	m/s
+typedef	^	RotMiscVarType	ReKi	AvgDiskVelDist	{3}	-	-	"disk-averaged U,V,W (disturbed)"	m/s
 # TailFin
 typedef	^	RotMiscVarType	ReKi	TFinAlpha	-	-	-	"Angle of attack for tailfin"
 typedef	^	RotMiscVarType	ReKi	TFinRe   	-	-	-	"Reynolds number for tailfin"
@@ -370,6 +372,7 @@ typedef ^   RotParameterType    ReKi    Pvap      -   -   -  "Vapour pressure" P
 typedef ^   RotParameterType    ReKi    WtrDpth -  -   -     "Water depth" m
 typedef ^   RotParameterType    ReKi    MSL2SWL -  -   -     "Offset between still-water level and mean sea level" m
 typedef	^	RotParameterType	IntKi	AeroProjMod   	-	1	-	"Flag to switch between different projection models"	-
+typedef	^	RotParameterType	IntKi	AeroBEM_Mod   	-      -1	-	"Flag to switch between different BEM Model"	-
 # parameters for output
 typedef	^	RotParameterType	IntKi	NumOuts	-	-	-	"Number of parameters in the output list (number of outputs requested)"	-
 typedef	^	RotParameterType	CHARACTER(1024)	RootName	-	-	-	"RootName for writing output files"	-

--- a/modules/aerodyn/src/AeroDyn_Types.f90
+++ b/modules/aerodyn/src/AeroDyn_Types.f90
@@ -100,6 +100,7 @@ IMPLICIT NONE
     REAL(R8Ki) , DIMENSION(1:3)  :: NacellePosition      !< X-Y-Z reference position of nacelle [m]
     REAL(R8Ki) , DIMENSION(1:3,1:3)  :: NacelleOrientation      !< DCM reference orientation of nacelle [-]
     INTEGER(IntKi)  :: AeroProjMod = 1      !< Flag to switch between different projection models [-]
+    INTEGER(IntKi)  :: AeroBEM_Mod = -1      !< Flag to switch between different BEM Model [-]
   END TYPE RotInitInputType
 ! =======================
 ! =========  AD_InitInputType  =======
@@ -342,7 +343,8 @@ IMPLICIT NONE
     TYPE(MeshType)  :: TwrBuoyLoad      !< line mesh for per unit length buoyant tower loads [-]
     TYPE(MeshMapType)  :: T_P_2_T_L      !< mapping data structure to map buoyant tower point loads (m%TwrBuoyLoadPoint) to buoyant tower line loads (m%TwrBuoyLoad) [-]
     LOGICAL  :: FirstWarn_TowerStrike      !< flag to avoid printing tower strike multiple times [-]
-    REAL(ReKi) , DIMENSION(1:3)  :: AvgDiskVel      !< disk-averaged U,V,W [m/s]
+    REAL(ReKi) , DIMENSION(1:3)  :: AvgDiskVel      !< disk-averaged U,V,W (undisturbed) [m/s]
+    REAL(ReKi) , DIMENSION(1:3)  :: AvgDiskVelDist      !< disk-averaged U,V,W (disturbed) [m/s]
     REAL(ReKi)  :: TFinAlpha      !< Angle of attack for tailfin [-]
     REAL(ReKi)  :: TFinRe      !< Reynolds number for tailfin [-]
     REAL(ReKi)  :: TFinVrel      !< Orthogonal relative velocity nrom at the reference point [-]
@@ -409,6 +411,7 @@ IMPLICIT NONE
     REAL(ReKi)  :: WtrDpth      !< Water depth [m]
     REAL(ReKi)  :: MSL2SWL      !< Offset between still-water level and mean sea level [m]
     INTEGER(IntKi)  :: AeroProjMod = 1      !< Flag to switch between different projection models [-]
+    INTEGER(IntKi)  :: AeroBEM_Mod = -1      !< Flag to switch between different BEM Model [-]
     INTEGER(IntKi)  :: NumOuts      !< Number of parameters in the output list (number of outputs requested) [-]
     CHARACTER(1024)  :: RootName      !< RootName for writing output files [-]
     TYPE(OutParmType) , DIMENSION(:), ALLOCATABLE  :: OutParam      !< Names and units (and other characteristics) of all requested output parameters [-]
@@ -1429,6 +1432,7 @@ ENDIF
     DstRotInitInputTypeData%NacellePosition = SrcRotInitInputTypeData%NacellePosition
     DstRotInitInputTypeData%NacelleOrientation = SrcRotInitInputTypeData%NacelleOrientation
     DstRotInitInputTypeData%AeroProjMod = SrcRotInitInputTypeData%AeroProjMod
+    DstRotInitInputTypeData%AeroBEM_Mod = SrcRotInitInputTypeData%AeroBEM_Mod
  END SUBROUTINE AD_CopyRotInitInputType
 
  SUBROUTINE AD_DestroyRotInitInputType( RotInitInputTypeData, ErrStat, ErrMsg, DEALLOCATEpointers )
@@ -1511,6 +1515,7 @@ ENDIF
       Db_BufSz   = Db_BufSz   + SIZE(InData%NacellePosition)  ! NacellePosition
       Db_BufSz   = Db_BufSz   + SIZE(InData%NacelleOrientation)  ! NacelleOrientation
       Int_BufSz  = Int_BufSz  + 1  ! AeroProjMod
+      Int_BufSz  = Int_BufSz  + 1  ! AeroBEM_Mod
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -1606,6 +1611,8 @@ ENDIF
       END DO
     END DO
     IntKiBuf(Int_Xferred) = InData%AeroProjMod
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = InData%AeroBEM_Mod
     Int_Xferred = Int_Xferred + 1
  END SUBROUTINE AD_PackRotInitInputType
 
@@ -1724,6 +1731,8 @@ ENDIF
       END DO
     END DO
     OutData%AeroProjMod = IntKiBuf(Int_Xferred)
+    Int_Xferred = Int_Xferred + 1
+    OutData%AeroBEM_Mod = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1
  END SUBROUTINE AD_UnPackRotInitInputType
 
@@ -9330,6 +9339,7 @@ ENDIF
          IF (ErrStat>=AbortErrLev) RETURN
     DstRotMiscVarTypeData%FirstWarn_TowerStrike = SrcRotMiscVarTypeData%FirstWarn_TowerStrike
     DstRotMiscVarTypeData%AvgDiskVel = SrcRotMiscVarTypeData%AvgDiskVel
+    DstRotMiscVarTypeData%AvgDiskVelDist = SrcRotMiscVarTypeData%AvgDiskVelDist
     DstRotMiscVarTypeData%TFinAlpha = SrcRotMiscVarTypeData%TFinAlpha
     DstRotMiscVarTypeData%TFinRe = SrcRotMiscVarTypeData%TFinRe
     DstRotMiscVarTypeData%TFinVrel = SrcRotMiscVarTypeData%TFinVrel
@@ -9996,6 +10006,7 @@ ENDIF
       END IF
       Int_BufSz  = Int_BufSz  + 1  ! FirstWarn_TowerStrike
       Re_BufSz   = Re_BufSz   + SIZE(InData%AvgDiskVel)  ! AvgDiskVel
+      Re_BufSz   = Re_BufSz   + SIZE(InData%AvgDiskVelDist)  ! AvgDiskVelDist
       Re_BufSz   = Re_BufSz   + 1  ! TFinAlpha
       Re_BufSz   = Re_BufSz   + 1  ! TFinRe
       Re_BufSz   = Re_BufSz   + 1  ! TFinVrel
@@ -11094,6 +11105,10 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     DO i1 = LBOUND(InData%AvgDiskVel,1), UBOUND(InData%AvgDiskVel,1)
       ReKiBuf(Re_Xferred) = InData%AvgDiskVel(i1)
+      Re_Xferred = Re_Xferred + 1
+    END DO
+    DO i1 = LBOUND(InData%AvgDiskVelDist,1), UBOUND(InData%AvgDiskVelDist,1)
+      ReKiBuf(Re_Xferred) = InData%AvgDiskVelDist(i1)
       Re_Xferred = Re_Xferred + 1
     END DO
     ReKiBuf(Re_Xferred) = InData%TFinAlpha
@@ -12519,6 +12534,12 @@ ENDIF
       OutData%AvgDiskVel(i1) = ReKiBuf(Re_Xferred)
       Re_Xferred = Re_Xferred + 1
     END DO
+    i1_l = LBOUND(OutData%AvgDiskVelDist,1)
+    i1_u = UBOUND(OutData%AvgDiskVelDist,1)
+    DO i1 = LBOUND(OutData%AvgDiskVelDist,1), UBOUND(OutData%AvgDiskVelDist,1)
+      OutData%AvgDiskVelDist(i1) = ReKiBuf(Re_Xferred)
+      Re_Xferred = Re_Xferred + 1
+    END DO
     OutData%TFinAlpha = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
     OutData%TFinRe = ReKiBuf(Re_Xferred)
@@ -13442,6 +13463,7 @@ ENDIF
     DstRotParameterTypeData%WtrDpth = SrcRotParameterTypeData%WtrDpth
     DstRotParameterTypeData%MSL2SWL = SrcRotParameterTypeData%MSL2SWL
     DstRotParameterTypeData%AeroProjMod = SrcRotParameterTypeData%AeroProjMod
+    DstRotParameterTypeData%AeroBEM_Mod = SrcRotParameterTypeData%AeroBEM_Mod
     DstRotParameterTypeData%NumOuts = SrcRotParameterTypeData%NumOuts
     DstRotParameterTypeData%RootName = SrcRotParameterTypeData%RootName
 IF (ALLOCATED(SrcRotParameterTypeData%OutParam)) THEN
@@ -13786,6 +13808,7 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! WtrDpth
       Re_BufSz   = Re_BufSz   + 1  ! MSL2SWL
       Int_BufSz  = Int_BufSz  + 1  ! AeroProjMod
+      Int_BufSz  = Int_BufSz  + 1  ! AeroBEM_Mod
       Int_BufSz  = Int_BufSz  + 1  ! NumOuts
       Int_BufSz  = Int_BufSz  + 1*LEN(InData%RootName)  ! RootName
   Int_BufSz   = Int_BufSz   + 1     ! OutParam allocated yes/no
@@ -14308,6 +14331,8 @@ ENDIF
     ReKiBuf(Re_Xferred) = InData%MSL2SWL
     Re_Xferred = Re_Xferred + 1
     IntKiBuf(Int_Xferred) = InData%AeroProjMod
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = InData%AeroBEM_Mod
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = InData%NumOuts
     Int_Xferred = Int_Xferred + 1
@@ -14987,6 +15012,8 @@ ENDIF
     OutData%MSL2SWL = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
     OutData%AeroProjMod = IntKiBuf(Int_Xferred)
+    Int_Xferred = Int_Xferred + 1
+    OutData%AeroBEM_Mod = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1
     OutData%NumOuts = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1

--- a/modules/aerodyn/src/FVW_IO.f90
+++ b/modules/aerodyn/src/FVW_IO.f90
@@ -85,7 +85,11 @@ SUBROUTINE FVW_ReadInputFile( FileName, p, m, Inp, ErrStat, ErrMsg )
    CALL ReadVarWDefault(UnIn,FileName,Inp%VTKBlades   , 'VTKBlades'          ,'',     0      ,ErrStat2,ErrMsg2); if(Failed())return
    CALL ReadVarWDefault(UnIn,FileName,Inp%VTKCoord    , 'VTKCoord'           ,'',     1      ,ErrStat2,ErrMsg2); if(Failed())return
    CALL ReadVar        (UnIn,FileName,sDummy          , 'VTK_fps'            ,''             ,ErrStat2,ErrMsg2); if(Failed())return
-   Inp%DTvtk = Get_DTvtk( sDummy, p%DTaero, Inp%DTfvw )
+   if (Inp%WrVTK==2 .or. Inp%WrVTK==0) then
+      Inp%DTvtk = HUGE(1.0_DbKi)
+   else
+      Inp%DTvtk = Get_DTvtk( sDummy, p%DTaero, Inp%DTfvw )
+   endif
 
    CALL ReadVarWDefault(UnIn,FileName,p%nGridOut      , 'nGridOut'           ,'',     0      ,ErrStat2,ErrMsg2);
    if (ErrStat2/=ErrID_None) then


### PR DESCRIPTION
This pull request ready to be merged. 

**Feature or improvement description**
This pull request:
- includes features of the new BEM for large coning and prebend. These features have now been tested (see plots below) and reported (official documentation to follow). 
- uses double precision for the calculation of induction factors in the BEM code
- further use the internal AeroDyn flag `BEM_Mod` to switch between BEM implementations
- reduces the differences between the legacy AeroDyn15 BEM code and the future BEM code that is still being tested and implemented. 
- exposes the new BEM interface via the temporary flag WakeMod=10, 11, 12 (similar to 0, 1, 2 but with the new BEM), to allow users to experiment with this feature. WakeMod=10,11,12 will be removed in the future. 
- fixes an issue with OLAF when WrVTK=2 (should output VTks only at init and end of simulation)

Documentation, test cases, and support for large yaw angles will be provided in future pull request (handled by another project). 

**Impacted areas of the software**
AeroDyn


**Test results, if applicable**
No change in the r-test results

**Verifcation results**
Test results for the IEA 15MW (straight blade) at 9.0m/s and 6.4 RPM, use WakeMod1=1(legacy BEM), 11 (future BEM) or 3 (OLAF).

![SimpleComp_bend](https://user-images.githubusercontent.com/1318316/228999973-d1fd33a2-d81d-4a44-82cb-ba68aa35d5e1.png)

![SimpleComp_cone](https://user-images.githubusercontent.com/1318316/228999306-1b2b7f81-196d-4b79-af5e-97fd5092b5c8.png)

**Typical input files**
Simulations, IEA 15MW  (straight blade) at 9.0m/s and 6.4 RPM,  50deg coning:
[ConeDriver.zip](https://github.com/OpenFAST/openfast/files/11117412/ConeDriver.zip)


**Acknowledgments**
The work was developped as part of the BAR project (@ptrbortolotti ) and in collaboration with Envision Energy (@bjonkman). 
