### PR TITLE
[BuFix] InflowWind was not setting InitOut MWS data.

### DIFF
--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -311,6 +311,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Uniform%RefHeight]
 
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
+
    case (Uniform_WindNumber)
 
       Uniform_InitInput%WindFileName = InputFileData%Uniform_FileName
@@ -331,6 +334,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Uniform%RefHeight]
 
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
+
    case (TSFF_WindNumber)
 
       TurbSim_InitInput%WindFileName = InputFileData%TSFF_FileName
@@ -345,6 +351,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
+
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (BladedFF_WindNumber)
 
@@ -371,7 +380,10 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
-      
+
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
+
    case (BladedFF_Shr_WindNumber)
 
       Bladed_InitInput%WindType           = BladedFF_Shr_WindNumber
@@ -394,6 +406,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
+
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (HAWC_WindNumber)
 
@@ -427,6 +442,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
 
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
+
    case (User_WindNumber)
 
       p%FlowField%FieldType = User_FieldType
@@ -440,6 +458,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%User%RefHeight]
 
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
+
    case (FDext_WindNumber)
 
       p%FlowField%FieldType = Grid4D_FieldType
@@ -451,6 +472,9 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid4D%RefHeight]
+
+      ! Set Mean Wind Speed
+      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (Point_WindNumber)
 

--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -128,8 +128,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
    Type(User_InitInputType)                              :: User_InitInput
    Type(Grid4D_InitInputType)                            :: Grid4D_InitInput
    Type(Points_InitInputType)                            :: Points_InitInput
-
-   Type(WindFileDat)                                     :: FileDat
    
 
    ! TYPE(InflowWind_IO_InitInputType)                      :: FlowField_InitData     !< initialization info
@@ -301,7 +299,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       Steady_InitInput%PLExp = InputFileData%Steady_PLexp
 
       p%FlowField%FieldType = Uniform_FieldType
-      call IfW_SteadyWind_Init(Steady_InitInput, SumFileUnit, p%FlowField%Uniform, FileDat, TmpErrStat, TmpErrMsg)
+      call IfW_SteadyWind_Init(Steady_InitInput, SumFileUnit, p%FlowField%Uniform, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -310,9 +308,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Uniform%RefHeight]
-
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (Uniform_WindNumber)
 
@@ -324,7 +319,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       Uniform_InitInput%PassedFileData = InitInp%WindType2Data
 
       p%FlowField%FieldType = Uniform_FieldType
-      call IfW_UniformWind_Init(Uniform_InitInput, SumFileUnit, p%FlowField%Uniform, FileDat, TmpErrStat, TmpErrMsg)
+      call IfW_UniformWind_Init(Uniform_InitInput, SumFileUnit, p%FlowField%Uniform, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -334,15 +329,12 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Uniform%RefHeight]
 
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
-
    case (TSFF_WindNumber)
 
       TurbSim_InitInput%WindFileName = InputFileData%TSFF_FileName
 
       p%FlowField%FieldType = Grid3D_FieldType
-      call IfW_TurbSim_Init(TurbSim_InitInput, SumFileUnit, p%FlowField%Grid3D, FileDat, TmpErrStat, TmpErrMsg)
+      call IfW_TurbSim_Init(TurbSim_InitInput, SumFileUnit, p%FlowField%Grid3D, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -351,9 +343,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
-
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (BladedFF_WindNumber)
 
@@ -371,7 +360,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       Bladed_InitInput%NativeBladedFmt    = .false.
 
       p%FlowField%FieldType = Grid3D_FieldType
-      call IfW_Bladed_Init(Bladed_InitInput, SumFileUnit, Bladed_InitOutput, p%FlowField%Grid3D, FileDat, TmpErrStat, TmpErrMsg)   
+      call IfW_Bladed_Init(Bladed_InitInput, SumFileUnit, Bladed_InitOutput, p%FlowField%Grid3D, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)   
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -380,9 +369,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
-
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (BladedFF_Shr_WindNumber)
 
@@ -393,7 +379,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       Bladed_InitInput%NativeBladedFmt    = .true.
 
       p%FlowField%FieldType = Grid3D_FieldType
-      call IfW_Bladed_Init(Bladed_InitInput, SumFileUnit, Bladed_InitOutput, p%FlowField%Grid3D, FileDat, TmpErrStat, TmpErrMsg)   
+      call IfW_Bladed_Init(Bladed_InitInput, SumFileUnit, Bladed_InitOutput, p%FlowField%Grid3D, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)   
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -406,9 +392,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
-
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (HAWC_WindNumber)
 
@@ -432,7 +415,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       HAWC_InitInput%G3D%XOffset = InputFileData%FF%XOffset
 
       p%FlowField%FieldType = Grid3D_FieldType
-      call IfW_HAWC_Init(HAWC_InitInput, SumFileUnit, p%FlowField%Grid3D, FileDat, TmpErrStat, TmpErrMsg)
+      call IfW_HAWC_Init(HAWC_InitInput, SumFileUnit, p%FlowField%Grid3D, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -442,13 +425,10 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid3D%RefHeight]
 
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
-
    case (User_WindNumber)
 
       p%FlowField%FieldType = User_FieldType
-      call IfW_User_Init(User_InitInput, SumFileUnit, p%FlowField%User, FileDat, TmpErrStat, TmpErrMsg)
+      call IfW_User_Init(User_InitInput, SumFileUnit, p%FlowField%User, InitOutData%WindFileInfo, TmpErrStat, TmpErrMsg)
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) then
          call Cleanup()
@@ -457,9 +437,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%User%RefHeight]
-
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (FDext_WindNumber)
 
@@ -472,9 +449,6 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
 
       ! Set reference position for wind rotation
       p%FlowField%RefPosition = [0.0_ReKi, 0.0_ReKi, p%FlowField%Grid4D%RefHeight]
-
-      ! Set Mean Wind Speed
-      InitOutData%WindFileInfo%MWS = FileDat%MWS
 
    case (Point_WindNumber)
 

--- a/modules/inflowwind/src/InflowWind_Driver.f90
+++ b/modules/inflowwind/src/InflowWind_Driver.f90
@@ -734,8 +734,7 @@ if (SettingsFlags%WindGrid .or. SettingsFlags%PointsFile .or. SettingsFlags%FFTc
    IF ( IfWDriver_Verbose >= 5_IntKi )    CALL WrScr(NewLine//'Calling InflowWind_CalcOutput...'//NewLine)
 
 
-   DO ITime =  0, MAX( Settings%NumTimeSteps, 1_IntKi )
-
+   DO ITime =  0, MAX( Settings%NumTimeSteps, 0_IntKi )
       TimeNow  =  Settings%TStart + Settings%DT*(ITime)
 
       IF ( SettingsFlags%WindGrid ) THEN

--- a/modules/inflowwind/src/InflowWind_Driver_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Driver_Subs.f90
@@ -1413,8 +1413,8 @@ SUBROUTINE UpdateSettingsWithCL( DvrFlags, DvrSettings, CLFlags, CLSettings, DVR
       DvrFlags%NumTimeStepsDefault  =  .FALSE.
    ENDIF
 
-      ! Make sure there is at least one timestep
-   DvrSettings%NumTimeSteps   =  MAX(DvrSettings%NumTimeSteps,1_IntKi)
+      ! Make sure there is at least one timestep (start at index 0)
+   DvrSettings%NumTimeSteps   =  MAX(DvrSettings%NumTimeSteps,0_IntKi)
 
 
       !--------------------------------------------


### PR DESCRIPTION
This bugfix is **NOT** ready for merging.  Need to check if the `.lin` files in the regression tests are affected.

**Feature or improvement description**
This fixes a bug in the reported windspeed from InfloWind to the glue code.  The wind speed was getting set to `HUGE()` which did not appear correctly in the `.lin` files.

**Related issue, if one exists**
#1622

**Impacted areas of the software**
Linearization was not reporting the correct wind speed in the `.lin` files.

**Test results, if applicable**
~The regression tests may need to be rerun as the reported wind speed in the `.lin` files is `0.0000 m/s`.  At the moment this doesn't make much sense to me since the reported value should be `HUGE()`.~
The linearization regression tests are run without inflow.