### PR TITLE
AD: UA: no linearization for UA states that are off

### DIFF
--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -770,7 +770,7 @@ subroutine UA_SetParameters( dt, InitInp, p, AFInfo, AFIndx, ErrStat, ErrMsg )
          do i=1,min(InitInp%UAOff_innerNode(j),size(p%UA_off_forGood,1)) !node
 !            call WrScr( 'Warning: Turning off Unsteady Aerodynamics on inner node (node '//trim(num2lstr(i))//', blade '//trim(num2lstr(j))//')' )
             p%UA_off_forGood(i,j) = .true.
-            !p%lin_nx = p%lin_nx - UA_NumLinStates
+            p%lin_nx = p%lin_nx - UA_NumLinStates
          end do
       end do
    end if
@@ -781,7 +781,7 @@ subroutine UA_SetParameters( dt, InitInp, p, AFInfo, AFIndx, ErrStat, ErrMsg )
 !            call WrScr( 'Warning: Turning off Unsteady Aerodynamics on outer node (node '//trim(num2lstr(i))//', blade '//trim(num2lstr(j))//')' )
             if (.not. p%UA_off_forGood(i,j)) then
                p%UA_off_forGood(i,j) = .true.
-               !p%lin_nx = p%lin_nx - UA_NumLinStates
+               p%lin_nx = p%lin_nx - UA_NumLinStates
             end if
          end do
       end do
@@ -795,7 +795,7 @@ subroutine UA_SetParameters( dt, InitInp, p, AFInfo, AFIndx, ErrStat, ErrMsg )
             if (ErrStat2 > ErrID_None) then
                call WrScr( 'Warning: Turning off Unsteady Aerodynamics because '//trim(ErrMsg2)//' (node '//trim(num2lstr(i))//', blade '//trim(num2lstr(j))//')' )
                p%UA_off_forGood(i,j) = .true.
-               !p%lin_nx = p%lin_nx - UA_NumLinStates
+               p%lin_nx = p%lin_nx - UA_NumLinStates
             end if
          end if
          
@@ -812,7 +812,7 @@ subroutine UA_SetParameters( dt, InitInp, p, AFInfo, AFIndx, ErrStat, ErrMsg )
       n = 1
       do j=1,size(p%UA_off_forGood,2) !blade
          do i=1,size(p%UA_off_forGood,1) !node
-            !if (.not. p%UA_off_forGood(i,j)) then
+            if (.not. p%UA_off_forGood(i,j)) then
                do k=1,UA_NumLinStates
                   p%lin_xIndx(n,1) = i ! node
                   p%lin_xIndx(n,2) = j ! blade
@@ -824,7 +824,7 @@ subroutine UA_SetParameters( dt, InitInp, p, AFInfo, AFIndx, ErrStat, ErrMsg )
                   endif
                   n = n + 1
                end do
-            !end if
+            end if
          end do
       end do
    end if

--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -761,15 +761,9 @@ subroutine UA_SetParameters( dt, InitInp, p, AFInfo, AFIndx, ErrStat, ErrMsg )
    end if
    
    ! Compute derivative step size
-   ! ---  ADENV
-   !p%dx    = 0.5_R8Ki * D2R_D
-   !p%dx(4) = 0.0001_R8Ki
-   ! --- ADLEG
-   p%dx = 2.0_R8Ki * D2R_D 
-   p%dx(4) = 0.001 ! x4 is a number between 0 and 1, so we need this to be small
-
-
-   
+   p%dx    = 0.5_R8Ki * D2R_D
+   p%dx(4) = 0.0001_R8Ki
+  
    p%UA_off_forGood = .false. ! flag that determines if UA should be turned off for the whole simulation
    if (allocated(InitInp%UAOff_innerNode)) then
       do j=1,min(size(p%UA_off_forGood,2), size(InitInp%UAOff_innerNode)) !blade

--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -2302,8 +2302,8 @@ subroutine UA_UpdateStates( i, j, t, n, u, uTimes, p, x, xd, OtherState, AFInfo,
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
 
       ! update states to value at t+dt:
-      !call UA_ABM4( i, j, t, n, u, utimes, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
-      call UA_BDF2( i, j, t, n, u_interp, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
+      call UA_ABM4( i, j, t, n, u, utimes, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
+      !call UA_BDF2( i, j, t, n, u_interp, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
 
       if (.not. p%ShedEffect) then

--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -2308,9 +2308,9 @@ subroutine UA_UpdateStates( i, j, t, n, u, uTimes, p, x, xd, OtherState, AFInfo,
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
 
       ! update states to value at t+dt:
-      call UA_ABM4( i, j, t, n, u, utimes, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
-      !call UA_BDF2( i, j, t, n, u_interp, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
-      !   call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+      !call UA_ABM4( i, j, t, n, u, utimes, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
+      call UA_BDF2( i, j, t, n, u_interp, p, x, OtherState, AFInfo, m, ErrStat2, ErrMsg2 )
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
 
       if (.not. p%ShedEffect) then
          ! Safety

--- a/reg_tests/lib/eva.py
+++ b/reg_tests/lib/eva.py
@@ -158,18 +158,18 @@ def eigA(A, nq=None, nq1=None, fullEV=False, normQ=None, sort=True):
 
     if m!=n:
         raise Exception('Matrix needs to be squared')
-    if nq is None:
-        if nq1 is None:
-            nq1=0
-        nq = int((n-nq1)/2)
-    else:
-        nq1 = n-2*nq
-    if n!=2*nq+nq1 or nq1<0:
-        raise Exception('Number of 1st and second order dofs should match the matrix shape (n= 2*nq + nq1')
     Q, Lambda = eig(A, sort=False)
     v = np.diag(Lambda)
 
     if not fullEV:
+        if nq is None:
+            if nq1 is None:
+                nq1=0
+            nq = int((n-nq1)/2)
+        else:
+            nq1 = n-2*nq
+        if n!=2*nq+nq1 or nq1<0:
+            raise Exception('Number of 1st and second order dofs should match the matrix shape (n= 2*nq + nq1')
         Q=np.delete(Q, slice(nq,2*nq), axis=0)
 
     # Selecting eigenvalues with positive imaginary part (frequency)


### PR DESCRIPTION
This pull request is ready to be merged

**Feature or improvement description**
This pull request:
- ~~Uses a 2nd order backward difference Newton scheme to perform the time integration of the UA states (should be more robust)~~
- Does not select UA states that are off for the linearization (results in less states and nicer A matrices (less zeros))

Also: 
- Performs an extrap interp of inputs before updating the states, and perform checks on the inputs to make sure they are consistent and dont introduce division by zero
- Uses smaller increments for the linearization of UA continuous states (`dx`) 
- The python script for comparison of lin files aborts only after checking all the lin files, and therfore displays all the errors that occurs (and on which module lin file). 


**Impacted areas of the software**
AeroDyn, UnsteadyAerodynamics

**Additional supporting information**


**Test results cahnge**
- OpenFASTLin: `Fake5MW*`:  the size of the states matrices is now changed. The change of `dx` slightly affects the lin results as well. No changes in frequencies and damping. 




