### PR TITLE
Linear trim solution: add error check

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -3254,6 +3254,12 @@ END DO
       RETURN
    end if
 
+   ! temporary work-around for error with CalcSteady
+   if (p%CalcSteady .and. p%NLinTimes == 1 ) then
+      call SetErrStat(ErrID_Info, "Setting NLinTimes to 2 to avoid problem with CalcSteady with only one time.", ErrStat,ErrMsg,RoutineName)
+      p%NLinTimes = 2
+   end if
+   
       ! LinInputs - Include inputs in linearization (switch) {0=none; 1=standard; 2=all module inputs (debug)}
    CALL ReadVar( UnIn, InputFile, p%LinInputs, "LinInputs", "Include inputs in linearization (switch) {0=none; 1=standard; 2=all module inputs (debug)}", ErrStat2, ErrMsg2, UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This code adds a check to see if `CalcSteady` is true and `NLinTimes` is 1. If so, it prints a warning message and increments `NLinTimes` to 2 so that the trim solution will work; otherwise it seems to always converge on the first step without actually finding the trim solution. When #857 is fixed, this code change should be reverted.

**Related issue, if one exists**
#857

**Impacted areas of the software**
Linearization when `CalcSteady` is true and `NLinTimes = 1`

**Additional supporting information**
Note: if `RotSpeed` is zero and `CalcSteady` is true, the code will still overwrite `NLinTimes` to be 1 later in the simulation.

**Test results, if applicable**
The current tests do not have `CalcSteady=true`, so this will not affect any of them. I will note that the `5MW_OC4Semi_Linear` case timed out 2 of the 3 times I ran the GH actions with this change. I don't think that is related to my changes, though.