### PR TITLE
ADI: probably memory leak in ADI_UpdateStates

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Inflow.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow.f90
@@ -228,10 +228,15 @@ subroutine ADI_UpdateStates( t, n, u, utimes, p, x, xd, z, OtherState, m, errSta
    ! Get state variables at next step: INPUT at step nt - 1, OUTPUT at step nt
    call AD_UpdateStates(t, n, u_AD(:), utimes(:), p%AD, x%AD, xd%AD, z%AD, OtherState%AD, m%AD, errStat2, errMsg2); if(Failed()) return
 
+   call CleanUp()
+
 contains
 
    subroutine CleanUp()
       !call ADI_DestroyConstrState(z_guess, errStat2, errMsg2); if(Failed()) return
+      do it=1,size(utimes)
+         call AD_DestroyInput(u_AD(it), errStat2, errMsg2); if(Failed()) return
+      enddo
    end subroutine
 
    logical function Failed()

--- a/modules/aerodyn/src/FVW.f90
+++ b/modules/aerodyn/src/FVW.f90
@@ -757,6 +757,7 @@ contains
 
    subroutine CleanUp()
       call FVW_DestroyConstrState(z_guess, ErrStat2, ErrMsg2); if(Failed()) return
+      call FVW_DestroyInput(uInterp, ErrStat2, ErrMsg2); if(Failed()) return
    end subroutine
 
    logical function Failed()


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
The ADI_UpdateStates routine makes a copy of the AD_Input, but never destroyed that data after usage.  This could lead to memory continuously getting allocated during a simulation with either ADI_C_Binding or the AD driver.

**Related issue, if one exists**
This issue was reported by e-mail.

**Impacted areas of the software**

- AeroDyn driver
- AeroDyn_Inflow_C_Binding library interface (for C-code coupling)

**Additional supporting information**


**Test results, if applicable**

