### PR TITLE
SubDyn summary file: fixes

### DIFF
--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -3837,12 +3837,12 @@ SUBROUTINE OutSummary(Init, p, m, InitInput, CBparams, Modes, Omega, Omega_Gy, E
    WRITE(UnSum, '(A9,9(A15))')  '#Member ID', 'DC(1,1)', 'DC(1,2)', 'DC(1,3)', 'DC(2,1)','DC(2,2)','DC(2,3)','DC(3,1)','DC(3,2)','DC(3,3)'
    DO i=1,p%NMembers
       mType = Init%Members(I, iMType)
-	  iNode1 = FINDLOCI(Init%Joints(:,1), Init%Members(i,2)) ! index of joint 1 of member i
+      iNode1 = FINDLOCI(Init%Joints(:,1), Init%Members(i,2)) ! index of joint 1 of member i
       iNode2 = FINDLOCI(Init%Joints(:,1), Init%Members(i,3)) ! index of joint 2 of member i
       XYZ1   = Init%Joints(iNode1,2:4)
       XYZ2   = Init%Joints(iNode2,2:4)
-	  if ((mType == idMemberSpring) .or. (mType == idMemberBeamArb)) then ! The direction cosine for these member types must be provided by the user 
-	     iDirCos = p%Elems(i, iMDirCosID)
+      if ((mType == idMemberSpring) .or. (mType == idMemberBeamArb)) then ! The direction cosine for these member types must be provided by the user
+         iDirCos = p%Elems(i, iMDirCosID)
          DirCos(1, 1) =  Init%COSMs(iDirCos, 2)
          DirCos(2, 1) =  Init%COSMs(iDirCos, 3)
          DirCos(3, 1) =  Init%COSMs(iDirCos, 4)

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -3567,6 +3567,7 @@ SUBROUTINE OutSummary(Init, p, m, InitInput, CBparams, Modes, Omega, Omega_Gy, E
    INTEGER(IntKi)         :: i, j, k, propIDs(2), Iprop(2)  !counter and temporary holders
    INTEGER(IntKi)         :: iNode1, iNode2 ! Node indices
    INTEGER(IntKi)         :: mType ! Member Type
+   INTEGER                :: iDirCos
    REAL(ReKi)             :: mMass, mLength ! Member mass and length
    REAL(ReKi)             :: M_O(6,6)    ! Equivalent mass matrix at origin
    REAL(ReKi)             :: M_P(6,6)    ! Equivalent mass matrix at P (ref point)
@@ -3835,11 +3836,25 @@ SUBROUTINE OutSummary(Init, p, m, InitInput, CBparams, Modes, Omega, Omega_Gy, E
    WRITE(UnSum, '(A, I6)') '#Direction Cosine Matrices for all Members: GLOBAL-2-LOCAL. No. of 3x3 matrices=', p%NMembers 
    WRITE(UnSum, '(A9,9(A15))')  '#Member ID', 'DC(1,1)', 'DC(1,2)', 'DC(1,3)', 'DC(2,1)','DC(2,2)','DC(2,3)','DC(3,1)','DC(3,2)','DC(3,3)'
    DO i=1,p%NMembers
-      iNode1 = FINDLOCI(Init%Joints(:,1), Init%Members(i,2)) ! index of joint 1 of member i
+      mType = Init%Members(I, iMType)
+	  iNode1 = FINDLOCI(Init%Joints(:,1), Init%Members(i,2)) ! index of joint 1 of member i
       iNode2 = FINDLOCI(Init%Joints(:,1), Init%Members(i,3)) ! index of joint 2 of member i
       XYZ1   = Init%Joints(iNode1,2:4)
       XYZ2   = Init%Joints(iNode2,2:4)
-      CALL GetDirCos(XYZ1(1:3), XYZ2(1:3), mType, DirCos, mLength, ErrStat, ErrMsg)
+	  if ((mType == idMemberSpring) .or. (mType == idMemberBeamArb)) then ! The direction cosine for these member types must be provided by the user 
+	     iDirCos = p%Elems(i, iMDirCosID)
+         DirCos(1, 1) =  Init%COSMs(iDirCos, 2)
+         DirCos(2, 1) =  Init%COSMs(iDirCos, 3)
+         DirCos(3, 1) =  Init%COSMs(iDirCos, 4)
+         DirCos(1, 2) =  Init%COSMs(iDirCos, 5)
+         DirCos(2, 2) =  Init%COSMs(iDirCos, 6)
+         DirCos(3, 2) =  Init%COSMs(iDirCos, 7)
+         DirCos(1, 3) =  Init%COSMs(iDirCos, 8)
+         DirCos(2, 3) =  Init%COSMs(iDirCos, 9)
+         DirCos(3, 3) =  Init%COSMs(iDirCos, 10)
+      else
+         CALL GetDirCos(XYZ1(1:3), XYZ2(1:3), mType, DirCos, mLength, ErrStat, ErrMsg)
+      endif
       DirCos=TRANSPOSE(DirCos) !This is now global to local
       WRITE(UnSum, '("#",I9,9(ES28.18E2))') Init%Members(i,1), ((DirCos(k,j),j=1,3),k=1,3)
    ENDDO


### PR DESCRIPTION
I believe this pull request can be merged.

**Feature or improvement description**
SubDyn can output in the summary file (`SumPrint = 1`) the cosine matrices (`OutCOSM = True`).

In the summary file, the direction cosine for a spring element is not properly written. The summary file looks as:
![Wrong](https://github.com/OpenFAST/openfast/assets/33709140/3dd7b7a8-2923-4bb5-a644-398c309d0b4c)

As can be observed, the summary file shows only zeros for the spring element. This is because the `subroutine OutSummary` tries to get the direction cosine based on the joint 1 and joint 2 of the member (and joint 1 and joint 2 are coincident for springs). In this PR, the `subroutine OutSummary` has been modified to properly account for the spring element (and arbitrary beams in the future). 

However, I believe that if the user defines a given direction cosine for a circular beam, the `subroutine GetDirCos` will also compute the direction cosine based on joint 1 and joint 2, effectively overwriting whatever the user provided as input. 

**Impacted areas of the software**
SubDyn summary file.

**Test results, if applicable**
Proper summary file:
![Right](https://github.com/OpenFAST/openfast/assets/33709140/43709f8b-dfa2-4205-85b9-c5ae751b3b04)
