### PR TITLE
[BugFix] ServoDyn inputs for Lidar allocated twice, and a few other minor issues

### DIFF
--- a/modules/inflowwind/src/Lidar.f90
+++ b/modules/inflowwind/src/Lidar.f90
@@ -362,7 +362,8 @@ SUBROUTINE Lidar_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMs
        MeasurementCurrentStep =  INT(t / p%lidar%MeasurementInterval)
        
    IF ( (p%lidar%MeasurementInterval * MeasurementCurrentStep) /= t ) THEN
-       Output%VelocityUVW(:,1) = 0 
+!This isn't returned, so don't set it.
+!       Output%VelocityUVW(:,1) = 0 
    RETURN
    ENDIF
    

--- a/modules/inflowwind/src/Lidar.f90
+++ b/modules/inflowwind/src/Lidar.f90
@@ -118,7 +118,7 @@ SUBROUTINE Lidar_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Init
       RETURN
     ENDIF  
 
-   CALL AllocAry(p%lidar%MsrPosition , 3, p%lidar%NumBeam, 'Array for measurement coordinates', TmpErrStat, TmpErrMsg )
+   CALL AllocAry(p%lidar%MsrPosition , 3, max(1,p%lidar%NumBeam), 'Array for measurement coordinates', TmpErrStat, TmpErrMsg )
    CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
    IF ( ErrStat>= AbortErrLev ) RETURN 
       

--- a/modules/servodyn/src/BladedInterface_EX.f90
+++ b/modules/servodyn/src/BladedInterface_EX.f90
@@ -375,25 +375,33 @@ contains
    subroutine InitLidarMeas()
       integer  :: I,J
       if (p%NumBeam == 0) return ! Nothing to set
-      ! Allocate arrays for inputs
-      if (allocated(InitInp%LidSpeed)) then    ! make sure we have the array allocated before setting it
-         CALL AllocAry(u%LidSpeed, size(InitInp%LidSpeed), 'u%LidSpeed', errStat2, ErrMsg2)
-         if (Failed())  return
+      ! Allocate arrays for inputs -- these may have been set in ServoDyn already
+      if (allocated(InitInp%LidSpeed)) then         ! make sure we have the array allocated before setting it
+         if (.not. allocated(u%LidSpeed)) then
+            CALL AllocAry(u%LidSpeed, size(InitInp%LidSpeed), 'u%LidSpeed', errStat2, ErrMsg2)
+            if (Failed())  return
+         endif
          u%LidSpeed = InitInp%LidSpeed
       endif
       if (allocated(InitInp%MsrPositionsX)) then    ! make sure we have the array allocated before setting it
-         CALL AllocAry(u%MsrPositionsX, size(InitInp%MsrPositionsX), 'u%MsrPositionsX', errStat2, ErrMsg2)
-         if (Failed())  return
+         if (.not. allocated(u%MsrPositionsX)) then
+            CALL AllocAry(u%MsrPositionsX, size(InitInp%MsrPositionsX), 'u%MsrPositionsX', errStat2, ErrMsg2)
+            if (Failed())  return
+         endif
          u%MsrPositionsX = InitInp%MsrPositionsX
       endif
       if (allocated(InitInp%MsrPositionsY)) then    ! make sure we have the array allocated before setting it
-         CALL AllocAry(u%MsrPositionsY, size(InitInp%MsrPositionsY), 'u%MsrPositionsY', errStat2, ErrMsg2)
-         if (Failed())  return
+         if (.not. allocated(u%MsrPositionsY)) then
+            CALL AllocAry(u%MsrPositionsY, size(InitInp%MsrPositionsY), 'u%MsrPositionsY', errStat2, ErrMsg2)
+            if (Failed())  return
+         endif
          u%MsrPositionsY = InitInp%MsrPositionsY
       endif
       if (allocated(InitInp%MsrPositionsZ)) then    ! make sure we have the array allocated before setting it
-         CALL AllocAry(u%MsrPositionsZ, size(InitInp%MsrPositionsZ), 'u%MsrPositionsZ', errStat2, ErrMsg2)
-         if (Failed())  return
+         if (.not. allocated(u%MsrPositionsZ)) then
+            CALL AllocAry(u%MsrPositionsZ, size(InitInp%MsrPositionsZ), 'u%MsrPositionsZ', errStat2, ErrMsg2)
+            if (Failed())  return
+         endif
          u%MsrPositionsZ = InitInp%MsrPositionsZ
       endif
       ! Write summary info to summary file


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
Release [v3.5.0](https://github.com/OpenFAST/openfast/releases/tag/v3.5.0) introduced a new Lidar capability into InflowWind.  Just prior to release a few minor issues were fixed, but a double allocation also got introduced.  This causes issues with most compilers.

Also fixed a couple minor issues with values getting set without allocation, and allocation to size 0.

**Related issue, if one exists**
#1606 reported by @foxton9

**Impacted areas of the software**
The Lidar module of OpenFAST should now function correctly.

**Test results, if applicable**
No test results are affected.