### PR TITLE
AWAE: fix early termination issue in AWAE_Init

### DIFF
--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1147,7 +1147,7 @@ subroutine AWAE_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitO
    allocate ( u%Vz_wake   (-p%NumRadii+1:p%NumRadii-1, -p%NumRadii+1:p%NumRadii-1, 0:p%NumPlanes-1,1:p%NumTurbines), STAT=ErrStat2 ); if (errStat2 /= 0) call SetErrStat ( ErrID_Fatal, 'Could not allocate memory for u%Vz_wake.', errStat, errMsg, RoutineName )
    allocate ( u%D_wake    (0:p%NumPlanes-1,1:p%NumTurbines), STAT=ErrStat2 ); if (errStat2 /= 0) call SetErrStat ( ErrID_Fatal, 'Could not allocate memory for u%D_wake.', errStat, errMsg, RoutineName )
    allocate ( u%WAT_k_mt  (0:p%NumRadii-1, 0:p%NumPlanes-1, 1:p%NumTurbines), STAT=ErrStat2 ); if (errStat2 /= 0) call SetErrStat ( ErrID_Fatal, 'Could not allocate memory for u%k_mt.', errStat, errMsg, RoutineName )
-   if (errStat /= ErrID_None) return
+   if (errStat >= AbortErrLev) return
 
    u%Vx_wake=0.0_ReKi
    u%Vy_wake=0.0_ReKi


### PR DESCRIPTION
This is ready for merging.

Init could terminate early if a warning occurs, which resulted in segfaults shortly after starting calculations

**Additional info**
This became an issue on a branch (LidarSim) where additional warnings were set early in the `AWAE_Init` subroutine.  While this is not really an issue in the dev branch, it could be an issue in other branches including the development work of the wake added turbulence.