### PR TITLE
SD Bug Fix: diameter not set properly for rectangular beams

### DIFF
--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -949,6 +949,8 @@ SUBROUTINE SetElementProperties(Init, p, ErrStat, ErrMsg)
          Ixx   = (Init%PropSetsX(P1, 8) + Init%PropSetsX(P2, 8)) / 2
          Iyy   = (Init%PropSetsX(P1, 9) + Init%PropSetsX(P2, 9)) / 2
          Jzz   = (Init%PropSetsX(P1, 10) + Init%PropSetsX(P2, 10)) / 2
+         D1 = 2._ReKi*(A/PI)**0.5 !Approximation, this value should not be used
+         D2 = D1
 
          p%ElemProps(i)%Ixx    = Ixx
          p%ElemProps(i)%Iyy    = Iyy


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
The diameter variable not set properly for rectangular beams. This variable is unused, but here it is approximated to keep the code in harmony with the circular beam properties. 

**Related issue, if one exists**
#1413 

**Impacted areas of the software**
SubDyn

