### PR TITLE
Fixed drag coefficient scaling

### DIFF
--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -2215,9 +2215,9 @@ CONTAINS
          CALL MD_DestroyInput( u_array(1), ErrStat2, ErrMsg2 )
 
          ! UNboost drag coefficient of each line type   <<<
-         DO I = 1, p%nLineTypes
-            m%LineTypeList(I)%Cdn = m%LineTypeList(I)%Cdn / InputFileDat%CdScaleIC
-            m%LineTypeList(I)%Cdt = m%LineTypeList(I)%Cdt / InputFileDat%CdScaleIC
+         DO I = 1, p%nLines
+            m%LineList(I)%Cdn = m%LineList(I)%Cdn / InputFileDat%CdScaleIC
+            m%LineList(I)%Cdt = m%LineList(I)%Cdt / InputFileDat%CdScaleIC 
          END DO
 
          DO I = 1, p%nBodies

--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -2074,9 +2074,23 @@ CONTAINS
          CALL WrScr("   Finalizing initial conditions using dynamic relaxation."//NewLine)  ! newline because next line writes over itself
 
          ! boost drag coefficient of each line type  <<<<<<<< does this actually do anything or do lines hold these coefficients???
-         DO I = 1, p%nLineTypes
-            m%LineTypeList(I)%Cdn = m%LineTypeList(I)%Cdn * InputFileDat%CdScaleIC
-            m%LineTypeList(I)%Cdt = m%LineTypeList(I)%Cdt * InputFileDat%CdScaleIC   ! <<<<< need to update this to apply to all objects' drag
+         DO I = 1, p%nLines
+            m%LineList(I)%Cdn = m%LineList(I)%Cdn * InputFileDat%CdScaleIC
+            m%LineList(I)%Cdt = m%LineList(I)%Cdt * InputFileDat%CdScaleIC 
+         END DO
+
+         DO I = 1, p%nBodies
+            m%BodyList(I)%bodyCdA = m%BodyList(I)%bodyCdA * InputFileDat%CdScaleIC 
+         END Do
+
+         DO I =1, p%nRods
+            m%RodList(I)%Cdn = m%RodList(I)%Cdn * InputFileDat%CdScaleIC
+            m%RodList(I)%Cdt = m%RodList(I)%Cdt * InputFileDat%CdScaleIC
+            m%RodList(I)%CdEnd = m%RodList(I)%CdEnd * InputFileDat%CdScaleIC
+         END Do
+
+         DO I = 1, p%nPoints
+            m%PointList(I)%pointCdA = m%PointList(I)%pointCdA * InputFileDat%CdScaleIC
          END DO
 
          ! allocate array holding 10 latest fairlead tensions
@@ -2204,6 +2218,20 @@ CONTAINS
          DO I = 1, p%nLineTypes
             m%LineTypeList(I)%Cdn = m%LineTypeList(I)%Cdn / InputFileDat%CdScaleIC
             m%LineTypeList(I)%Cdt = m%LineTypeList(I)%Cdt / InputFileDat%CdScaleIC
+         END DO
+
+         DO I = 1, p%nBodies
+            m%BodyList(I)%bodyCdA = m%BodyList(I)%bodyCdA / InputFileDat%CdScaleIC 
+         END Do
+
+         DO I =1, p%nRods
+            m%RodList(I)%Cdn = m%RodList(I)%Cdn / InputFileDat%CdScaleIC
+            m%RodList(I)%Cdt = m%RodList(I)%Cdt / InputFileDat%CdScaleIC
+            m%RodList(I)%CdEnd = m%RodList(I)%CdEnd / InputFileDat%CdScaleIC
+         END Do
+
+         DO I = 1, p%nPoints
+            m%PointList(I)%pointCdA = m%PointList(I)%pointCdA / InputFileDat%CdScaleIC
          END DO
 
       end if ! InputFileDat%TMaxIC > 0


### PR DESCRIPTION
**Feature or improvement description**
Update/fix the drag scaling in the dynamic relaxation phase. 

**Related issue, if one exists**
#1815 

**Impacted areas of the software**
MoorDyn

**Additional supporting information**
n/a

**Test results, if applicable**
n/a

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
