### PR TITLE
AD: fix offset introduced in TwrPotent_Bak (see #1595)

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -4628,13 +4628,16 @@ FUNCTION CalculateTowerInfluence(p, xbar_in, ybar, zbar, W_tower, TwrCd, TwrTI) 
          v_TwrPotent = ( -2.0*xbar    * ybar    ) / denom
 
       elseif (p%TwrPotent == TwrPotent_Bak) then
-         xbar = xbar + 0.1
+         ! Reference: Bak, Madsen, Johansen (2001): Influence from Blade-Tower Interaction on Fatigue Loads and Dynamics (poster);
+         !            Proceedings: EWEC'01; Copenhagen (DK)
+         xbar = xbar + 0.1 ! offset added as part of the original model of Bak et al.
          denom = (xbar**2 + ybar**2)**2
          u_TwrPotent = ( -1.0*xbar**2 + ybar**2 ) / denom
          v_TwrPotent = ( -2.0*xbar    * ybar    ) / denom
          denom = TwoPi*(xbar**2 + ybar**2)
          u_TwrPotent = u_TwrPotent + TwrCd*xbar / denom
          v_TwrPotent = v_TwrPotent + TwrCd*ybar / denom
+         xbar = xbar - 0.1 ! removing offset
                
       end if
    end if


### PR DESCRIPTION
This pull request ready to be merged

**Feature or improvement description**
Remove offset introduced in the variable `xbar` as part of Bak's potential flow model after it has been used so that when the variable `xbar` is reused in the tower shadow model it does not have the offset. 

**Related issue, if one exists**
See #1595

**Impacted areas of the software**
AeroDyn

