### PR TITLE
SeaState: Fix typo in message about adjusting WvHiCOff based on WaveDT

### DIFF
--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -819,7 +819,7 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
       TmpFreq = REAL( Pi/InputFileData%Waves%WaveDT,SiKi)
       if ( InputFileData%Waves%WvHiCOff > TmpFreq ) then
          InputFileData%Waves%WvHiCOff =  TmpFreq
-         call SetErrStat( ErrID_Info,'WvLowCOff adjusted to '//trim(num2lstr(TmpFreq))//' rad/s, based on WaveDT.',ErrStat,ErrMsg,RoutineName)
+         call SetErrStat( ErrID_Info,'WvHiCOff adjusted to '//trim(num2lstr(TmpFreq))//' rad/s, based on WaveDT.',ErrStat,ErrMsg,RoutineName)
       end if
    end if
 


### PR DESCRIPTION
**Feature or improvement description**
This is a simple fix for an error in the SeaState message about adjusting WvHiCOff based on WaveDT. 

**Impacted areas of the software**
SeaState

**Test results, if applicable**
No change to test results.