### PR TITLE
[BugFix] change time handling to double precision for G4D timestep index

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -57,6 +57,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
             -DCMAKE_BUILD_TYPE:STRING=DEBUG \
             -DBUILD_SHARED_LIBS:BOOL=OFF \
             -DGENERATE_TYPES=ON \
@@ -95,6 +96,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
             -DCMAKE_BUILD_TYPE:STRING=DEBUG \
             -DBUILD_SHARED_LIBS:BOOL=OFF \
             -DVARIABLE_TRACKING=OFF \
@@ -133,6 +135,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
             -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
             -DVARIABLE_TRACKING=OFF \
             -DBUILD_TESTING:BOOL=ON \
@@ -177,6 +180,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
             -DCMAKE_BUILD_TYPE:STRING=RELWITHDEBINFO \
             -DOPENMP:BOOL=ON \
             -DDOUBLE_PRECISION=ON \
@@ -217,6 +221,12 @@ jobs:
           pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
           sudo apt-get update -y
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
+      - name: Configure build
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            ${GITHUB_WORKSPACE}
       - name: Build OpenFAST C-Interfaces
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
@@ -248,6 +258,12 @@ jobs:
           pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
           sudo apt-get update -y
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
+      - name: Configure build
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            ${GITHUB_WORKSPACE}
       - name: Build OpenFAST glue-code
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
@@ -279,6 +295,12 @@ jobs:
           pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
           sudo apt-get update -y
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
+      - name: Configure build
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            ${GITHUB_WORKSPACE}
       - name: Build FAST.Farm
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
@@ -320,6 +342,7 @@ jobs:
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
             -DCMAKE_BUILD_TYPE:STRING=DEBUG \
             -DBUILD_SHARED_LIBS:BOOL=OFF \
             -DGENERATE_TYPES=ON \
@@ -371,6 +394,14 @@ jobs:
           pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
           sudo apt-get update -y
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
+      - name: Configure Tests
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
       - name: Run AeroDyn tests
         uses: ./.github/actions/tests-module-aerodyn
         with:
@@ -422,6 +453,7 @@ jobs:
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
           cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \
             ${GITHUB_WORKSPACE}
@@ -475,6 +507,14 @@ jobs:
           pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3" vtk
           sudo apt-get update -y
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
+      - name: Configure Tests
+        working-directory: ${{runner.workspace}}/openfast/build
+        run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
       - name: Run Interface / API tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
@@ -517,6 +557,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -564,6 +609,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -608,6 +658,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -652,6 +707,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -696,6 +756,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -740,6 +805,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -784,6 +854,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run OpenFAST linearization tests
         working-directory: ${{runner.workspace}}/openfast/build
@@ -828,6 +903,11 @@ jobs:
       - name: Configure Tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
+          cmake \
+            -DPython_ROOT_DIR:STRING=${{env.pythonLocation}} \
+            -DBUILD_TESTING:BOOL=ON \
+            -DCTEST_PLOT_ERRORS:BOOL=ON \
+            ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run FAST.Farm tests
         working-directory: ${{runner.workspace}}/openfast/build

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -1589,7 +1589,7 @@ subroutine Grid4DField_GetVel(G4D, Time, Position, Velocity, ErrStat, ErrMsg)
    !----------------------------------------------------------------------------
 
    do i = 1, 3
-      tmp = (Position(i) - G4D%pZero(i))/G4D%delta(i)
+      tmp = (Position(i) - G4D%pZero(i))/real(G4D%delta(i),Reki)
       Indx_Lo(i) = INT(tmp) + 1                          ! convert REAL to INTEGER, then add one since our grid indices start at 1, not 0
       xi(i) = 2.0_ReKi*(tmp - aint(tmp)) - 1.0_ReKi   ! convert to value between -1 and 1
    end do

--- a/modules/inflowwind/src/IfW_FlowField.txt
+++ b/modules/inflowwind/src/IfW_FlowField.txt
@@ -95,10 +95,10 @@ typedef  ^              ^                      LOGICAL             BoxExceedWarn
 
 #----------------------------------------------------------------------------------------------------------------------------------
 typedef  ^              Grid4DFieldType        IntKi               n                   4     -         -     "number of evenly-spaced grid points in the x, y, z, and t directions"      -
-typedef  ^              ^                      ReKi                delta               4     -         -     "size between 2 consecutive grid points in each grid direction"            "m,m,m,s"
+typedef  ^              ^                      DbKi                delta               4     -         -     "size between 2 consecutive grid points in each grid direction"            "m,m,m,s"
 typedef  ^              ^                      ReKi                pZero               3     -         -     "fixed position of the XYZ grid (i.e., XYZ coordinates of m%V(:,1,1,1,:))" "m"
 typedef  ^              ^                      SiKi                Vel                 ::::: -         -     "this is the 4-d velocity field for each wind component [{uvw},nx,ny,nz,nt]" -
-typedef  ^              ^                      ReKi                TimeStart           -     -         -     "this is the time where the first time grid in m%V starts (i.e, the time associated with m%V(:,:,:,:,1))" s
+typedef  ^              ^                      DbKi                TimeStart           -     -         -     "this is the time where the first time grid in m%V starts (i.e, the time associated with m%V(:,:,:,:,1))" s
 typedef  ^              ^                      ReKi                RefHeight           -     -         -     "reference height; used to center the wind"                   meters
 
 #----------------------------------------------------------------------------------------------------------------------------------

--- a/modules/inflowwind/src/IfW_FlowField_Types.f90
+++ b/modules/inflowwind/src/IfW_FlowField_Types.f90
@@ -130,10 +130,10 @@ IMPLICIT NONE
 ! =========  Grid4DFieldType  =======
   TYPE, PUBLIC :: Grid4DFieldType
     INTEGER(IntKi) , DIMENSION(1:4)  :: n      !< number of evenly-spaced grid points in the x, y, z, and t directions [-]
-    REAL(ReKi) , DIMENSION(1:4)  :: delta      !< size between 2 consecutive grid points in each grid direction [m,m,m,s]
+    REAL(DbKi) , DIMENSION(1:4)  :: delta      !< size between 2 consecutive grid points in each grid direction [m,m,m,s]
     REAL(ReKi) , DIMENSION(1:3)  :: pZero      !< fixed position of the XYZ grid (i.e., XYZ coordinates of m%V(:,1,1,1,:)) [m]
     REAL(SiKi) , DIMENSION(:,:,:,:,:), ALLOCATABLE  :: Vel      !< this is the 4-d velocity field for each wind component [{uvw},nx,ny,nz,nt] [-]
-    REAL(ReKi)  :: TimeStart      !< this is the time where the first time grid in m%V starts (i.e, the time associated with m%V(:,:,:,:,1)) [s]
+    REAL(DbKi)  :: TimeStart      !< this is the time where the first time grid in m%V starts (i.e, the time associated with m%V(:,:,:,:,1)) [s]
     REAL(ReKi)  :: RefHeight      !< reference height; used to center the wind [meters]
   END TYPE Grid4DFieldType
 ! =======================
@@ -2390,14 +2390,14 @@ ENDIF
   Db_BufSz  = 0
   Int_BufSz  = 0
       Int_BufSz  = Int_BufSz  + SIZE(InData%n)  ! n
-      Re_BufSz   = Re_BufSz   + SIZE(InData%delta)  ! delta
+      Db_BufSz   = Db_BufSz   + SIZE(InData%delta)  ! delta
       Re_BufSz   = Re_BufSz   + SIZE(InData%pZero)  ! pZero
   Int_BufSz   = Int_BufSz   + 1     ! Vel allocated yes/no
   IF ( ALLOCATED(InData%Vel) ) THEN
     Int_BufSz   = Int_BufSz   + 2*5  ! Vel upper/lower bounds for each dimension
       Re_BufSz   = Re_BufSz   + SIZE(InData%Vel)  ! Vel
   END IF
-      Re_BufSz   = Re_BufSz   + 1  ! TimeStart
+      Db_BufSz   = Db_BufSz   + 1  ! TimeStart
       Re_BufSz   = Re_BufSz   + 1  ! RefHeight
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
@@ -2431,8 +2431,8 @@ ENDIF
       Int_Xferred = Int_Xferred + 1
     END DO
     DO i1 = LBOUND(InData%delta,1), UBOUND(InData%delta,1)
-      ReKiBuf(Re_Xferred) = InData%delta(i1)
-      Re_Xferred = Re_Xferred + 1
+      DbKiBuf(Db_Xferred) = InData%delta(i1)
+      Db_Xferred = Db_Xferred + 1
     END DO
     DO i1 = LBOUND(InData%pZero,1), UBOUND(InData%pZero,1)
       ReKiBuf(Re_Xferred) = InData%pZero(i1)
@@ -2473,8 +2473,8 @@ ENDIF
         END DO
       END DO
   END IF
-    ReKiBuf(Re_Xferred) = InData%TimeStart
-    Re_Xferred = Re_Xferred + 1
+    DbKiBuf(Db_Xferred) = InData%TimeStart
+    Db_Xferred = Db_Xferred + 1
     ReKiBuf(Re_Xferred) = InData%RefHeight
     Re_Xferred = Re_Xferred + 1
  END SUBROUTINE IfW_FlowField_PackGrid4DFieldType
@@ -2519,8 +2519,8 @@ ENDIF
     i1_l = LBOUND(OutData%delta,1)
     i1_u = UBOUND(OutData%delta,1)
     DO i1 = LBOUND(OutData%delta,1), UBOUND(OutData%delta,1)
-      OutData%delta(i1) = ReKiBuf(Re_Xferred)
-      Re_Xferred = Re_Xferred + 1
+      OutData%delta(i1) = DbKiBuf(Db_Xferred)
+      Db_Xferred = Db_Xferred + 1
     END DO
     i1_l = LBOUND(OutData%pZero,1)
     i1_u = UBOUND(OutData%pZero,1)
@@ -2566,8 +2566,8 @@ ENDIF
         END DO
       END DO
   END IF
-    OutData%TimeStart = ReKiBuf(Re_Xferred)
-    Re_Xferred = Re_Xferred + 1
+    OutData%TimeStart = DbKiBuf(Db_Xferred)
+    Db_Xferred = Db_Xferred + 1
     OutData%RefHeight = ReKiBuf(Re_Xferred)
     Re_Xferred = Re_Xferred + 1
  END SUBROUTINE IfW_FlowField_UnPackGrid4DFieldType

--- a/modules/inflowwind/src/InflowWind_IO.f90
+++ b/modules/inflowwind/src/InflowWind_IO.f90
@@ -1031,7 +1031,7 @@ subroutine IfW_Grid4D_Init(InitInp, G4D, ErrStat, ErrMsg)
 
    ! Initialize field from inputs
    G4D%n = InitInp%n
-   G4D%delta = InitInp%delta
+   G4D%delta = real(InitInp%delta, DbKi)
    G4D%pZero = InitInp%pZero
    G4D%TimeStart = 0.0_ReKi
    G4D%RefHeight = InitInp%pZero(3) + (InitInp%n(3)/2) * InitInp%delta(3)

--- a/modules/inflowwind/src/InflowWind_IO.f90
+++ b/modules/inflowwind/src/InflowWind_IO.f90
@@ -2540,8 +2540,8 @@ subroutine Grid3D_ScaleTurbulence(InitInp, Vel, ScaleFactors, ErrStat, ErrMsg)
       iy = (ny + 1)/2 ! integer division
 
       ! compute the actual sigma at the point specified by (iy,iz). (This sigma should be close to 1.)
-      vSum = sum(Vel(:, iy, iz, :), dim=2)
-      vSum2 = sum(Vel(:, iy, iz, :)**2, dim=2)
+      vSum = sum(real(Vel(:, iy, iz, :),R8Ki), dim=2)
+      vSum2 = sum(real(Vel(:, iy, iz, :),R8Ki)**2, dim=2)
       vMean = vSum/nt
       ActualSigma = real(SQRT(ABS((vSum2/nt) - vMean**2)), ReKi)
 

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -387,6 +387,7 @@ ifw_regression("ifw_uniform"                                  "inflowwind")
 ifw_regression("ifw_nativeBladed"                             "inflowwind")
 ifw_regression("ifw_BoxExceed"                                "inflowwind")
 ifw_regression("ifw_BoxExceedTwr"                             "inflowwind")
+ifw_regression("ifw_HAWC"                                     "inflowwind")
 
 # Py-InflowWind regression tests
 py_ifw_regression("py_ifw_turbsimff"                          "inflowwind;python")

--- a/reg_tests/executeInflowwindRegressionCase.py
+++ b/reg_tests/executeInflowwindRegressionCase.py
@@ -94,6 +94,7 @@ if not os.path.isdir(testBuildDirectory):
     os.makedirs(testBuildDirectory)
     for file in (glob.glob(os.path.join(inputsDirectory,"*.inp")) +
                  glob.glob(os.path.join(inputsDirectory,"*.bts"))+
+                 glob.glob(os.path.join(inputsDirectory,"*.bin"))+
                  glob.glob(os.path.join(inputsDirectory,"*.wnd"))+
                  glob.glob(os.path.join(inputsDirectory,"*.hh"))+
                  glob.glob(os.path.join(inputsDirectory,"*.sum"))):


### PR DESCRIPTION
This PR is ready for merging, pending testing from @MYMahfouz (see https://github.com/OpenFAST/openfast/discussions/1615#discussioncomment-6432016).

**Feature or improvement description**
The time handling for G4D time index finding was a mix of single and double precision.  This could lead to finding the wrong index in a G4D wind grid passed from FF to an OpenFAST turbine, in which case the index might be outside the G4D box that was passed.  We think this can occur with a long simulation of 4,200 s, with an OpenFAST DT of 0.0378 s, which resulted in a time index out of bounds at time 4132 seconds.


**Related issue, if one exists**
https://github.com/OpenFAST/openfast/discussions/1615#discussioncomment-6317168

**Impacted areas of the software**
This only affects long simulations with FAST.Farm.


**Test results, if applicable**
No test cases are affected (we don't run any of them that long).