### PR TITLE
[BugFix] segfault with gfortran 10.4.0  -- NWTC_Base.f90

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -260,5 +260,7 @@ macro(set_fast_flang)
      set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fopenmp")
   endif()
 
+  add_definitions(-DFLANG_COMPILER)
+
   check_f2008_features()
 endmacro(set_fast_flang)

--- a/modules/nwtc-library/src/NWTC_Base.f90
+++ b/modules/nwtc-library/src/NWTC_Base.f90
@@ -58,7 +58,9 @@ MODULE NWTC_Base
    
    INTEGER(IntKi), PARAMETER     :: NWTC_MAX_DLL_PROC  = 5                        !< maximum number of procedures that can be dynamically loaded from a DLL (see DLL_Type nwtc_base::dll_type)
    
+#ifdef FLANG_COMPILER
    TYPE(C_FUNPTR), PARAMETER     :: NULL_PROC_ADDR(NWTC_MAX_DLL_PROC) = C_NULL_FUNPTR  !< this is a hack so the Flang compiler will initialize ProcAddr to C_NULL_FUNPTR in DLL_Type (remove if no longer needed)
+#endif
 
       !> Type definition for dynamically loaded libraries:
       !! Note that changes here may need to be reflected in DLLTypePack() (nwtc_io::dlltypepack) DLLTypeUnPack() (nwtc_io::dlltypeunpack), 
@@ -68,7 +70,11 @@ MODULE NWTC_Base
 
       INTEGER(C_INTPTR_T)       :: FileAddr  = INT(0,C_INTPTR_T)                   !< The address of file FileName.         (RETURN value from LoadLibrary ) [Windows]
       TYPE(C_PTR)               :: FileAddrX = C_NULL_PTR                          !< The address of file FileName.         (RETURN value from dlopen ) [Linux]
+#ifdef FLANG_COMPILER
       TYPE(C_FUNPTR)            :: ProcAddr(NWTC_MAX_DLL_PROC) = NULL_PROC_ADDR    !< The address of procedure ProcName.    (RETURN value from GetProcAddress or dlsym) [initialized to Null for pack/unpack]
+#else
+      TYPE(C_FUNPTR)            :: ProcAddr(NWTC_MAX_DLL_PROC) = C_NULL_FUNPTR     !< The address of procedure ProcName.    (RETURN value from GetProcAddress or dlsym) [initialized to Null for pack/unpack]
+#endif
 
       CHARACTER(1024)           :: FileName                                        !< The name of the DLL file including the full path to the current working directory.
       CHARACTER(1024)           :: ProcName(NWTC_MAX_DLL_PROC)  = ""               !< The name of the procedure in the DLL that will be called.


### PR DESCRIPTION
PR #1538 introduced a seg-fault with some gfortran compilers.  Added an #ifdef for the Flang compiler

**Feature or improvement description**
PR #1538 can cause segmentation faults with some compilers.  I noticed this with gfotran 10.4.0: see https://github.com/OpenFAST/openfast/pull/1538#issuecomment-1517234765 for errors with gfortran 10.4.0 (Mac, Ventura 13.3, Intel) for a screenshot.

To remedy this I wrapped the changes to the `NWTC_Base.f90` introduced in #1538 in an `#ifdef`.

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/pull/1538#issuecomment-1517234765
#1538 

**Impacted areas of the software**
Compiler only

**Additional supporting information**

**Test results, if applicable**
