### PR TITLE
AD15 driver: segmentation fault with intel compiler when no blades

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -2848,6 +2848,8 @@ subroutine DiskAvgValues(p, u, m, x_hat_disk, y_hat_disk, z_hat_disk, Azimuth)
    ! calculate disk-averaged velocities
    m%AvgDiskVel = 0.0_ReKi
    m%AvgDiskVelDist = 0.0_ReKi ! TODO potentially get rid of that in the future
+   if (p%NumBlades <= 0) return  ! The Intel compiler gets array bounds issues in this routine with no blades.
+
    do k=1,p%NumBlades
       do j=1,p%NumBlNds
          m%AvgDiskVelDist = m%AvgDiskVelDist + m%DisturbedInflow(:,j,k)


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
Issue #1781 highlights a bug that appears with the intel compiler.  The `DiskAvgValues` routine can trigger a segmentation fault if there are no blades on a turbine.  The `ad_QuadRotor_OLAF` case has 5 effective turbines in the model, but only 4 rotors.  When the 5th rotor is evaluated by the `DiskAvgValues` with the Intel compiler, a segmentation fault or underflow can occur (I've seen both during debugging).  I'm not entirely sure how, but the line `m%AvgDiskVelDist = m%AvgDiskVelDist / real( p%NumBlades * p%NumBlNds, ReKi )` (AeroDyn.f90 line 2859) was triggering the access violation in mentioned bug report (reproduced on v3.5.0).

**Related issue, if one exists**
#1781

**Impacted areas of the software**
AeroDyn driver, only when a multi-rotor case is evaluated with one rotor having no blades.

**Additional supporting information**
This doesn't appear to be an issue with any of the gcc compilers, which is why we had not seen it in testing.
