### PR TITLE
AD: Adding rtest for TailFin polar-based model

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -282,6 +282,7 @@ of_regression("EllipticalWing_OLAF"                    "openfast;aerodyn15;olaf"
 of_regression("StC_test_OC4Semi"                       "openfast;servodyn;hydrodyn;moordyn;offshore;stc")
 of_regression("MHK_RM1_Fixed"                          "openfast;elastodyn;aerodyn15;mhk")
 of_regression("MHK_RM1_Floating"                       "openfast;elastodyn;aerodyn15;hydrodyn;moordyn;mhk")
+of_regression("Tailfin_FreeYaw1DOF_PolarBased"         "openfast;elastodyn;aerodyn15")
 
 # OpenFAST C++ API test
 if(BUILD_OPENFAST_CPP_API)

--- a/reg_tests/executeOpenfastRegressionCase.py
+++ b/reg_tests/executeOpenfastRegressionCase.py
@@ -93,7 +93,7 @@ if not os.path.isdir(inputsDirectory):
 
 # create the local output directory if it does not already exist
 # and initialize it with input files for all test cases
-for data in ["AOC", "AWT27", "SWRT", "UAE_VI", "WP_Baseline"]:
+for data in ["AOC", "AWT27", "_DummyTurbineData", "SWRT", "UAE_VI", "WP_Baseline"]:
     dataDir = os.path.join(buildDirectory, data)
     if not os.path.isdir(dataDir):
         rtl.copyTree(os.path.join(moduleDirectory, data), dataDir, excludeExt=excludeExt)


### PR DESCRIPTION
This pull request ready to be merged

**Feature or improvement description**
Test the tailfin polar-based aerodynamic model documented here:
https://openfast.readthedocs.io/en/dev/source/user/aerodyn/theory_tailfin.html

**Impacted areas of the software**
AeroDyn / TailFin 


**Test results, if applicable**
The test case is documented there:
https://github.com/OpenFAST/r-test/tree/f/tailfin/glue-codes/openfast/Tailfin_FreeYaw1DOF_PolarBased

The time integration of the system in OpenFAST and python provides consistent results, verifying that the implementation is (at least partially) correct. Below are comparison of the structural states, and of some of the outputs (angle of attack and relative velocity at the tailfin reference point): 

![vtk_Tailfin_ComparisonStates](https://github.com/OpenFAST/openfast/assets/1318316/ba42a8ee-ebeb-4413-ac30-249557dfecfc)
![vtk_Tailfin_ComparisonOutputs](https://github.com/OpenFAST/openfast/assets/1318316/775139b4-48ed-4983-90fd-013402dc8c82)
