### PR TITLE
 Resolve BeamDyn initial strain for rotated blade

### DIFF
--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -153,7 +153,7 @@ SUBROUTINE BD_Init( InitInp, u, p, x, xd, z, OtherState, y, MiscVar, Interval, I
       ! set mass and stiffness matrices: p%Stif0_QP and p%Mass0_QP
    call InitializeMassStiffnessMatrices(InputFileData, p, ErrStat2,ErrMsg2); if (Failed()) return
 
-      ! Set the initial displacements: p%uu0, p%rrN0, p%E10
+      ! Set the initial displacements: p%uu0, p%E10
    CALL BD_QuadraturePointDataAt0(p)
 
 
@@ -164,28 +164,8 @@ SUBROUTINE BD_Init( InitInp, u, p, x, xd, z, OtherState, y, MiscVar, Interval, I
 
 
       ! Actuator
-   p%UsePitchAct = InputFileData%UsePitchAct
 
    if (p%UsePitchAct) then
-
-      p%pitchK = InputFileData%pitchK
-      p%pitchC = InputFileData%pitchC
-      p%pitchJ = InputFileData%pitchJ
-
-         ! calculate (I-hA)^-1
-
-      p%torqM(1,1) =  p%pitchJ + p%pitchC*p%dt
-      p%torqM(2,1) = -p%pitchK * p%dt
-      p%torqM(1,2) =  p%pitchJ * p%dt
-      p%torqM(2,2) =  p%pitchJ
-      denom        =  p%pitchJ + p%pitchC*p%dt + p%pitchK*p%dt**2
-      if (EqualRealNos(denom,0.0_BDKi)) then
-         call SetErrStat(ErrID_Fatal,"Cannot invert matrix for pitch actuator: J+c*dt+k*dt^2 is zero.",ErrStat,ErrMsg,RoutineName)
-         call Cleanup()
-         return
-      else
-         p%torqM(:,:) =  p%torqM / denom
-      end if
 
          ! Calculate the pitch angle
       TmpDCM(:,:) = MATMUL(u%RootMotion%Orientation(:,:,1),TRANSPOSE(u%HubMotion%Orientation(:,:,1)))
@@ -614,8 +594,12 @@ subroutine InitializeNodalLocations(member_total,kp_member,kp_coordinate,p,GLL_n
 
         tangent = tangent / TwoNorm(tangent)
 
+        ! Calculate the node initial rotation
         CALL BD_ComputeIniNodalCrv(tangent, twist, temp_CRV, ErrStat, ErrMsg)
+
+        ! Store rotation in node initial position vector and save node twist
         p%uuN0(4:6,i,elem) = temp_CRV
+        p%twN0(i,elem) = twist
 
       enddo
 
@@ -752,11 +736,11 @@ SUBROUTINE BD_InitShpDerJaco( GLL_Nodes, p )
 
    CALL BD_diffmtc(p%nodes_per_elem,GLL_nodes,p%QPtN,p%nqp,p%Shp,p%ShpDer)
 
+   ! Calculate the Jacobian relating element axial length to real coordinates
    DO nelem = 1,p%elem_total
       DO idx_qp = 1, p%nqp
-         Gup0(:) = 0.0_BDKi
-         DO i=1,p%nodes_per_elem
-            Gup0(:) = Gup0(:) + p%ShpDer(i,idx_qp)*p%uuN0(1:3,i,nelem)
+         DO i=1,3
+            Gup0(i) = dot_product(p%ShpDer(:,idx_qp), p%uuN0(i,:,nelem))
          ENDDO
          p%Jacobian(idx_qp,nelem) = TwoNorm(Gup0)
       ENDDO
@@ -918,6 +902,7 @@ subroutine SetParameters(InitInp, InputFileData, p, OtherState, ErrStat, ErrMsg)
    integer(intKi)                               :: ErrStat2          ! temporary Error status
    character(ErrMsgLen)                         :: ErrMsg2           ! temporary Error message
    character(*), parameter                      :: RoutineName = 'SetParameters'
+   real(DbKi)                                   :: denom
 
 
 
@@ -987,7 +972,25 @@ subroutine SetParameters(InitInp, InputFileData, p, OtherState, ErrStat, ErrMsg)
    p%dof_elem = p%dof_node     * p%nodes_per_elem
    p%rot_elem = (p%dof_node/2) * p%nodes_per_elem
 
+      ! Actuator
+   p%UsePitchAct = InputFileData%UsePitchAct
+   if (p%UsePitchAct) then
+      p%pitchK = InputFileData%pitchK
+      p%pitchC = InputFileData%pitchC
+      p%pitchJ = InputFileData%pitchJ
 
+         ! calculate (I-hA)^-1
+      p%torqM(1,1) =  p%pitchJ + p%pitchC*p%dt
+      p%torqM(2,1) = -p%pitchK * p%dt
+      p%torqM(1,2) =  p%pitchJ * p%dt
+      p%torqM(2,2) =  p%pitchJ
+      denom        =  p%pitchJ + p%pitchC*p%dt + p%pitchK*p%dt**2
+      if (EqualRealNos(denom,0.0_BDKi)) then
+         call SetErrStat(ErrID_Fatal,"Cannot invert matrix for pitch actuator: J+c*dt+k*dt^2 is zero.",ErrStat,ErrMsg,RoutineName)
+      else
+         p%torqM(:,:) =  p%torqM / denom
+      end if
+   end if
 
    !................................
    ! allocate some parameter arrays
@@ -1009,7 +1012,7 @@ subroutine SetParameters(InitInp, InputFileData, p, OtherState, ErrStat, ErrMsg)
    
    
    CALL AllocAry(p%uuN0, p%dof_node,p%nodes_per_elem,      p%elem_total,'uuN0 (initial position) array',ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
-   CALL AllocAry(p%rrN0, (p%dof_node/2),p%nodes_per_elem,  p%elem_total,'p%rrN0',ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+   CALL AllocAry(p%twN0, p%nodes_per_elem,                 p%elem_total,'twN0 (initial twist) array',ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
    CALL AllocAry(p%uu0,  p%dof_node,    p%nqp,             p%elem_total,'p%uu0', ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
    CALL AllocAry(p%E10,  (p%dof_node/2),p%nqp,             p%elem_total,'p%E10', ErrStat2,ErrMsg2); CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
@@ -2248,72 +2251,57 @@ SUBROUTINE BD_QuadraturePointDataAt0( p )
 
    TYPE(BD_ParameterType),       INTENT(INOUT)  :: p           !< Parameters
 
-   REAL(BDKi)                    :: rot0_temp(3)
-   REAL(BDKi)                    :: rotu_temp(3)
-   REAL(BDKi)                    :: rot_temp(3)
-   REAL(BDKi)                    :: R0_temp(3,3)
-
+   CHARACTER(*), PARAMETER       :: RoutineName = 'BD_QuadraturePointDataAt0'
+   INTEGER(IntKi)                :: ErrStat2       ! The error status code
+   CHARACTER(ErrMsgLen)          :: ErrMsg2        ! The error message, if an error occurred
    INTEGER(IntKi)                :: nelem          ! number of current element
    INTEGER(IntKi)                :: idx_qp         ! index of current quadrature point
-   INTEGER(IntKi)                :: idx_node       ! index of current GLL node
+   INTEGER(IntKi)                :: i
+   REAL(BDKi)                    :: twist, tan_vect(3), R0(3), u0(3)
 
-   CHARACTER(*), PARAMETER       :: RoutineName = 'BD_QuadraturePointDataAt0'
-
-
-      ! Initialize to zero for the summation
-   p%uu0(:,:,:)   = 0.0_BDKi
-   p%rrN0(:,:,:)  = 0.0_BDKi
-   p%E10(:,:,:)   = 0.0_BDKi
-
-
-      ! calculate rrN0 (Initial relative rotation array)
+   ! Loop through elements
    DO nelem = 1,p%elem_total
-      p%rrN0(1:3,1,nelem) = (/ 0.0_BDKi, 0.0_BDKi, 0.0_BDKi /)    ! first node has no rotation relative to itself.
-      DO idx_node=2,p%nodes_per_elem
-            ! Find resulting rotation parameters R(Nr) = Ri^T(Nu(1)) R(Nu(:))
-            ! where R(Nu(1))^T is the transpose rotation parameters for the root node
-         CALL BD_CrvCompose(p%rrN0(1:3,idx_node,nelem),p%uuN0(4:6,1,nelem),p%uuN0(4:6,idx_node,nelem),FLAG_R1TR2)  ! rrN0  = node composed with root
-      ENDDO
+
+      ! Loop through quadrature points
+      do idx_qp = 1, p%nqp
+
+         ! Loop through displacement DOFs
+         do i = 1,3
+
+            ! Calculate the quadrature point initial positions by using the 
+            ! shape functions to interpolate from the node initial positions
+            ! Initial displacement field \n
+            !    \f$   \underline{u_0}\left( \xi \right) =
+            !                \sum_{k=1}^{p+1} h^k\left( \xi \right) \underline{\hat{u}_0}^k
+            !    \f$
+            u0(i) = dot_product(p%Shp(:,idx_qp), p%uuN0(i,:,nelem))
+
+            ! Calculate \f$ x_0^\prime \f$, the derivative with respect to \f$ \hat{x} \f$-direction
+            ! (tangent to curve through this GLL point)
+            ! This uses the shape function derivative to calculate the tangent at the quadrature points
+            ! with respect to the element axis from the node positions.
+            ! Note: this is a unit vector after scaling by the Jacobian
+            tan_vect(i) = dot_product(p%ShpDer(:,idx_qp), p%uuN0(i,:,nelem)) / p%Jacobian(idx_qp,nelem)
+
+         end do
+
+         ! Interpolate the twist to QP from the shape function and node values
+         twist = dot_product(p%Shp(:,idx_qp), p%twN0(:,nelem))
+
+         ! Calculate quadrature point initial rotation, R0
+         ! The nodal rotation function is used to avoid errors that occur when 
+         ! when interpolating the QP rotations from the node rotations.
+         call BD_ComputeIniNodalCrv(tan_vect, twist, R0, ErrStat2, ErrMsg2)
+
+         ! Save initial position and rotation
+         p%uu0(1:3,idx_qp,nelem) = u0
+         p%uu0(4:6,idx_qp,nelem) = R0
+
+         ! Save initial tangent vector for calculating strain
+         p%E10(1:3,idx_qp,nelem) = tan_vect
+
+      end do
    ENDDO
-
-
-   DO nelem = 1,p%elem_total
-       DO idx_qp = 1,p%nqp
-            !> ### Calculate the the initial displacement fields in an element
-            !! Initial displacement field \n
-            !!    \f$   \underline{u_0}\left( \xi \right) =
-            !!                \sum_{k=1}^{p+1} h^k\left( \xi \right) \underline{\hat{u}_0}^k
-            !!    \f$ \n
-            !! and curvature \n
-            !!    \f$   \underline{c_0}\left( \xi \right) =
-            !!                \sum_{k=1}^{p+1} h^k\left( \xi \right) \underline{\hat{c}_0}^k
-            !!    \f$
-
-            ! Note that p%uu0 was set to zero prior to this routine call, so the following is the summation.
-
-         DO idx_node=1,p%nodes_per_elem
-            p%uu0(1:3,idx_qp,nelem) =  p%uu0(1:3,idx_qp,nelem) + p%Shp(idx_node,idx_qp)*p%uuN0(1:3,idx_node,nelem)
-            p%uu0(4:6,idx_qp,nelem) =  p%uu0(4:6,idx_qp,nelem) + p%Shp(idx_node,idx_qp)*p%rrN0(1:3,idx_node,nelem)
-         ENDDO
-
-
-            !> Add the blade root rotation parameters. That is,
-            !! compose the rotation parameters calculated with the shape functions with the rotation parameters
-            !! for the blade root.
-         rot0_temp(:) = p%uuN0(4:6,1,nelem)        ! Rotation at root
-         rotu_temp(:) = p%uu0( 4:6,idx_qp,nelem)   ! Rotation at current GLL point without root rotation
-
-         CALL BD_CrvCompose(rot_temp,rot0_temp,rotu_temp,FLAG_R1R2)  ! rot_temp = rot0_temp composed with rotu_temp
-         p%uu0(4:6,idx_qp,nelem) = rot_temp(:)     ! Rotation parameters at current GLL point with the root orientation
-
-
-            !> Set the initial value of \f$ x_0^\prime \f$, the derivative with respect to \f$ \hat{x} \f$-direction
-            !! (tangent to curve through this GLL point).  This is simply the
-         CALL BD_CrvMatrixR(p%uu0(4:6,idx_qp,nelem),R0_temp)         ! returns R0_temp (the transpose of the DCM orientation matrix)
-         p%E10(:,idx_qp,nelem) = R0_temp(:,3)                        ! unit vector tangent to curve through this GLL point (derivative with respect to z in IEC coords).
-      ENDDO
-   ENDDO
-
 
 END SUBROUTINE BD_QuadraturePointDataAt0
 
@@ -2362,48 +2350,43 @@ SUBROUTINE BD_DisplacementQP( nelem, p, x, m )
    TYPE(BD_ContinuousStateType), INTENT(IN   )  :: x                 !< Continuous states at t
    TYPE(BD_MiscVarType),         INTENT(INOUT)  :: m                 !< misc/optimization variables
 
-   INTEGER(IntKi)                :: idx_qp            !< index to the current quadrature point
-   INTEGER(IntKi)                :: elem_start        !< Node point of first node in current element
-   INTEGER(IntKi)                :: idx_node
+   INTEGER(IntKi)                :: node_start        !< Node point of first node in current element
+   INTEGER(IntKi)                :: node_end          !< Node point of last node in current element
+   INTEGER(IntKi)                :: i, idx_qp
    CHARACTER(*), PARAMETER       :: RoutineName = 'BD_DisplacementQP'
 
+   ! Node at start and end of element
+   node_start = p%node_elem_idx(nelem,1)
+   node_end = node_start + p%nodes_per_elem - 1
 
-   DO idx_qp=1,p%nqp
-            ! Node point before start of this element
-         elem_start = p%node_elem_idx( nelem,1 )
+   !> ### Calculate the the displacement fields in an element
+   !! Using equations (27) and (28) \n
+   !!    \f$   \underline{u}\left( \xi \right) =
+   !!                \sum_{i=1}^{p+1} h^i\left( \xi \right) \underline{\hat{u}}^i
+   !!    \f$ \n
+   !! and \n
+   !!    \f$   \underline{u}^\prime \left( \xi \right) =
+   !!                \sum_{k=1}^{p+1} h^{k\prime} \left( \xi \right) \underline{\hat{u}}^i
+   !!    \f$
+   !!
+   !! |  Variable                               |  Value                                                                      |
+   !! | :---------:                             |  :------------------------------------------------------------------------- |
+   !! | \f$ \xi \f$                             |  Element natural coordinate \f$ \in [-1,1] \f$                              |
+   !! | \f$ k \f$                               |  Node number of a \f$ p^\text{th} \f$ order Langrangian-interpolant         |
+   !! | \f$ h^i \left( \xi \right ) \f$         |  Component of the shape function matrix, \f$ \underline{\underline{N}} \f$  |
+   !! | \f$ h^{k\prime} \left( \xi \right ) \f$ |  \f$ \frac{\mathrm{d}}{\mathrm{d}x_1} h^i \left( \xi \right) \f$            |
+   !! | \f$ \underline{\hat{u}}^i \f$           |  \f$ k^\text{th} \f$ nodal value        
 
+   ! Loop through all quadrature points and displacement DOFs
+   ! dot_product appears to be more exact that matmul
+   forall (idx_qp = 1:p%nqp, i = 1:3)
+      m%qp%uuu(i,idx_qp,nelem) = dot_product(p%Shp(:,idx_qp), x%q(i,node_start:node_end))
+      m%qp%uup(i,idx_qp,nelem) = dot_product(p%ShpDer(:,idx_qp), x%q(i,node_start:node_end)) / p%Jacobian(idx_qp,nelem)
+   end forall
 
-            !> ### Calculate the the displacement fields in an element
-            !! Using equations (27) and (28) \n
-            !!    \f$   \underline{u}\left( \xi \right) =
-            !!                \sum_{i=1}^{p+1} h^i\left( \xi \right) \underline{\hat{u}}^i
-            !!    \f$ \n
-            !! and \n
-            !!    \f$   \underline{u}^\prime \left( \xi \right) =
-            !!                \sum_{k=1}^{p+1} h^{k\prime} \left( \xi \right) \underline{\hat{u}}^i
-            !!    \f$
-            !!
-            !! |  Variable                               |  Value                                                                      |
-            !! | :---------:                             |  :------------------------------------------------------------------------- |
-            !! | \f$ \xi \f$                             |  Element natural coordinate \f$ \in [-1,1] \f$                              |
-            !! | \f$ k \f$                               |  Node number of a \f$ p^\text{th} \f$ order Langrangian-interpolant         |
-            !! | \f$ h^i \left( \xi \right ) \f$         |  Component of the shape function matrix, \f$ \underline{\underline{N}} \f$  |
-            !! | \f$ h^{k\prime} \left( \xi \right ) \f$ |  \f$ \frac{\mathrm{d}}{\mathrm{d}x_1} h^i \left( \xi \right) \f$            |
-            !! | \f$ \underline{\hat{u}}^i \f$           |  \f$ k^\text{th} \f$ nodal value                                            |
+   !> Calculate \f$ \underline{E}_1 = x_0^\prime + u^\prime \f$ (equation 23).  Note E_1 is along the z direction.
+   m%qp%E1(1:3,:,nelem) = p%E10(1:3,:,nelem) + m%qp%uup(1:3,:,nelem)
 
-            ! Initialize values for summation
-         m%qp%uuu(:,idx_qp,nelem) = 0.0_BDKi    ! displacement field \f$ \underline{u}        \left( \xi \right) \f$
-         m%qp%uup(:,idx_qp,nelem) = 0.0_BDKi    ! displacement field \f$ \underline{u}^\prime \left( \xi \right) \f$
-
-         DO idx_node=1,p%nodes_per_elem
-            m%qp%uuu(1:3,idx_qp,nelem) = m%qp%uuu(1:3,idx_qp,nelem)  + p%Shp(idx_node,idx_qp)                            *x%q(1:3,elem_start - 1 + idx_node)
-            m%qp%uup(1:3,idx_qp,nelem) = m%qp%uup(1:3,idx_qp,nelem)  + p%ShpDer(idx_node,idx_qp)/p%Jacobian(idx_qp,nelem)*x%q(1:3,elem_start - 1 + idx_node)
-         ENDDO
-
-            !> Calculate \f$ \underline{E}_1 = x_0^\prime + u^\prime \f$ (equation 23).  Note E_1 is along the z direction.
-         m%qp%E1(1:3,idx_qp,nelem) = p%E10(1:3,idx_qp,nelem) + m%qp%uup(1:3,idx_qp,nelem)
-
-   ENDDO
 END SUBROUTINE  BD_DisplacementQP
 
 

--- a/modules/beamdyn/src/BeamDyn_Types.f90
+++ b/modules/beamdyn/src/BeamDyn_Types.f90
@@ -163,7 +163,8 @@ IMPLICIT NONE
     REAL(DbKi)  :: dt      !< module dt [s]
     REAL(DbKi) , DIMENSION(1:9)  :: coef      !< GA2 Coefficient [-]
     REAL(DbKi)  :: rhoinf      !< Numerical Damping Coefficient for GA2 [-]
-    REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: uuN0      !< Initial Postion Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element) [-]
+    REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: uuN0      !< Initial Position Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element) [-]
+    REAL(R8Ki) , DIMENSION(:,:), ALLOCATABLE  :: twN0      !< Initial Twist of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element) [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: Stif0_QP      !< Sectional Stiffness Properties at quadrature points (6x6xqp) [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: Mass0_QP      !< Sectional Mass Properties at quadrature points (6x6xqp) [-]
     REAL(R8Ki) , DIMENSION(1:3)  :: gravity      !< Gravitational acceleration -- intertial frame!!! [m/s^2]
@@ -181,7 +182,6 @@ IMPLICIT NONE
     REAL(R8Ki) , DIMENSION(:,:), ALLOCATABLE  :: ShpDer      !< Derivative of shape function matrix (index 1 = FE nodes; index 2=quadrature points) [-]
     REAL(R8Ki) , DIMENSION(:,:), ALLOCATABLE  :: Jacobian      !< Jacobian value at each quadrature point [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: uu0      !< Initial Disp/Rot value at quadrature point (at T=0) [-]
-    REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: rrN0      !< Initial relative rotation array, relative to root (at T=0) (index 1=rot DOF; index 2=FE nodes; index 3=element) [-]
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: E10      !< Initial E10 at quadrature point [-]
     INTEGER(IntKi)  :: nodes_per_elem      !< Finite element (GLL) nodes per element [-]
     INTEGER(IntKi) , DIMENSION(:,:), ALLOCATABLE  :: node_elem_idx      !< Index to first and last nodes of element in p%node_total sized arrays [-]
@@ -3735,6 +3735,20 @@ IF (ALLOCATED(SrcParamData%uuN0)) THEN
   END IF
     DstParamData%uuN0 = SrcParamData%uuN0
 ENDIF
+IF (ALLOCATED(SrcParamData%twN0)) THEN
+  i1_l = LBOUND(SrcParamData%twN0,1)
+  i1_u = UBOUND(SrcParamData%twN0,1)
+  i2_l = LBOUND(SrcParamData%twN0,2)
+  i2_u = UBOUND(SrcParamData%twN0,2)
+  IF (.NOT. ALLOCATED(DstParamData%twN0)) THEN 
+    ALLOCATE(DstParamData%twN0(i1_l:i1_u,i2_l:i2_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%twN0.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%twN0 = SrcParamData%twN0
+ENDIF
 IF (ALLOCATED(SrcParamData%Stif0_QP)) THEN
   i1_l = LBOUND(SrcParamData%Stif0_QP,1)
   i1_u = UBOUND(SrcParamData%Stif0_QP,1)
@@ -3879,22 +3893,6 @@ IF (ALLOCATED(SrcParamData%uu0)) THEN
     END IF
   END IF
     DstParamData%uu0 = SrcParamData%uu0
-ENDIF
-IF (ALLOCATED(SrcParamData%rrN0)) THEN
-  i1_l = LBOUND(SrcParamData%rrN0,1)
-  i1_u = UBOUND(SrcParamData%rrN0,1)
-  i2_l = LBOUND(SrcParamData%rrN0,2)
-  i2_u = UBOUND(SrcParamData%rrN0,2)
-  i3_l = LBOUND(SrcParamData%rrN0,3)
-  i3_u = UBOUND(SrcParamData%rrN0,3)
-  IF (.NOT. ALLOCATED(DstParamData%rrN0)) THEN 
-    ALLOCATE(DstParamData%rrN0(i1_l:i1_u,i2_l:i2_u,i3_l:i3_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%rrN0.', ErrStat, ErrMsg,RoutineName)
-      RETURN
-    END IF
-  END IF
-    DstParamData%rrN0 = SrcParamData%rrN0
 ENDIF
 IF (ALLOCATED(SrcParamData%E10)) THEN
   i1_l = LBOUND(SrcParamData%E10,1)
@@ -4197,6 +4195,9 @@ ENDIF
 IF (ALLOCATED(ParamData%uuN0)) THEN
   DEALLOCATE(ParamData%uuN0)
 ENDIF
+IF (ALLOCATED(ParamData%twN0)) THEN
+  DEALLOCATE(ParamData%twN0)
+ENDIF
 IF (ALLOCATED(ParamData%Stif0_QP)) THEN
   DEALLOCATE(ParamData%Stif0_QP)
 ENDIF
@@ -4226,9 +4227,6 @@ IF (ALLOCATED(ParamData%Jacobian)) THEN
 ENDIF
 IF (ALLOCATED(ParamData%uu0)) THEN
   DEALLOCATE(ParamData%uu0)
-ENDIF
-IF (ALLOCATED(ParamData%rrN0)) THEN
-  DEALLOCATE(ParamData%rrN0)
 ENDIF
 IF (ALLOCATED(ParamData%E10)) THEN
   DEALLOCATE(ParamData%E10)
@@ -4333,6 +4331,11 @@ ENDIF
     Int_BufSz   = Int_BufSz   + 2*3  ! uuN0 upper/lower bounds for each dimension
       Db_BufSz   = Db_BufSz   + SIZE(InData%uuN0)  ! uuN0
   END IF
+  Int_BufSz   = Int_BufSz   + 1     ! twN0 allocated yes/no
+  IF ( ALLOCATED(InData%twN0) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*2  ! twN0 upper/lower bounds for each dimension
+      Db_BufSz   = Db_BufSz   + SIZE(InData%twN0)  ! twN0
+  END IF
   Int_BufSz   = Int_BufSz   + 1     ! Stif0_QP allocated yes/no
   IF ( ALLOCATED(InData%Stif0_QP) ) THEN
     Int_BufSz   = Int_BufSz   + 2*3  ! Stif0_QP upper/lower bounds for each dimension
@@ -4389,11 +4392,6 @@ ENDIF
   IF ( ALLOCATED(InData%uu0) ) THEN
     Int_BufSz   = Int_BufSz   + 2*3  ! uu0 upper/lower bounds for each dimension
       Db_BufSz   = Db_BufSz   + SIZE(InData%uu0)  ! uu0
-  END IF
-  Int_BufSz   = Int_BufSz   + 1     ! rrN0 allocated yes/no
-  IF ( ALLOCATED(InData%rrN0) ) THEN
-    Int_BufSz   = Int_BufSz   + 2*3  ! rrN0 upper/lower bounds for each dimension
-      Db_BufSz   = Db_BufSz   + SIZE(InData%rrN0)  ! rrN0
   END IF
   Int_BufSz   = Int_BufSz   + 1     ! E10 allocated yes/no
   IF ( ALLOCATED(InData%E10) ) THEN
@@ -4627,6 +4625,26 @@ ENDIF
         END DO
       END DO
   END IF
+  IF ( .NOT. ALLOCATED(InData%twN0) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%twN0,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%twN0,1)
+    Int_Xferred = Int_Xferred + 2
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%twN0,2)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%twN0,2)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i2 = LBOUND(InData%twN0,2), UBOUND(InData%twN0,2)
+        DO i1 = LBOUND(InData%twN0,1), UBOUND(InData%twN0,1)
+          DbKiBuf(Db_Xferred) = InData%twN0(i1,i2)
+          Db_Xferred = Db_Xferred + 1
+        END DO
+      END DO
+  END IF
   IF ( .NOT. ALLOCATED(InData%Stif0_QP) ) THEN
     IntKiBuf( Int_Xferred ) = 0
     Int_Xferred = Int_Xferred + 1
@@ -4841,31 +4859,6 @@ ENDIF
         DO i2 = LBOUND(InData%uu0,2), UBOUND(InData%uu0,2)
           DO i1 = LBOUND(InData%uu0,1), UBOUND(InData%uu0,1)
             DbKiBuf(Db_Xferred) = InData%uu0(i1,i2,i3)
-            Db_Xferred = Db_Xferred + 1
-          END DO
-        END DO
-      END DO
-  END IF
-  IF ( .NOT. ALLOCATED(InData%rrN0) ) THEN
-    IntKiBuf( Int_Xferred ) = 0
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    IntKiBuf( Int_Xferred ) = 1
-    Int_Xferred = Int_Xferred + 1
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%rrN0,1)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%rrN0,1)
-    Int_Xferred = Int_Xferred + 2
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%rrN0,2)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%rrN0,2)
-    Int_Xferred = Int_Xferred + 2
-    IntKiBuf( Int_Xferred    ) = LBOUND(InData%rrN0,3)
-    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%rrN0,3)
-    Int_Xferred = Int_Xferred + 2
-
-      DO i3 = LBOUND(InData%rrN0,3), UBOUND(InData%rrN0,3)
-        DO i2 = LBOUND(InData%rrN0,2), UBOUND(InData%rrN0,2)
-          DO i1 = LBOUND(InData%rrN0,1), UBOUND(InData%rrN0,1)
-            DbKiBuf(Db_Xferred) = InData%rrN0(i1,i2,i3)
             Db_Xferred = Db_Xferred + 1
           END DO
         END DO
@@ -5432,6 +5425,29 @@ ENDIF
         END DO
       END DO
   END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! twN0 not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    i2_l = IntKiBuf( Int_Xferred    )
+    i2_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%twN0)) DEALLOCATE(OutData%twN0)
+    ALLOCATE(OutData%twN0(i1_l:i1_u,i2_l:i2_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%twN0.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i2 = LBOUND(OutData%twN0,2), UBOUND(OutData%twN0,2)
+        DO i1 = LBOUND(OutData%twN0,1), UBOUND(OutData%twN0,1)
+          OutData%twN0(i1,i2) = REAL(DbKiBuf(Db_Xferred), R8Ki)
+          Db_Xferred = Db_Xferred + 1
+        END DO
+      END DO
+  END IF
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! Stif0_QP not allocated
     Int_Xferred = Int_Xferred + 1
   ELSE
@@ -5686,34 +5702,6 @@ ENDIF
         DO i2 = LBOUND(OutData%uu0,2), UBOUND(OutData%uu0,2)
           DO i1 = LBOUND(OutData%uu0,1), UBOUND(OutData%uu0,1)
             OutData%uu0(i1,i2,i3) = REAL(DbKiBuf(Db_Xferred), R8Ki)
-            Db_Xferred = Db_Xferred + 1
-          END DO
-        END DO
-      END DO
-  END IF
-  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! rrN0 not allocated
-    Int_Xferred = Int_Xferred + 1
-  ELSE
-    Int_Xferred = Int_Xferred + 1
-    i1_l = IntKiBuf( Int_Xferred    )
-    i1_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    i2_l = IntKiBuf( Int_Xferred    )
-    i2_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    i3_l = IntKiBuf( Int_Xferred    )
-    i3_u = IntKiBuf( Int_Xferred + 1)
-    Int_Xferred = Int_Xferred + 2
-    IF (ALLOCATED(OutData%rrN0)) DEALLOCATE(OutData%rrN0)
-    ALLOCATE(OutData%rrN0(i1_l:i1_u,i2_l:i2_u,i3_l:i3_u),STAT=ErrStat2)
-    IF (ErrStat2 /= 0) THEN 
-       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%rrN0.', ErrStat, ErrMsg,RoutineName)
-       RETURN
-    END IF
-      DO i3 = LBOUND(OutData%rrN0,3), UBOUND(OutData%rrN0,3)
-        DO i2 = LBOUND(OutData%rrN0,2), UBOUND(OutData%rrN0,2)
-          DO i1 = LBOUND(OutData%rrN0,1), UBOUND(OutData%rrN0,1)
-            OutData%rrN0(i1,i2,i3) = REAL(DbKiBuf(Db_Xferred), R8Ki)
             Db_Xferred = Db_Xferred + 1
           END DO
         END DO

--- a/modules/beamdyn/src/Registry_BeamDyn.txt
+++ b/modules/beamdyn/src/Registry_BeamDyn.txt
@@ -171,7 +171,8 @@ typedef   ^        ParameterType DbKi           coef             {9}       - -  
 typedef   ^        ParameterType DbKi           rhoinf           -         - -  "Numerical Damping Coefficient for GA2"
 #vvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvvv
 #the following are BDKi = R8Ki
-typedef   ^        ParameterType R8Ki           uuN0             {:}{:}{:} - -  "Initial Postion Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element)" -
+typedef   ^        ParameterType R8Ki           uuN0             {:}{:}{:} - -  "Initial Position Vector of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element)" -
+typedef   ^        ParameterType  ^             twN0             {:}{:}    - -  "Initial Twist of GLL (FE) nodes (index 1=DOF; index 2=FE nodes; index 3=element)" -
 typedef   ^        ParameterType  ^             Stif0_QP         {:}{:}{:} - -  "Sectional Stiffness Properties at quadrature points (6x6xqp)" -
 typedef   ^        ParameterType  ^             Mass0_QP         {:}{:}{:} - -  "Sectional Mass Properties at quadrature points (6x6xqp)" -
 typedef   ^        ParameterType  ^             gravity          {3}       - -  "Gravitational acceleration -- intertial frame!!!" m/s^2
@@ -189,7 +190,6 @@ typedef   ^        ParameterType  ^             Shp              {:}{:}    - -  
 typedef   ^        ParameterType  ^             ShpDer           {:}{:}    - -  "Derivative of shape function matrix (index 1 = FE nodes; index 2=quadrature points)" -
 typedef   ^        ParameterType  ^             Jacobian         {:}{:}    - -  "Jacobian value at each quadrature point" -
 typedef   ^        ParameterType  ^             uu0              {:}{:}{:} - -  "Initial Disp/Rot value at quadrature point (at T=0)" -
-typedef   ^        ParameterType  ^             rrN0             {:}{:}{:} - -  "Initial relative rotation array, relative to root (at T=0) (index 1=rot DOF; index 2=FE nodes; index 3=element)" -
 typedef   ^        ParameterType  ^             E10              {:}{:}{:} - -  "Initial E10 at quadrature point" -
 #end of BDKi-type variables
 #^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/modules/beamdyn/tests/test_BD_QuadraturePointData.F90
+++ b/modules/beamdyn/tests/test_BD_QuadraturePointData.F90
@@ -27,7 +27,6 @@ module test_BD_QuadraturePointData
 
     real(BDKi), allocatable    :: gll_nodes(:)
     real(BDKi), allocatable    :: baseline_uu0(:,:,:)
-    real(BDKi), allocatable    :: baseline_rrN0(:,:,:)
     real(BDKi), allocatable    :: baseline_E10(:,:,:)
 
     real(BDKi), allocatable    :: baseline_uuu(:,:,:)
@@ -91,7 +90,6 @@ contains
 
         call AllocAry(baseline_uu0  , p%dof_node,   p%nqp,            p%elem_total, 'baseline_uu0'     , ErrStat, ErrMsg)
         call AllocAry(baseline_E10  , p%dof_node/2, p%nqp,            p%elem_total, 'baseline_E10'     , ErrStat, ErrMsg)
-        call AllocAry(baseline_rrN0 , p%dof_node/2, p%nodes_per_elem, p%elem_total, 'baseline_rrN0'    , ErrStat, ErrMsg)
 
         call AllocAry(baseline_uuu  , p%dof_node,   p%nqp,            p%elem_total, 'baseline_uuu'     , ErrStat, ErrMsg)
         call AllocAry(baseline_uup  , p%dof_node/2, p%nqp,            p%elem_total, 'baseline_uup'     , ErrStat, ErrMsg)
@@ -103,6 +101,10 @@ contains
         call AllocAry(baseline_RR0 , 3, 3, p%nqp, p%elem_total, 'baseline_RR0'    , ErrStat, ErrMsg)
 
         call AllocAry(baseline_Stif , 6, 6, p%nqp, p%elem_total, 'baseline_Stif'    , ErrStat, ErrMsg)
+
+        ! Allocate memory for GLL node positions in 1D parametric space
+        call AllocAry(gll_nodes, nodes_per_elem, "GLL points array", ErrStat, ErrMsg)
+        gll_nodes = (/ -1., -0.6546536707079771, 0., 0.6546536707079771, 1. /)
 
         ! assign baseline results
     
@@ -123,36 +125,25 @@ contains
         p%uuN0(1:3,5,1) = (/  -1., 1., 5. /)
         p%uuN0(4:6,5,1) = (/  -1.0730193445455083,-0.42803085368057275,1.292451050059679 /)
 
-
-        ! the following is uuN0(4:6) with rotation of first node removed
-        baseline_rrN0(1:3,1,1) = (/ 0., 0., 0. /)
-        baseline_rrN0(1:3,2,1) = (/ -0.18695562365337798,-0.0032641497706398077,0.048935661676787534 /)
-        baseline_rrN0(1:3,3,1) = (/ -0.6080640291857297,-0.08595023366039768,0.4027112581652146 /)
-        baseline_rrN0(1:3,4,1) = (/ -1.1980591841054526,-0.3478409509012645,0.9658032687192992 /)
-        baseline_rrN0(1:3,5,1) = (/ -1.5856082606694464,-0.3853274394272689,1.3714709059387975 /)
-
         ! We are just looking at one randomly selected point in the domain to test interpolation; can be expanded
         p%QptN(1) = 0.3
+
+        ! Twist at nodes (nodes_per_elem, elem_total)
+        p%twN0(:,1) = 90.0*((gll_nodes+1)/2)**2
 
         ! Input baseline/reference quantities; uu0 and E10 are only for at quadrature points, so just 1 point here 
         ! uu0 is reference line evaluated at quadrature point
         ! E10 is tangent evaluated at qudrature point 
         baseline_uu0(1:3,1,1) = (/ 0.29298750000000007,-0.03250000000000007,3.2499999999999996  /)
-        baseline_uu0(4:6,1,1) = (/ -0.419497643454797,-0.1153574679103733,0.610107968645409 /)
-        baseline_E10(1:3,1,1) = (/ -0.22332806017852783,0.3449485111415417,0.9116661133321399 /)
- 
-        ! Allocate memory for GLL node positions in 1D parametric space
-        call AllocAry(gll_nodes, nodes_per_elem, "GLL points array", ErrStat, ErrMsg)
-        gll_nodes = (/ -1., -0.6546536707079771, 0., 0.6546536707079771, 1. /)
+        baseline_uu0(4:6,1,1) = (/ -0.42032456079463276,-0.10798264336200536,0.61929246125947701 /)
+        baseline_E10(1:3,1,1) = (/ -0.21838554154630824,0.34664371674017153,0.91222030721097547 /)
+
         
         ! Build the shape functions and derivative of shape functions evaluated at QP points; this is tested elsewhere
         call BD_InitShpDerJaco(gll_nodes, p)
 
         ! **** primary function being tested *****
         call BD_QuadraturePointDataAt0( p )
-
-        testname = "5 node, 1 element, 1 qp, curved: BD_DisplacementQPAt0: rrN0"
-        @assertEqual(baseline_rrN0(:,:,1), p%rrN0(:,:,1), tolerance, testname)
 
         ! Test uu0; only one quadrature point for now
         testname = "5 node, 1 element, 1 qp, curved: BD_DisplacementQPAt0: uu0"
@@ -192,7 +183,7 @@ contains
         baseline_uuu(1:3,idx_qp,nelem) = (/ 0.42250000000000015,-0.14787500000000003,0.4774250000000001 /)
         baseline_uuu(4:6,idx_qp,nelem) = (/ 0.042250000000000024,0.1300000000000001,0.02746250000000002 /)
         baseline_uup(1:3,idx_qp,nelem) = (/ 0.23717727987485349,-0.005929431996871376,0.2834268494504499 /)
-        baseline_E1(1:3, idx_qp,nelem)  = (/ 0.01384921969632566, 0.33901907914467033, 1.1950929627825897 /)
+        baseline_E1(1:3, idx_qp,nelem)  = (/ 0.018791738328546054, 0.34071428474330018, 1.1956471566614264 /)
 
         call BD_DisplacementQP( nelem, p, x, m )
 
@@ -214,9 +205,9 @@ contains
 
         baseline_kappa(1:3,1,1)  = (/ 0.024664714695954715,0.036297077098213545,0.02229356260962948 /)
 
-        baseline_RR0(1,1:3,1,nelem)  = (/0.7967507798136657,-0.5939809735620473,-0.11124206898740374/)
-        baseline_RR0(2,1:3,1,nelem)  = (/0.5966254150993577,0.7439195402109748,0.3010346022466711 /)
-        baseline_RR0(3,1:3,1,nelem)  = (/-0.09605367730511442,-0.30621939967705303,0.9471026186942948 /)
+        baseline_RR0(1,1:3,1,nelem)  = (/0.79124185715259476, -0.60219094249350502, -0.1063127098163618/)
+        baseline_RR0(2,1:3,1,nelem)  = (/0.60261503127580685, 0.7383322551011402, 0.30285409879630898/)
+        baseline_RR0(3,1:3,1,nelem)  = (/-0.10388189240754285, -0.30369647652886939, 0.94708869836662024/)
 
         CALL BD_RotationalInterpQP( nelem, p, x, m )
 
@@ -242,12 +233,12 @@ contains
           enddo 
         enddo 
         ! the following should be the result from  MATMUL(tempR6,MATMUL(p%Stif0_QP(1:6,1:6,temp_id2+idx_qp),TRANSPOSE(tempR6)))
-        baseline_Stif(1,1:6,idx_qp,nelem) = (/4.5918231909187375, -33.558422946165074, -19.41124878362651, 2.60126686515566, -69.25969416961556, -31.26026770547517 /)
-        baseline_Stif(2,1:6,idx_qp,nelem) = (/-18.923545538732206, 138.2989541247406, 79.99647091096304, -10.720184539884109, 285.4288856786646, 128.8279349796045 /)
-        baseline_Stif(3,1:6,idx_qp,nelem) = (/ -13.509458152867301, 98.7311774904666, 57.109222684340786, -7.65310518243836, 203.76676129761876, 91.96984745617996 /)
-        baseline_Stif(4,1:6,idx_qp,nelem) = (/ 2.852586665816869, -20.847560074045475, -12.058885358769254, 1.6159897420374438, -43.026325677681456, -19.419872917332995 /)
-        baseline_Stif(5,1:6,idx_qp,nelem) = (/-50.11731488891121, 366.27238899233606, 211.8634858589486, -28.39144827024861, 755.9328304872744, 341.18924335009 /)
-        baseline_Stif(6,1:6,idx_qp,nelem) = (/-23.86246662028767, 174.39407269994138, 100.87502434184734, -13.518082286573822, 359.9239499295936, 162.45117977068867 /)
+        baseline_Stif(1,1:6,idx_qp,nelem) = (/4.7536759583339689, -33.907248359179356, -19.542837968671446, 2.9365509821876983, -70.008981029110458, -31.39174980281188/)
+        baseline_Stif(2,1:6,idx_qp,nelem) = (/-19.401250769011185, 138.38617399872942, 79.760485041818299, -11.984990668437774, 285.72873055166156, 128.11963106880802/)
+        baseline_Stif(3,1:6,idx_qp,nelem) = (/-13.830884167369799, 98.653595365050748, 56.86015004293688, -8.5439345976052863, 203.69207236173781, 91.33471846615123/)
+        baseline_Stif(4,1:6,idx_qp,nelem) = (/3.141919298405611, -22.410832986789217, -12.916744914371989, 1.9408992709130821, -46.272099841270119, -20.748226294907653/)
+        baseline_Stif(5,1:6,idx_qp,nelem) = (/-51.422828167125537, 366.79122036858701, 211.40439684348502, -31.766102251101898, 757.32124637229549, 339.57984728541373/)
+        baseline_Stif(6,1:6,idx_qp,nelem) = (/-24.340652516975311, 173.61817619702015, 100.06686033300799, -15.036272493606024, 358.4729576086462, 160.73785435679258/)
 
         CALL BD_StifAtDeformedQP( nelem, p, m )
    
@@ -259,9 +250,6 @@ contains
         ! dealocate baseline variables
         if (allocated(gll_nodes)) deallocate(gll_nodes)
         if (allocated(baseline_uu0)) deallocate(baseline_uu0)
-        if (allocated(baseline_E10)) deallocate(baseline_E10)
-        if (allocated(baseline_rrN0)) deallocate(baseline_rrN0)
-        if (allocated(baseline_rrN0)) deallocate(baseline_rrN0)
         if (allocated(baseline_E10)) deallocate(baseline_E10)
         if (allocated(baseline_uuu)) deallocate(baseline_uuu)
         if (allocated(baseline_uup)) deallocate(baseline_uup)

--- a/modules/beamdyn/tests/test_tools.F90
+++ b/modules/beamdyn/tests/test_tools.F90
@@ -132,10 +132,10 @@ contains
         call AllocAry(p%QPtw_ShpDer, p%nqp, p%nodes_per_elem, 'QPtw_ShpDer', ErrStat, ErrMsg)
         call AllocAry(p%Jacobian, p%nqp, p%elem_total, 'Jacobian', ErrStat, ErrMsg)
         call AllocAry(p%uuN0, p%dof_node, p%nodes_per_elem, p%elem_total,'uuN0', ErrStat, ErrMsg)
+        call AllocAry(p%twN0, p%nodes_per_elem, p%elem_total,'twN0', ErrStat, ErrMsg)
 
         call AllocAry(p%uu0, p%dof_node, p%nqp,   p%elem_total,'uu0', ErrStat, ErrMsg)
         call AllocAry(p%E10, p%dof_node/2, p%nqp, p%elem_total,'E10', ErrStat, ErrMsg)
-        call AllocAry(p%rrN0, p%dof_node/2, p%nodes_per_elem, p%elem_total,'rrN0', ErrStat, ErrMsg)
 
         CALL AllocAry(p%node_elem_idx,p%elem_total,2,'start and end node numbers of elements in p%node_total sized arrays',ErrStat,ErrMsg)
 


### PR DESCRIPTION
This pull request is ready to be merged. Copy of PR #1663 applied to the `rc-3.5.1` branch.

**Feature or improvement description**
In the BeamDyn driver, and likely in the glue-code, if the blade was initially rotated then an initial strain was introduced which produced forces when no loads or gravity had been applied. The cause was traced to the calculation of R0 (initial rotation) at the quadrature points which was interpolated via the shape functions from the element nodal rotations. The shape function interpolation is not exact and introduced strains on the order of 1e-7, but with the large stiffness of the blade, forces of 6200 N could be produced at the root for the IEA 15MW blade. This was resolved by directly calculating the quadrature point initial rotations in uu0(4:6) via interpolated tangent and twist, which are well behaved. This was only a problem for non-straight blades such as the IEA 15MW.

This commit also fixes a bug where the parameter UsePitchAct wasn't initialized from the input file until after it was used in SetOutParam. The initialization has been moved to SetParameters.

**Related issue, if one exists**
This changes resolves Issue #366 when QuasiStaticInit is set to False.

**Impacted areas of the software**
BeamDyn

**Test results, if applicable**
The BeamDyn unit test test_BD_QuadraturePointData.F90 was updated to account for the slight difference in R0, E1, Stiffness that resulted from this change.
