### PR TITLE
IfW: Bug Fix: compute vel avg profile when exceed allowed

### DIFF
--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -516,7 +516,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
       end if
 
       ! Calculate field average if box is allowed to be exceeded
-      if (p%FlowField%Grid3D%BoxExceedAllowF .and. p%FlowField%Grid3D%BoxExceedAllowIdx > 0) then
+      if (p%FlowField%Grid3D%BoxExceedAllowF) then 
          call IfW_Grid3DField_CalcVelAvgProfile(p%FlowField%Grid3D, p%FlowField%AccFieldValid, TmpErrStat, TmpErrMsg)
          call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
          if (ErrStat >= AbortErrLev) return


### PR DESCRIPTION
This pull request ready to be merged

**Feature or improvement description**
When using OLAF, VelAvg was not computed, and box extrapolation using VelAvg would result in  access violations. 


**Related issue, if one exists**
#1746

**Impacted areas of the software**
InflowWind, OLAF

**Additional supporting information**
We could also implement periodic boundary conditions (for lateral extent) instead of using the average profile. 


