### PR TITLE
Readthedocs configuration changes

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -5,19 +5,20 @@
 # Required
 version: 2
 
+# select the docker image to use: stable | latest
+build:
+  os: "ubuntu-22.04"
+  tools:
+    python: "3.11"
+
 formats:
   - htmlzip
   # - pdf
   # - epub
 
 python:
-  version: 3.7
   install:
     - requirements: docs/requirements.txt
-
-# select the docker image to use: stable | latest
-build:
-  image: stable
 
 sphinx:
   builder: html

--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -14,7 +14,6 @@ python:
   version: 3.7
   install:
     - requirements: docs/requirements.txt
-  system_packages: true
 
 # select the docker image to use: stable | latest
 build:


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
Documentation hosted on readthedocs.org no longer builds due to a configuration change on their end.  The previous options of `python.system_packages` and `build.image` have been deprecated.  This new configuration updates those options.

**Related issue, if one exists**
None

**Impacted areas of the software**
Automated documentation builds on readthedocs.org

**Additional supporting information**
See notes from readthedocs.org: https://blog.readthedocs.com/drop-support-system-packages/ and https://blog.readthedocs.com/use-build-os-config/

Successful build with this pr: https://readthedocs.org/projects/ap-openfast/builds/22051768/, with results here: https://ap-openfast.readthedocs.io/en/b-rtd_pythonupdate/

