### PR TITLE
Use pointers to couple InflowWind and FAST.Farm

### DIFF
--- a/glue-codes/fast-farm/src/FASTWrapper.f90
+++ b/glue-codes/fast-farm/src/FASTWrapper.f90
@@ -158,6 +158,7 @@ SUBROUTINE FWrap_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Init
       ExternInitData%windGrid_delta(4) = InitInp%dt_high
       
       ExternInitData%windGrid_pZero = InitInp%p_ref_high - InitInp%p_ref_Turbine
+      ExternInitData%windGrid_data => InitInp%Vdist_High
             
       
       CALL FAST_InitializeAll_T( t_initial, InitInp%TurbNum, m%Turbine, ErrStat2, ErrMsg2, InitInp%FASTInFile, ExternInitData ) 
@@ -183,10 +184,7 @@ SUBROUTINE FWrap_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Init
          call cleanup()
          return
       end if
-      
-      call move_alloc(m%Turbine%IfW%p%FlowField%Grid4D%Vel, u%Vdist_High)
-         
-      
+           
       !.................
       ! Define parameters here:
       !.................
@@ -555,10 +553,6 @@ SUBROUTINE FWrap_CalcOutput(p, u, y, m, ErrStat, ErrMsg)
    ErrStat = ErrID_None
    ErrMsg  = ''
 
-      ! put this back!
-   call move_alloc(m%Turbine%IfW%p%FlowField%Grid4D%Vel, u%Vdist_High)
-   
-   
    ! Turbine-dependent commands to the super controller:
    if (m%Turbine%p_FAST%UseSC) then
       y%toSC = m%Turbine%SC_DX%u%toSC
@@ -712,8 +706,7 @@ SUBROUTINE FWrap_SetInputs(u, m, t)
    REAL(DbKi),                      INTENT(IN   )  :: t           !< current simulation time
 
    ! set the 4d-wind-inflow input array (a bit of a hack [simplification] so that we don't have large amounts of data copied in multiple data structures):
-      call move_alloc(u%Vdist_High, m%Turbine%IfW%p%FlowField%Grid4D%Vel)
-      m%Turbine%IfW%p%FlowField%Grid4D%TimeStart = t
+   m%Turbine%IfW%p%FlowField%Grid4D%TimeStart = t
       
       ! do something with the inputs from the super-controller:
    if ( m%Turbine%p_FAST%UseSC )  then

--- a/glue-codes/fast-farm/src/FASTWrapper_Registry.txt
+++ b/glue-codes/fast-farm/src/FASTWrapper_Registry.txt
@@ -40,6 +40,7 @@ typedef      ^            InitInputType       IntKi      NumCtrl2SC             
 typedef      ^            InitInputType       Logical    UseSC                     -      -      -   "Use the SuperController? (flag)" -
 typedef      ^            InitInputType       SiKi       fromSCGlob               {:}     -      -   "Global outputs from SuperController" -
 typedef      ^            InitInputType       SiKi       fromSC                   {:}     -      -   "Turbine-specific outputs from SuperController" -
+typedef      ^            InitInputType       SiKi      *Vdist_High     {:}{:}{:}{:}{:}   -      -   "Pointer to UVW components of disturbed wind [nx^high, ny^high, nz^high, n^high/low] (ambient + deficits) across the high-resolution domain around the turbine for each high-resolution time step within a low-resolution time step"      "(m/s)"
 
 # Define outputs from the initialization routine here:
 #typedef   ^               InitOutputType CHARACTER(ChanLen) WriteOutputHdr  {:} - -   "Names of the output-to-file channels" -
@@ -85,7 +86,6 @@ typedef      ^            ParameterType       ReKi       p_ref_Turbine          
 # Define inputs that are contained on the mesh here:
 typedef      ^            InputType           SiKi       fromSCglob              {:}     -      -      "Global (turbine-independent) commands from the super controller"      "(various units)"
 typedef      ^            InputType           SiKi       fromSC                  {:}     -      -      "Turbine-dependent commands from the super controller from the super controller"      "(various units)"
-typedef      ^            InputType           SiKi       Vdist_High     {:}{:}{:}{:}{:}   -      -      "UVW components of disturbed wind [nx^high, ny^high, nz^high, n^high/low] (ambient + deficits) across the high-resolution domain around the turbine for each high-resolution time step within a low-resolution time step"      "(m/s)"
 
 # ..... Outputs ...................................................................................................................
 # Define outputs that are contained on the mesh here:

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -1736,6 +1736,9 @@ SUBROUTINE Farm_InitFAST( farm, WD_InitInp, AWAE_InitOutput, SC_InitOutput, SC_y
          FWrap_InitInp%dX_high       = AWAE_InitOutput%dX_high(nt)
          FWrap_InitInp%dY_high       = AWAE_InitOutput%dY_high(nt)
          FWrap_InitInp%dZ_high       = AWAE_InitOutput%dZ_high(nt)
+
+         FWrap_InitInp%Vdist_High   => AWAE_InitOutput%Vdist_High(nt)%data
+
          if (SC_InitOutput%NumSC2Ctrl>0) then
             FWrap_InitInp%fromSC = SC_y%fromSC((nt-1)*SC_InitOutput%NumSC2Ctrl+1:nt*SC_InitOutput%NumSC2Ctrl)
          end if
@@ -2063,7 +2066,6 @@ subroutine FARM_InitialCO(farm, ErrStat, ErrMsg)
       !--------------------
       ! 1c. transfer y_AWAE to u_F and u_WD         
    
-   call Transfer_AWAE_to_FAST(farm)      
    call Transfer_AWAE_to_WD(farm)   
 
    if (farm%p%UseSC) then
@@ -2155,8 +2157,7 @@ subroutine FARM_InitialCO(farm, ErrStat, ErrMsg)
    !.......................................................................................
    ! Transfer y_AWAE to u_F and u_WD
    !.......................................................................................
-   
-   call Transfer_AWAE_to_FAST(farm)              
+
    call Transfer_AWAE_to_WD(farm)   
    
    !.......................................................................................
@@ -2732,7 +2733,6 @@ subroutine FARM_CalcOutput(t, farm, ErrStat, ErrMsg)
 
       !--------------------
       ! 2. Transfer y_AWAE to u_F  and u_WD   
-   call Transfer_AWAE_to_FAST(farm)      
    call Transfer_AWAE_to_WD(farm)   
    
    
@@ -2878,18 +2878,6 @@ SUBROUTINE Transfer_AWAE_to_WD(farm)
    END DO
    
 END SUBROUTINE Transfer_AWAE_to_WD
-!----------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE Transfer_AWAE_to_FAST(farm)
-   type(All_FastFarm_Data),  INTENT(INOUT) :: farm                            !< FAST.Farm data  
-
-   integer(intKi)  :: nt
-   
-   DO nt = 1,farm%p%NumTurbines
-         ! allocated in FAST's IfW initialization as 3,x,y,z,t
-      farm%FWrap(nt)%u%Vdist_High = farm%AWAE%y%Vdist_High(nt)%data
-   END DO
-   
-END SUBROUTINE Transfer_AWAE_to_FAST
 !----------------------------------------------------------------------------------------------------------------------------------
 SUBROUTINE Transfer_WD_to_AWAE(farm)
    type(All_FastFarm_Data),  INTENT(INOUT) :: farm                            !< FAST.Farm data  

--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1176,6 +1176,13 @@ subroutine AWAE_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitO
       if (errStat2 /= 0) call SetErrStat ( ErrID_Fatal, 'Could not allocate memory for y%TI_amb.', errStat, errMsg, RoutineName )
    if (errStat >= AbortErrLev) return
 
+   ! Set pointers to high resolution wind in InitOutput
+   allocate(InitOut%Vdist_High(1:p%NumTurbines), STAT=ErrStat2 )
+      if (errStat2 /= 0) call SetErrStat ( ErrID_Fatal, 'Could not allocate memory for y%Vdist_High.', errStat, errMsg, RoutineName )
+   do i = 1, p%NumTurbines
+      InitOut%Vdist_High(i)%data => y%Vdist_High(i)%data      
+   end do
+
       ! This next step is not strictly necessary
    y%V_plane       = 0.0_Reki
    y%Vx_wind_disk  = 0.0_Reki

--- a/modules/awae/src/AWAE_Registry.txt
+++ b/modules/awae/src/AWAE_Registry.txt
@@ -23,7 +23,8 @@ param	^                    -               INTEGER         MeanderMod_TruncJinc 
 param	^                    -               INTEGER         MeanderMod_WndwdJinc   - 3 -  "Spatial filter model for wake meandering: windowed jinc" -
 
 # ..... Wind 3D Data .......................................................................................................
-typedef   AWAE/AWAE   AWAE_HighWindGrid       SiKi            data         {:}{:}{:}{:}{:} - - "UVW components of wind data across the high-res regularly-spaced grid" m/s
+typedef   AWAE/AWAE   AWAE_HighWindGrid       SiKi          &data         {:}{:}{:}{:}{:} - - "UVW components of wind data across the high-res regularly-spaced grid" m/s
+typedef   AWAE/AWAE   AWAE_HighWindGridPtr    SiKi          *data         {:}{:}{:}{:}{:} - - "Pointer to UVW components of wind data across the high-res regularly-spaced grid" m/s
 # ..... InputFile Data .......................................................................................................
 typedef   AWAE/AWAE   AWAE_InputFileType  ReKi            dr             - - -  "Radial increment of radial finite-difference grid [>0.0]" m
 typedef   ^           ^                   DbKi            dt_low             - - -  "Low-resolution (FAST.Farm driver/glue code) time step" s
@@ -99,6 +100,7 @@ typedef   ^ InitOutputType IntKi              nZ_low           -  - -   "Number 
 typedef   ^ InitOutputType ReKi               X0_low           -  - -   "X-component of the origin of the low-resolution spatial domain" m
 typedef   ^ InitOutputType ReKi               Y0_low           -  - -   "Y-component of the origin of the low-resolution spatial domain" m
 typedef   ^ InitOutputType ReKi               Z0_low           -  - -   "Z-component of the origin of the low-resolution spatial domain" m
+typedef   ^ InitOutputType AWAE_HighWindGridPtr Vdist_High    {:} - -   "Pointers to Wind velocity of disturbed wind (ambient + wakes) across each high-resolution domain around a turbine for each high-resolution step within a low-resolution step"      m/s
 
 # ..... States ....................................................................................................................
 # Define continuous (differentiable) states here:

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -251,7 +251,7 @@ subroutine IfW_FlowField_GetVelAcc(FF, IStart, Time, PositionXYZ, VelocityUVW, A
       !-------------------------------------------------------------------------
 
       ! If field is not allocated, return error
-      if (.not. allocated(FF%Grid4D%Vel)) then
+      if (.not. associated(FF%Grid4D%Vel)) then
          call SetErrStat(ErrID_Fatal, "Grid4D Field not allocated", ErrStat, ErrMsg, RoutineName)
          return
       end if
@@ -1629,6 +1629,8 @@ subroutine Grid4DField_GetVel(G4D, Time, Position, Velocity, ErrStat, ErrMsg)
       end if
       Indx_Hi(i) = min(Indx_Lo(i) + 1, G4D%n(i))     ! make sure it's a valid index
    end do
+   Indx_Lo = Indx_Lo-1
+   Indx_Hi = Indx_Hi-1
 
    !----------------------------------------------------------------------------
    ! Clamp isopc to [-1, 1] so we don't extrapolate (effectively nearest neighbor)

--- a/modules/inflowwind/src/IfW_FlowField.txt
+++ b/modules/inflowwind/src/IfW_FlowField.txt
@@ -97,7 +97,7 @@ typedef  ^              ^                      LOGICAL             BoxExceedWarn
 typedef  ^              Grid4DFieldType        IntKi               n                   4     -         -     "number of evenly-spaced grid points in the x, y, z, and t directions"      -
 typedef  ^              ^                      ReKi                delta               4     -         -     "size between 2 consecutive grid points in each grid direction"            "m,m,m,s"
 typedef  ^              ^                      ReKi                pZero               3     -         -     "fixed position of the XYZ grid (i.e., XYZ coordinates of m%V(:,1,1,1,:))" "m"
-typedef  ^              ^                      SiKi                Vel                 ::::: -         -     "this is the 4-d velocity field for each wind component [{uvw},nx,ny,nz,nt]" -
+typedef  ^              ^                      SiKi               *Vel                 ::::: -         -     "this is the 4-d velocity field for each wind component [{uvw},nx,ny,nz,nt]" -
 typedef  ^              ^                      ReKi                TimeStart           -     -         -     "this is the time where the first time grid in m%V starts (i.e, the time associated with m%V(:,:,:,:,1))" s
 typedef  ^              ^                      ReKi                RefHeight           -     -         -     "reference height; used to center the wind"                   meters
 

--- a/modules/inflowwind/src/InflowWind_IO.f90
+++ b/modules/inflowwind/src/InflowWind_IO.f90
@@ -1023,8 +1023,6 @@ subroutine IfW_Grid4D_Init(InitInp, G4D, ErrStat, ErrMsg)
    character(*), intent(out)              :: ErrMsg
 
    character(*), parameter                :: RoutineName = "IfW_Grid4D_Init"
-   integer(IntKi)                         :: TmpErrStat
-   character(ErrMsgLen)                   :: TmpErrMsg
 
    ErrStat = ErrID_None
    ErrMsg = ""
@@ -1035,15 +1033,7 @@ subroutine IfW_Grid4D_Init(InitInp, G4D, ErrStat, ErrMsg)
    G4D%pZero = InitInp%pZero
    G4D%TimeStart = 0.0_ReKi
    G4D%RefHeight = InitInp%pZero(3) + (InitInp%n(3)/2) * InitInp%delta(3)
-
-   ! uvw velocity components at x,y,z,t coordinates
-   call AllocAry(G4D%Vel, 3, G4D%n(1), G4D%n(2), G4D%n(3), G4D%n(4), &
-                 'External Grid Velocity', TmpErrStat, TmpErrMsg)
-   call SetErrStat(ErrStat, ErrMsg, TmpErrStat, TmpErrMsg, RoutineName)
-   if (ErrStat >= AbortErrLev) return
-
-   ! Initialize velocities to zero
-   G4D%Vel = 0.0_SiKi
+   G4D%Vel => InitInp%Vel
 
 end subroutine
 

--- a/modules/inflowwind/src/InflowWind_IO.txt
+++ b/modules/inflowwind/src/InflowWind_IO.txt
@@ -87,6 +87,7 @@ typedef  ^              User_InitInputType    SiKi                    Dummy     
 typedef  ^              Grid4D_InitInputType  IntKi                   n                       4     -     -     "number of grid points in the x, y, z, and t directions"                     -
 typedef  ^              ^                     ReKi                    delta                   4     -     -     "size between 2 consecutive grid points in each grid direction"               "m,m,m,s"
 typedef  ^              ^                     ReKi                    pZero                   3     -     -     "fixed position of the XYZ grid (i.e., XYZ coordinates of m%V(:,1,1,1,:))"    "m"
+typedef  ^              ^                     SiKi                   *Vel                   :::::   -     -     "pointer to 4D grid velocity data"      "m/s"
 
 #----------------------------------------------------------------------------------------------------------------------------------
 typedef  ^              Points_InitInputType  IntKi                   NumWindPoints           -     -     -     "Number of points where wind components will be provided"                     -

--- a/modules/inflowwind/src/InflowWind_IO_Types.f90
+++ b/modules/inflowwind/src/InflowWind_IO_Types.f90
@@ -132,6 +132,7 @@ IMPLICIT NONE
     INTEGER(IntKi) , DIMENSION(1:4)  :: n      !< number of grid points in the x, y, z, and t directions [-]
     REAL(ReKi) , DIMENSION(1:4)  :: delta      !< size between 2 consecutive grid points in each grid direction [m,m,m,s]
     REAL(ReKi) , DIMENSION(1:3)  :: pZero      !< fixed position of the XYZ grid (i.e., XYZ coordinates of m%V(:,1,1,1,:)) [m]
+    REAL(SiKi) , DIMENSION(:,:,:,:,:), POINTER  :: Vel => NULL()      !< pointer to 4D grid velocity data [m/s]
   END TYPE Grid4D_InitInputType
 ! =======================
 ! =========  Points_InitInputType  =======
@@ -1836,6 +1837,10 @@ CONTAINS
 ! Local 
    INTEGER(IntKi)                 :: i,j,k
    INTEGER(IntKi)                 :: i1, i1_l, i1_u  !  bounds (upper/lower) for an array dimension 1
+   INTEGER(IntKi)                 :: i2, i2_l, i2_u  !  bounds (upper/lower) for an array dimension 2
+   INTEGER(IntKi)                 :: i3, i3_l, i3_u  !  bounds (upper/lower) for an array dimension 3
+   INTEGER(IntKi)                 :: i4, i4_l, i4_u  !  bounds (upper/lower) for an array dimension 4
+   INTEGER(IntKi)                 :: i5, i5_l, i5_u  !  bounds (upper/lower) for an array dimension 5
    INTEGER(IntKi)                 :: ErrStat2
    CHARACTER(ErrMsgLen)           :: ErrMsg2
    CHARACTER(*), PARAMETER        :: RoutineName = 'InflowWind_IO_CopyGrid4D_InitInputType'
@@ -1845,6 +1850,7 @@ CONTAINS
     DstGrid4D_InitInputTypeData%n = SrcGrid4D_InitInputTypeData%n
     DstGrid4D_InitInputTypeData%delta = SrcGrid4D_InitInputTypeData%delta
     DstGrid4D_InitInputTypeData%pZero = SrcGrid4D_InitInputTypeData%pZero
+    DstGrid4D_InitInputTypeData%Vel => SrcGrid4D_InitInputTypeData%Vel
  END SUBROUTINE InflowWind_IO_CopyGrid4D_InitInputType
 
  SUBROUTINE InflowWind_IO_DestroyGrid4D_InitInputType( Grid4D_InitInputTypeData, ErrStat, ErrMsg )
@@ -1860,6 +1866,7 @@ CONTAINS
   ErrStat = ErrID_None
   ErrMsg  = ""
 
+NULLIFY(Grid4D_InitInputTypeData%Vel)
  END SUBROUTINE InflowWind_IO_DestroyGrid4D_InitInputType
 
  SUBROUTINE InflowWind_IO_PackGrid4D_InitInputType( ReKiBuf, DbKiBuf, IntKiBuf, Indata, ErrStat, ErrMsg, SizeOnly )
@@ -1955,6 +1962,10 @@ CONTAINS
   INTEGER(IntKi)                 :: Int_Xferred
   INTEGER(IntKi)                 :: i
   INTEGER(IntKi)                 :: i1, i1_l, i1_u  !  bounds (upper/lower) for an array dimension 1
+  INTEGER(IntKi)                 :: i2, i2_l, i2_u  !  bounds (upper/lower) for an array dimension 2
+  INTEGER(IntKi)                 :: i3, i3_l, i3_u  !  bounds (upper/lower) for an array dimension 3
+  INTEGER(IntKi)                 :: i4, i4_l, i4_u  !  bounds (upper/lower) for an array dimension 4
+  INTEGER(IntKi)                 :: i5, i5_l, i5_u  !  bounds (upper/lower) for an array dimension 5
   INTEGER(IntKi)                 :: ErrStat2
   CHARACTER(ErrMsgLen)           :: ErrMsg2
   CHARACTER(*), PARAMETER        :: RoutineName = 'InflowWind_IO_UnPackGrid4D_InitInputType'
@@ -1986,6 +1997,7 @@ CONTAINS
       OutData%pZero(i1) = ReKiBuf(Re_Xferred)
       Re_Xferred = Re_Xferred + 1
     END DO
+  NULLIFY(OutData%Vel)
  END SUBROUTINE InflowWind_IO_UnPackGrid4D_InitInputType
 
  SUBROUTINE InflowWind_IO_CopyPoints_InitInputType( SrcPoints_InitInputTypeData, DstPoints_InitInputTypeData, CtrlCode, ErrStat, ErrMsg )

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -752,6 +752,7 @@ typedef	^	FAST_ExternInitType	logical	FarmIntegration	-	.false.	-	"whether this 
 typedef	^	FAST_ExternInitType	IntKi	windGrid_n	4	-	-	"number of grid points in the x, y, z, and t directions for IfW"	-
 typedef	^	FAST_ExternInitType	ReKi	windGrid_delta	4	-	-	"size between 2 consecutive grid points in each grid direction for IfW"	"m,m,m,s"
 typedef	^	FAST_ExternInitType	ReKi	windGrid_pZero	3	-	-	"fixed position of the XYZ grid (i.e., XYZ coordinates of IfW m%V(:,1,1,1,:))"	m
+typedef	^	FAST_ExternInitType	SiKi	*windGrid_data	:::::	-	-	"Pointers to Wind velocity of disturbed wind (ambient + wakes) across each high-resolution domain around a turbine for each high-resolution step within a low-resolution step"      m/s
 typedef	^	FAST_ExternInitType	CHARACTER(1024)	RootName	-	-	-	"Root name of FAST output files (overrides normal operation)"	-
 typedef	^	FAST_ExternInitType	IntKi	NumActForcePtsBlade	-	-	-	"number of actuator line force points in blade"	-
 typedef	^	FAST_ExternInitType	IntKi	NumActForcePtsTower	-	-	-	"number of actuator line force points in tower"	-

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -603,6 +603,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
             Init%InData_IfW%FDext%n      = ExternInitData%windGrid_n
             Init%InData_IfW%FDext%delta  = ExternInitData%windGrid_delta
             Init%InData_IfW%FDext%pZero  = ExternInitData%windGrid_pZero
+            Init%InData_IfW%FDext%Vel   => ExternInitData%windGrid_data
          end if
       ELSE
          Init%InData_IfW%Use4Dext                  = .false.

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -772,6 +772,7 @@ IMPLICIT NONE
     INTEGER(IntKi) , DIMENSION(1:4)  :: windGrid_n      !< number of grid points in the x, y, z, and t directions for IfW [-]
     REAL(ReKi) , DIMENSION(1:4)  :: windGrid_delta      !< size between 2 consecutive grid points in each grid direction for IfW [m,m,m,s]
     REAL(ReKi) , DIMENSION(1:3)  :: windGrid_pZero      !< fixed position of the XYZ grid (i.e., XYZ coordinates of IfW m%V(:,1,1,1,:)) [m]
+    REAL(SiKi) , DIMENSION(:,:,:,:,:), POINTER  :: windGrid_data => NULL()      !< Pointers to Wind velocity of disturbed wind (ambient + wakes) across each high-resolution domain around a turbine for each high-resolution step within a low-resolution step [m/s]
     CHARACTER(1024)  :: RootName      !< Root name of FAST output files (overrides normal operation) [-]
     INTEGER(IntKi)  :: NumActForcePtsBlade      !< number of actuator line force points in blade [-]
     INTEGER(IntKi)  :: NumActForcePtsTower      !< number of actuator line force points in tower [-]
@@ -48375,6 +48376,10 @@ ENDIF
 ! Local 
    INTEGER(IntKi)                 :: i,j,k
    INTEGER(IntKi)                 :: i1, i1_l, i1_u  !  bounds (upper/lower) for an array dimension 1
+   INTEGER(IntKi)                 :: i2, i2_l, i2_u  !  bounds (upper/lower) for an array dimension 2
+   INTEGER(IntKi)                 :: i3, i3_l, i3_u  !  bounds (upper/lower) for an array dimension 3
+   INTEGER(IntKi)                 :: i4, i4_l, i4_u  !  bounds (upper/lower) for an array dimension 4
+   INTEGER(IntKi)                 :: i5, i5_l, i5_u  !  bounds (upper/lower) for an array dimension 5
    INTEGER(IntKi)                 :: ErrStat2
    CHARACTER(ErrMsgLen)           :: ErrMsg2
    CHARACTER(*), PARAMETER        :: RoutineName = 'FAST_CopyExternInitType'
@@ -48418,6 +48423,7 @@ ENDIF
     DstExternInitTypeData%windGrid_n = SrcExternInitTypeData%windGrid_n
     DstExternInitTypeData%windGrid_delta = SrcExternInitTypeData%windGrid_delta
     DstExternInitTypeData%windGrid_pZero = SrcExternInitTypeData%windGrid_pZero
+    DstExternInitTypeData%windGrid_data => SrcExternInitTypeData%windGrid_data
     DstExternInitTypeData%RootName = SrcExternInitTypeData%RootName
     DstExternInitTypeData%NumActForcePtsBlade = SrcExternInitTypeData%NumActForcePtsBlade
     DstExternInitTypeData%NumActForcePtsTower = SrcExternInitTypeData%NumActForcePtsTower
@@ -48443,6 +48449,7 @@ ENDIF
 IF (ALLOCATED(ExternInitTypeData%fromSC)) THEN
   DEALLOCATE(ExternInitTypeData%fromSC)
 ENDIF
+NULLIFY(ExternInitTypeData%windGrid_data)
  END SUBROUTINE FAST_DestroyExternInitType
 
  SUBROUTINE FAST_PackExternInitType( ReKiBuf, DbKiBuf, IntKiBuf, Indata, ErrStat, ErrMsg, SizeOnly )
@@ -48624,6 +48631,10 @@ ENDIF
   INTEGER(IntKi)                 :: Int_Xferred
   INTEGER(IntKi)                 :: i
   INTEGER(IntKi)                 :: i1, i1_l, i1_u  !  bounds (upper/lower) for an array dimension 1
+  INTEGER(IntKi)                 :: i2, i2_l, i2_u  !  bounds (upper/lower) for an array dimension 2
+  INTEGER(IntKi)                 :: i3, i3_l, i3_u  !  bounds (upper/lower) for an array dimension 3
+  INTEGER(IntKi)                 :: i4, i4_l, i4_u  !  bounds (upper/lower) for an array dimension 4
+  INTEGER(IntKi)                 :: i5, i5_l, i5_u  !  bounds (upper/lower) for an array dimension 5
   INTEGER(IntKi)                 :: ErrStat2
   CHARACTER(ErrMsgLen)           :: ErrMsg2
   CHARACTER(*), PARAMETER        :: RoutineName = 'FAST_UnPackExternInitType'
@@ -48715,6 +48726,7 @@ ENDIF
       OutData%windGrid_pZero(i1) = ReKiBuf(Re_Xferred)
       Re_Xferred = Re_Xferred + 1
     END DO
+  NULLIFY(OutData%windGrid_data)
     DO I = 1, LEN(OutData%RootName)
       OutData%RootName(I:I) = CHAR(IntKiBuf(Int_Xferred))
       Int_Xferred = Int_Xferred + 1


### PR DESCRIPTION
This pull request is ready to merge.

**Feature or improvement description**

This commit is the initial attempt to use pointers to couple the wind velocities generated by AWAE in FAST.Farm to the InflowWind FlowField which is used by AeroDyn to calculate the wind velocities. The Vdist_High data in AWAE has been changed to a pointer and FlowField%Grid4D%Vel is associated with this member to alleviate the need to copy the data between the modules.

**Impacted areas of the software**

- FAST.Farm
- AWAE
- InflowWind
- Openfast Library

Many of these areas were impacted because pointers were added to InitInput structures to make use of standard initialization functions. It would have been possible to skip these changes and directly associate the pointers in FAST.Farm, but I thought doing it this way would be clearer.

**Test results, if applicable**
FAST.Farm test results are unchanged though the regression tests run slightly faster.
