### PR TITLE
Make CMake module libs STATIC

### DIFF
--- a/glue-codes/openfast-cpp/CMakeLists.txt
+++ b/glue-codes/openfast-cpp/CMakeLists.txt
@@ -29,7 +29,10 @@ find_package(ZLIB REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C HL)
 find_package(yaml-cpp REQUIRED)
 
-add_library(openfastcpplib src/OpenFAST.cpp src/SC.cpp)
+add_library(openfastcpplib
+  src/OpenFAST.cpp
+  src/SC.cpp
+)
 set_property(TARGET openfastcpplib PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(openfastcpplib
   openfastlib

--- a/modules/aerodyn/CMakeLists.txt
+++ b/modules/aerodyn/CMakeLists.txt
@@ -27,7 +27,7 @@ if (GENERATE_TYPES)
 endif()
 
 # AeroDyn Library
-add_library(aerodynlib 
+add_library(aerodynlib STATIC
   src/AeroDyn.f90
   src/AeroDyn_IO_Params.f90
   src/AeroDyn_IO.f90
@@ -71,7 +71,7 @@ add_library(aerodynlib
 target_link_libraries(aerodynlib ifwlib nwtclibs)
 
 # AeroDyn Driver Subs Library
-add_library(aerodyn_driver_subs
+add_library(aerodyn_driver_subs STATIC
   src/AeroDyn_Driver_Subs.f90
   src/AeroDyn_Driver_Types.f90
 )

--- a/modules/aerodyn14/CMakeLists.txt
+++ b/modules/aerodyn14/CMakeLists.txt
@@ -19,7 +19,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/Registry-DWM.txt ${CMAKE_CURRENT_LIST_DIR}/src/DWM_Types.f90)
 endif()
 
-add_library(aerodyn14lib 
+add_library(aerodyn14lib STATIC
   src/AeroDyn14.f90
   src/AeroSubs.f90
   src/DWM.f90

--- a/modules/awae/CMakeLists.txt
+++ b/modules/awae/CMakeLists.txt
@@ -17,7 +17,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/AWAE_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/AWAE_Types.f90 -noextrap)
 endif()
 
-add_library(awaelib 
+add_library(awaelib STATIC
   src/AWAE.f90
   src/AWAE_IO.f90
   src/AWAE_Types.f90

--- a/modules/beamdyn/CMakeLists.txt
+++ b/modules/beamdyn/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/Registry_BeamDyn.txt ${CMAKE_CURRENT_LIST_DIR}/src/BeamDyn_Types.f90)
 endif()
 
-add_library(beamdynlib 
+add_library(beamdynlib STATIC
   src/BeamDyn.f90
   src/BeamDyn_IO.f90
   src/BeamDyn_BldNdOuts_IO.f90

--- a/modules/elastodyn/CMakeLists.txt
+++ b/modules/elastodyn/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/ElastoDyn_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/ElastoDyn_Types.f90)
 endif()
 
-add_library(elastodynlib 
+add_library(elastodynlib STATIC
   src/ElastoDyn.f90
   src/ElastoDyn_IO.f90
   src/ElastoDyn_AllBldNdOuts_IO.f90

--- a/modules/extptfm/CMakeLists.txt
+++ b/modules/extptfm/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/ExtPtfm_MCKF_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/ExtPtfm_MCKF_Types.f90)
 endif()
 
-add_library(extptfm_mckflib 
+add_library(extptfm_mckflib STATIC
   src/ExtPtfm_MCKF.f90
   src/ExtPtfm_MCKF_IO.f90
   src/ExtPtfm_MCKF_Types.f90

--- a/modules/feamooring/CMakeLists.txt
+++ b/modules/feamooring/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/FEAM_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/FEAMooring_Types.f90)
 endif()
 
-add_library(feamlib
+add_library(feamlib STATIC
   src/FEAM.f90
   src/FEAMooring_Types.f90
 )

--- a/modules/hydrodyn/CMakeLists.txt
+++ b/modules/hydrodyn/CMakeLists.txt
@@ -24,7 +24,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/WAMIT2.txt ${CMAKE_CURRENT_LIST_DIR}/src/WAMIT2_Types.f90)
 endif()
 
-add_library(hydrodynlib 
+add_library(hydrodynlib STATIC
   src/Conv_Radiation.f90
   src/HydroDyn.f90
   src/HydroDyn_Input.f90
@@ -47,7 +47,7 @@ add_library(hydrodynlib
 target_link_libraries(hydrodynlib seastlib nwtclibs)
 
 # HydroDyn Driver Subs Library
-add_library(hydrodyn_driver_subs
+add_library(hydrodyn_driver_subs STATIC
   src/HydroDyn_DriverSubs.f90
 )
 target_link_libraries(hydrodyn_driver_subs hydrodynlib)

--- a/modules/icedyn/CMakeLists.txt
+++ b/modules/icedyn/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/Registry_IceDyn.txt ${CMAKE_CURRENT_LIST_DIR}/src/IceDyn_Types.f90)
 endif()
 
-add_library(icedynlib 
+add_library(icedynlib STATIC
   src/IceDyn.f90
   src/IceDyn_Types.f90
 )

--- a/modules/icefloe/CMakeLists.txt
+++ b/modules/icefloe/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/interfaces/FAST/IceFloe_FASTRegistry.inp ${CMAKE_CURRENT_LIST_DIR}/src/icefloe/IceFloe_Types.f90)
 endif()
 
-add_library(icefloelib 
+add_library(icefloelib STATIC
   src/icefloe/IceFlexBase.F90
   src/icefloe/IceFlexIEC.f90
   src/icefloe/IceFlexISO.f90

--- a/modules/inflowwind/CMakeLists.txt
+++ b/modules/inflowwind/CMakeLists.txt
@@ -22,7 +22,7 @@ if (GENERATE_TYPES)
 endif()
 
 # InflowWind object library
-add_library(ifwlib 
+add_library(ifwlib STATIC
   src/IfW_FlowField_Types.f90
   src/IfW_FlowField.f90
   src/InflowWind_IO_Types.f90

--- a/modules/map/CMakeLists.txt
+++ b/modules/map/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 file(GLOB MAP_CLIB_SOURCES src/*.c src/*.cc src/*/*.c src/*/*.cc)
 file(GLOB MAP_C_HEADERS src/*.h src/*/*.h)
 
-add_library(maplib 
+add_library(maplib STATIC
   src/map.f90
   src/MAP_Types.f90
   src/MAP_Fortran_Types.f90

--- a/modules/moordyn/CMakeLists.txt
+++ b/modules/moordyn/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/MoorDyn_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/MoorDyn_Types.f90)
 endif()
 
-add_library(moordynlib
+add_library(moordynlib STATIC
   src/MoorDyn.f90
   src/MoorDyn_Body.f90
   src/MoorDyn_IO.f90

--- a/modules/nwtc-library/CMakeLists.txt
+++ b/modules/nwtc-library/CMakeLists.txt
@@ -136,7 +136,10 @@ if (CMAKE_BUILD_TYPE MATCHES Debug)
 endif()
 
 # Create NWTC Library
-add_library(nwtclibs ${NWTC_SYS_FILE} ${NWTCLIBS_SOURCES})
+add_library(nwtclibs STATIC
+  ${NWTC_SYS_FILE} 
+  ${NWTCLIBS_SOURCES}
+)
 target_link_libraries(nwtclibs PUBLIC
   ${LAPACK_LIBRARIES} 
   ${CMAKE_DL_LIBS} 

--- a/modules/openfast-library/CMakeLists.txt
+++ b/modules/openfast-library/CMakeLists.txt
@@ -37,7 +37,9 @@ elseif (${_compiler_id} MATCHES "^INTEL" AND ${_build_type} STREQUAL "RELEASE" A
   set_source_files_properties(src/FAST_Types.f90 PROPERTIES COMPILE_FLAGS "-O2")
 endif()
 
-add_library(openfast_prelib src/FAST_Types.f90)
+add_library(openfast_prelib STATIC
+  src/FAST_Types.f90
+)
 target_link_libraries(openfast_prelib 
   nwtclibs
   versioninfolib
@@ -61,7 +63,7 @@ target_link_libraries(openfast_prelib
   subdynlib
 )
 
-add_library(openfast_postlib
+add_library(openfast_postlib STATIC
   src/FAST_Lin.f90
   src/FAST_Mods.f90
   src/FAST_Subs.f90
@@ -78,7 +80,9 @@ add_library(openfastlib_static INTERFACE)
 target_link_libraries(openfastlib_static INTERFACE openfast_postlib)
 
 # OpenFAST Library shared (Python, openfast_cpp, openfastcpplib)
-add_library(openfastlib SHARED src/FAST_Library.f90)
+add_library(openfastlib SHARED 
+  src/FAST_Library.f90
+)
 target_link_libraries(openfastlib openfast_postlib)
 if(APPLE OR UNIX)
   target_compile_definitions(openfastlib PRIVATE IMPLICIT_DLLEXPORT)

--- a/modules/openfoam/CMakeLists.txt
+++ b/modules/openfoam/CMakeLists.txt
@@ -18,10 +18,14 @@ if (GENERATE_TYPES)
   generate_f90_types(src/OpenFOAM_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/OpenFOAM_Types.f90 -ccode)
 endif()
 
-add_library(foamtypeslib src/OpenFOAM_Types.f90)
+add_library(foamtypeslib STATIC
+  src/OpenFOAM_Types.f90
+)
 target_link_libraries(foamtypeslib nwtclibs)
 
-add_library(foamfastlib src/OpenFOAM.f90)
+add_library(foamfastlib STATIC
+  src/OpenFOAM.f90
+)
 target_link_libraries(foamfastlib openfast_prelib)
 target_include_directories(foamfastlib PUBLIC 
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>  

--- a/modules/orcaflex-interface/CMakeLists.txt
+++ b/modules/orcaflex-interface/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/OrcaFlexInterface.txt ${CMAKE_CURRENT_LIST_DIR}/src/OrcaFlexInterface_Types.f90)
 endif()
 
-add_library(orcaflexlib 
+add_library(orcaflexlib STATIC
   src/OrcaFlexInterface.f90
   src/OrcaFlexInterface_Types.f90
 )

--- a/modules/seastate/CMakeLists.txt
+++ b/modules/seastate/CMakeLists.txt
@@ -22,7 +22,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/SeaState.txt ${CMAKE_CURRENT_LIST_DIR}/src/SeaState_Types.f90 -noextrap)
 endif()
 
-add_library(seastlib
+add_library(seastlib STATIC
   src/Current.f90
   src/Waves.f90
   src/Waves2.f90

--- a/modules/servodyn/CMakeLists.txt
+++ b/modules/servodyn/CMakeLists.txt
@@ -32,7 +32,9 @@ set(SERVODYN_SRCS
   src/ServoDyn_Types.f90
 )
 
-add_library(servodynlib ${SERVODYN_SRCS})
+add_library(servodynlib STATIC
+  ${SERVODYN_SRCS}
+)
 target_link_libraries(servodynlib nwtclibs)
 
 # Driver

--- a/modules/subdyn/CMakeLists.txt
+++ b/modules/subdyn/CMakeLists.txt
@@ -18,7 +18,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/SubDyn_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/SubDyn_Types.f90)
 endif()
 
-add_library(subdynlib
+add_library(subdynlib STATIC
   src/SubDyn.f90
   src/FEM.f90
   src/SD_FEM.f90

--- a/modules/supercontroller/CMakeLists.txt
+++ b/modules/supercontroller/CMakeLists.txt
@@ -19,12 +19,12 @@ if (GENERATE_TYPES)
   generate_f90_types(src/SC_DataEx_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/SCDataEx_Types.f90 -ccode -noextrap)
 endif()
 
-add_library(sctypeslib
+add_library(sctypeslib STATIC
   src/SCDataEx_Types.f90
 )
 target_link_libraries(sctypeslib nwtclibs)
 
-add_library(scfastlib
+add_library(scfastlib STATIC
   src/SC_DataEx.f90
   src/SuperController_Types.f90
   src/SuperController.f90

--- a/modules/version/CMakeLists.txt
+++ b/modules/version/CMakeLists.txt
@@ -27,7 +27,9 @@ else()
 endif()
 add_definitions(-DGIT_VERSION_INFO="${GIT_DESCRIBE}")
 
-add_library(versioninfolib src/VersionInfo.f90)
+add_library(versioninfolib STATIC
+  src/VersionInfo.f90
+)
 target_link_libraries(versioninfolib nwtclibs)
 
 install(TARGETS versioninfolib

--- a/modules/wakedynamics/CMakeLists.txt
+++ b/modules/wakedynamics/CMakeLists.txt
@@ -17,7 +17,7 @@ if (GENERATE_TYPES)
   generate_f90_types(src/WakeDynamics_Registry.txt ${CMAKE_CURRENT_LIST_DIR}/src/WakeDynamics_Types.f90 -noextrap)
 endif()
 
-add_library(wdlib
+add_library(wdlib STATIC
   src/WakeDynamics.f90
   #src/WakeDynamics_IO.f90
   src/WakeDynamics_Types.f90


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**
This PR changes the CMakeLists.txt files in each module so that the module libraries are built as STATIC even if CMake is configured with `-DBUILD_SHARED_LIBS=ON`. Interface libraries (C-Bindings) and `openfastlib` are always built as shared libraries so this change will not affect downstream users. This option is part of CMake: [BUILD_SHARED_LIBS](https://cmake.org/cmake/help/latest/variable/BUILD_SHARED_LIBS.html)

**Impacted areas of the software**
CMakeLists.txt files of all modules

**Additional supporting information**
This change arose from a problem installing WEIS which built OpenFAST with `-DBUILD_SHARED_LIBS=ON`. At one point, the only way to build `openfastlib` as a shared library was to set `-DBUILD_SHARED_LIBS=ON`. This library is currently always built as shared but many users still set `BUILD_SHARED_LIBS=ON` which causes all module libraries to be created as shared libraries so they are dynamically loaded at run time. This commit changes the CMakeLists.txt files to build all module libs as `STATIC` regardless of how `BUILD_SHARED_LIBS` is set. As a result, all module libraries will be statically linked into `openfast`, `openfastlib` and `FAST.Farm` which should improve performance and reduce complexity. This also prevents a problem with building the Simulink MEX file which wouldn't work if `BUILD_SHARED_LIBS=ON`.
