### PR TITLE
Fix segfault in HD when no outputs specified

### DIFF
--- a/modules/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules/hydrodyn/src/HydroDyn_Input.f90
@@ -3105,7 +3105,18 @@ SUBROUTINE HydroDynInput_ProcessInitData( InitInp, Interval, InputFileData, ErrS
       IF (ErrStat >= AbortErrLev ) RETURN
 
       DEALLOCATE(foundMask)
-      
+
+   ELSE
+
+      ! Set number of outputs to zero
+      InputFileData%NumOuts = 0
+      InputFileData%Waves2%NumOuts = 0
+      InputFileData%Morison%NumOuts = 0
+
+      ! Allocate outlist with zero length
+      call AllocAry(InputFileData%OutList, 0, "InputFileData%OutList", ErrStat2, ErrMsg2); 
+      call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+
    END IF
       ! Now that we have the sub-lists organized, lets do some additional validation.
    


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
This commit fixes a bug where HydroDyn would segfault if no outputs were specified in the input file. This was caused by NumOutputs not being set for the Morison and Waves2 submodules if no outputs were specified. The segfault would occur when the OutList array was accessed with uninitialized NumOutputs variables.

This bug was been resolved in the `dev` branch during `SeaState` development.

**Related issue, if one exists**
#1863

**Impacted areas of the software**
`HydroDyn_Input.f90`