### PR TITLE
AD/TailFin: Bug Fix: remove chord in fy (see #1653)

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -4353,7 +4353,7 @@ SUBROUTINE TFin_CalcOutput(p, p_AD, u, m, y, ErrStat, ErrMsg )
       force_tf(:)    = 0.0_ReKi
       moment_tf(:)    = 0.0_ReKi
       force_tf(1)    = Cx * q
-      force_tf(2)    = Cy * q * p%TFin%TFinChord
+      force_tf(2)    = Cy * q
       force_tf(3)    = 0.0_ReKi
       moment_tf(1:2) = 0.0_ReKi
       moment_tf(3)   = AFI_interp%Cm * q * p%TFin%TFinChord


### PR DESCRIPTION
This pull request is ready to be merged


**Feature or improvement description**
Removes a "chord" factor which was introduced by mistake. in the y-force of the tailfin.

**Related issue, if one exists**
#1653

**Impacted areas of the software**
AeroDyn Tailfin aerodynamics

