### PR TITLE
[BugFix] Limit urllib3 version for readthedocs building

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinxcontrib-doxylink>=1.3
 sphinxcontrib-mermaid>=0.6
 sphinx_rtd_theme>=0.3
 requests[security]
+urllib3<2.0.0


### PR DESCRIPTION
This PR is ready for merging

**Description**

Readthedocs was throwing the following error:

`"urllib3 v2.0 only supports OpenSSL 1.1.1+, currently "
ImportError: urllib3 v2.0 only supports OpenSSL 1.1.1+, currently the 'ssl' module is compiled with OpenSSL 1.0.2n  7 Dec 2017. See: https://github.com/urllib3/urllib3/issues/2168`

A quick search showed that this was an incompatibility with the more recent versions of `urllib3` with the `requests` package.


**Related issues**
See https://github.com/psf/requests/issues/6432 for issue others have run into.

Using the following solution: https://github.com/open-mmlab/mmengine/pull/1132

