### PR TITLE
MAP++ linear spring approach improvement

### DIFF
--- a/modules/map/src/lineroutines.c
+++ b/modules/map/src/lineroutines.c
@@ -667,7 +667,7 @@ MAP_ERROR_CODE solve_linear_spring_cable(Line* line, char* map_msg, MAP_ERROR_CO
   };
 
   *(line->H.value) = sqrt(force.x*force.x + force.y*force.y);
-  *(line->V.value) = fabs(force.z);
+  *(line->V.value) = -force.z; /* vertical force can be positive or negative. Important for systems with the anchor point above the fairlead connection */
   return MAP_SAFE;
 };
 


### PR DESCRIPTION
Small modification for the linear spring approach in MAP++. This modification allows to study conventional catenary systems as well as lines that have the anchor point above the fairlead connection.

**Feature or improvement description**
The default MAP++ version can only apply vertical forces in the downward direction. This is the force that we would expect in a conventional mooring line system. However, there are some conditions when the force should be applied in the upward direction (e.g., when then anchor location is above the fairlead connection).

The proposed modifications allows MAP++ to apply positive or negative forces in the vertical direction when using the linear spring approach.

For reference MAP++ can solve a mathematical problem by means of a catenary formulation or a linear spring formulation. The modifications presented here, only impact the linear spring formulation.

**Related issue, if one exists**
This modification solves the problems for the linear spring approach in MAP++ reported here: https://github.com/OpenFAST/openfast/issues/1750

**Impacted areas of the software**
The modifications only affect MAP++ when the `linear_spring` flag is selected in the line properties section.

**Additional supporting information**
Sometimes, when performing scale tests of floating offshore wind turbines in a wave tank, horizontal mooring lines are used. Usually monofilament fishing lines connected in series to a spring are used to reproduce a similar elastic restoring force as the corresponding catenary line. See for reference section 2.4 of the paper: https://doi.org/10.3390/machines11090865. For this kind of applications, the linear spring approach from MAP++ is a convenient approach to simulate the system.

**Test results, if applicable**
Several tests cases have been performed with satisfactory results. The outputs from the modified code (MAP++) has been also compared against MoorDyn v2. See for reference: https://github.com/OpenFAST/openfast/issues/1750