### PR TITLE
Fix FAST_SFunc build using wrong libraries.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -151,6 +151,9 @@ endif()
 #-------------------------------------------------------------------------------
 
 if (BUILD_OPENFAST_SIMULINK_API)
+  if (BUILD_SHARED_LIBS)
+    message(FATAL_ERROR "OpenFAST's Simulink API is not compatible with BUILD_SHARED_LIBS=ON")
+  endif ()
   find_package(Matlab REQUIRED SIMULINK)
 endif ()
 

--- a/glue-codes/simulink/CMakeLists.txt
+++ b/glue-codes/simulink/CMakeLists.txt
@@ -15,23 +15,61 @@
 #
 
 # Build the matlab shared library (mex) using the current toolchain.
-# Most of the openfast-library is recompiled with COMPILE_SIMULINK defined. 
+# Recommpiles FAST_* files with COMPILE_SIMULINK defined.
+# Links directly to library files, bypassing dependencies so MATLAB specific
+# libraries can be substituted (nwtclibs and servodynlib). openfast_postlib
+# is used as a dependency to ensure that all library files exist before
+# the FAST_SFunc target is built.
 matlab_add_mex(
   NAME FAST_SFunc
-  SRC src/FAST_SFunc.c
-    ${NWTC_SYS_FILE_MATLAB}
-    ${PROJECT_SOURCE_DIR}/modules/servodyn/src/ServoDyn.f90
+  SRC 
+    src/FAST_SFunc.c
     ${PROJECT_SOURCE_DIR}/modules/openfast-library/src/FAST_Subs.f90
     ${PROJECT_SOURCE_DIR}/modules/openfast-library/src/FAST_Lin.f90
     ${PROJECT_SOURCE_DIR}/modules/openfast-library/src/FAST_Mods.f90
     ${PROJECT_SOURCE_DIR}/modules/openfast-library/src/FAST_Solver.f90
     ${PROJECT_SOURCE_DIR}/modules/openfast-library/src/FAST_Library.f90
-  LINK_TO openfast_prelib foamfastlib scfastlib
+  LINK_TO 
+    $<TARGET_FILE:nwtclibs-matlab>  # MATLAB Specific
+    $<TARGET_FILE:versioninfolib>
+    $<TARGET_FILE:aerodyn14lib>
+    $<TARGET_FILE:aerodynlib>
+    $<TARGET_FILE:beamdynlib>
+    $<TARGET_FILE:elastodynlib>
+    $<TARGET_FILE:extptfm_mckflib>
+    $<TARGET_FILE:feamlib>
+    $<TARGET_FILE:foamtypeslib>
+    $<TARGET_FILE:hydrodynlib>
+    $<TARGET_FILE:icedynlib>
+    $<TARGET_FILE:icefloelib>
+    $<TARGET_FILE:ifwlib>
+    $<TARGET_FILE:maplib>
+    $<TARGET_FILE:moordynlib>
+    $<TARGET_FILE:orcaflexlib>
+    $<TARGET_FILE:sctypeslib>
+    $<TARGET_FILE:servodynlib-matlab> # MATLAB Specific
+    $<TARGET_FILE:subdynlib>
+    $<TARGET_FILE:openfast_prelib>
+    $<TARGET_FILE:foamfastlib>
+    $<TARGET_FILE:scfastlib>
+    $<TARGET_FILE:wdlib>
+    $<TARGET_FILE:awaelib>
+    ${LAPACK_LIBRARIES} 
+    ${CMAKE_DL_LIBS} 
+    ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}
 )
+add_dependencies(FAST_SFunc openfast_postlib) # guarantees that library files exist
 target_compile_definitions(FAST_SFunc PUBLIC COMPILE_SIMULINK)
+set_target_properties(FAST_SFunc PROPERTIES 
+  Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/matlab)
 target_include_directories(FAST_SFunc PUBLIC 
-  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/openfast-library/src>  
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/openfast-library/src>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/openfoam/src>
+  $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/modules/supercontroller/src>
 )
+if(APPLE OR UNIX)
+   target_compile_definitions(FAST_SFunc PRIVATE IMPLICIT_DLLEXPORT)
+endif()
 
 install(TARGETS FAST_SFunc
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"

--- a/modules/icefloe/CMakeLists.txt
+++ b/modules/icefloe/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/interfaces/FAST/IceFloe_FASTRegistry.inp ${CMAKE_CURRENT_LIST_DIR}/src/icefloe/IceFloe_Types.f90)
 endif()
 
-add_library(icefloelib OBJECT 
+add_library(icefloelib 
   src/icefloe/IceFlexBase.F90
   src/icefloe/IceFlexIEC.f90
   src/icefloe/IceFlexISO.f90

--- a/modules/nwtc-library/CMakeLists.txt
+++ b/modules/nwtc-library/CMakeLists.txt
@@ -14,14 +14,52 @@
 # limitations under the License.
 #
 
+#-------------------------------------------------------------------------------
+# NWTC System File
+#-------------------------------------------------------------------------------
+
+if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
+  if (WIN32)
+    set(NWTC_SYS_FILE src/SysGnuWin.f90)
+    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabWindows.f90)
+  elseif (APPLE OR UNIX OR CYGWIN)
+    set(NWTC_SYS_FILE src/SysGnuLinux.f90)
+    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabLinuxGnu.f90)
+  endif ()
+elseif (${CMAKE_Fortran_COMPILER_ID} MATCHES "^Intel")
+  if (APPLE OR UNIX)
+    set(NWTC_SYS_FILE src/SysIFL.f90)
+    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabLinuxIntel.f90)
+  elseif (WIN32)
+    set(NWTC_SYS_FILE src/SysIVF.f90)
+    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabWindows.f90)
+  endif (APPLE OR UNIX)
+elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Flang")
+  if(APPLE OR UNIX)
+    set(NWTC_SYS_FILE src/SysFlangLinux.f90)
+  endif()
+endif ()
+
+# System file
+if (NWTC_SYS_FILE)
+  message("-- Setting system file as: ${NWTC_SYS_FILE}")
+else ()
+  message(FATAL_ERROR "Cannot determine system file used with NWTC_Library")
+endif ()
+
+#-------------------------------------------------------------------------------
+# NWTC Library
+#-------------------------------------------------------------------------------
+
 set(NWTCLIBS_SOURCES
+
+  src/NWTC_Base.f90
   src/SingPrec.f90
 
   src/ModMesh.f90
   src/ModMesh_Mapping.f90
   src/ModMesh_Types.f90
 
-  src/NWTC_Base.f90 
   src/NWTC_IO.f90
   src/NWTC_Library.f90
   src/NWTC_Num.f90
@@ -60,7 +98,8 @@ set(NWTCLIBS_SOURCES
   src/NetLib/slatec/i1mach.f
   src/NetLib/slatec/j4save.f
   src/NetLib/slatec/xgetua.f
-  src/NetLib/slatec/xermsg.f  )
+  src/NetLib/slatec/xermsg.f  
+)
 
 get_filename_component(FCNAME ${CMAKE_Fortran_COMPILER} NAME)
 
@@ -96,50 +135,8 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
    endif()
 endif()
 
-if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
-  if (WIN32)
-    set(NWTC_SYS_FILE src/SysGnuWin.f90)
-    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabWindows.f90)
-  elseif (APPLE OR UNIX OR CYGWIN)
-    set(NWTC_SYS_FILE src/SysGnuLinux.f90)
-    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabLinuxGnu.f90)
-  endif ()
-elseif (${CMAKE_Fortran_COMPILER_ID} MATCHES "^Intel")
-  if (APPLE OR UNIX)
-    set(NWTC_SYS_FILE src/SysIFL.f90)
-    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabLinuxIntel.f90)
-  elseif (WIN32)
-    set(NWTC_SYS_FILE src/SysIVF.f90)
-    set(NWTC_SYS_FILE_MATLAB ${CMAKE_CURRENT_SOURCE_DIR}/src/SysMatlabWindows.f90)
-  endif (APPLE OR UNIX)
-elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Flang")
-  if(APPLE OR UNIX)
-    set(NWTC_SYS_FILE src/SysFlangLinux.f90)
-  endif()
-endif ()
-
-# MATLAB Library
-if(BUILD_OPENFAST_SIMULINK_API)
-  if (NWTC_SYS_FILE_MATLAB)
-    message("-- Setting Matlab system file as: ${NWTC_SYS_FILE_MATLAB}")
-    message(STATUS "In NWTC Matlab_MEX_LIBRARY: ${Matlab_MEX_LIBRARY}")
-    # reset NWTC_SYS_FILE so it gets used picked up and added to the NWTCLIBS_SOURCES
-    set(NWTC_SYS_FILE ${NWTC_SYS_FILE_MATLAB})
-  else ()
-    message(FATAL_ERROR "Cannot determine Matlab system file used with NWTC_Library")
-  endif ()
-endif(BUILD_OPENFAST_SIMULINK_API)
-
-# System file
-if (NWTC_SYS_FILE)
-  message("-- Setting system file as: ${NWTC_SYS_FILE}")
-  list(APPEND NWTCLIBS_SOURCES ${NWTC_SYS_FILE})
-else ()
-  message(FATAL_ERROR "Cannot determine system file used with NWTC_Library")
-endif ()
-
-# Create static library for nwtclibs
-add_library(nwtclibs ${NWTCLIBS_SOURCES})
+# Create NWTC Library
+add_library(nwtclibs ${NWTC_SYS_FILE} ${NWTCLIBS_SOURCES})
 target_link_libraries(nwtclibs PUBLIC
   ${LAPACK_LIBRARIES} 
   ${CMAKE_DL_LIBS} 
@@ -152,10 +149,50 @@ if (USE_LOCAL_STATIC_LAPACK)
   add_dependencies(nwtclibs lapack)
 endif()
 
+# Install libraries
 install(TARGETS nwtclibs
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
   ARCHIVE DESTINATION lib
 )
+
+#-------------------------------------------------------------------------------
+# NWTC Library for MATLAB
+#-------------------------------------------------------------------------------
+
+if (BUILD_OPENFAST_SIMULINK_API)
+  
+  # Check that matlab system file was found
+  if (NWTC_SYS_FILE_MATLAB)
+    message("-- Setting Matlab system file as: ${NWTC_SYS_FILE_MATLAB}")
+    message(STATUS "In NWTC Matlab_MEX_LIBRARY: ${Matlab_MEX_LIBRARY}")
+  else ()
+    message(FATAL_ERROR "Cannot determine Matlab system file used with NWTC_Library")
+  endif ()
+
+  # NWTC Library with MATLAB system file
+  add_library(nwtclibs-matlab ${NWTC_SYS_FILE_MATLAB} ${NWTCLIBS_SOURCES})
+  set_target_properties(nwtclibs-matlab PROPERTIES 
+    Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/matlab)
+  if (USE_DLL_INTERFACE)
+    target_compile_definitions(nwtclibs-matlab PRIVATE USE_DLL_INTERFACE)
+  endif (USE_DLL_INTERFACE)
+  target_link_libraries(nwtclibs-matlab PUBLIC
+    ${LAPACK_LIBRARIES} 
+    ${CMAKE_DL_LIBS} 
+    ${CMAKE_Fortran_IMPLICIT_LINK_LIBRARIES}
+  )
+  if (USE_LOCAL_STATIC_LAPACK)
+    add_dependencies(nwtclibs lapack)
+  endif()
+
+  # Install matlab nwtc libraries
+  install(TARGETS nwtclibs-matlab
+    EXPORT "${CMAKE_PROJECT_NAME}Libraries"
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+endif ()
 

--- a/modules/openfast-library/CMakeLists.txt
+++ b/modules/openfast-library/CMakeLists.txt
@@ -47,7 +47,7 @@ target_link_libraries(openfast_prelib
   elastodynlib
   extptfm_mckflib
   feamlib
-  foamtypeslib 
+  foamtypeslib
   hydrodynlib
   icedynlib
   icefloelib

--- a/modules/servodyn/CMakeLists.txt
+++ b/modules/servodyn/CMakeLists.txt
@@ -19,18 +19,20 @@ if (GENERATE_TYPES)
   generate_f90_types(src/ServoDyn_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/ServoDyn_Types.f90)
 endif()
 
-add_library(servodynlib 
+set(SERVODYN_SRCS
+  src/ServoDyn.f90
   src/BladedInterface.f90
   src/BladedInterface_EX.f90
   src/UserSubs.f90
   src/PitchCntrl_ACH.f90
   src/StrucCtrl.f90
   src/UserVSCont_KP.f90
-  src/ServoDyn.f90
   src/ServoDyn_IO.f90
   src/StrucCtrl_Types.f90
   src/ServoDyn_Types.f90
 )
+
+add_library(servodynlib ${SERVODYN_SRCS})
 target_link_libraries(servodynlib nwtclibs)
 
 # Driver
@@ -47,4 +49,26 @@ install(TARGETS servodynlib servodyn_driver # strucctrl_driver
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+  ARCHIVE DESTINATION lib
+)
+
+#-------------------------------------------------------------------------------
+# MATLAB Library
+#-------------------------------------------------------------------------------
+
+if (BUILD_OPENFAST_SIMULINK_API)
+
+  add_library(servodynlib-matlab ${SERVODYN_SRCS})
+  target_compile_definitions(servodynlib-matlab PUBLIC COMPILE_SIMULINK)
+  set_target_properties(servodynlib-matlab PROPERTIES 
+    Fortran_MODULE_DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/matlab)
+  target_link_libraries(servodynlib-matlab nwtclibs-matlab)
+
+  install(TARGETS servodynlib-matlab
+    EXPORT "${CMAKE_PROJECT_NAME}Libraries"
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib
+  )
+
+endif()


### PR DESCRIPTION
This pull request is ready to be merged once all tests pass.

**Feature or improvement description**
Building the Matlab MEX file picked up the wrong system library so output wasn't going to the terminal in MATLAB. This commit fixes the problem by linking directly to the correct libraries. Some duplication exists
in specifying libraries in the glue-codes/simulink/CMakeLists.txt file. Matlab specific versions of nwtclibs and servodyn are built and linked. This also resolves a warning about `dllexport` when building the MEX file.

A CMake error message was added to the main CMakeLists.txt indicating the the Simulink API cannot be built with `BUILD_SHARED_LIBS=ON`. The MEX file needs to be statically linked to the OpenFAST libraries to deal with the Matlab specific versions of `nwtclib` and `servodyn`.

**Impacted areas of the software**
CMakeLists.txt for simulink, nwtc-library, openfast-library, servodyn, icefloe.

