### PR TITLE
Resolve BeamDyn initial strain for rotated blade

### DIFF
--- a/modules/beamdyn/src/BeamDyn_Subs.f90
+++ b/modules/beamdyn/src/BeamDyn_Subs.f90
@@ -1067,7 +1067,7 @@ SUBROUTINE BD_ComputeIniNodalCrv(e3, phi, cc, ErrStat, ErrMsg)
    Rr(:,2) = Cross_Product(e3,e1)
    Rr(:,1) = e1(:)
  
-   identity = 0.
+   identity = 0.0_BDKi
    do i = 1,3
      identity(i,i) = 1.0_BDKi
    enddo

--- a/modules/beamdyn/src/BeamDyn_Types.f90
+++ b/modules/beamdyn/src/BeamDyn_Types.f90
@@ -161,7 +161,8 @@ IMPLICIT NONE
     REAL(DbKi)  :: dt      !< module dt [s]
     REAL(DbKi) , DIMENSION(1:9)  :: coef      !< GA2 Coefficient [-]
     REAL(DbKi)  :: rhoinf      !< Numerical Damping Coefficient for GA2 [-]
-    REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: uuN0      !< Initial Postion Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element) [-]
+    REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: uuN0      !< Initial Position Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element) [-]
+    REAL(R8Ki) , DIMENSION(:,:), ALLOCATABLE  :: twN0      !< Initial Twist of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element) [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: Stif0_QP      !< Sectional Stiffness Properties at quadrature points (6x6xqp) [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: Mass0_QP      !< Sectional Mass Properties at quadrature points (6x6xqp) [-]
     REAL(R8Ki) , DIMENSION(1:3)  :: gravity      !< Gravitational acceleration [m/s^2]
@@ -182,7 +183,6 @@ IMPLICIT NONE
     REAL(R8Ki) , DIMENSION(:,:), ALLOCATABLE  :: ShpDer      !< Derivative of shape function matrix (index 1 = FE nodes; index 2=quadrature points) [-]
     REAL(R8Ki) , DIMENSION(:,:), ALLOCATABLE  :: Jacobian      !< Jacobian value at each quadrature point [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: uu0      !< Initial Disp/Rot value at quadrature point (at T=0) [-]
-    REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: rrN0      !< Initial relative rotation array, relative to root (at T=0) (index 1=rot DOF; index 2=FE nodes; index 3=element) [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: E10      !< Initial E10 at quadrature point [-]
     INTEGER(IntKi)  :: nodes_per_elem      !< Finite element (GLL) nodes per element [-]
     INTEGER(IntKi) , DIMENSION(:,:), ALLOCATABLE  :: node_elem_idx      !< Index to first and last nodes of element in p%node_total sized arrays [-]
@@ -3701,6 +3701,20 @@ IF (ALLOCATED(SrcParamData%uuN0)) THEN
   END IF
     DstParamData%uuN0 = SrcParamData%uuN0
 ENDIF
+IF (ALLOCATED(SrcParamData%twN0)) THEN
+  i1_l = LBOUND(SrcParamData%twN0,1)
+  i1_u = UBOUND(SrcParamData%twN0,1)
+  i2_l = LBOUND(SrcParamData%twN0,2)
+  i2_u = UBOUND(SrcParamData%twN0,2)
+  IF (.NOT. ALLOCATED(DstParamData%twN0)) THEN 
+    ALLOCATE(DstParamData%twN0(i1_l:i1_u,i2_l:i2_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%twN0.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%twN0 = SrcParamData%twN0
+ENDIF
 IF (ALLOCATED(SrcParamData%Stif0_QP)) THEN
   i1_l = LBOUND(SrcParamData%Stif0_QP,1)
   i1_u = UBOUND(SrcParamData%Stif0_QP,1)
@@ -3848,22 +3862,6 @@ IF (ALLOCATED(SrcParamData%uu0)) THEN
     END IF
   END IF
     DstParamData%uu0 = SrcParamData%uu0
-ENDIF
-IF (ALLOCATED(SrcParamData%rrN0)) THEN
-  i1_l = LBOUND(SrcParamData%rrN0,1)
-  i1_u = UBOUND(SrcParamData%rrN0,1)
-  i2_l = LBOUND(SrcParamData%rrN0,2)
-  i2_u = UBOUND(SrcParamData%rrN0,2)
-  i3_l = LBOUND(SrcParamData%rrN0,3)
-  i3_u = UBOUND(SrcParamData%rrN0,3)
-  IF (.NOT. ALLOCATED(DstParamData%rrN0)) THEN 
-    ALLOCATE(DstParamData%rrN0(i1_l:i1_u,i2_l:i2_u,i3_l:i3_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%rrN0.', ErrStat, ErrMsg,RoutineName)
-      RETURN
-    END IF
-  END IF
-    DstParamData%rrN0 = SrcParamData%rrN0
 ENDIF
 IF (ALLOCATED(SrcParamData%E10)) THEN
   i1_l = LBOUND(SrcParamData%E10,1)
@@ -4167,6 +4165,9 @@ ENDIF
 IF (ALLOCATED(ParamData%uuN0)) THEN
   DEALLOCATE(ParamData%uuN0)
 ENDIF
+IF (ALLOCATED(ParamData%twN0)) THEN
+  DEALLOCATE(ParamData%twN0)
+ENDIF
 IF (ALLOCATED(ParamData%Stif0_QP)) THEN
   DEALLOCATE(ParamData%Stif0_QP)
 ENDIF
@@ -4196,9 +4197,6 @@ IF (ALLOCATED(ParamData%Jacobian)) THEN
 ENDIF
 IF (ALLOCATED(ParamData%uu0)) THEN
   DEALLOCATE(ParamData%uu0)
-ENDIF
-IF (ALLOCATED(ParamData%rrN0)) THEN
-  DEALLOCATE(ParamData%rrN0)
 ENDIF
 IF (ALLOCATED(ParamData%E10)) THEN
   DEALLOCATE(ParamData%E10)
@@ -4303,6 +4301,11 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*3  ! uuN0 upper/lower bounds for each dimension
       Db_BufSz   = Db_BufSz   + SIZE(InData%uuN0)  ! uuN0
   END IF
+  Int_BufSz   = Int_BufSz   + 1     ! twN0 allocated yes/no
+  IF ( ALLOCATED(InData%twN0) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*2  ! twN0 upper/lower bounds for each dimension
+      Db_BufSz   = Db_BufSz   + SIZE(InData%twN0)  ! twN0
+  END IF
   Int_BufSz   = Int_BufSz   + 1     ! Stif0_QP allocated yes/no
   IF ( ALLOCATED(InData%Stif0_QP) ) THEN
     Int_BufSz   = Int_BufSz   + 2*3  ! Stif0_QP upper/lower bounds for each dimension
@@ -4362,11 +4365,6 @@ ENDIF
   IF ( ALLOCATED(InData%uu0) ) THEN
     Int_BufSz   = Int_BufSz   + 2*3  ! uu0 upper/lower bounds for each dimension
       Db_BufSz   = Db_BufSz   + SIZE(InData%uu0)  ! uu0
-  END IF
-  Int_BufSz   = Int_BufSz   + 1     ! rrN0 allocated yes/no
-  IF ( ALLOCATED(InData%rrN0) ) THEN
-    Int_BufSz   = Int_BufSz   + 2*3  ! rrN0 upper/lower bounds for each dimension
-      Db_BufSz   = Db_BufSz   + SIZE(InData%rrN0)  ! rrN0
   END IF
   Int_BufSz   = Int_BufSz   + 1     ! E10 allocated yes/no
   IF ( ALLOCATED(InData%E10) ) THEN
@@ -4601,6 +4599,26 @@ ENDIF
         END DO
       END DO
   END IF
+  IF ( .NOT. ALLOCATED(InData%twN0) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%twN0,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%twN0,1)
+    Int_Xferred = Int_Xferred + 2
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%twN0,2)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%twN0,2)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i2 = LBOUND(InData%twN0,2), UBOUND(InData%twN0,2)
+        DO i1 = LBOUND(InData%twN0,1), UBOUND(InData%twN0,1)
+          DbKiBuf(Db_Xferred) = InData%twN0(i1,i2)
+          Db_Xferred = Db_Xferred + 1
+        END DO
+      END DO
+  END IF
   IF ( .NOT. ALLOCATED(InData%Stif0_QP) ) THEN
     IntKiBuf( Int_Xferred ) = 0
     Int_Xferred = Int_Xferred + 1
@@ -4829,31 +4847,6 @@ ENDIF
         DO i2 = LBOUND(InData%uu0,2), UBOUND(InData%uu0,2)
           DO i1 = LBOUND(InData%uu0,1), UBOUND(InData%uu0,1)
             DbKiBuf(Db_Xferred) = InData%uu0(i1,i2,i3)
-            Db_Xferred = Db_Xferred + 1
-          END DO
-        END DO
-      END DO
-  END IF
-  IF ( .NOT. ALLOCATED(InData%rrN0) ) THEN
-    IntKiBuf( Int_Xferred ) = 0
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    IntKiBuf( Int_Xferred ) = 1
-    Int_Xferred = Int_Xferred + 1
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%rrN0,1)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%rrN0,1)
-    Int_Xferred = Int_Xferred + 2
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%rrN0,2)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%rrN0,2)
-    Int_Xferred = Int_Xferred + 2
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%rrN0,3)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%rrN0,3)
-    Int_Xferred = Int_Xferred + 2
-
-      DO i3 = LBOUND(InData%rrN0,3), UBOUND(InData%rrN0,3)
-        DO i2 = LBOUND(InData%rrN0,2), UBOUND(InData%rrN0,2)
-          DO i1 = LBOUND(InData%rrN0,1), UBOUND(InData%rrN0,1)
-            DbKiBuf(Db_Xferred) = InData%rrN0(i1,i2,i3)
             Db_Xferred = Db_Xferred + 1
           END DO
         END DO
@@ -5422,6 +5415,29 @@ ENDIF
         END DO
       END DO
   END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! twN0 not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    i2_l = IntKiBuf( Int_Xferred    )
+    i2_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%twN0)) DEALLOCATE(OutData%twN0)
+    ALLOCATE(OutData%twN0(i1_l:i1_u,i2_l:i2_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%twN0.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i2 = LBOUND(OutData%twN0,2), UBOUND(OutData%twN0,2)
+        DO i1 = LBOUND(OutData%twN0,1), UBOUND(OutData%twN0,1)
+          OutData%twN0(i1,i2) = REAL(DbKiBuf(Db_Xferred), R8Ki)
+          Db_Xferred = Db_Xferred + 1
+        END DO
+      END DO
+  END IF
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! Stif0_QP not allocated
     Int_Xferred = Int_Xferred + 1
   ELSE
@@ -5698,34 +5714,6 @@ ENDIF
         DO i2 = LBOUND(OutData%uu0,2), UBOUND(OutData%uu0,2)
           DO i1 = LBOUND(OutData%uu0,1), UBOUND(OutData%uu0,1)
             OutData%uu0(i1,i2,i3) = REAL(DbKiBuf(Db_Xferred), R8Ki)
-            Db_Xferred = Db_Xferred + 1
-          END DO
-        END DO
-      END DO
-  END IF
-  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! rrN0 not allocated
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    Int_Xferred = Int_Xferred + 1
-    i1_l = IntKiBuf( Int_Xferred    )
-    i1_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    i2_l = IntKiBuf( Int_Xferred    )
-    i2_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    i3_l = IntKiBuf( Int_Xferred    )
-    i3_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    IF (ALLOCATED(OutData%rrN0)) DEALLOCATE(OutData%rrN0)
-    ALLOCATE(OutData%rrN0(i1_l:i1_u,i2_l:i2_u,i3_l:i3_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%rrN0.', ErrStat, ErrMsg,RoutineName)
-       RETURN
-    END IF
-      DO i3 = LBOUND(OutData%rrN0,3), UBOUND(OutData%rrN0,3)
-        DO i2 = LBOUND(OutData%rrN0,2), UBOUND(OutData%rrN0,2)
-          DO i1 = LBOUND(OutData%rrN0,1), UBOUND(OutData%rrN0,1)
-            OutData%rrN0(i1,i2,i3) = REAL(DbKiBuf(Db_Xferred), R8Ki)
             Db_Xferred = Db_Xferred + 1
           END DO
         END DO

--- a/modules/beamdyn/src/Registry_BeamDyn.txt
+++ b/modules/beamdyn/src/Registry_BeamDyn.txt
@@ -168,7 +168,8 @@ typedef   ^        ParameterType DbKi           coef             {9}       - -  
 typedef   ^        ParameterType DbKi           rhoinf           -         - -  "Numerical Damping Coefficient for GA2"
 #vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 #the following are BDKi = R8Ki
-typedef   ^        ParameterType R8Ki           uuN0             {:}{:}{:} - -  "Initial Postion Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element)" -
+typedef   ^        ParameterType R8Ki           uuN0             {:}{:}{:} - -  "Initial Position Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element)" -
+typedef   ^        ParameterType  ^             twN0             {:}{:}    - -  "Initial Twist of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element)" -
 typedef   ^        ParameterType  ^             Stif0_QP         {:}{:}{:} - -  "Sectional Stiffness Properties at quadrature points (6x6xqp)" -
 typedef   ^        ParameterType  ^             Mass0_QP         {:}{:}{:} - -  "Sectional Mass Properties at quadrature points (6x6xqp)" -
 typedef   ^        ParameterType  ^             gravity          {3}       - -  "Gravitational acceleration" m/s^2
@@ -189,7 +190,6 @@ typedef   ^        ParameterType  ^             Shp              {:}{:}    - -  
 typedef   ^        ParameterType  ^             ShpDer           {:}{:}    - -  "Derivative of shape function matrix (index 1 = FE nodes; index 2=quadrature points)" -
 typedef   ^        ParameterType  ^             Jacobian         {:}{:}    - -  "Jacobian value at each quadrature point" -
 typedef   ^        ParameterType  ^             uu0              {:}{:}{:} - -  "Initial Disp/Rot value at quadrature point (at T=0)" -
-typedef   ^        ParameterType  ^             rrN0             {:}{:}{:} - -  "Initial relative rotation array, relative to root (at T=0) (index 1=rot DOF; index 2=FE nodes; index 3=element)" -
 typedef   ^        ParameterType  ^             E10              {:}{:}{:} - -  "Initial E10 at quadrature point" -
 #end of BDKi-type variables
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/modules/beamdyn/tests/test_BD_QuadraturePointData.F90
+++ b/modules/beamdyn/tests/test_BD_QuadraturePointData.F90
@@ -27,7 +27,6 @@ module test_BD_QuadraturePointData
 
     real(BDKi), allocatable    :: gll_nodes(:)
     real(BDKi), allocatable    :: baseline_uu0(:,:,:)
-    real(BDKi), allocatable    :: baseline_rrN0(:,:,:)
     real(BDKi), allocatable    :: baseline_E10(:,:,:)
 
     real(BDKi), allocatable    :: baseline_uuu(:,:,:)
@@ -91,7 +90,6 @@ contains
 
         call AllocAry(baseline_uu0  , p%dof_node,   p%nqp,            p%elem_total, 'baseline_uu0'     , ErrStat, ErrMsg)
         call AllocAry(baseline_E10  , p%dof_node/2, p%nqp,            p%elem_total, 'baseline_E10'     , ErrStat, ErrMsg)
-        call AllocAry(baseline_rrN0 , p%dof_node/2, p%nodes_per_elem, p%elem_total, 'baseline_rrN0'    , ErrStat, ErrMsg)
 
         call AllocAry(baseline_uuu  , p%dof_node,   p%nqp,            p%elem_total, 'baseline_uuu'     , ErrStat, ErrMsg)
         call AllocAry(baseline_uup  , p%dof_node/2, p%nqp,            p%elem_total, 'baseline_uup'     , ErrStat, ErrMsg)
@@ -103,6 +101,10 @@ contains
         call AllocAry(baseline_RR0 , 3, 3, p%nqp, p%elem_total, 'baseline_RR0'    , ErrStat, ErrMsg)
 
         call AllocAry(baseline_Stif , 6, 6, p%nqp, p%elem_total, 'baseline_Stif'    , ErrStat, ErrMsg)
+
+        ! Allocate memory for GLL node positions in 1D parametric space
+        call AllocAry(gll_nodes, nodes_per_elem, "GLL points array", ErrStat, ErrMsg)
+        gll_nodes = (/ -1., -0.6546536707079771, 0., 0.6546536707079771, 1. /)
 
         ! assign baseline results
     
@@ -123,36 +125,25 @@ contains
         p%uuN0(1:3,5,1) = (/  -1., 1., 5. /)
         p%uuN0(4:6,5,1) = (/  -1.0730193445455083,-0.42803085368057275,1.292451050059679 /)
 
-
-        ! the following is uuN0(4:6) with rotation of first node removed
-        baseline_rrN0(1:3,1,1) = (/ 0., 0., 0. /)
-        baseline_rrN0(1:3,2,1) = (/ -0.18695562365337798,-0.0032641497706398077,0.048935661676787534 /)
-        baseline_rrN0(1:3,3,1) = (/ -0.6080640291857297,-0.08595023366039768,0.4027112581652146 /)
-        baseline_rrN0(1:3,4,1) = (/ -1.1980591841054526,-0.3478409509012645,0.9658032687192992 /)
-        baseline_rrN0(1:3,5,1) = (/ -1.5856082606694464,-0.3853274394272689,1.3714709059387975 /)
-
         ! We are just looking at one randomly selected point in the domain to test interpolation; can be expanded
         p%QptN(1) = 0.3
+
+        ! Twist at nodes (nodes_per_elem, elem_total)
+        p%twN0(:,1) = 90.0*((gll_nodes+1)/2)**2
 
         ! Input baseline/reference quantities; uu0 and E10 are only for at quadrature points, so just 1 point here 
         ! uu0 is reference line evaluated at quadrature point
         ! E10 is tangent evaluated at qudrature point 
         baseline_uu0(1:3,1,1) = (/ 0.29298750000000007,-0.03250000000000007,3.2499999999999996  /)
-        baseline_uu0(4:6,1,1) = (/ -0.419497643454797,-0.1153574679103733,0.610107968645409 /)
-        baseline_E10(1:3,1,1) = (/ -0.22332806017852783,0.3449485111415417,0.9116661133321399 /)
- 
-        ! Allocate memory for GLL node positions in 1D parametric space
-        call AllocAry(gll_nodes, nodes_per_elem, "GLL points array", ErrStat, ErrMsg)
-        gll_nodes = (/ -1., -0.6546536707079771, 0., 0.6546536707079771, 1. /)
+        baseline_uu0(4:6,1,1) = (/ -0.42032456079463276,-0.10798264336200536,0.61929246125947701 /)
+        baseline_E10(1:3,1,1) = (/ -0.21838554154630824,0.34664371674017153,0.91222030721097547 /)
+
         
         ! Build the shape functions and derivative of shape functions evaluated at QP points; this is tested elsewhere
         call BD_InitShpDerJaco(gll_nodes, p)
 
         ! **** primary function being tested *****
         call BD_QuadraturePointDataAt0( p )
-
-        testname = "5 node, 1 element, 1 qp, curved: BD_DisplacementQPAt0: rrN0"
-        @assertEqual(baseline_rrN0(:,:,1), p%rrN0(:,:,1), tolerance, testname)
 
         ! Test uu0; only one quadrature point for now
         testname = "5 node, 1 element, 1 qp, curved: BD_DisplacementQPAt0: uu0"
@@ -192,7 +183,7 @@ contains
         baseline_uuu(1:3,idx_qp,nelem) = (/ 0.42250000000000015,-0.14787500000000003,0.4774250000000001 /)
         baseline_uuu(4:6,idx_qp,nelem) = (/ 0.042250000000000024,0.1300000000000001,0.02746250000000002 /)
         baseline_uup(1:3,idx_qp,nelem) = (/ 0.23717727987485349,-0.005929431996871376,0.2834268494504499 /)
-        baseline_E1(1:3, idx_qp,nelem)  = (/ 0.01384921969632566, 0.33901907914467033, 1.1950929627825897 /)
+        baseline_E1(1:3, idx_qp,nelem)  = (/ 0.018791738328546054, 0.34071428474330018, 1.1956471566614264 /)
 
         call BD_DisplacementQP( nelem, p, x, m )
 
@@ -214,9 +205,9 @@ contains
 
         baseline_kappa(1:3,1,1)  = (/ 0.024664714695954715,0.036297077098213545,0.02229356260962948 /)
 
-        baseline_RR0(1,1:3,1,nelem)  = (/0.7967507798136657,-0.5939809735620473,-0.11124206898740374/)
-        baseline_RR0(2,1:3,1,nelem)  = (/0.5966254150993577,0.7439195402109748,0.3010346022466711 /)
-        baseline_RR0(3,1:3,1,nelem)  = (/-0.09605367730511442,-0.30621939967705303,0.9471026186942948 /)
+        baseline_RR0(1,1:3,1,nelem)  = (/0.79124185715259476, -0.60219094249350502, -0.1063127098163618/)
+        baseline_RR0(2,1:3,1,nelem)  = (/0.60261503127580685, 0.7383322551011402, 0.30285409879630898/)
+        baseline_RR0(3,1:3,1,nelem)  = (/-0.10388189240754285, -0.30369647652886939, 0.94708869836662024/)
 
         CALL BD_RotationalInterpQP( nelem, p, x, m )
 
@@ -242,12 +233,12 @@ contains
           enddo 
         enddo 
         ! the following should be the result from  MATMUL(tempR6,MATMUL(p%Stif0_QP(1:6,1:6,temp_id2+idx_qp),TRANSPOSE(tempR6)))
-        baseline_Stif(1,1:6,idx_qp,nelem) = (/4.5918231909187375, -33.558422946165074, -19.41124878362651, 2.60126686515566, -69.25969416961556, -31.26026770547517 /)
-        baseline_Stif(2,1:6,idx_qp,nelem) = (/-18.923545538732206, 138.2989541247406, 79.99647091096304, -10.720184539884109, 285.4288856786646, 128.8279349796045 /)
-        baseline_Stif(3,1:6,idx_qp,nelem) = (/ -13.509458152867301, 98.7311774904666, 57.109222684340786, -7.65310518243836, 203.76676129761876, 91.96984745617996 /)
-        baseline_Stif(4,1:6,idx_qp,nelem) = (/ 2.852586665816869, -20.847560074045475, -12.058885358769254, 1.6159897420374438, -43.026325677681456, -19.419872917332995 /)
-        baseline_Stif(5,1:6,idx_qp,nelem) = (/-50.11731488891121, 366.27238899233606, 211.8634858589486, -28.39144827024861, 755.9328304872744, 341.18924335009 /)
-        baseline_Stif(6,1:6,idx_qp,nelem) = (/-23.86246662028767, 174.39407269994138, 100.87502434184734, -13.518082286573822, 359.9239499295936, 162.45117977068867 /)
+        baseline_Stif(1,1:6,idx_qp,nelem) = (/4.7536759583339689, -33.907248359179356, -19.542837968671446, 2.9365509821876983, -70.008981029110458, -31.39174980281188/)
+        baseline_Stif(2,1:6,idx_qp,nelem) = (/-19.401250769011185, 138.38617399872942, 79.760485041818299, -11.984990668437774, 285.72873055166156, 128.11963106880802/)
+        baseline_Stif(3,1:6,idx_qp,nelem) = (/-13.830884167369799, 98.653595365050748, 56.86015004293688, -8.5439345976052863, 203.69207236173781, 91.33471846615123/)
+        baseline_Stif(4,1:6,idx_qp,nelem) = (/3.141919298405611, -22.410832986789217, -12.916744914371989, 1.9408992709130821, -46.272099841270119, -20.748226294907653/)
+        baseline_Stif(5,1:6,idx_qp,nelem) = (/-51.422828167125537, 366.79122036858701, 211.40439684348502, -31.766102251101898, 757.32124637229549, 339.57984728541373/)
+        baseline_Stif(6,1:6,idx_qp,nelem) = (/-24.340652516975311, 173.61817619702015, 100.06686033300799, -15.036272493606024, 358.4729576086462, 160.73785435679258/)
 
         CALL BD_StifAtDeformedQP( nelem, p, m )
    
@@ -259,9 +250,6 @@ contains
         ! dealocate baseline variables
         if (allocated(gll_nodes)) deallocate(gll_nodes)
         if (allocated(baseline_uu0)) deallocate(baseline_uu0)
-        if (allocated(baseline_E10)) deallocate(baseline_E10)
-        if (allocated(baseline_rrN0)) deallocate(baseline_rrN0)
-        if (allocated(baseline_rrN0)) deallocate(baseline_rrN0)
         if (allocated(baseline_E10)) deallocate(baseline_E10)
         if (allocated(baseline_uuu)) deallocate(baseline_uuu)
         if (allocated(baseline_uup)) deallocate(baseline_uup)

--- a/modules/beamdyn/tests/test_tools.F90
+++ b/modules/beamdyn/tests/test_tools.F90
@@ -131,10 +131,10 @@ contains
         call AllocAry(p%QPtw_ShpDer, p%nqp, p%nodes_per_elem, 'QPtw_ShpDer', ErrStat, ErrMsg)
         call AllocAry(p%Jacobian, p%nqp, p%elem_total, 'Jacobian', ErrStat, ErrMsg)
         call AllocAry(p%uuN0, p%dof_node, p%nodes_per_elem, p%elem_total,'uuN0', ErrStat, ErrMsg)
+        call AllocAry(p%twN0, p%nodes_per_elem, p%elem_total,'twN0', ErrStat, ErrMsg)
 
         call AllocAry(p%uu0, p%dof_node, p%nqp,   p%elem_total,'uu0', ErrStat, ErrMsg)
         call AllocAry(p%E10, p%dof_node/2, p%nqp, p%elem_total,'E10', ErrStat, ErrMsg)
-        call AllocAry(p%rrN0, p%dof_node/2, p%nodes_per_elem, p%elem_total,'rrN0', ErrStat, ErrMsg)
 
         CALL AllocAry(p%node_elem_idx,p%elem_total,2,'start and end node numbers of elements in p%node_total sized arrays',ErrStat,ErrMsg)
 


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**

In the BeamDyn driver, and in the glue-code, if the blade was initially rotated then an initial strain was introduced which produced forces when no loads or gravity had been applied. The cause was traced to the calculation of R0 (initial rotation) at the quadrature points which was interpolated via the shape functions from the element nodal rotations. The shape function interpolation is not exact and introduced strains on the order of 1e-7, but with the large stiffness of the blade, forces of 6200 N could be produced at the root for the IEA 15MW blade. This was resolved by directly calculating the quadrature point initial rotations in uu0(4:6) via interpolated node position and twist, which are well behaved. This was only a problem for non-straight blades such as the IEA 15MW where the tangent vector was not aligned with the Z axis.

This PR also fixes a bug where the parameter `p%UsePitchAct` wasn't initialized from the input file until after it was used in `SetOutParam`. The initialization has been moved to the `SetParameters` subroutine in `BeamDyn.f90`.

**Related issue, if one exists**
This changes resolves Issue #366 when QuasiStaticInit is set to `False`. The original issue files have been updated to work with OpenFAST 3.5.0-dev [bd_sim.zip](https://github.com/OpenFAST/openfast/files/11898275/bd_sim.zip) and the simulation completes with a DT of 0.01 seconds (previously required DT to be 0.0001 seconds). Will need to investigate why this test fails when QuasiStaticInit is `True`.

**Impacted areas of the software**
BeamDyn

**Test results, if applicable**
The BeamDyn unit test `test_BD_QuadraturePointData.F90` was updated to account for the slight difference in R0, E1, Stiffness that resulted from this change.