### PR TITLE
Bugfixes for PR #1010 (CMake)

### DIFF
--- a/modules/map/CMakeLists.txt
+++ b/modules/map/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 file(GLOB MAP_CLIB_SOURCES src/*.c src/*.cc src/*/*.c src/*/*.cc)
 file(GLOB MAP_C_HEADERS src/*.h src/*/*.h)
 
-add_library(mapcpplib_obj OBJECT ${MAP_CLIB_SOURCES} src/MAP_Types.f90 src/MAP_Fortran_Types.f90)
+add_library(mapcpplib_obj OBJECT ${MAP_CLIB_SOURCES})
 
 target_include_directories(mapcpplib_obj PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bstring>
@@ -52,7 +52,7 @@ set(MAP_F_SOURCES
   src/MAP_Fortran_Types.f90
 )
 
-add_library(maplib_obj OBJECT src/map.f90)
+add_library(maplib_obj OBJECT ${MAP_F_SOURCES})
 target_link_libraries(maplib_obj mapcpplib_obj nwtclibs_obj)
 
 add_library(maplib $<TARGET_OBJECTS:mapcpplib_obj> $<TARGET_OBJECTS:maplib_obj>)

--- a/modules/nwtc-library/CMakeLists.txt
+++ b/modules/nwtc-library/CMakeLists.txt
@@ -127,7 +127,7 @@ if (USE_LOCAL_STATIC_LAPACK)
 endif()
 
 add_library(nwtclibs_obj OBJECT ${NWTCLIBS_SOURCES})
-target_link_libraries(nwtclibs_obj nwtcbaselib_obj ${LAPACK_LIBRARIES} ${CMAKE_DL_LIBS})
+target_link_libraries(nwtclibs_obj nwtcbaselib_obj nwtcsyslib_obj ${LAPACK_LIBRARIES} ${CMAKE_DL_LIBS})
 if (USE_LOCAL_STATIC_LAPACK)
   add_dependencies(nwtclibs_obj lapack)
 endif()


### PR DESCRIPTION
This PR is ready for merging.

**Description**
There were a few minor issues with PR #1010.  A couple of targets would not build directly including `nwtclibs_obj` and `maplib_obj`.  The `maplib_obj` and `mapcpplib_obj` were linking the wrong files.  This has now been corrected.

**Related**
This partially addresses #1523, but only for linux and mac (the Windows CMake is not addressed in this PR).

**Impacted areas**
The `CMake` build system

**Test results**
None changed.