### PR TITLE
Fix potential error when requesting wind below the ground (also fix build issue with SD syntax)

### DIFF
--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -333,6 +333,7 @@ contains
          U = 0.0_ReKi
       end select
       
+      !bjj: is there a reason we aren't adding the mean vertical and/or horizontal shear here, as in CalculateMeanVelocity() and Grid3D_AddMeanVelocity()?
    end function
 
 end subroutine

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -310,6 +310,12 @@ contains
       type(Grid3DFieldType), intent(in)  :: GF
       real(ReKi), intent(in)           :: PosZ
       real(ReKi)                       :: U
+      
+      if  (PosZ <= 0.0_ReKi) then
+         U = 0.0_ReKi
+         return
+      end if
+      
       select case (GF%WindProfileType)
       case (WindProfileType_None)
          U = 0.0_ReKi
@@ -326,6 +332,7 @@ contains
       case default
          U = 0.0_ReKi
       end select
+      
    end function
 
 end subroutine
@@ -1715,6 +1722,11 @@ function CalculateMeanVelocity(G3D, z, y) result(u)
    real(ReKi), intent(IN)  :: y                 ! lateral location
    real(ReKi)                                               :: u                 ! mean wind speed at position (y,z)
 
+   if  (Z <= 0.0_ReKi) then
+      U = 0.0_ReKi
+      return
+   end if
+   
    select case (G3D%WindProfileType)
 
    case (WindProfileType_PL)

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -1166,8 +1166,8 @@ if (ErrStat2/=0) then
    deallocate(StrArray)
    CALL AllocAry(StrArray, nColumns, 'StrArray',ErrStat2,ErrMsg2); if (Failed()) return 
    CALL ReadCAryFromStr ( Line, StrArray, nColumns, 'Members', 'First line of members array', ErrStat2, ErrMsg2 ); if(Failed()) return
-   call LegacyWarning('Member table contains 6 columns instead of 7,  using default member directional cosines ID (-1) for all members.\
-   The directional cosines will be computed based on the member nodes for all members.')
+   call LegacyWarning('Member table contains 6 columns instead of 7,  using default member directional cosines ID (-1) for all members. &
+   &The directional cosines will be computed based on the member nodes for all members.')
    Init%Members(:,7) = -1
 endif
 ! Extract fields from first line


### PR DESCRIPTION
**Feature or improvement description**
This fixes a couple of issues:
- the SubDyn.f90 code did not build on my Windows Intel 2019 compiler due to the way the string constant was specified on a continuation line.
- InflowWind could potentially add shear below the ground or return NaN if trying to compute the power law below the ground. This change sets the mean velocity to 0 below ground.

**Related issue, if one exists**
None reported on OpenFAST code.

**Impacted areas of the software**
Any place that requests inflow below the ground; likely not a common occurrence.

Also note the question in IfW_FlowField.f90's `GetMeanVelocity` function: I am not sure why it is not adding the mean horizontal or vertical shear there.

**Test results, if applicable**
This should not change any existing r-test cases since they likely don't request wind speeds below z=0.