### PR TITLE
IfW: add VTK output of slice in XY to driver

### DIFF
--- a/modules/inflowwind/src/InflowWind_Driver.f90
+++ b/modules/inflowwind/src/InflowWind_Driver.f90
@@ -503,6 +503,23 @@ PROGRAM InflowWind_Driver
       END IF
    END IF
    
+
+   IF (SettingsFlags%XYslice) THEN
+      CALL IfW_WriteXYslice( InflowWind_p%FlowField, InflowWind_InitInp%RootName, Settings%XYslice_height, ErrStat, ErrMsg )
+      IF (ErrStat > ErrID_None) THEN
+         CALL WrScr( TRIM(ErrMsg) )
+         IF ( ErrStat >= AbortErrLev ) THEN
+            CALL DriverCleanup()
+            CALL ProgAbort( ErrMsg )
+         ELSEIF ( IfWDriver_Verbose >= 7_IntKi ) THEN
+            CALL WrScr(NewLine//' IfW_WriteXYslice returned: ErrStat: '//TRIM(Num2LStr(ErrStat)))
+         END IF
+      ELSE IF ( IfWDriver_Verbose >= 5_IntKi ) THEN
+         CALL WrScr(NewLine//'IfW_WriteXYslice CALL returned without errors.'//NewLine)
+      END IF
+   END IF
+
+
    !--------------------------------------------------------------------------------------------------------------------------------
    !-=-=- Other Setup -=-=-
    !--------------------------------------------------------------------------------------------------------------------------------

--- a/modules/inflowwind/src/InflowWind_Driver_Types.f90
+++ b/modules/inflowwind/src/InflowWind_Driver_Types.f90
@@ -76,6 +76,8 @@ MODULE InflowWind_Driver_Types
       LOGICAL                 :: WrBladed             = .FALSE.      !< Requested file conversion to Bladed format?
       LOGICAL                 :: WrVTK                = .FALSE.      !< Requested file output as VTK?
       LOGICAL                 :: WrUniform            = .FALSE.      !< Requested file output as Uniform wind format?
+
+      LOGICAL                 :: XYslice              = .FALSE.      !< Take XY slice at one elevation
    END TYPE IfWDriver_Flags
 
 
@@ -105,6 +107,7 @@ MODULE InflowWind_Driver_Types
       TYPE(OutputFile)        :: FFTOutput
       TYPE(OutputFile)        :: PointsVelOutput
 
+      REAL(ReKi)              :: XYslice_height       = 0.0_ReKi  !< height to take XY slice
    END TYPE IfWDriver_Settings
 
 

--- a/modules/inflowwind/src/InflowWind_IO.f90
+++ b/modules/inflowwind/src/InflowWind_IO.f90
@@ -39,7 +39,8 @@ public :: IfW_SteadyWind_Init, &
 public :: Uniform_WriteHH, &
           Grid3D_WriteBladed, &
           Grid3D_WriteHAWC, &
-          Grid3D_WriteVTK
+          Grid3D_WriteVTK, &
+          Grid3D_WriteVTKsliceXY
 
 type(ProgDesc), parameter :: InflowWind_IO_Ver = ProgDesc('InflowWind_IO', '', '')
 
@@ -2923,5 +2924,80 @@ subroutine Grid3D_WriteHAWC(G3D, FileRootName, unit, ErrStat, ErrMsg)
    end do
 
 end subroutine Grid3D_WriteHAWC
+
+
+subroutine Grid3D_WriteVTKsliceXY(G3D, FileRootName, XYslice_height, unit, ErrStat, ErrMsg)
+
+   type(Grid3DFieldType), intent(in)   :: G3D            !< Parameters
+   character(*), intent(in)            :: FileRootName   !< RootName for output files
+   real(ReKi),    intent(in)           :: XYslice_height
+   integer(IntKi), intent(in)           :: unit           !< Error status of the operation
+   integer(IntKi), intent(out)          :: ErrStat        !< Error status of the operation
+   character(*), intent(out)            :: ErrMsg         !< Error message if ErrStat /= ErrID_None
+
+   character(*), parameter                :: RoutineName = 'Grid3D_WriteVTKsliceXY'
+   character(1024)                        :: RootPathName
+   character(1024)                        :: FileName
+   character(3)                           :: ht_str
+   integer                                :: it          !< time index for slice
+   integer                                :: ix
+   integer                                :: iy
+   integer                                :: iz
+   real(ReKi)                             :: time        !< time for this slice
+   real(ReKi)                             :: ht          !< nearest grid slice elevation
+   integer(IntKi)                         :: ErrStat2
+   character(ErrMsgLen)                   :: ErrMsg2
+
+   call GetPath(FileRootName, RootPathName)
+   RootPathName = trim(RootPathName)//PathSep//"vtk"
+   call MkDir(trim(RootPathName))  ! make this directory if it doesn't already exist
+
+   ! get indices for this slice
+   iz    = nint((G3D%GridBase + XYslice_height)*G3D%InvDZ)
+   ht    = real(iz,ReKi) / G3D%InvDZ + G3D%GridBase         ! nearest height index
+   write(ht_str,'(i3)') nint(ht)
+
+   ! check for errors in slice height
+   if (iz <= 0_IntKi) then
+      call SetErrStat(ErrID_Warn,"No grid points near XY slice height of "//trim(num2lstr(XYslice_height))//".  Skipping writing slice file.",ErrStat,ErrMsg,RoutineName)
+      return
+   endif
+
+   ! Loop through time steps
+   do it = 1, G3D%NSteps
+
+      time  = real(it - 1, ReKi)*G3D%DTime
+
+      ! Create the output vtk file with naming <WindFilePath>/vtk/DisYZ.t<i>.vtk
+      FileName = trim(RootPathName)//PathSep//"DisXY.Z"//ht_str//".t"//trim(num2lstr(it))//".vtp"
+ 
+      ! see WrVTK_SP_header
+      call OpenFOutFile(unit, TRIM(FileName), ErrStat2, ErrMsg2)
+      call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+      if (ErrStat >= AbortErrLev) return
+ 
+      write (unit, '(A)') '# vtk DataFile Version 3.0'
+      write (unit, '(A)') "InflowWind XY Slice at T= "//trim(num2lstr(time))//" s"
+      write (unit, '(A)') 'ASCII'
+      write (unit, '(A)') 'DATASET STRUCTURED_POINTS'
+ 
+      ! Note: gridVals must be stored such that the left-most dimension is X
+      ! and the right-most dimension is Z (see WrVTK_SP_vectors3D)
+      write (unit, '(A,3(i5,1X))') 'DIMENSIONS ', G3D%NSteps, G3D%NYGrids, 1
+      write (unit, '(A,3(f10.2,1X))') 'ORIGIN ', G3D%InitXPosition+time*G3D%MeanWS, -G3D%YHWid, ht
+      write (unit, '(A,3(f10.2,1X))') 'SPACING ', -G3D%Dtime*G3D%MeanWS, 1.0_ReKi/G3D%InvDY, 0.0_ReKi
+      write (unit, '(A,i9)') 'POINT_DATA ', G3D%NSteps*G3D%NYGrids
+      write (unit, '(A)') 'VECTORS DisXY float'
+ 
+      do iy = 1, G3D%NYGrids
+         do ix = 1, G3D%NSteps      ! time and X are interchangeable
+            write (unit, '(3(f10.2,1X))') G3D%Vel(:, iy, iz, ix)
+         end do
+      end do
+
+   enddo
+
+   close (unit)
+end subroutine Grid3D_WriteVTKsliceXY
 
 end module InflowWind_IO


### PR DESCRIPTION
This PR is ready to merge.

**Feature or improvement description**
This allows visualizing a slice through hub-height (or other height) when comparing with a simulation.  The user can specify the height at which to export the slice.  At the moment it is a very slow process due to the looping and because it exports over the entire time range (this could be improved later).

![Screenshot 2023-06-21 at 2 26 44 PM](https://github.com/OpenFAST/openfast/assets/2745453/5b8313f3-14da-4aaf-a32e-b4d322780f35)
This figure shows the XY plane at the hub height for a Mann wind field (HAWC format).  The vertical plane is exported from the driver using the `WrVTK` option.  Both are taken at 23.625 seconds.

**Related issue, if one exists**
none

**Impacted areas of the software**
InflowWind driver only

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
No test cases are affected.  I did not add a test case for this since it is a very slow code to execute.