### PR TITLE
SD: removing static improvement method (SIM) from SubDyn elastic output mesh (y3 mesh)

### DIFF
--- a/docs/source/user/subdyn/theory.rst
+++ b/docs/source/user/subdyn/theory.rst
@@ -1842,7 +1842,7 @@ Similar considerations apply for Eq. :eq:`bigY2`.
 
 
 The coupling load :math:`F_{{TP},cpl}` given in Eq. :eq:`bigY1` corresponds to the rection force at the TP reference position. 
-In the "free boundary condition" case, there is no need to correct this output load since the reference position is at the deflected position.
+In the "free boundary condition" (floating) case, there is no need to correct this output load since the reference position is at the deflected position.
 For the "fixed boundary condition" case, the reference position does not correspond to the deflected position, so the reaction moment needs to be transfered to the deflected position as follows:
 
 .. math::

--- a/docs/source/user/subdyn/theory.rst
+++ b/docs/source/user/subdyn/theory.rst
@@ -1935,9 +1935,9 @@ dynamic solution.
 The SIM formulation provides a correction for the displacements of the
 internal nodes. The uncorrected displacements are now noted :math:`{\hat{U}}_{L}`, while
 the corrected displacements are noted :math:`U_L`. The SIM correction
-consists in an additional term :math:`U_L` obtained by adding the total
-static deflection of all the internal
-DOFs (:math:`U_{L0}`), and subtracting the static deflection associated
+consists in an additional term :math:`U_{L,\text{SIM}}` obtained 
+as the static deflection of all the internal DOFs (:math:`U_{L0}`)
+minus the static deflection associated
 with C-B modes (:math:`U_{L0m}`), as cast in :eq:`SIM` :
 
 .. math::   :label: SIM

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -5622,6 +5622,7 @@ SUBROUTINE WrVTK_AllMeshes(p_FAST, y_FAST, MeshMapData, ED, BD, AD, IfW, OpFM, H
    IF ( p_FAST%CompSub == Module_SD .and. allocated(SD%Input)) THEN
       !call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%TPMesh, trim(p_FAST%VTK_OutFileRoot)//'.SD_TPMesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, p_FAST%VTK_tWidth )
       call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%LMesh, trim(p_FAST%VTK_OutFileRoot)//'.SD_LMesh_y2Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, p_FAST%VTK_tWidth, SD%y%y2Mesh )
+      call MeshWrVTK(p_FAST%TurbinePos, SD%Input(1)%LMesh, trim(p_FAST%VTK_OutFileRoot)//'.SD_LMesh_y3Mesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, p_FAST%VTK_tWidth, SD%y%y3Mesh )
 
       call MeshWrVTK(p_FAST%TurbinePos, SD%y%y1Mesh, trim(p_FAST%VTK_OutFileRoot)//'.SD_y1Mesh_TPMesh', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, p_FAST%VTK_tWidth, SD%Input(1)%TPMesh )
       !call MeshWrVTK(p_FAST%TurbinePos, SD%y%y3Mesh, trim(p_FAST%VTK_OutFileRoot)//'.SD_y3Mesh_motion', y_FAST%VTK_count, p_FAST%VTK_fields, ErrStat2, ErrMsg2, p_FAST%VTK_tWidth )

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -543,16 +543,6 @@ SUBROUTINE SD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
          m%UL_dotdot     = matmul( p%C2_61, x%qm    )    + matmul( p%C2_62   , x%qmdot )    & 
                          + matmul( p%D2_63, udotdot_TP ) + matmul( p%D2_64,    m%F_L   )
       end if
-      ! Static improvement (modify UL)
-      if (p%SttcSolve/=idSIM_None) then
-         FLt  = MATMUL(p%PhiL_T      , m%F_L) ! NOTE: Gravity in F_L
-         ULS  = MATMUL(p%PhiLInvOmgL2, FLt ) 
-         if ( p%nDOFM > 0) then
-            UL0M = MATMUL(p%PhiLInvOmgL2(:,1:p%nDOFM), FLt(1:p%nDOFM)       )
-            ULS = ULS-UL0M
-         end if          
-         m%UL = m%UL + ULS 
-      endif    
       ! --- Adding Guyan contribution to R and L DOFs
       if (.not.p%Floating) then
          ! Then we add the Guyan motion here
@@ -566,6 +556,16 @@ SUBROUTINE SD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
          ! We know that the Guyan modes are rigid body modes.
          ! We will add them in the "Full system" later
       endif
+      ! Static improvement (modify UL)
+      if (p%SttcSolve/=idSIM_None) then
+         FLt  = MATMUL(p%PhiL_T      , m%F_L) ! NOTE: Gravity in F_L
+         ULS  = MATMUL(p%PhiLInvOmgL2, FLt ) 
+         if ( p%nDOFM > 0) then
+            UL0M = MATMUL(p%PhiLInvOmgL2(:,1:p%nDOFM), FLt(1:p%nDOFM)       )
+            ULS = ULS-UL0M
+         end if          
+         m%UL = m%UL + ULS 
+      endif    
       m%UL_NS = m%UL ! TODO TODO TODO remove SIM later
 
       ! --- Build original DOF vectors ("full" prior to constraints and CB)

--- a/modules/subdyn/src/SubDyn_Output.f90
+++ b/modules/subdyn/src/SubDyn_Output.f90
@@ -85,6 +85,7 @@ SUBROUTINE SDOut_Init( Init, y,  p, misc, InitOut, WtrDpth, ErrStat, ErrMsg )
    CALL AllocAry(misc%SDWrOutput       , p%NumOuts + p%OutAllInt*p%OutAllDims, 'SDWrOutupt' , ErrStat2, ErrMsg2) ; if(Failed()) return
    ! Allocate WriteOuput  
    CALL AllocAry(y%WriteOutput         , p%NumOuts + p%OutAllInt*p%OutAllDims, 'WriteOutput', ErrStat2, ErrMsg2); if(Failed()) return
+   allocate(misc%AllOuts(0:MaxOutPts + p%OutAllInt*p%OutAllDims)) ! Need to start at 0... 
    ! Header, and Units, copy of data already available in the OutParam data structure ! TODO TODO TODO remove copy
    CALL AllocAry(InitOut%WriteOutputHdr, p%NumOuts + p%OutAllint*p%OutAllDims, 'WriteOutputHdr', ErrStat2, ErrMsg2); if(Failed()) return
    CALL AllocAry(InitOut%WriteOutputUnt, p%NumOuts + p%OutAllint*p%OutAllDims, 'WriteOutputUnt', ErrStat2, ErrMsg2); if(Failed()) return

--- a/modules/subdyn/src/SubDyn_Registry.txt
+++ b/modules/subdyn/src/SubDyn_Registry.txt
@@ -140,7 +140,8 @@ typedef  ^    MiscVarType    ReKi           qmdotdot      {:}  -  -  "2nd Deriva
 typedef  ^    MiscVarType    ReKi           u_TP           6   -  -  
 typedef  ^    MiscVarType    ReKi           udot_TP        6   -  -  
 typedef  ^    MiscVarType    ReKi           udotdot_TP     6   -  -  
-typedef  ^    MiscVarType    ReKi           F_L           {:}  -  -  
+typedef  ^    MiscVarType    ReKi           F_L           {:}  -  -  "Loads on internal DOF, size nL" 
+typedef  ^    MiscVarType    ReKi           F_L2          {:}  -  -  "Loads on internal DOF, size nL, used for SIM and ADM4" 
 typedef  ^    MiscVarType    ReKi           UR_bar        {:}  -  -  
 typedef  ^    MiscVarType    ReKi           UR_bar_dot    {:}  -  -  
 typedef  ^    MiscVarType    ReKi           UR_bar_dotdot {:}  -  -  
@@ -157,10 +158,14 @@ typedef  ^    MiscVarType    ReKi           U_full_elast  {:}  -  -  "Elastic di
 typedef  ^    MiscVarType    ReKi           U_red          {:}  -  -  
 typedef  ^    MiscVarType    ReKi           FC_unit   {:}   -  -   "Cable Force vector (for varying cable load, of unit cable load)"  N
 typedef  ^    MiscVarType    ReKi           SDWrOutput {:} -  -    "Data from previous step to be written to a SubDyn output file"
+typedef  ^    MiscVarType    ReKi           AllOuts    {:} -  -    "Data for output file"
 typedef  ^    MiscVarType    DbKi           LastOutTime -  -  -    "The time of the most recent stored output data"  "s"
 typedef  ^    MiscVarType    IntKi          Decimat     -  -  -    "Current output decimation counter"  "-"
 typedef  ^    MiscVarType    ReKi           Fext      {:} -  -     "External loads on unconstrained DOFs"  "-"
 typedef  ^    MiscVarType    ReKi           Fext_red  {:} -  -     "External loads on constrained DOFs, Fext_red= T^t Fext"  "-"
+# SIM
+typedef  ^    MiscVarType    ReKi           UL_SIM        {:}  -  -  "UL for SIM = PhiL qL0- PhiM qm0, size nL" 
+typedef  ^    MiscVarType    ReKi           UL_0m         {:}  -  -  "Intermediate UL term for SIM = PhiM qm0, size nL" 
 ### data for writing to an output file (this data is associated with time, but saved/written in CalcOutput so not stored as an other state) ###
 
 # ============================== Parameters ============================================================================================================================================

--- a/modules/subdyn/src/SubDyn_Registry.txt
+++ b/modules/subdyn/src/SubDyn_Registry.txt
@@ -154,10 +154,7 @@ typedef  ^    MiscVarType    ReKi           U_full_NS     {:}  -  -  "Displaceme
 typedef  ^    MiscVarType    ReKi           U_full_dot    {:}  -  -  
 typedef  ^    MiscVarType    ReKi           U_full_dotdot {:}  -  -  
 typedef  ^    MiscVarType    ReKi           U_full_elast  {:}  -  -  "Elastic displacements for computation of K ue (without rigid body mode for floating), includes SIM"
-typedef  ^    MiscVarType    ReKi           U_full_elast_NS {:} - -  "Elastic displacements (no Guyan for floating), No SIM (NS)"
 typedef  ^    MiscVarType    ReKi           U_red          {:}  -  -  
-typedef  ^    MiscVarType    ReKi           U_red_dot      {:}  -  -  
-typedef  ^    MiscVarType    ReKi           U_red_dotdot   {:}  -  -  
 typedef  ^    MiscVarType    ReKi           FC_unit   {:}   -  -   "Cable Force vector (for varying cable load, of unit cable load)"  N
 typedef  ^    MiscVarType    ReKi           SDWrOutput {:} -  -    "Data from previous step to be written to a SubDyn output file"
 typedef  ^    MiscVarType    DbKi           LastOutTime -  -  -    "The time of the most recent stored output data"  "s"

--- a/modules/subdyn/src/SubDyn_Registry.txt
+++ b/modules/subdyn/src/SubDyn_Registry.txt
@@ -144,14 +144,17 @@ typedef  ^    MiscVarType    ReKi           F_L           {:}  -  -
 typedef  ^    MiscVarType    ReKi           UR_bar        {:}  -  -  
 typedef  ^    MiscVarType    ReKi           UR_bar_dot    {:}  -  -  
 typedef  ^    MiscVarType    ReKi           UR_bar_dotdot {:}  -  -  
-typedef  ^    MiscVarType    ReKi           UL            {:}  -  -  
+typedef  ^    MiscVarType    ReKi           UL            {:}  -  -  "Internal DOFs (L) displacements " 
+typedef  ^    MiscVarType    ReKi           UL_NS         {:}  -  -  "Internal DOFs (L) displacements, No SIM (NS)" 
 typedef  ^    MiscVarType    ReKi           UL_dot        {:}  -  -  
 typedef  ^    MiscVarType    ReKi           UL_dotdot     {:}  -  -  
-typedef  ^    MiscVarType    ReKi           DU_full       {:}  -  -  "Delta U used for extra moment" 
-typedef  ^    MiscVarType    ReKi           U_full        {:}  -  -  
+typedef  ^    MiscVarType    ReKi           DU_full       {:}  -  -  "Delta U used for extra moment, size nDOF" 
+typedef  ^    MiscVarType    ReKi           U_full        {:}  -  -  "Displacement of all DOFs (full system) with SIM"
+typedef  ^    MiscVarType    ReKi           U_full_NS     {:}  -  -  "Displacement of all DOFs (full system), No SIM (NS)"
 typedef  ^    MiscVarType    ReKi           U_full_dot    {:}  -  -  
 typedef  ^    MiscVarType    ReKi           U_full_dotdot {:}  -  -  
-typedef  ^    MiscVarType    ReKi           U_full_elast  {:}  -  -  "Elastic displacements for computation of K ue (without rigid body mode for floating)"
+typedef  ^    MiscVarType    ReKi           U_full_elast  {:}  -  -  "Elastic displacements for computation of K ue (without rigid body mode for floating), includes SIM"
+typedef  ^    MiscVarType    ReKi           U_full_elast_NS {:} - -  "Elastic displacements (no Guyan for floating), No SIM (NS)"
 typedef  ^    MiscVarType    ReKi           U_red          {:}  -  -  
 typedef  ^    MiscVarType    ReKi           U_red_dot      {:}  -  -  
 typedef  ^    MiscVarType    ReKi           U_red_dotdot   {:}  -  -  

--- a/modules/subdyn/src/SubDyn_Types.f90
+++ b/modules/subdyn/src/SubDyn_Types.f90
@@ -205,10 +205,7 @@ IMPLICIT NONE
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_dot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_dotdot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_elast      !< Elastic displacements for computation of K ue (without rigid body mode for floating), includes SIM [-]
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_elast_NS      !< Elastic displacements (no Guyan for floating), No SIM (NS) [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_red 
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_red_dot 
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_red_dotdot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: FC_unit      !< Cable Force vector (for varying cable load, of unit cable load) [N]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: SDWrOutput      !< Data from previous step to be written to a SubDyn output file [-]
     REAL(DbKi)  :: LastOutTime      !< The time of the most recent stored output data [s]
@@ -6083,18 +6080,6 @@ IF (ALLOCATED(SrcMiscData%U_full_elast)) THEN
   END IF
     DstMiscData%U_full_elast = SrcMiscData%U_full_elast
 ENDIF
-IF (ALLOCATED(SrcMiscData%U_full_elast_NS)) THEN
-  i1_l = LBOUND(SrcMiscData%U_full_elast_NS,1)
-  i1_u = UBOUND(SrcMiscData%U_full_elast_NS,1)
-  IF (.NOT. ALLOCATED(DstMiscData%U_full_elast_NS)) THEN 
-    ALLOCATE(DstMiscData%U_full_elast_NS(i1_l:i1_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%U_full_elast_NS.', ErrStat, ErrMsg,RoutineName)
-      RETURN
-    END IF
-  END IF
-    DstMiscData%U_full_elast_NS = SrcMiscData%U_full_elast_NS
-ENDIF
 IF (ALLOCATED(SrcMiscData%U_red)) THEN
   i1_l = LBOUND(SrcMiscData%U_red,1)
   i1_u = UBOUND(SrcMiscData%U_red,1)
@@ -6106,30 +6091,6 @@ IF (ALLOCATED(SrcMiscData%U_red)) THEN
     END IF
   END IF
     DstMiscData%U_red = SrcMiscData%U_red
-ENDIF
-IF (ALLOCATED(SrcMiscData%U_red_dot)) THEN
-  i1_l = LBOUND(SrcMiscData%U_red_dot,1)
-  i1_u = UBOUND(SrcMiscData%U_red_dot,1)
-  IF (.NOT. ALLOCATED(DstMiscData%U_red_dot)) THEN 
-    ALLOCATE(DstMiscData%U_red_dot(i1_l:i1_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%U_red_dot.', ErrStat, ErrMsg,RoutineName)
-      RETURN
-    END IF
-  END IF
-    DstMiscData%U_red_dot = SrcMiscData%U_red_dot
-ENDIF
-IF (ALLOCATED(SrcMiscData%U_red_dotdot)) THEN
-  i1_l = LBOUND(SrcMiscData%U_red_dotdot,1)
-  i1_u = UBOUND(SrcMiscData%U_red_dotdot,1)
-  IF (.NOT. ALLOCATED(DstMiscData%U_red_dotdot)) THEN 
-    ALLOCATE(DstMiscData%U_red_dotdot(i1_l:i1_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%U_red_dotdot.', ErrStat, ErrMsg,RoutineName)
-      RETURN
-    END IF
-  END IF
-    DstMiscData%U_red_dotdot = SrcMiscData%U_red_dotdot
 ENDIF
 IF (ALLOCATED(SrcMiscData%FC_unit)) THEN
   i1_l = LBOUND(SrcMiscData%FC_unit,1)
@@ -6249,17 +6210,8 @@ ENDIF
 IF (ALLOCATED(MiscData%U_full_elast)) THEN
   DEALLOCATE(MiscData%U_full_elast)
 ENDIF
-IF (ALLOCATED(MiscData%U_full_elast_NS)) THEN
-  DEALLOCATE(MiscData%U_full_elast_NS)
-ENDIF
 IF (ALLOCATED(MiscData%U_red)) THEN
   DEALLOCATE(MiscData%U_red)
-ENDIF
-IF (ALLOCATED(MiscData%U_red_dot)) THEN
-  DEALLOCATE(MiscData%U_red_dot)
-ENDIF
-IF (ALLOCATED(MiscData%U_red_dotdot)) THEN
-  DEALLOCATE(MiscData%U_red_dotdot)
 ENDIF
 IF (ALLOCATED(MiscData%FC_unit)) THEN
   DEALLOCATE(MiscData%FC_unit)
@@ -6388,25 +6340,10 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*1  ! U_full_elast upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%U_full_elast)  ! U_full_elast
   END IF
-  Int_BufSz   = Int_BufSz   + 1     ! U_full_elast_NS allocated yes/no
-  IF ( ALLOCATED(InData%U_full_elast_NS) ) THEN
-    Int_BufSz   = Int_BufSz   + 2*1  ! U_full_elast_NS upper/lower bounds for each dimension
-      Re_BufSz   = Re_BufSz   + SIZE(InData%U_full_elast_NS)  ! U_full_elast_NS
-  END IF
   Int_BufSz   = Int_BufSz   + 1     ! U_red allocated yes/no
   IF ( ALLOCATED(InData%U_red) ) THEN
     Int_BufSz   = Int_BufSz   + 2*1  ! U_red upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%U_red)  ! U_red
-  END IF
-  Int_BufSz   = Int_BufSz   + 1     ! U_red_dot allocated yes/no
-  IF ( ALLOCATED(InData%U_red_dot) ) THEN
-    Int_BufSz   = Int_BufSz   + 2*1  ! U_red_dot upper/lower bounds for each dimension
-      Re_BufSz   = Re_BufSz   + SIZE(InData%U_red_dot)  ! U_red_dot
-  END IF
-  Int_BufSz   = Int_BufSz   + 1     ! U_red_dotdot allocated yes/no
-  IF ( ALLOCATED(InData%U_red_dotdot) ) THEN
-    Int_BufSz   = Int_BufSz   + 2*1  ! U_red_dotdot upper/lower bounds for each dimension
-      Re_BufSz   = Re_BufSz   + SIZE(InData%U_red_dotdot)  ! U_red_dotdot
   END IF
   Int_BufSz   = Int_BufSz   + 1     ! FC_unit allocated yes/no
   IF ( ALLOCATED(InData%FC_unit) ) THEN
@@ -6694,21 +6631,6 @@ ENDIF
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
-  IF ( .NOT. ALLOCATED(InData%U_full_elast_NS) ) THEN
-    IntKiBuf( Int_Xferred ) = 0
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    IntKiBuf( Int_Xferred ) = 1
-    Int_Xferred = Int_Xferred + 1
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%U_full_elast_NS,1)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%U_full_elast_NS,1)
-    Int_Xferred = Int_Xferred + 2
-
-      DO i1 = LBOUND(InData%U_full_elast_NS,1), UBOUND(InData%U_full_elast_NS,1)
-        ReKiBuf(Re_Xferred) = InData%U_full_elast_NS(i1)
-        Re_Xferred = Re_Xferred + 1
-      END DO
-  END IF
   IF ( .NOT. ALLOCATED(InData%U_red) ) THEN
     IntKiBuf( Int_Xferred ) = 0
     Int_Xferred = Int_Xferred + 1
@@ -6721,36 +6643,6 @@ ENDIF
 
       DO i1 = LBOUND(InData%U_red,1), UBOUND(InData%U_red,1)
         ReKiBuf(Re_Xferred) = InData%U_red(i1)
-        Re_Xferred = Re_Xferred + 1
-      END DO
-  END IF
-  IF ( .NOT. ALLOCATED(InData%U_red_dot) ) THEN
-    IntKiBuf( Int_Xferred ) = 0
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    IntKiBuf( Int_Xferred ) = 1
-    Int_Xferred = Int_Xferred + 1
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%U_red_dot,1)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%U_red_dot,1)
-    Int_Xferred = Int_Xferred + 2
-
-      DO i1 = LBOUND(InData%U_red_dot,1), UBOUND(InData%U_red_dot,1)
-        ReKiBuf(Re_Xferred) = InData%U_red_dot(i1)
-        Re_Xferred = Re_Xferred + 1
-      END DO
-  END IF
-  IF ( .NOT. ALLOCATED(InData%U_red_dotdot) ) THEN
-    IntKiBuf( Int_Xferred ) = 0
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    IntKiBuf( Int_Xferred ) = 1
-    Int_Xferred = Int_Xferred + 1
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%U_red_dotdot,1)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%U_red_dotdot,1)
-    Int_Xferred = Int_Xferred + 2
-
-      DO i1 = LBOUND(InData%U_red_dotdot,1), UBOUND(InData%U_red_dotdot,1)
-        ReKiBuf(Re_Xferred) = InData%U_red_dotdot(i1)
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
@@ -7135,24 +7027,6 @@ ENDIF
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
-  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_full_elast_NS not allocated
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    Int_Xferred = Int_Xferred + 1
-    i1_l = IntKiBuf( Int_Xferred    )
-    i1_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    IF (ALLOCATED(OutData%U_full_elast_NS)) DEALLOCATE(OutData%U_full_elast_NS)
-    ALLOCATE(OutData%U_full_elast_NS(i1_l:i1_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%U_full_elast_NS.', ErrStat, ErrMsg,RoutineName)
-       RETURN
-    END IF
-      DO i1 = LBOUND(OutData%U_full_elast_NS,1), UBOUND(OutData%U_full_elast_NS,1)
-        OutData%U_full_elast_NS(i1) = ReKiBuf(Re_Xferred)
-        Re_Xferred = Re_Xferred + 1
-      END DO
-  END IF
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_red not allocated
     Int_Xferred = Int_Xferred + 1
   ELSE
@@ -7168,42 +7042,6 @@ ENDIF
     END IF
       DO i1 = LBOUND(OutData%U_red,1), UBOUND(OutData%U_red,1)
         OutData%U_red(i1) = ReKiBuf(Re_Xferred)
-        Re_Xferred = Re_Xferred + 1
-      END DO
-  END IF
-  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_red_dot not allocated
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    Int_Xferred = Int_Xferred + 1
-    i1_l = IntKiBuf( Int_Xferred    )
-    i1_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    IF (ALLOCATED(OutData%U_red_dot)) DEALLOCATE(OutData%U_red_dot)
-    ALLOCATE(OutData%U_red_dot(i1_l:i1_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%U_red_dot.', ErrStat, ErrMsg,RoutineName)
-       RETURN
-    END IF
-      DO i1 = LBOUND(OutData%U_red_dot,1), UBOUND(OutData%U_red_dot,1)
-        OutData%U_red_dot(i1) = ReKiBuf(Re_Xferred)
-        Re_Xferred = Re_Xferred + 1
-      END DO
-  END IF
-  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_red_dotdot not allocated
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    Int_Xferred = Int_Xferred + 1
-    i1_l = IntKiBuf( Int_Xferred    )
-    i1_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    IF (ALLOCATED(OutData%U_red_dotdot)) DEALLOCATE(OutData%U_red_dotdot)
-    ALLOCATE(OutData%U_red_dotdot(i1_l:i1_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%U_red_dotdot.', ErrStat, ErrMsg,RoutineName)
-       RETURN
-    END IF
-      DO i1 = LBOUND(OutData%U_red_dotdot,1), UBOUND(OutData%U_red_dotdot,1)
-        OutData%U_red_dotdot(i1) = ReKiBuf(Re_Xferred)
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF

--- a/modules/subdyn/src/SubDyn_Types.f90
+++ b/modules/subdyn/src/SubDyn_Types.f90
@@ -195,14 +195,17 @@ IMPLICIT NONE
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UR_bar 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UR_bar_dot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UR_bar_dotdot 
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UL 
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UL      !< Internal DOFs (L) displacements  [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UL_NS      !< Internal DOFs (L) displacements, No SIM (NS) [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UL_dot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: UL_dotdot 
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: DU_full      !< Delta U used for extra moment [-]
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full 
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: DU_full      !< Delta U used for extra moment, size nDOF [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full      !< Displacement of all DOFs (full system) with SIM [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_NS      !< Displacement of all DOFs (full system), No SIM (NS) [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_dot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_dotdot 
-    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_elast      !< Elastic displacements for computation of K ue (without rigid body mode for floating) [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_elast      !< Elastic displacements for computation of K ue (without rigid body mode for floating), includes SIM [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_full_elast_NS      !< Elastic displacements (no Guyan for floating), No SIM (NS) [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_red 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_red_dot 
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: U_red_dotdot 
@@ -5972,6 +5975,18 @@ IF (ALLOCATED(SrcMiscData%UL)) THEN
   END IF
     DstMiscData%UL = SrcMiscData%UL
 ENDIF
+IF (ALLOCATED(SrcMiscData%UL_NS)) THEN
+  i1_l = LBOUND(SrcMiscData%UL_NS,1)
+  i1_u = UBOUND(SrcMiscData%UL_NS,1)
+  IF (.NOT. ALLOCATED(DstMiscData%UL_NS)) THEN 
+    ALLOCATE(DstMiscData%UL_NS(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%UL_NS.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstMiscData%UL_NS = SrcMiscData%UL_NS
+ENDIF
 IF (ALLOCATED(SrcMiscData%UL_dot)) THEN
   i1_l = LBOUND(SrcMiscData%UL_dot,1)
   i1_u = UBOUND(SrcMiscData%UL_dot,1)
@@ -6020,6 +6035,18 @@ IF (ALLOCATED(SrcMiscData%U_full)) THEN
   END IF
     DstMiscData%U_full = SrcMiscData%U_full
 ENDIF
+IF (ALLOCATED(SrcMiscData%U_full_NS)) THEN
+  i1_l = LBOUND(SrcMiscData%U_full_NS,1)
+  i1_u = UBOUND(SrcMiscData%U_full_NS,1)
+  IF (.NOT. ALLOCATED(DstMiscData%U_full_NS)) THEN 
+    ALLOCATE(DstMiscData%U_full_NS(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%U_full_NS.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstMiscData%U_full_NS = SrcMiscData%U_full_NS
+ENDIF
 IF (ALLOCATED(SrcMiscData%U_full_dot)) THEN
   i1_l = LBOUND(SrcMiscData%U_full_dot,1)
   i1_u = UBOUND(SrcMiscData%U_full_dot,1)
@@ -6055,6 +6082,18 @@ IF (ALLOCATED(SrcMiscData%U_full_elast)) THEN
     END IF
   END IF
     DstMiscData%U_full_elast = SrcMiscData%U_full_elast
+ENDIF
+IF (ALLOCATED(SrcMiscData%U_full_elast_NS)) THEN
+  i1_l = LBOUND(SrcMiscData%U_full_elast_NS,1)
+  i1_u = UBOUND(SrcMiscData%U_full_elast_NS,1)
+  IF (.NOT. ALLOCATED(DstMiscData%U_full_elast_NS)) THEN 
+    ALLOCATE(DstMiscData%U_full_elast_NS(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstMiscData%U_full_elast_NS.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstMiscData%U_full_elast_NS = SrcMiscData%U_full_elast_NS
 ENDIF
 IF (ALLOCATED(SrcMiscData%U_red)) THEN
   i1_l = LBOUND(SrcMiscData%U_red,1)
@@ -6183,6 +6222,9 @@ ENDIF
 IF (ALLOCATED(MiscData%UL)) THEN
   DEALLOCATE(MiscData%UL)
 ENDIF
+IF (ALLOCATED(MiscData%UL_NS)) THEN
+  DEALLOCATE(MiscData%UL_NS)
+ENDIF
 IF (ALLOCATED(MiscData%UL_dot)) THEN
   DEALLOCATE(MiscData%UL_dot)
 ENDIF
@@ -6195,6 +6237,9 @@ ENDIF
 IF (ALLOCATED(MiscData%U_full)) THEN
   DEALLOCATE(MiscData%U_full)
 ENDIF
+IF (ALLOCATED(MiscData%U_full_NS)) THEN
+  DEALLOCATE(MiscData%U_full_NS)
+ENDIF
 IF (ALLOCATED(MiscData%U_full_dot)) THEN
   DEALLOCATE(MiscData%U_full_dot)
 ENDIF
@@ -6203,6 +6248,9 @@ IF (ALLOCATED(MiscData%U_full_dotdot)) THEN
 ENDIF
 IF (ALLOCATED(MiscData%U_full_elast)) THEN
   DEALLOCATE(MiscData%U_full_elast)
+ENDIF
+IF (ALLOCATED(MiscData%U_full_elast_NS)) THEN
+  DEALLOCATE(MiscData%U_full_elast_NS)
 ENDIF
 IF (ALLOCATED(MiscData%U_red)) THEN
   DEALLOCATE(MiscData%U_red)
@@ -6295,6 +6343,11 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*1  ! UL upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%UL)  ! UL
   END IF
+  Int_BufSz   = Int_BufSz   + 1     ! UL_NS allocated yes/no
+  IF ( ALLOCATED(InData%UL_NS) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! UL_NS upper/lower bounds for each dimension
+      Re_BufSz   = Re_BufSz   + SIZE(InData%UL_NS)  ! UL_NS
+  END IF
   Int_BufSz   = Int_BufSz   + 1     ! UL_dot allocated yes/no
   IF ( ALLOCATED(InData%UL_dot) ) THEN
     Int_BufSz   = Int_BufSz   + 2*1  ! UL_dot upper/lower bounds for each dimension
@@ -6315,6 +6368,11 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*1  ! U_full upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%U_full)  ! U_full
   END IF
+  Int_BufSz   = Int_BufSz   + 1     ! U_full_NS allocated yes/no
+  IF ( ALLOCATED(InData%U_full_NS) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! U_full_NS upper/lower bounds for each dimension
+      Re_BufSz   = Re_BufSz   + SIZE(InData%U_full_NS)  ! U_full_NS
+  END IF
   Int_BufSz   = Int_BufSz   + 1     ! U_full_dot allocated yes/no
   IF ( ALLOCATED(InData%U_full_dot) ) THEN
     Int_BufSz   = Int_BufSz   + 2*1  ! U_full_dot upper/lower bounds for each dimension
@@ -6329,6 +6387,11 @@ ENDIF
   IF ( ALLOCATED(InData%U_full_elast) ) THEN
     Int_BufSz   = Int_BufSz   + 2*1  ! U_full_elast upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%U_full_elast)  ! U_full_elast
+  END IF
+  Int_BufSz   = Int_BufSz   + 1     ! U_full_elast_NS allocated yes/no
+  IF ( ALLOCATED(InData%U_full_elast_NS) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! U_full_elast_NS upper/lower bounds for each dimension
+      Re_BufSz   = Re_BufSz   + SIZE(InData%U_full_elast_NS)  ! U_full_elast_NS
   END IF
   Int_BufSz   = Int_BufSz   + 1     ! U_red allocated yes/no
   IF ( ALLOCATED(InData%U_red) ) THEN
@@ -6496,6 +6559,21 @@ ENDIF
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
+  IF ( .NOT. ALLOCATED(InData%UL_NS) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%UL_NS,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%UL_NS,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%UL_NS,1), UBOUND(InData%UL_NS,1)
+        ReKiBuf(Re_Xferred) = InData%UL_NS(i1)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
   IF ( .NOT. ALLOCATED(InData%UL_dot) ) THEN
     IntKiBuf( Int_Xferred ) = 0
     Int_Xferred = Int_Xferred + 1
@@ -6556,6 +6634,21 @@ ENDIF
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
+  IF ( .NOT. ALLOCATED(InData%U_full_NS) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%U_full_NS,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%U_full_NS,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%U_full_NS,1), UBOUND(InData%U_full_NS,1)
+        ReKiBuf(Re_Xferred) = InData%U_full_NS(i1)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
   IF ( .NOT. ALLOCATED(InData%U_full_dot) ) THEN
     IntKiBuf( Int_Xferred ) = 0
     Int_Xferred = Int_Xferred + 1
@@ -6598,6 +6691,21 @@ ENDIF
 
       DO i1 = LBOUND(InData%U_full_elast,1), UBOUND(InData%U_full_elast,1)
         ReKiBuf(Re_Xferred) = InData%U_full_elast(i1)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
+  IF ( .NOT. ALLOCATED(InData%U_full_elast_NS) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%U_full_elast_NS,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%U_full_elast_NS,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%U_full_elast_NS,1), UBOUND(InData%U_full_elast_NS,1)
+        ReKiBuf(Re_Xferred) = InData%U_full_elast_NS(i1)
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
@@ -6865,6 +6973,24 @@ ENDIF
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! UL_NS not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%UL_NS)) DEALLOCATE(OutData%UL_NS)
+    ALLOCATE(OutData%UL_NS(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%UL_NS.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%UL_NS,1), UBOUND(OutData%UL_NS,1)
+        OutData%UL_NS(i1) = ReKiBuf(Re_Xferred)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! UL_dot not allocated
     Int_Xferred = Int_Xferred + 1
   ELSE
@@ -6937,6 +7063,24 @@ ENDIF
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_full_NS not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%U_full_NS)) DEALLOCATE(OutData%U_full_NS)
+    ALLOCATE(OutData%U_full_NS(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%U_full_NS.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%U_full_NS,1), UBOUND(OutData%U_full_NS,1)
+        OutData%U_full_NS(i1) = ReKiBuf(Re_Xferred)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_full_dot not allocated
     Int_Xferred = Int_Xferred + 1
   ELSE
@@ -6988,6 +7132,24 @@ ENDIF
     END IF
       DO i1 = LBOUND(OutData%U_full_elast,1), UBOUND(OutData%U_full_elast,1)
         OutData%U_full_elast(i1) = ReKiBuf(Re_Xferred)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! U_full_elast_NS not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%U_full_elast_NS)) DEALLOCATE(OutData%U_full_elast_NS)
+    ALLOCATE(OutData%U_full_elast_NS(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%U_full_elast_NS.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%U_full_elast_NS,1), UBOUND(OutData%U_full_elast_NS,1)
+        OutData%U_full_elast_NS(i1) = ReKiBuf(Re_Xferred)
         Re_Xferred = Re_Xferred + 1
       END DO
   END IF


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
This feature removes the static improvement method contribution from the Y3 mesh. The contribution is stilll present in the write outputs of SubDyn (displacements and elastic loads).

Additional cleanup of the code was performed as part of this pullrequest. 

More variables are allocated as part of Misc to avoid reallocation at each time step. (e.g. AllOuts and internal load vector)


**Impacted areas of the software**
SubDyn

**Additional supporting information**
This change came about while thinking about the future tight coupling algorithm of OpenFAST and could improve the stability. 

**Test results, if applicable**
Results should be unchanged.

