### PR TITLE
Update minimum cmake version for regression tests

### DIFF
--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -18,7 +18,7 @@
 # -- OpenFAST Testing
 # -----------------------------------------------------------
 
-cmake_minimum_required(VERSION 2.8.12)
+cmake_minimum_required(VERSION 3.15)
 project(OpenFAST_RegressionTest Fortran)
 
 include(CTest)


### PR DESCRIPTION
This is ready to merge

**Description**
CMake v 3.27 gives warnings about dropping support for older CMake input files.  Updating the reg_tests/CMakeLists.txt to mimimum 3.15 to match the main repository `cmake_minimum_required` version.

**Related issue, if one exists**
none

**Impacted areas of the software**
CMake build system for regression tests only

**Test results, if applicable**
No test results are affected.