### PR TITLE
MHK: add parameters for readability

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -187,7 +187,7 @@ subroutine AD_SetInitOut(MHK, WtrDpth, p, p_AD, InputFileData, InitOut, errStat,
          CALL SetErrStat(ErrID_Fatal,"Error allocating memory for TwrElev.", ErrStat, ErrMsg, RoutineName)
          RETURN
       END IF
-      IF ( MHK == 1 ) THEN
+      IF ( MHK == MHK_FixedBottom ) THEN
          InitOut%TwrElev(:) = InputFileData%TwrElev(:) - WtrDpth
       ELSE      
          InitOut%TwrElev(:) = InputFileData%TwrElev(:)
@@ -1083,7 +1083,7 @@ subroutine Init_u( u, p, p_AD, InputFileData, MHK, WtrDpth, InitInp, errStat, er
          ! set node initial position/orientation
       position = 0.0_ReKi
       do j=1,p%NumTwrNds         
-         IF ( MHK == 1 ) THEN
+         IF ( MHK == MHK_FixedBottom ) THEN
             position(3) = InputFileData%TwrElev(j) - WtrDpth
          ELSE
             position(3) = InputFileData%TwrElev(j)
@@ -3506,11 +3506,11 @@ SUBROUTINE ValidateInputData( InitInp, InputFileData, NumBl, ErrStat, ErrMsg )
       enddo
    endif
    
-   if (InitInp%MHK == 0 .and. InputFileData%CavitCheck) call SetErrStat ( ErrID_Fatal, 'A cavitation check can only be performed for an MHK turbine.', ErrStat, ErrMsg, RoutineName )
-   if (InitInp%MHK == 0 .and. InputFileData%Buoyancy) call SetErrStat ( ErrID_Fatal, 'Buoyancy can only be calculated for an MHK turbine.', ErrStat, ErrMsg, RoutineName )
-   if (InitInp%MHK == 1 .and. InputFileData%CompAA .or. InitInp%MHK == 2 .and. InputFileData%CompAA) call SetErrStat ( ErrID_Fatal, 'The aeroacoustics module cannot be used with an MHK turbine.', ErrStat, ErrMsg, RoutineName )
+   if (InitInp%MHK == MHK_None .and. InputFileData%CavitCheck) call SetErrStat ( ErrID_Fatal, 'A cavitation check can only be performed for an MHK turbine.', ErrStat, ErrMsg, RoutineName )
+   if (InitInp%MHK == MHK_None .and. InputFileData%Buoyancy) call SetErrStat ( ErrID_Fatal, 'Buoyancy can only be calculated for an MHK turbine.', ErrStat, ErrMsg, RoutineName )
+   if (InitInp%MHK /= MHK_None .and. InputFileData%CompAA ) call SetErrStat ( ErrID_Fatal, 'The aeroacoustics module cannot be used with an MHK turbine.', ErrStat, ErrMsg, RoutineName )
    do iR = 1,size(NumBl)
-      if (InitInp%MHK == 1 .and. InputFileData%rotors(iR)%TFinAero .or. InitInp%MHK == 2 .and. InputFileData%rotors(iR)%TFinAero) call SetErrStat ( ErrID_Fatal, 'A tail fin cannot be modeled for an MHK turbine.', ErrStat, ErrMsg, RoutineName )
+      if (InitInp%MHK /= MHK_None .and. InputFileData%rotors(iR)%TFinAero) call SetErrStat ( ErrID_Fatal, 'A tail fin cannot be modeled for an MHK turbine.', ErrStat, ErrMsg, RoutineName )
    enddo
    
    if (InputFileData%AirDens <= 0.0) call SetErrStat ( ErrID_Fatal, 'The density of the working fluid must be greater than zero.', ErrStat, ErrMsg, RoutineName )
@@ -3618,12 +3618,12 @@ SUBROUTINE ValidateInputData( InitInp, InputFileData, NumBl, ErrStat, ErrMsg )
          
             ! check that the elevation is increasing:
          do j=2,InputFileData%rotors(iR)%NumTwrNds
-            if ( InitInp%MHK /= 2 ) then
+            if ( InitInp%MHK /= MHK_Floating ) then
                if ( InputFileData%rotors(iR)%TwrElev(j) <= InputFileData%rotors(iR)%TwrElev(j-1) )  then
                   call SetErrStat( ErrID_Fatal, 'The tower nodes must be entered in increasing elevation.', ErrStat, ErrMsg, RoutineName )
                   exit
                end if
-            else if ( InitInp%MHK == 2 ) then
+            else
                if ( InputFileData%rotors(iR)%TwrElev(j) >= InputFileData%rotors(iR)%TwrElev(j-1) )  then
                   call SetErrStat( ErrID_Fatal, 'The tower nodes must be entered in decreasing elevation for a floating MHK turbine.', ErrStat, ErrMsg, RoutineName )
                   exit

--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -1021,7 +1021,7 @@ subroutine Dvr_ReadInputFile(fileName, dvr, errStat, errMsg )
       if (wt%BasicHAWTFormat) then
          ! --- Basic Geometry
          call ParseAry(FileInfo_In, CurLine, 'baseOriginInit'//sWT , wt%originInit , 3 , errStat2, errMsg2 , unEc); if(Failed()) return
-         if ( dvr%MHK == 1 ) then
+         if ( dvr%MHK == MHK_FixedBottom ) then
             wt%originInit(3) = wt%originInit(3) - dvr%WtrDpth
          end if
          call ParseVar(FileInfo_In, CurLine, 'numBlades'//sWT      , wt%numBlades      , errStat2, errMsg2 , unEc); if(Failed()) return
@@ -1059,7 +1059,7 @@ subroutine Dvr_ReadInputFile(fileName, dvr, errStat, errMsg )
          ! --- Advanced geometry
          ! Rotor origin and orientation
          call ParseAry(FileInfo_In, CurLine, 'baseOriginInit'//sWT     , wt%originInit, 3         , errStat2, errMsg2, unEc); if(Failed()) return
-         if ( dvr%MHK == 1 ) then
+         if ( dvr%MHK == MHK_FixedBottom ) then
             wt%originInit(3) = wt%originInit(3) - dvr%WtrDpth
          end if
          call ParseAry(FileInfo_In, CurLine, 'baseOrientationInit'//sWT, wt%orientationInit, 3    , errStat2, errMsg2, unEc); if(Failed()) return
@@ -1345,7 +1345,7 @@ subroutine ValidateInputs(dvr, errStat, errMsg)
    ! Turbine Data:
    !if ( dvr%numBlades < 1 ) call SetErrStat( ErrID_Fatal, "There must be at least 1 blade (numBlades).", errStat, ErrMsg, RoutineName)
       ! Combined-Case Analysis:
-   if (dvr%MHK /= 0 .and. dvr%MHK /= 1 .and. dvr%MHK /= 2) call SetErrStat(ErrID_Fatal, 'MHK switch must be 0, 1, or 2.', ErrStat, ErrMsg, RoutineName)
+   if (dvr%MHK /= MHK_None .and. dvr%MHK /= MHK_FixedBottom .and. dvr%MHK /= MHK_Floating) call SetErrStat(ErrID_Fatal, 'MHK switch must be 0, 1, or 2.', ErrStat, ErrMsg, RoutineName)
    
    if (dvr%DT < epsilon(0.0_ReKi) ) call SetErrStat(ErrID_Fatal,'dT must be larger than 0.',errStat, errMsg,RoutineName)
    if (Check(.not.(ANY((/0,1/) == dvr%IW_InitInp%compInflow) ), 'CompInflow needs to be 0 or 1')) return

--- a/modules/aerodyn/src/AeroDyn_Inflow.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow.f90
@@ -458,7 +458,7 @@ subroutine ADI_Set_IW_Inputs(p_AD, u_AD, o_AD, u_IfW, hubHeightFirst, errStat, e
       enddo
    endif
    call AD_SetExternalWindPositions(u_AD, o_AD, u_IfW%PositionXYZ, node, errStat, errMsg)
-   if ( p_AD%MHK == 1 .or. p_AD%MHK == 2 ) then
+   if ( p_AD%MHK /= MHK_None ) then
       u_IfW%PositionXYZ(3,:) = u_IfW%PositionXYZ(3,:) + p_AD%WtrDpth
    endif 
 end subroutine ADI_Set_IW_Inputs
@@ -584,7 +584,7 @@ subroutine Init_MeshMap_For_ADI(FED, p, uAD, errStat, errMsg)
          if (y_ED%hasTower) then
             twrHeightAD=uAD%rotors(iWT)%TowerMotion%Position(3,uAD%rotors(iWT)%TowerMotion%nNodes)-uAD%rotors(iWT)%TowerMotion%Position(3,1)
             ! Check tower height
-            if ( p%MHK==2 ) then
+            if ( p%MHK==MHK_Floating ) then
                if (twrHeightAD>0) then
                   errStat=ErrID_Fatal
                   errMsg='First AeroDyn tower height should be larger than last AD tower height for a floating MHK turbine'
@@ -597,9 +597,9 @@ subroutine Init_MeshMap_For_ADI(FED, p, uAD, errStat, errMsg)
             endif
 
             twrHeightAD=uAD%rotors(iWT)%TowerMotion%Position(3,uAD%rotors(iWT)%TowerMotion%nNodes) ! NOTE: assuming start a z=0
-            if ( p%MHK==1 ) then
+            if ( p%MHK==MHK_FixedBottom ) then
                twrHeightAD = twrHeightAD + p%WtrDpth
-            elseif ( p%MHK==2 ) then
+            elseif ( p%MHK==MHK_Floating ) then
                twrHeightAD = abs(twrHeightAD)
             endif
 
@@ -615,13 +615,13 @@ subroutine Init_MeshMap_For_ADI(FED, p, uAD, errStat, errMsg)
             ! Adjust tower position (AeroDyn return values assuming (0,0,0) for tower base
             Pbase = y_ED%TwrPtMesh%Position(:,1)
             Ptop = y_ED%NacelleMotion%Position(:,1)
-            if ( p%MHK==2 ) then
+            if ( p%MHK==MHK_Floating ) then
                DeltaP = Pbase-Ptop
             else
                DeltaP = Ptop-Pbase
             endif
             do i = 1, uAD%rotors(iWT)%TowerMotion%nNodes
-               if ( p%MHK==1 ) then
+               if ( p%MHK==MHK_FixedBottom ) then
                   zBar = (uAD%rotors(iWT)%TowerMotion%Position(3,i) + p%WtrDpth) / twrHeight
                else
                   zBar = uAD%rotors(iWT)%TowerMotion%Position(3,i)/twrHeight

--- a/modules/aerodyn/src/FVW_Subs.f90
+++ b/modules/aerodyn/src/FVW_Subs.f90
@@ -1625,7 +1625,7 @@ subroutine FakeGroundEffect(p, x, m, ErrStat, ErrMsg)
    ErrStat = ErrID_None
    ErrMsg  = ""
 
-   if ( p%MHK == 1 .or. p%MHK == 2 ) then
+   if ( p%MHK /= MHK_None ) then
       GROUND         = 1.e-4_ReKi - p%WtrDpth
       ABOVE_GROUND   = 0.1_ReKi - p%WtrDpth
    else

--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -760,7 +760,7 @@ SUBROUTINE ED_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
          m%AllOuts( TipRDxb(K) ) = DOT_PRODUCT( m%RtHS%AngPosHM(:,K,p%TipNode), m%CoordSys%j1(K,         :) )*R2D
          m%AllOuts( TipRDyb(K) ) = DOT_PRODUCT( m%RtHS%AngPosHM(:,K,p%TipNode), m%CoordSys%j2(K,         :) )*R2D
          ! There is no sense computing AllOuts( TipRDzc(K) ) here since it is always zero for FAST simulation results.
-         IF ( p%MHK == 2 ) THEN
+         IF ( p%MHK == MHK_Floating ) THEN
             IF ( rOSTipzn < 0.0 )  THEN   ! Tip of blade K is above the yaw bearing.
                m%AllOuts(TipClrnc(K) ) = SQRT( rOSTipxn*rOSTipxn + rOSTipyn*rOSTipyn + rOSTipzn*rOSTipzn ) ! Absolute distance from the tower top / yaw bearing to the tip of blade 1.
             ELSE                          ! Tip of blade K is below the yaw bearing.
@@ -3413,7 +3413,7 @@ SUBROUTINE SetPrimaryParameters( InitInp, p, InputFileData, ErrStat, ErrMsg  )
    p%DT        = InputFileData%DT
    p%OverHang  = InputFileData%OverHang
    p%ShftGagL  = InputFileData%ShftGagL
-   IF ( InitInp%MHK == 1 ) THEN
+   IF ( InitInp%MHK == MHK_FixedBottom ) THEN
       p%TowerHt   = InputFileData%TowerHt - InitInp%WtrDpth
       p%TowerBsHt = InputFileData%TowerBsHt - InitInp%WtrDpth
       p%PtfmRefzt = InputFileData%PtfmRefzt - InitInp%WtrDpth
@@ -3502,7 +3502,7 @@ SUBROUTINE SetPrimaryParameters( InitInp, p, InputFileData, ErrStat, ErrMsg  )
    p%BldFlexL  = p%TipRad    - p%HubRad                                            ! Length of the flexible portion of the blade.
    if (p%BD4Blades) p%BldFlexL = 0.0_ReKi
    
-   IF ( InitInp%MHK == 1 ) THEN
+   IF ( InitInp%MHK == MHK_FixedBottom ) THEN
       p%rZYzt     = InputFileData%PtfmCMzt - InitInp%WtrDpth - p%PtfmRefzt
    ELSE
       p%rZYzt     = InputFileData%PtfmCMzt - p%PtfmRefzt

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -4183,9 +4183,9 @@ SUBROUTINE ValidatePrimaryData( InputFileData, BD4Blades, Linearize, MHK, ErrSta
    IF ( InputFileData%YawBrMass < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'YawBrMass must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF ( InputFileData%NacMass   < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'NacMass must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF ( InputFileData%HubMass   < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'HubMass must not be negative.',ErrStat,ErrMsg,RoutineName)
-   IF ( MHK /= 2 ) THEN
+   IF ( MHK /= MHK_Floating ) THEN
       IF ( InputFileData%Twr2Shft  < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'Twr2Shft must not be negative.',ErrStat,ErrMsg,RoutineName)
-   ELSEIF ( MHK == 2 ) THEN
+   ELSE
       IF ( InputFileData%Twr2Shft  > 0.0_ReKi) call SetErrStat(ErrID_Fatal,'Twr2Shft must not be positive for a floating MHK turbine.',ErrStat,ErrMsg,RoutineName)
    ENDIF
       
@@ -4198,9 +4198,9 @@ SUBROUTINE ValidatePrimaryData( InputFileData, BD4Blades, Linearize, MHK, ErrSta
    IF ( InputFileData%HubIner  < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'HubIner must not be negative.',ErrStat,ErrMsg,RoutineName)
 
       ! Check that TowerHt is in the range [0,inf):
-   IF ( MHK /= 2 ) THEN
+   IF ( MHK /= MHK_Floating ) THEN
       IF ( InputFileData%TowerHt <= 0.0_ReKi ) CALL SetErrStat( ErrID_Fatal, 'TowerHt must be greater than zero.',ErrStat,ErrMsg,RoutineName )
-   ELSEIF ( MHK == 2 ) THEN
+   ELSE
       IF ( InputFileData%TowerHt >= 0.0_ReKi ) CALL SetErrStat( ErrID_Fatal, 'TowerHt must be less than zero for a floating MHK turbine.',ErrStat,ErrMsg,RoutineName )
    ENDIF
 
@@ -4241,7 +4241,7 @@ SUBROUTINE ValidatePrimaryData( InputFileData, BD4Blades, Linearize, MHK, ErrSta
       END IF
    ENDIF
 
-   IF ( MHK /= 2 ) THEN
+   IF ( MHK /= MHK_Floating ) THEN
 
       IF ( InputFileData%TowerBsHt >= InputFileData%TowerHt ) CALL SetErrStat( ErrID_Fatal, 'TowerBsHt must be less than TowerHt.',ErrStat,ErrMsg,RoutineName)
 
@@ -4251,7 +4251,7 @@ SUBROUTINE ValidatePrimaryData( InputFileData, BD4Blades, Linearize, MHK, ErrSta
       IF ( InputFileData%PtfmRefzt  > InputFileData%TowerBsHt ) &
          CALL SetErrStat( ErrID_Fatal, 'PtfmRefzt must not be greater than TowerBsHt.',ErrStat,ErrMsg,RoutineName)
 
-   ELSEIF ( MHK == 2 ) THEN
+   ELSE
 
       IF ( InputFileData%TowerBsHt <= InputFileData%TowerHt ) CALL SetErrStat( ErrID_Fatal, 'TowerBsHt must be greater than TowerHt for a floating MHK turbine.',ErrStat,ErrMsg,RoutineName)
          
@@ -4261,15 +4261,15 @@ SUBROUTINE ValidatePrimaryData( InputFileData, BD4Blades, Linearize, MHK, ErrSta
       IF (InputFileData%HubRad >= InputFileData%TipRad ) &
       CALL SetErrStat( ErrID_Fatal, 'HubRad must be less than TipRad.',ErrStat,ErrMsg,RoutineName)
 
-      IF ( MHK /= 2 ) THEN
+      IF ( MHK /= MHK_Floating ) THEN
          IF ( InputFileData%TowerHt + InputFileData%Twr2Shft + InputFileData%OverHang*SIN(InputFileData%ShftTilt) &
                                     <= InputFileData%TipRad )  THEN
             CALL SetErrStat( ErrID_Fatal, 'TowerHt + Twr2Shft + OverHang*SIN(ShftTilt) must be greater than TipRad.',ErrStat,ErrMsg,RoutineName)
          END IF
-      ELSEIF ( MHK == 2 ) THEN
+      ELSE
          IF ( -InputFileData%TowerHt - InputFileData%Twr2Shft - InputFileData%OverHang*SIN(InputFileData%ShftTilt) &
                                     <= InputFileData%TipRad )  THEN
-            CALL SetErrStat( ErrID_Fatal, 'TowerHt + Twr2Shft + OverHang*SIN(ShftTilt) must be greater than TipRad.',ErrStat,ErrMsg,RoutineName)
+            CALL SetErrStat( ErrID_Fatal, '-TowerHt - Twr2Shft - OverHang*SIN(ShftTilt) must be greater than TipRad.',ErrStat,ErrMsg,RoutineName)
          END IF
       ENDIF
    END IF

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -679,7 +679,7 @@ SUBROUTINE InflowWind_ValidateInput( InitInp, InputFileData, ErrStat, ErrMsg )
 
       ! make sure that all values for WindVzi are above ground.  Set to 0 otherwise.
 
-   IF ( InitInp%MHK == 1 .or. InitInp%MHK == 2 ) THEN
+   IF ( InitInp%MHK /= MHK_None ) THEN
       DO I = 1, InputFileData%NWindVel
          IF ( InputFileData%WindVziList(I) >= InitInp%WtrDpth + InitInp%MSL2SWL ) THEN
             CALL SetErrStat( ErrID_Warn, ' Requested wind velocity at point ( '//   &

--- a/modules/nwtc-library/src/NWTC_Library.f90
+++ b/modules/nwtc-library/src/NWTC_Library.f90
@@ -81,6 +81,11 @@ MODULE NWTC_Library
 #endif
 
     IMPLICIT  NONE
+    
+    INTEGER, PARAMETER ::MHK_None = 0
+    INTEGER, PARAMETER ::MHK_FixedBottom = 1
+    INTEGER, PARAMETER ::MHK_Floating = 2
+
 
     CONTAINS
 

--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -375,7 +375,7 @@ SUBROUTINE ED_InputSolve( p_FAST, u_ED, y_ED, p_AD14, y_AD14, y_AD, y_SrvD, u_AD
          END IF
    END IF
 
-   IF ( p_FAST%CompAero == Module_AD .and. p_FAST%MHK > 0 .and. .not. (p_FAST%CompElast == Module_BD .and. BD_Solve_Option1)) THEN
+   IF ( p_FAST%CompAero == Module_AD .and. p_FAST%MHK /= MHK_None .and. .not. (p_FAST%CompElast == Module_BD .and. BD_Solve_Option1)) THEN
       u_ED%HubPtLoad%Force = 0.0_ReKi
       u_ED%HubPtLoad%Moment = 0.0_ReKi
       IF ( u_AD%rotors(1)%HubMotion%Committed ) THEN
@@ -474,7 +474,7 @@ SUBROUTINE IfW_InputSolve( p_FAST, m_FAST, u_IfW, p_IfW, u_AD14, u_AD, OtherSt_A
                
 
 
-   IF ( p_FAST%MHK==1 .or. p_FAST%MHK==2 ) THEN
+   IF ( p_FAST%MHK /= MHK_None ) THEN
       u_IfW%PositionXYZ(3,:) = u_IfW%PositionXYZ(3,:) + p_FAST%WtrDpth
    ENDIF
 
@@ -2902,7 +2902,7 @@ CONTAINS
             MeshMapData%u_ED_HubPtLoad%Force  = MeshMapData%u_ED_HubPtLoad%Force  + MeshMapData%u_ED_HubPtLoad_2%Force  
             MeshMapData%u_ED_HubPtLoad%Moment = MeshMapData%u_ED_HubPtLoad%Moment + MeshMapData%u_ED_HubPtLoad_2%Moment                
          end do
-         IF ( p_FAST%CompAero == Module_AD .and. p_FAST%MHK > 0) THEN
+         IF ( p_FAST%CompAero == Module_AD .and. p_FAST%MHK /= MHK_None) THEN
             IF ( u_AD%rotors(1)%HubMotion%Committed ) THEN
                CALL Transfer_Point_to_Point( y_AD%rotors(1)%HubLoad, MeshMapData%u_ED_HubPtLoad_2, MeshMapData%AD_P_2_ED_P_H, ErrStat2, ErrMsg2, u_AD%rotors(1)%HubMotion, y_ED2%HubPtMotion )
                   CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -472,9 +472,9 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       Init%InData_AD%InputFile          = p_FAST%AeroFile
       Init%InData_AD%RootName           = p_FAST%OutFileRoot
       Init%InData_AD%MHK                = p_FAST%MHK
-      if ( p_FAST%MHK == 0 ) then
+      if ( p_FAST%MHK == MHK_None ) then
          Init%InData_AD%defFldDens      = p_FAST%AirDens
-      elseif ( p_FAST%MHK == 1 .or. p_FAST%MHK == 2 ) then
+      else
          Init%InData_AD%defFldDens      = p_FAST%WtrDens
       end if
       Init%InData_AD%defKinVisc         = p_FAST%KinVisc
@@ -550,7 +550,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       Init%InData_IfW%RootName         = TRIM(p_FAST%OutFileRoot)//'.'//TRIM(y_FAST%Module_Abrev(Module_IfW))
       Init%InData_IfW%UseInputFile     = .TRUE.
       Init%InData_IfW%FixedWindFileRootName = .FALSE.
-      Init%InData_IfW%OutputAccel      = p_FAST%MHK > 0
+      Init%InData_IfW%OutputAccel      = p_FAST%MHK /= MHK_None
 
       Init%InData_IfW%MHK              = p_FAST%MHK
       Init%InData_IfW%WtrDpth          = p_FAST%WtrDpth
@@ -1974,11 +1974,11 @@ SUBROUTINE ValidateInputData(p, m_FAST, ErrStat, ErrMsg)
    IF (p%CompElast == Module_BD .and. p%CompAero == Module_AD14 ) CALL SetErrStat( ErrID_Fatal, 'AeroDyn14 cannot be used when BeamDyn is used. Change CompAero or CompElast in the FAST input file.', ErrStat, ErrMsg, RoutineName )
    if (p%CompInflow == MODULE_OpFM .and. p%CompAero == Module_AD14 ) CALL SetErrStat( ErrID_Fatal, 'AeroDyn14 cannot be used when OpenFOAM is used. Change CompAero or CompInflow in the FAST input file.', ErrStat, ErrMsg, RoutineName )
    
-   IF (p%MHK /= 0 .and. p%MHK /= 1 .and. p%MHK /= 2) CALL SetErrStat( ErrID_Fatal, 'MHK switch is invalid. Set MHK to 0, 1, or 2 in the FAST input file.', ErrStat, ErrMsg, RoutineName )
+   IF (p%MHK /= MHK_None .and. p%MHK /= MHK_FixedBottom .and. p%MHK /= MHK_Floating) CALL SetErrStat( ErrID_Fatal, 'MHK switch is invalid. Set MHK to 0, 1, or 2 in the FAST input file.', ErrStat, ErrMsg, RoutineName )
 
-   IF (p%MHK == 1 .and. p%CompAero == Module_AD14 .or. p%MHK == 2 .and. p%CompAero == Module_AD14) CALL SetErrStat( ErrID_Fatal, 'AeroDyn14 cannot be used with an MHK turbine. Change CompAero or MHK in the FAST input file.', ErrStat, ErrMsg, RoutineName )
+   IF (p%MHK /= MHK_None .and. p%CompAero == Module_AD14) CALL SetErrStat( ErrID_Fatal, 'AeroDyn14 cannot be used with an MHK turbine. Change CompAero or MHK in the FAST input file.', ErrStat, ErrMsg, RoutineName )
 
-   IF (p%MHK == 1 .and. p%Linearize .or. p%MHK == 2 .and. p%Linearize) CALL SetErrStat( ErrID_Fatal, 'Linearization has not yet been implemented for an MHK turbine. Change MHK or Linearize in the FAST input file.', ErrStat, ErrMsg, RoutineName )
+   IF (p%MHK /= MHK_None .and. p%Linearize) CALL SetErrStat( ErrID_Fatal, 'Linearization has not yet been implemented for an MHK turbine. Change MHK or Linearize in the FAST input file.', ErrStat, ErrMsg, RoutineName )
 
    IF (p%Gravity < 0.0_ReKi) CALL SetErrStat( ErrID_Fatal, 'Gravity must not be negative.', ErrStat, ErrMsg, RoutineName )
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This PR is for code readability. 
- It replaces the `MHK=={0|1|2}` statements using parameters for the 3 allowed values of MHK. I am not thrilled with putting the MHK parameters in NWTC Library, but they are used in many different modules so that's where I put them (at least for now).
- It also simplifies some of the logic statements. For example `IF (A) THEN ... ELSEIF (NOT A)` statements are now `IF (A) THEN... ELSE`, avoiding a second check that must always be true. 

**Related issue, if one exists**
None.

**Impacted areas of the software**
This impacts the places that check the value of the `MHK` variable: ElastoDyn, AeroDyn, InflowWind, and OpenFAST glue code

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
This shouldn't affect any tests. Tests have have failed are related to GH Actions getting the wrong patch version of python.

