### PR TITLE
r-test: update of lin file comparison

### DIFF
--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -236,16 +236,24 @@ try:
                     raise Exception('Failed to compare A-matrix frequencies\n\tLinfile: {}.\n\tException: {}'.format(local_file, indent(e.args[0])))
             else:
 
-                if verbose:
-                    print(CasePrefix+'freq_ref:', np.around(freq_bas[:8]    ,5), '[Hz]')
-                    print(CasePrefix+'freq_new:', np.around(freq_loc[:8]    ,5),'[Hz]')
-                    print(CasePrefix+'damp_ref:', np.around(zeta_bas[:8]*100,5), '[%]')
-                    print(CasePrefix+'damp_new:', np.around(zeta_loc[:8]*100,5), '[%]')
+                #if verbose:
+                print(CasePrefix+'freq_ref:', np.around(freq_bas[:8]    ,5), '[Hz]')
+                print(CasePrefix+'freq_new:', np.around(freq_loc[:8]    ,5),'[Hz]')
+                print(CasePrefix+'damp_ref:', np.around(zeta_bas[:8]*100,5), '[%]')
+                print(CasePrefix+'damp_new:', np.around(zeta_loc[:8]*100,5), '[%]')
 
                 try:
                     np.testing.assert_allclose(freq_loc[:10], freq_bas[:10], rtol=rtol_f, atol=atol_f)
                 except Exception as e:
                     raise Exception('Failed to compare A-matrix frequencies\n\tLinfile: {}.\n\tException: {}'.format(local_file, indent(e.args[0])))
+
+
+                if caseName=='Ideal_Beam_Free_Free_Linear':
+                    # The free-free case is a bit weird, smae frequencies but dampings are +/- a value
+                    zeta_loc=np.abs(zeta_loc)
+                    zeta_bas=np.abs(zeta_bas)
+
+
                 try:
                     # Note: damping ratios in [%]
                     np.testing.assert_allclose(zeta_loc[:10]*100, zeta_bas[:10]*100, rtol=rtol_d, atol=atol_d)

--- a/reg_tests/lib/eva.py
+++ b/reg_tests/lib/eva.py
@@ -1,0 +1,334 @@
+""" 
+Taken from python-toolbox https://github.com/openfast/python-toolbox
+
+Eigenvalue analyses (EVA) tools for:
+    - arbitrary systems:  system matrix (A)
+    - and mechnical systems: mass (M), stiffness (K) and damping (C) matrices
+
+Some definitions:
+
+    - zeta: damping ratio 
+
+    - delta/log_dec: logarithmic decrement
+
+    - xi: approximation of logarithmic decrement: xi = 2 pi zeta
+
+    - omega0  : natural frequency
+
+    - omega_d : damped frequency  omega_d = omega_0 sqrt(1-zeta^2)
+
+
+"""
+import pandas as pd    
+import numpy as np
+# from scipy import linalg
+from numpy import linalg
+
+def polyeig(*A, sort=False, normQ=None):
+    """
+    Solve the polynomial eigenvalue problem:
+        (A0 + e A1 +...+  e**p Ap)x = 0
+
+    Return the eigenvectors [x_i] and eigenvalues [e_i] that are solutions.
+
+    Usage:
+        X,e = polyeig(A0,A1,..,Ap)
+
+    Most common usage, to solve a second order system: (K + C e + M e**2) x =0
+        X,e = polyeig(K,C,M)
+
+    """
+    if len(A)<=0:
+        raise Exception('Provide at least one matrix')
+    for Ai in A:
+        if Ai.shape[0] != Ai.shape[1]:
+            raise Exception('Matrices must be square')
+        if Ai.shape != A[0].shape:
+            raise Exception('All matrices must have the same shapes');
+
+    n = A[0].shape[0]
+    l = len(A)-1 
+    # Assemble matrices for generalized problem
+    C = np.block([
+        [np.zeros((n*(l-1),n)), np.eye(n*(l-1))],
+        [-np.column_stack( A[0:-1])]
+        ])
+    D = np.block([
+        [np.eye(n*(l-1)), np.zeros((n*(l-1), n))],
+        [np.zeros((n, n*(l-1))), A[-1]          ]
+        ]);
+    # Solve generalized eigenvalue problem
+    e, X = linalg.eig(C, D);
+    if np.all(np.isreal(e)):
+        e=np.real(e)
+    X=X[:n,:]
+
+    # Sort eigen values
+    if sort:
+        I = np.argsort(e)
+        X = X[:,I]
+        e = e[I]
+
+    # Scaling each mode by max
+    if normQ=='byMax':
+        X /= np.tile(np.max(np.abs(X),axis=0), (n,1))
+
+    return X, e
+
+
+def eig(K, M=None, freq_out=False, sort=True, normQ=None, discardIm=False, massScaling=True):
+    """ performs eigenvalue analysis and return same values as matlab 
+
+    returns:
+       Q     : matrix of column eigenvectors
+       Lambda: matrix where diagonal values are eigenvalues
+              frequency = np.sqrt(np.diag(Lambda))/(2*np.pi)
+         or
+    frequencies (if freq_out is True)
+    """
+    if M is not None:
+        D,Q = linalg.eig(K,M)
+        # --- rescaling using mass matrix to be consistent with Matlab
+        # TODO, this can be made smarter
+        # TODO this should be a normQ
+        if massScaling:
+            for j in range(M.shape[1]):
+                q_j = Q[:,j]
+                modalmass_j = np.dot(q_j.T,M).dot(q_j)
+                Q[:,j]= Q[:,j]/np.sqrt(modalmass_j)
+        Lambda=np.dot(Q.T,K).dot(Q)
+    else:
+        D,Q = linalg.eig(K)
+        Lambda = np.diag(D)
+
+    # --- Sort
+    lambdaDiag=np.diag(Lambda)
+    if sort:
+        I = np.argsort(lambdaDiag)
+        Q          = Q[:,I]
+        lambdaDiag = lambdaDiag[I]
+    if freq_out:
+        Lambda = np.sqrt(lambdaDiag)/(2*np.pi) # frequencies [Hz]
+    else:
+        Lambda = np.diag(lambdaDiag) # enforcing purely diagonal
+
+    # --- Renormalize modes if users wants to
+    if normQ == 'byMax':
+        for j in range(Q.shape[1]):
+            q_j = Q[:,j]
+            iMax = np.argmax(np.abs(q_j))
+            scale = q_j[iMax] # not using abs to normalize to "1" and not "+/-1"
+            Q[:,j]= Q[:,j]/scale
+
+    # --- Sanitization, ensure real values
+    if discardIm:
+        Q_im    = np.imag(Q)
+        Q       = np.real(Q)
+        imm     = np.mean(np.abs(Q_im),axis = 0)
+        bb = imm>0
+        if sum(bb)>0:
+            W=list(np.where(bb)[0])
+            print('[WARN] Found {:d} complex eigenvectors at positions {}/{}'.format(sum(bb),W,Q.shape[0]))
+        Lambda = np.real(Lambda)
+
+    return Q,Lambda
+
+
+def eigA(A, nq=None, nq1=None, fullEV=False, normQ=None, sort=True):
+    """
+    Perform eigenvalue analysis on a "state" matrix A
+    where states are assumed to be ordered as {q, q_dot, q1}
+    This order is only relevant for returning the eigenvectors.
+
+    INPUTS:
+     - A : square state matrix
+     - nq: number of second order states, optional, relevant if fullEV is False
+     - nq1: number of first order states, optional, relevant if fullEV is False
+     - fullEV: if True, the entire eigenvectors are returned, otherwise, 
+                only the part associated with q and q1 are returned
+     - normQ: 'byMax': normalize by maximum
+              None: do not normalize
+    OUPUTS:
+     - freq_d: damped frequencies [Hz]
+     - zeta  : damping ratios [-]
+     - Q     : column eigenvectors
+     - freq_0: natural frequencies [Hz]
+    """
+    n,m = A.shape
+
+    if m!=n:
+        raise Exception('Matrix needs to be squared')
+    if nq is None:
+        if nq1 is None:
+            nq1=0
+        nq = int((n-nq1)/2)
+    else:
+        nq1 = n-2*nq
+    if n!=2*nq+nq1 or nq1<0:
+        raise Exception('Number of 1st and second order dofs should match the matrix shape (n= 2*nq + nq1')
+    Q, Lambda = eig(A, sort=False)
+    v = np.diag(Lambda)
+
+    if not fullEV:
+        Q=np.delete(Q, slice(nq,2*nq), axis=0)
+
+    # Selecting eigenvalues with positive imaginary part (frequency)
+    Ipos = np.imag(v)>0
+    Q = Q[:,Ipos]
+    v = v[Ipos]
+
+    # Frequencies and damping based on compled eigenvalues
+    omega_0 = np.abs(v)              # natural cylic frequency [rad/s]
+    freq_d  = np.imag(v)/(2*np.pi)   # damped frequency [Hz]
+    zeta    = - np.real(v)/omega_0   # damping ratio
+    freq_0  = omega_0/(2*np.pi)      # natural frequency [Hz]
+
+    # Sorting
+    if sort:
+        I = np.argsort(freq_0)
+        freq_d = freq_d[I]
+        freq_0 = freq_0[I]
+        zeta   = zeta[I]
+        Q      = Q[:,I]
+
+    # Normalize Q
+    if normQ=='byMax':
+        for j in range(Q.shape[1]):
+            q_j = Q[:,j]
+            scale = np.max(np.abs(q_j))
+            Q[:,j]= Q[:,j]/scale
+    return freq_d, zeta, Q, freq_0 
+
+
+
+def eigMK(M, K, sort=True, normQ=None, discardIm=False, freq_out=True, massScaling=True):
+    """ 
+    Eigenvalue analysis of a mechanical system
+    M, K: mass, and stiffness matrices respectively
+
+    Should be equivalent to calling eig(K, M) in Matlab (NOTE: argument swap)
+    except that frequencies are returned instead of "Lambda"
+
+    OUTPUTS:
+      Q, freq_0 if freq_out
+      Q, Lambda otherwise
+    """
+    return eig(K, M, sort=sort, normQ=normQ, discardIm=discardIm, freq_out=freq_out, massScaling=massScaling)
+
+
+def eigMCK(M, C, K, method='full_matrix', sort=True, normQ=None): 
+    """
+    Eigenvalue analysis of a mechanical system
+    M, C, K: mass, damping, and stiffness matrices respectively
+
+    NOTE: full_matrix, state_space and state_space_gen should return the same
+          when damping is present
+    """
+    if np.linalg.norm(C)<1e-14:
+        if method.lower() not in ['state_space', 'state_space_gen']:
+            # No damping
+            Q, freq_0 =  eigMK(M, K, sort=sort, freq_out=True, normQ=normQ)
+            freq_d = freq_0
+            zeta   = freq_0*0
+            return freq_d, zeta, Q, freq_0
+
+
+    n = M.shape[0] # Number of DOFs
+
+    if method.lower()=='diag_beta':
+        ## using K, M and damping assuming diagonal beta matrix (Rayleigh Damping)
+        Q, Lambda   = eig(K,M, sort=False) # provide scaled EV, important, no sorting here!
+        freq_0      = np.sqrt(np.diag(Lambda))/(2*np.pi)
+        betaMat     = np.dot(Q,C).dot(Q.T)
+        xi          = (np.diag(betaMat)*np.pi/(2*np.pi*freq_0))
+        xi[xi>2*np.pi] = np.NAN
+        zeta        = xi/(2*np.pi)
+        freq_d      = freq_0*np.sqrt(1-zeta**2)
+
+    elif method.lower()=='full_matrix':
+        ## Method 2 - Damping based on K, M and full D matrix
+        Q,v = polyeig(K,C,M, sort=sort, normQ=normQ)
+        #omega0 = np.abs(e)
+        zeta = - np.real(v) / np.abs(v)
+        freq_d = np.imag(v) / (2*np.pi)
+        # Keeping only positive frequencies
+        bValid = freq_d > 1e-08
+        freq_d = freq_d[bValid]
+        zeta   = zeta[bValid]
+        Q      = Q[:,bValid]
+        # logdec2 = 2*pi*dampratio_sorted./sqrt(1-dampratio_sorted.^2);
+
+    elif method.lower()=='state_space':
+        # See welib.system.statespace.StateMatrix
+        Minv = np.linalg.inv(M)
+        I = np.eye(n)
+        Z = np.zeros((n, n))
+        A = np.block([[np.zeros((n, n)), np.eye(n)],
+                      [ -Minv@K        , -Minv@C  ]])
+        return eigA(A, normQ=normQ, sort=sort)
+
+    elif method.lower()=='state_space_gen':
+        I = np.eye(n)
+        Z = np.zeros((n, n))
+        A = np.block([[Z, I],
+                      [-K, -C]])
+        B = np.block([[I, Z],
+                      [Z, M]])
+        # solve the generalized eigenvalue problem
+        D, Q = linalg.eig(A, B)
+        # Keeping every other states (assuming pairs..)
+        v = D[::2]
+        Q = Q[:n, ::2]
+
+        # calculate natural frequencies and damping
+        omega_0 = np.abs(v)              # natural cyclic frequency [rad/s]
+        freq_d  = np.imag(v)/(2*np.pi)   # damped frequency [Hz]
+        zeta    = - np.real(v)/omega_0   # damping ratio
+
+    else:
+        raise NotImplementedError()
+
+    # Sorting
+    if sort:
+        I = np.argsort(freq_d)
+        freq_d = freq_d[I]
+        zeta   = zeta[I]
+        Q      = Q[:,I]
+    # Undamped frequency 
+    freq_0 = freq_d / np.sqrt(1 - zeta**2)
+    #xi = 2 * np.pi * zeta # pseudo log-dec
+    return freq_d, zeta, Q, freq_0
+
+
+if __name__=='__main__':
+    np.set_printoptions(linewidth=300, precision=4)
+    nDOF   = 2
+    M      = np.zeros((nDOF,nDOF))
+    K      = np.zeros((nDOF,nDOF))
+    C      = np.zeros((nDOF,nDOF))
+    M[0,0] = 430000;
+    M[1,1] = 42000000;
+    C[0,0] = 7255;
+    C[1,1] = M[1,1]*0.001;
+    K[0,0] = 2700000.;
+    K[1,1] = 200000000.;
+
+    freq_d, zeta, Q, freq, xi = eigMCK(M,C,K)
+    print(freq_d)
+    print(Q)
+
+
+    #M = diag([3,0,0,0], [0, 1,0,0], [0,0,3,0],[0,0,0, 1])
+    M = np.diag([3,1,3,1])
+    C = np.array([[0.4 , 0 , -0.3 , 0] , [0 , 0  , 0 , 0] , [-0.3 , 0 , 0.5 , -0.2 ] , [ 0 , 0 , -0.2 , 0.2]])
+    K = np.array([[-7  , 2 , 4    , 0] , [2 , -4 , 2 , 0] , [4    , 2 , -9  , 3    ] , [ 0 , 0 , 3    , -3]])
+
+    X,e = polyeig(K,C,M)
+    print('X:\n',X)
+    print('e:\n',e)
+    # Test taht first eigenvector and valur satisfy eigenvalue problem:
+    s = e[0];
+    x = X[:,0];
+    res = (M*s**2 + C*s + K).dot(x) # residuals
+    assert(np.all(np.abs(res)<1e-12))
+

--- a/reg_tests/lib/fast_linearization_file.py
+++ b/reg_tests/lib/fast_linearization_file.py
@@ -1,3 +1,6 @@
+""" 
+Taken from python-toolbox https://github.com/openfast/python-toolbox
+"""
 import os
 import numpy as np
 import re

--- a/reg_tests/lib/fast_linearization_file.py
+++ b/reg_tests/lib/fast_linearization_file.py
@@ -1,0 +1,388 @@
+import os
+import numpy as np
+import re
+class BrokenFormatError(Exception): pass
+
+class FASTLinearizationFile(dict):
+    """ 
+    Read/write an OpenFAST linearization file. The object behaves like a dictionary.
+
+    Main keys
+    ---------
+    - 'x', 'xdot' 'u', 'y', 'A', 'B', 'C', 'D'
+
+    Main methods
+    ------------
+    - read, write, toDataFrame, keys, xdescr, ydescr, udescr
+
+    Examples
+    --------
+
+        f = FASTLinearizationFile('5MW.1.lin')
+        print(f.keys())
+        print(f['u'])     # input operating point
+        print(f.udescr()) # description of inputs
+
+        # use a dataframe with "named" columns and rows
+        df = f.toDataFrame()
+        print(df['A'].columns)
+        print(df['A'])
+
+    """
+    @staticmethod
+    def defaultExtensions():
+        return ['.lin']
+
+    @staticmethod
+    def formatName():
+        return 'FAST linearization output'
+
+    def __init__(self, filename=None, **kwargs):
+        """ Class constructor. If a `filename` is given, the file is read. """
+        self.filename = filename
+        if filename:
+            self.read(**kwargs)
+
+    def read(self, filename=None, **kwargs):
+        """ Reads the file self.filename, or `filename` if provided """
+        
+        # --- Standard tests and exceptions (generic code)
+        if filename:
+            self.filename = filename
+        if not self.filename:
+            raise Exception('No filename provided')
+        if not os.path.isfile(self.filename):
+            raise OSError(2,'File not found:',self.filename)
+        if os.stat(self.filename).st_size == 0:
+            raise EmptyFileError('File is empty:',self.filename)
+        # --- Calling (children) function to read
+        self._read(**kwargs)
+
+    def _read(self, *args, **kwargs):
+        self['header']=[]
+
+        def extractVal(lines, key):
+            for l in lines:
+                if l.find(key)>=0:
+                    return l.split(key)[1].split()[0]
+            return None
+
+        def readToMarker(fid, marker, nMax):
+            lines=[]
+            for i, line in enumerate(fid):
+                if i>nMax:
+                    raise BrokenFormatError('`{}` not found in file'.format(marker))
+                if line.find(marker)>=0:
+                    break
+                lines.append(line.strip())
+            return lines, line
+        
+        def readOP(fid, n, name=''):
+            OP=[]
+            Var = {'RotatingFrame': [], 'DerivativeOrder': [], 'Description': []}
+            colNames=fid.readline().strip()
+            dummy=   fid.readline().strip()
+            bHasDeriv= colNames.find('Derivative Order')>=0
+            for i, line in enumerate(fid):
+                sp=line.strip().split()
+                if sp[1].find(',')>=0:
+                    #  Most likely this OP has three values (e.g. orientation angles)
+                    # For now we discard the two other values
+                    OP.append(float(sp[1][:-1]))
+                    iRot=4
+                else:
+                    OP.append(float(sp[1]))
+                    iRot=2
+                Var['RotatingFrame'].append(sp[iRot])
+                if bHasDeriv:
+                    Var['DerivativeOrder'].append(int(sp[iRot+1]))
+                    Var['Description'].append(' '.join(sp[iRot+2:]).strip())
+                else:
+                    Var['DerivativeOrder'].append(-1)
+                    Var['Description'].append(' '.join(sp[iRot+1:]).strip())
+                if i>=n-1:
+                    break
+            OP=np.asarray(OP)
+            return OP, Var
+
+        def readMat(fid, n, m, name=''):
+            pattern = re.compile(r"[\*]+")
+            vals=[pattern.sub(' inf ', fid.readline().strip() ).split() for i in np.arange(n)]
+            vals = np.array(vals)
+            try:
+                vals = np.array(vals).astype(float) # This could potentially fail
+            except:
+                raise Exception('Failed to convert into an array of float the matrix `{}`\n\tin linfile: {}'.format(name, self.filename))
+            if vals.shape[0]!=n or vals.shape[1]!=m:
+                shape1 = vals.shape
+                shape2 = (n,m)
+                raise Exception('Shape of matrix `{}` has wrong dimension ({} instead of {})\n\tin linfile: {}'.format(name, shape1, shape2, name, self.filename))
+
+            nNaN = sum(np.isnan(vals.ravel()))
+            nInf = sum(np.isinf(vals.ravel()))
+            if nInf>0:
+                raise Exception('Some ill-formated/infinite values (e.g. `*******`) were found in the matrix `{}`\n\tin linflile: {}'.format(name, self.filename))
+            if nNaN>0:
+                raise Exception('Some NaN values were found in the matrix `{}`\n\tin linfile: `{}`.'.format(name, self.filename))
+            return vals
+
+
+        # Reading 
+        with open(self.filename, 'r', errors="surrogateescape") as f:
+            # --- Reader header
+            self['header'], lastLine=readToMarker(f, 'Jacobians included', 30)
+            self['header'].append(lastLine)
+            nx  = int(extractVal(self['header'],'Number of continuous states:'))
+            nxd = int(extractVal(self['header'],'Number of discrete states:'  ))
+            nz  = int(extractVal(self['header'],'Number of constraint states:'))
+            nu  = int(extractVal(self['header'],'Number of inputs:'           ))
+            ny  = int(extractVal(self['header'],'Number of outputs:'          ))
+            bJac = extractVal(self['header'],'Jacobians included in this file?')
+            try:
+                self['Azimuth'] = float(extractVal(self['header'],'Azimuth:'))
+            except:
+                self['Azimuth'] = None
+            try:
+                self['RotSpeed'] = float(extractVal(self['header'],'Rotor Speed:')) # rad/s
+            except:
+                self['RotSpeed'] = None
+            try:
+                self['WindSpeed'] = float(extractVal(self['header'],'Wind Speed:'))
+            except:
+                self['WindSpeed'] = None
+
+            for i, line in enumerate(f):
+                line = line.strip()
+                if line.find('Order of continuous states:')>=0:
+                    self['x'], self['x_info'] = readOP(f, nx, 'x')
+                elif line.find('Order of continuous state derivatives:')>=0:
+                    self['xdot'], self['xdot_info'] = readOP(f, nx, 'xdot')
+                elif line.find('Order of inputs')>=0:
+                    self['u'], self['u_info'] = readOP(f, nu, 'u')
+                elif line.find('Order of outputs')>=0:
+                    self['y'], self['y_info'] = readOP(f, ny, 'y')
+                elif line.find('A:')>=0:
+                    self['A'] = readMat(f, nx, nx, 'A')
+                elif line.find('B:')>=0:
+                    self['B'] = readMat(f, nx, nu, 'B')
+                elif line.find('C:')>=0:
+                    self['C'] = readMat(f, ny, nx, 'C')
+                elif line.find('D:')>=0:
+                    self['D'] = readMat(f, ny, nu, 'D')
+                elif line.find('dUdu:')>=0:
+                    self['dUdu'] = readMat(f, nu, nu,'dUdu')
+                elif line.find('dUdy:')>=0:
+                    self['dUdy'] = readMat(f, nu, ny,'dUdy')
+                elif line.find('StateRotation:')>=0:
+                    pass
+                    # TODO
+                    #StateRotation:
+                elif line.find('ED M:')>=0:
+                    self['EDDOF'] = line[5:].split()
+                    self['M']     = readMat(f, 24, 24,'M')
+
+    def toString(self):
+        s=''
+        return s
+
+    def _write(self):
+        with open(self.filename,'w') as f:
+            f.write(self.toString())
+
+    def short_descr(self,slist):
+        def shortname(s):
+            s=s.strip()
+            s = s.replace('(m/s)'   , '_[m/s]'  );
+            s = s.replace('(kW)'    , '_[kW]'   );
+            s = s.replace('(deg)'   , '_[deg]'  );
+            s = s.replace('(N)'     , '_[N]'    );
+            s = s.replace('(kN-m)'  , '_[kNm]' );
+            s = s.replace('(N-m)'  , '_[Nm]' );
+            s = s.replace('(kN)'  , '_[kN]' );
+            s = s.replace('(rpm)'   , '_[rpm]'  );
+            s = s.replace('(rad)'   , '_[rad]'  );
+            s = s.replace('(rad/s)' , '_[rad/s]'  );
+            s = s.replace('(rad/s^2)', '_[rad/s^2]'  );
+            s = s.replace('(m/s^2)' , '_[m/s^2]');
+            s = s.replace('(deg/s^2)','_[deg/s^2]');
+            s = s.replace('(m)'     , '_[m]'    );
+            s = s.replace(', m/s/s','_[m/s^2]');
+            s = s.replace(', m/s^2','_[m/s^2]');
+            s = s.replace(', m/s','_[m/s]');
+            s = s.replace(', m','_[m]');
+            s = s.replace(', rad/s/s','_[rad/s^2]');
+            s = s.replace(', rad/s^2','_[rad/s^2]');
+            s = s.replace(', rad/s','_[rad/s]');
+            s = s.replace(', rad','_[rad]');
+            s = s.replace(', -','_[-]');
+            s = s.replace(', Nm/m','_[Nm/m]');
+            s = s.replace(', Nm','_[Nm]');
+            s = s.replace(', N/m','_[N/m]');
+            s = s.replace(', N','_[N]');
+            s = s.replace('(1)','1')
+            s = s.replace('(2)','2')
+            s = s.replace('(3)','3')
+            s= re.sub(r'\([^)]*\)','', s) # remove parenthesis
+            s = s.replace('ED ','');
+            s = s.replace('BD_','BD_B');
+            s = s.replace('IfW ','');
+            s = s.replace('Extended input: ','')
+            s = s.replace('1st tower ','qt1');
+            s = s.replace('2nd tower ','qt2');
+            nd = s.count('First time derivative of ')
+            if nd>=0:
+                s = s.replace('First time derivative of '     ,'');
+                if nd==1:
+                    s = 'd_'+s.strip()
+                elif nd==2:
+                    s = 'dd_'+s.strip()
+            s = s.replace('Variable speed generator DOF ','psi_rot'); # NOTE: internally in FAST this is the azimuth of the rotor
+            s = s.replace('fore-aft bending mode DOF '    ,'FA'     );
+            s = s.replace('side-to-side bending mode DOF','SS'     );
+            s = s.replace('bending-mode DOF of blade '    ,''     );
+            s = s.replace(' rotational-flexibility DOF, rad','-ROT'   );
+            s = s.replace('rotational displacement in ','rot'   );
+            s = s.replace('Drivetrain','DT'   );
+            s = s.replace('translational displacement in ','trans'   );
+            s = s.replace('finite element node ','N'   );
+            s = s.replace('-component position of node ','posN')
+            s = s.replace('-component inflow on tower node','TwrN')
+            s = s.replace('-component inflow on blade 1, node','Bld1N')
+            s = s.replace('-component inflow on blade 2, node','Bld2N')
+            s = s.replace('-component inflow on blade 3, node','Bld3N')
+            s = s.replace('-component inflow velocity at node','N')
+            s = s.replace('X translation displacement, node','TxN')
+            s = s.replace('Y translation displacement, node','TyN')
+            s = s.replace('Z translation displacement, node','TzN')
+            s = s.replace('X translation velocity, node','TVxN')
+            s = s.replace('Y translation velocity, node','TVyN')
+            s = s.replace('Z translation velocity, node','TVzN')
+            s = s.replace('X translation acceleration, node','TAxN')
+            s = s.replace('Y translation acceleration, node','TAyN')
+            s = s.replace('Z translation acceleration, node','TAzN')
+            s = s.replace('X orientation angle, node'  ,'RxN')
+            s = s.replace('Y orientation angle, node'  ,'RyN')
+            s = s.replace('Z orientation angle, node'  ,'RzN')
+            s = s.replace('X rotation velocity, node'  ,'RVxN')
+            s = s.replace('Y rotation velocity, node'  ,'RVyN')
+            s = s.replace('Z rotation velocity, node'  ,'RVzN')
+            s = s.replace('X rotation acceleration, node'  ,'RAxN')
+            s = s.replace('Y rotation acceleration, node'  ,'RAyN')
+            s = s.replace('Z rotation acceleration, node'  ,'RAzN')
+            s = s.replace('X force, node','FxN')
+            s = s.replace('Y force, node','FyN')
+            s = s.replace('Z force, node','FzN')
+            s = s.replace('X moment, node','MxN')
+            s = s.replace('Y moment, node','MyN')
+            s = s.replace('Z moment, node','MzN')
+            s = s.replace('FX', 'Fx')
+            s = s.replace('FY', 'Fy')
+            s = s.replace('FZ', 'Fz')
+            s = s.replace('MX', 'Mx')
+            s = s.replace('MY', 'My')
+            s = s.replace('MZ', 'Mz')
+            s = s.replace('FKX', 'FKx')
+            s = s.replace('FKY', 'FKy')
+            s = s.replace('FKZ', 'FKz')
+            s = s.replace('MKX', 'MKx')
+            s = s.replace('MKY', 'MKy')
+            s = s.replace('MKZ', 'MKz')
+            s = s.replace('Nodes motion','')
+            s = s.replace('cosine','cos'   );
+            s = s.replace('sine','sin'   );
+            s = s.replace('collective','coll.');
+            s = s.replace('Blade','Bld');
+            s = s.replace('rotZ','TORS-R');
+            s = s.replace('transX','FLAP-D');
+            s = s.replace('transY','EDGE-D');
+            s = s.replace('rotX','EDGE-R');
+            s = s.replace('rotY','FLAP-R');
+            s = s.replace('flapwise','FLAP');
+            s = s.replace('edgewise','EDGE');
+            s = s.replace('horizontal surge translation DOF','Surge');
+            s = s.replace('horizontal sway translation DOF','Sway');
+            s = s.replace('vertical heave translation DOF','Heave');
+            s = s.replace('roll tilt rotation DOF','Roll');
+            s = s.replace('pitch tilt rotation DOF','Pitch');
+            s = s.replace('yaw rotation DOF','Yaw');
+            s = s.replace('vertical power-law shear exponent','alpha')
+            s = s.replace('horizontal wind speed ','WS')
+            s = s.replace('propagation direction','WD')
+            s = s.replace(' pitch command','pitch')
+            s = s.replace('HSS_','HSS')
+            s = s.replace('Bld','B')
+            s = s.replace('tower','Twr')
+            s = s.replace('Tower','Twr')
+            s = s.replace('Nacelle','Nac')
+            s = s.replace('Platform','Ptfm')
+            s = s.replace('SrvD','SvD')
+            s = s.replace('Generator torque','Qgen')
+            s = s.replace('coll. blade-pitch command','PitchColl')
+            s = s.replace('wave elevation at platform ref point','WaveElevRefPoint')
+            s = s.replace('1)','1');
+            s = s.replace('2)','2');
+            s = s.replace('3)','3');
+            s = s.replace(',','');
+            s = s.replace(' ','');
+            s=s.strip()
+            return s
+        return [shortname(s) for s in slist]
+
+    def xdescr(self):
+        if 'x_info' in self.keys():
+            return self.short_descr(self['x_info']['Description'])
+        else:
+            return []
+
+    def xdotdescr(self):
+        if 'xdot_info' in self.keys():
+            return self.short_descr(self['xdot_info']['Description'])
+        else:
+            return []
+
+    def ydescr(self):
+        if 'y_info' in self.keys():
+            return self.short_descr(self['y_info']['Description'])
+        else:
+            return []
+    def udescr(self):
+        if 'u_info' in self.keys():
+            return self.short_descr(self['u_info']['Description'])
+        else:
+            return []
+
+    def toDataFrame(self):
+        import pandas as pd
+        dfs={}
+
+        xdescr_short    = self.xdescr()
+        xdotdescr_short = self.xdotdescr()
+        ydescr_short    = self.ydescr()
+        udescr_short    = self.udescr()
+
+        if 'A' in self.keys():
+            dfs['A'] = pd.DataFrame(data = self['A'], index=xdescr_short, columns=xdescr_short)
+        if 'B' in self.keys():
+            dfs['B'] = pd.DataFrame(data = self['B'], index=xdescr_short, columns=udescr_short)
+        if 'C' in self.keys():
+            dfs['C'] = pd.DataFrame(data = self['C'], index=ydescr_short, columns=xdescr_short)
+        if 'D' in self.keys():
+            dfs['D'] = pd.DataFrame(data = self['D'], index=ydescr_short, columns=udescr_short)
+        if 'x' in self.keys():
+            dfs['x'] = pd.DataFrame(data = np.asarray(self['x']).reshape((1,-1)), columns=xdescr_short)
+        if 'xdot' in self.keys():
+            dfs['xdot'] = pd.DataFrame(data = np.asarray(self['xdot']).reshape((1,-1)), columns=xdotdescr_short)
+        if 'u' in self.keys():
+            dfs['u'] = pd.DataFrame(data = np.asarray(self['u']).reshape((1,-1)), columns=udescr_short)
+        if 'y' in self.keys():
+            dfs['y'] = pd.DataFrame(data = np.asarray(self['y']).reshape((1,-1)), columns=ydescr_short)
+        if 'M' in self.keys():
+            dfs['M'] = pd.DataFrame(data = self['M'], index=self['EDDOF'], columns=self['EDDOF'])
+        if 'dUdu' in self.keys():
+            dfs['dUdu'] = pd.DataFrame(data = self['dUdu'], index=udescr_short, columns=udescr_short)
+        if 'dUdy' in self.keys():
+            dfs['dUdy'] = pd.DataFrame(data = self['dUdy'], index=udescr_short, columns=ydescr_short)
+
+        return dfs
+
+

--- a/reg_tests/lib/rtestlib.py
+++ b/reg_tests/lib/rtestlib.py
@@ -25,7 +25,9 @@ from stat import ST_MODE
 import shutil 
 
 def exitWithError(error, code=1):
-    print(error)
+    # Making errors a bit more visible. 
+    # The best would be colors. I tried with termcolor.cprint but failed.
+    print('\n\n'+'Error: '+error+'\n\n')
     sys.exit(code)
 
 def validInput(argv, nArgsExpected):


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
Comparison of `.lin` files has been broken so the r-tests have not been working as intended, and were not performing any comparison. I'm not sure since when this is the case. 

Instead of using and ad-hoc script for reading the `.lin` file, this pull request uses a file from the [python toolbox ](https://github.com/OpenFAST/python-toolbox) to read the lin files (not my greatest script, but it should be fairly robust). For now, I've copy pasted the file in the `lib` folder. In the future, we could simply git clone the python toolbox. 

Errors will be thrown if:
-  the files don't have the same number of lines 
-  the files don't have the same variables (vectors and matrices)
-  the first 10 frequencies and damping differ 
-  the variables (vectors and matrices) have different dimensions
-  the variables contain NaN or **** values. 
-  the operating points, state matrices, and Jacobian are not within a given tolerance. 

The script returns fairly verbose messages (which file, variable and array index fails). 
For instance: 

```
46: Error:  Case: StC_test_OC4Semi_Linear_Nac: Failed to compare variable `A`, Element [4,7], new : 8.618, baseline: 8.602
46:     in linfile: C:/W0/Work/2018-NREL/BAR-Cone-BEM/openfast-rc3.5.1/build-double-release/reg_tests/glue-codes/openfast\StC_test_OC4Semi_Linear_Nac\StC_test_OC4Semi_Linear_Nac.1.lin.
46:     Exception:
46: Not equal to tolerance rtol=1e-05, atol=1e-05
46:
46: Mismatched elements: 1 / 1 (100%)
46: Max absolute difference: 0.016
46: Max relative difference: 0.00186003
46:  x: array(8.618)
46:  y: array(8.602)
```


**Related issue, if one exists**
#1693

**Impacted areas of the software**
r-test linearization tests. 

**Additional supporting information**
The script currently uses `numpy.all_close`, but I believe it is the same as the function `isclose` which was previously implemented. The tolerances `atol=1e-5` and `rtol=1e-5`  are still used.

It might be that if this test is finicky, we will have to revise the comparison of elements. 


**Test results, if applicable**
Currently with `atol=1e-5` and `rtol=1e-5` the following 4 tests fail: 
	 43 - 5MW_Land_BD_Linear (Failed)
	 44 - 5MW_OC4Semi_Linear (Failed)
	 45 - StC_test_OC4Semi_Linear_Nac (Failed)
	 46 - StC_test_OC4Semi_Linear_Tow (Failed)
 
The differences are sufficiently large that I don't think that increasing the tolerance value will make the test pass. We'll likely have to redo the baseline.


**Checklist**
- [x] Update the baselines



