### PR TITLE
[BugFix] HD wave visualization with 2nd order waves

### DIFF
--- a/modules/hydrodyn/src/HydroDyn.f90
+++ b/modules/hydrodyn/src/HydroDyn.f90
@@ -493,6 +493,7 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
             RETURN
          END IF
          tmpWaveElevXY = InitInp%WaveElevXY
+         CALL MOVE_ALLOC(tmpWaveElevXY, InputFileData%Waves%WaveElevXY) ! move this back for waves2 later 
       ENDIF
 
  


### PR DESCRIPTION
This was reported in issue #1484

**Feature or improvement description**
There has been a bug in HydroDyn for some time that if surface visualization was turned on with second order waves, the simulation would abort.

**Related issue, if one exists**
This was reported in #1484.

**Impacted areas of the software**
This only affects visualization of surfaces when second order waves are turned on.

**Additional supporting information**
This bug has been in the code for some time -- at least since v 3.3.0, but perhaps earlier.

**Test results, if applicable**
No test results are affected (we don't extensively test the visualization on GitHub actions due to the resource expense).