### PR TITLE
TurbSim documentation

### DIFF
--- a/docs/OtherSupporting/TurbSim/Corrections.md
+++ b/docs/OtherSupporting/TurbSim/Corrections.md
@@ -1,0 +1,5 @@
+# Corrections to TurbSim_v2.00.pdf DRAFT
+
+## p. 34: Input file for User-Defined Profiles
+The User-Defined profiles listed in the "Profiles" section contain horizontal angles, not wind direction, so it should say
+  `3. Horizontal wind angle (degrees, measured clockwise from above)`

--- a/docs/source/user/turbsim/examples/TurbSim_User.profiles
+++ b/docs/source/user/turbsim/examples/TurbSim_User.profiles
@@ -6,8 +6,8 @@ Made up profiles
 1.0             StdScale2      - v-component scaling factor for the input standard deviation
 0.534           StdScale3      - w-component scaling factor for the input standard deviation
 -----------------------------------------------------------------------------------
-Height    Wind Speed       Wind --Direction--        Standard Deviation    Length Scale
- (m)        (m/s)       (deg, cntr-clockwise )            (m/s)              (m)
+Height    Wind Speed       Wind --Angle--        Standard Deviation    Length Scale
+ (m)        (m/s)         (deg, clockwise )              (m/s)              (m)
 -----------------------------------------------------------------------------------
 15.0           3            00                            .100                  3
 25.0           4            00                            .200                  4


### PR DESCRIPTION
**Feature or improvement description**
The TurbSim documentation incorrectly specified that the wind direction column in the user profiles was the meteorological wind direction (counter-clockwise from above). However, it was actually implemented as an angle, clockwise from above.

**Impacted areas of the software**
documentation
