### PR TITLE
IfW: check that uniform wind file time vector is always increasing

### DIFF
--- a/modules/inflowwind/src/InflowWind_IO.f90
+++ b/modules/inflowwind/src/InflowWind_IO.f90
@@ -256,6 +256,7 @@ subroutine IfW_UniformWind_Init(InitInp, SumFileUnit, UF, FileDat, ErrStat, ErrM
          call SetErrStat(ErrID_Fatal, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       end if
    end do
+   if (ErrStat >= AbortErrLev) return
 
    !----------------------------------------------------------------------------
    ! Find out information on the timesteps and range
@@ -276,6 +277,24 @@ subroutine IfW_UniformWind_Init(InitInp, SumFileUnit, UF, FileDat, ErrStat, ErrM
       WindFileConstantDT = .false.
       WindFileDT = 0.0_ReKi
    end if
+
+   !----------------------------------------------------------------------------
+   ! Check that time is always increasing
+   !----------------------------------------------------------------------------
+
+   ! Check that last timestep is always increasing
+   if (UF%DataSize > 2) then
+      do I = 2, UF%DataSize
+         if (UF%Time(I)<=UF%Time(I-1)) then
+            TmpErrMsg = ' Time vector must always increase in the uniform wind file. Error around wind step ' &
+                        //TRIM(Num2LStr(I))//' at time '//TRIM(Num2LStr(UF%Time(I)))//' in wind file ' &
+                        //TRIM(InitInp%WindFileName)//'.'
+            call SetErrStat(ErrID_Fatal, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
+            exit
+         endif
+      end do
+      if (ErrStat >= AbortErrLev) return
+   endif
 
    !----------------------------------------------------------------------------
    ! Store wind file metadata


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
If an InflowWind uniform file has time that is not sequential, OpenFAST would fail with a mysterious error that was very difficult to trace.  @RBergua discovered this while working with an external user.

**Related issue, if one exists**
None.  Internal e-mails only

**Impacted areas of the software**
Error checking for Uniform wind files in InfowWind only.

**Test results, if applicable**
No test results change.