### PR TITLE
TurbSim bug fix: fix index into Z array for text grid files

### DIFF
--- a/modules/turbsim/src/TS_FileIO.f90
+++ b/modules/turbsim/src/TS_FileIO.f90
@@ -2627,7 +2627,7 @@ CHARACTER(ErrMsgLen)         :: ErrMsg
 
       WRITE (UFFF,"(I14,I6,F11.3,F11.3,F15.3,F11.2,F10.2)")  p_grid%NumGrid_Y, p_grid%NumGrid_Z, p_grid%GridRes_Y, p_grid%GridRes_Z, p_grid%TimeStep, p_grid%HubHt, UHub
       WRITE (UFFF,"(/,' Z Coordinates (m):')")
-      WRITE (UFFF,FormStr5)  ( p_grid%Z(p_grid%GridPtIndx(IZ))-p_grid%HubHt, IZ=1,p_grid%NPoints,p_grid%NumGrid_Y )
+      WRITE (UFFF,FormStr5)  ( p_grid%Z(p_grid%GridPtIndx(IZ))-p_grid%HubHt, IZ=1,p_grid%NumGrid_Y*p_grid%NumGrid_Z,p_grid%NumGrid_Y )
       WRITE (UFFF,"(/,' Y Coordinates (m):')")
       WRITE (UFFF,FormStr5)  ( p_grid%Y(p_grid%GridPtIndx(IY)), IY=1,p_grid%NumGrid_Y )
 


### PR DESCRIPTION
**Feature or improvement description**
When requesting both tower points and text-formatted grid file outputs, an array could exceed the size of the array, causing an access violation. 

**Related issue, if one exists**
This was reported on the NREL Forum: https://forums.nrel.gov/t/difference-between-fast-and-openfast-results/4665/29

**Impacted areas of the software**
TurbSim, only when both `WrADTWR` and `WrFMTFF` are true (and probably only when the number of tower points is more than the number of horizontal grid points).


**Test results, if applicable**
This doesn't get tested, so will not affect any results. Text-based full-field grid files are rarely used anywhere.
