### PR TITLE
ED/AD: fix segfault when BldNd_BladesOut==0

### DIFF
--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -993,6 +993,10 @@ SUBROUTINE ParsePrimaryFileInfo( PriPath, InitInp, InputFile, RootName, NumBlade
    call ReadOutputListFromFileInfo( FileInfo_In, CurLine, InputFileData%BldNd_OutList, InputFileData%BldNd_NumOuts, ErrStat2, ErrMsg2, UnEc )
          if (FailedNodal()) return;
 
+!FIXME: improve logic on the node outputs
+   ! Prevent segfault when no blades specified.  All logic tests on BldNd_NumOuts at present.
+   if (InputFileData%BldNd_BladesOut <= 0)   InputFileData%BldNd_NumOuts = 0
+
    RETURN
 CONTAINS
    !-------------------------------------------------------------------------------------------------

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -3631,6 +3631,10 @@ SUBROUTINE ReadPrimaryFile( InputFile, InputFileData, BldFile, FurlFile, TwrFile
       CALL Cleanup()
       RETURN
    ENDIF
+
+!FIXME: this is a hack to fix a segfault.  Better logic is really needed for the nodal outputs.
+   ! Node outputs.  If no blades specified set BldNd_Outs to 0 (all checks are currently done on NumOuts, not BladesOut).
+   if (InputFileData%BldNd_BladesOut <= 0)   InputFileData%BldNd_NumOuts = 0
    !---------------------- END OF FILE -----------------------------------------
    
    call cleanup()


### PR DESCRIPTION
This PR is ready for merging.

**Feature or improvement description**
If the number of blade node outputs is set to 0, a segmentation fault due to an array bounds issue occurs in both ElastoDyn and BeamDyn.  This is a temporary fix -- the logic really should be improved elsewhere in the code for checking if any blades are output.  However, we don't actually have logic in place yet for only outputting specified blades, so this temporary fix can be improved when that is done.

**Related issue, if one exists**
#1651

**Impacted areas of the software**
AeroDyn15 and ElastoDyn -- this only fixes a potential segfault if the number of blades to output in the nodal outputs is set to zero.
