### PR TITLE
FF: fix bug with Mod_AmbWind=3 -- hub point wasn't shifted.

### DIFF
--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1455,7 +1455,7 @@ subroutine AWAE_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errM
             end do
             do n_hl=0, n_high_low
                   ! Set the hub position and orientation to pass to IfW (IfW always calculates hub and disk avg vel)
-               m%u_IfW_High%HubPosition =  (/ p%X0_high(nt) + 0.5*p%nX_high*p%dX_high(nt), p%Y0_high(nt) + 0.5*p%nY_high*p%dY_high(nt), p%Z0_high(nt) + 0.5*p%nZ_high*p%dZ_high(nt) /)
+               m%u_IfW_High%HubPosition =  (/ p%X0_high(nt) + 0.5*p%nX_high*p%dX_high(nt), p%Y0_high(nt) + 0.5*p%nY_high*p%dY_high(nt), p%Z0_high(nt) + 0.5*p%nZ_high*p%dZ_high(nt) /) - p%WT_Position(:,nt)
                call Eye(m%u_IfW_High%HubOrientation,ErrStat2,ErrMsg2)
                call InflowWind_CalcOutput(t+p%dt_low+n_hl*p%DT_high, m%u_IfW_High, p%IfW(nt), x%IfW(nt), xd%IfW(nt), z%IfW(nt), OtherState%IfW(nt), m%y_IfW_High, m%IfW(nt), errStat2, errMsg2)
                   call SetErrStat( ErrStat2, ErrMsg2, errStat, errMsg, RoutineName )

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -1733,7 +1733,7 @@ SUBROUTINE InflowWind_GetHubValues( Time, InputData, p, x, xd, z, OtherStates, m
 
    IMPLICIT                                                    NONE
 
-   CHARACTER(*),              PARAMETER                     :: RoutineName="InflowWind_GetSpatialAverage"
+   CHARACTER(*),              PARAMETER                     :: RoutineName="InflowWind_GetHubValues"
 
 
       ! Inputs / Outputs


### PR DESCRIPTION
This PR is ready for merging.

**Feature or improvement description**
In v3.5.0 we added the hub point to AWAE at the center of the grid now that IfW calculates the disk average velocity every time IfW_CalcOutput gets called. But this point needs to be shifted by the turbine position so it is in the box.

This will all change in 4.0.0 when we switch to pointers for all this and don't call IfW_CalcOutput directly anymore.

**Related issue, if one exists**
See comment 2 and discussion in #1615 here: https://github.com/OpenFAST/openfast/discussions/1615#discussioncomment-6167270

**Impacted areas of the software**
The `ModAmbWind=3` option in FAST.Farm should in theory now work correctly.

**Additional supporting information**
In v4.0.0, this will all be changed.  So for now we will keep the calculations of disk average velocity in the InflowWind_CalcOutput routine.

**Test results, if applicable**
No test results change.  We don't currently have a `Mod_AmbWind=3` FAST.Farm test case.  This would have been caught by it.