### PR TITLE
Add Mod_AmbWind=3 regression test to the CI

### DIFF
--- a/reg_tests/CMakeLists.txt
+++ b/reg_tests/CMakeLists.txt
@@ -157,6 +157,11 @@ add_custom_command(
   DEPENDS DISCON
   COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${ff_dest}/DISCON_WT3.dll"
 )
+add_custom_command(
+  OUTPUT "${ff_dest}/DISCON_WT4.dll"
+  DEPENDS DISCON
+  COMMAND "${CMAKE_COMMAND}" -E copy "${src}/DISCON/build/DISCON.dll" "${ff_dest}/DISCON_WT4.dll"
+)
 
 add_custom_target(
   regression_test_controllers
@@ -170,6 +175,7 @@ add_custom_target(
     "${ff_dest}/DISCON_WT1.dll"
     "${ff_dest}/DISCON_WT2.dll"
     "${ff_dest}/DISCON_WT3.dll"
+    "${ff_dest}/DISCON_WT4.dll"
 )
 
 add_custom_target(

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -323,6 +323,7 @@ if(BUILD_FASTFARM)
   ff_regression("LESinflow"  "fastfarm")
 #   ff_regression("Uninflow_curl"  "fastfarm")
   ff_regression("TSinflow_curl"  "fastfarm")
+  ff_regression("ModAmb_3"  "fastfarm")
 endif()
 
 # AeroDyn regression tests


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
Adds a regression test for the `Mod_AmbWind = 3` option in FAST.Farm.  Thanks to @MYMahfouz the example case.

Also updates `cmake_minimum_version` to match the main OpenFAST repository

**Related issue, if one exists**
This may have been mentioned in an issue, but I could not find one in a quick search.

**Impacted areas of the software**
New test case

**Additional supporting information**
We recommend using the `Mod_AmbWind=3` option in FAST.Farm, but have not had an example regression test until now.

Companion PR in r-test: https://github.com/OpenFAST/r-test/pull/111

**Test results, if applicable**