### PR TITLE
Apply the FakeGroundEffect to all FWspan points

### DIFF
--- a/modules/aerodyn/src/FVW_Subs.f90
+++ b/modules/aerodyn/src/FVW_Subs.f90
@@ -1620,6 +1620,7 @@ subroutine FakeGroundEffect(p, x, m, ErrStat, ErrMsg)
    character(*),                    intent(  out) :: ErrMsg  !< Error message if ErrStat /= ErrID_None
    integer(IntKi) :: iAge, iW, iSpan
    integer(IntKi) :: nBelow
+   integer(IntKi) :: nBelowFW
    real(ReKi) :: GROUND
    real(ReKi) :: ABOVE_GROUND
    ErrStat = ErrID_None
@@ -1634,6 +1635,7 @@ subroutine FakeGroundEffect(p, x, m, ErrStat, ErrMsg)
    endif
 
    nBelow=0
+   nBelowFW=0
    do iW = 1,p%nWings
       do iAge = 1,m%nNW+1
          do iSpan = 1,p%W(iW)%nSpan+1
@@ -1647,10 +1649,11 @@ subroutine FakeGroundEffect(p, x, m, ErrStat, ErrMsg)
    if (m%nFW>0) then
       do iW = 1,p%nWings
          do iAge = 1,m%nFW+1
-            do iSpan = 1,FWnSpan
+            do iSpan = 1,FWnSpan+1
                if (x%W(iW)%r_FW(3, iSpan, iAge) < GROUND) then
                   x%W(iW)%r_FW(3, iSpan, iAge) = ABOVE_GROUND ! could use m%dxdt
                   nBelow=nBelow+1
+                  nBelowFW=nBelowFW+1
                endif
             enddo
          enddo
@@ -1658,6 +1661,9 @@ subroutine FakeGroundEffect(p, x, m, ErrStat, ErrMsg)
    endif
    if (nBelow>0) then
       print*,'[WARN] Check the simulation, some vortices were found below the ground: ',nBelow
+   endif
+   if (nBelowFW>0) then
+      print*,'[WARN] Check the simulation, some far-wake vortices were found below the ground: ',nBelowFW
    endif
 end subroutine FakeGroundEffect
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->
Ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
Bug fix. The FakeGroundEffect is applied to all FW nodes.  Current code did not apply the FakeGroundEffect to all FW points.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
Possibly related to is issue #1787 since FW points can go below the ground.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
aerodyn


**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
ad_VerticalAxis_OLAF with longer simulation time, free far-wake and turbine closer to the ground shows that FW points can go below the ground. This is fixed with the correction.

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
