### PR TITLE
bug fixes from PR #1932

### DIFF
--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -1145,6 +1145,7 @@ subroutine FAST_CFD_AdvanceToNextTimeStep(iTurb, ErrStat_c, ErrMsg_c) BIND (C, N
    INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
    INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
    CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+   REAL(DbKi)                            :: t_now            ! current timestep of this turbine
 
 
    IF ( n_t_global > Turbine(iTurb)%p_FAST%n_TMax_m1 ) THEN !finish
@@ -1166,7 +1167,8 @@ subroutine FAST_CFD_AdvanceToNextTimeStep(iTurb, ErrStat_c, ErrMsg_c) BIND (C, N
 
    ELSE
 
-      CALL FAST_AdvanceToNextTimeStep_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
+      t_now = n_t_global*Turbine(iTurb)%p_FAST%dt
+      CALL FAST_AdvanceToNextTimeStep_T( t_now, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
 
       ! if(Turbine(iTurb)%SC%p%scOn) then
       !    CALL SC_SetInputs(Turbine(iTurb)%p_FAST, Turbine(iTurb)%SrvD%y, Turbine(iTurb)%SC, ErrStat, ErrMsg)
@@ -1193,8 +1195,10 @@ subroutine FAST_CFD_WriteOutput(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_
    INTEGER(C_INT),         INTENT(IN   ) :: iTurb            ! Turbine number
    INTEGER(C_INT),         INTENT(  OUT) :: ErrStat_c
    CHARACTER(KIND=C_CHAR), INTENT(  OUT) :: ErrMsg_c(IntfStrLen)
+   REAL(DbKi)                            :: t_now            ! current timestep of this turbine
 
-   CALL FAST_WriteOutput_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
+   t_now = n_t_global*Turbine(iTurb)%p_FAST%dt
+   CALL FAST_WriteOutput_T( t_now, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
 
 end subroutine FAST_CFD_WriteOutput
 !==================================================================================================================================
@@ -1228,7 +1232,7 @@ subroutine FAST_CFD_Step(iTurb, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_CFD_Ste
 
    ELSE
 
-      CALL FAST_Solution_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
+      CALL FAST_Solution_T(t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
 
       if (iTurb .eq. (NumTurbines-1) ) then
          n_t_global = n_t_global + 1

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -45,7 +45,7 @@ param	^	-	INTEGER	Module_ED	-	4	-	"ElastoDyn"	-
 param	^	-	INTEGER	Module_BD	-	5	-	"BeamDyn"	-
 param	^	-	INTEGER	Module_AD14	-	6	-	"AeroDyn14"	-
 param	^	-	INTEGER	Module_AD	-	7	-	"AeroDyn"	-
-param	^	-	INTEGER	Module_ExtLd	-	8	-	"AeroDyn"	-
+param	^	-	INTEGER	Module_ExtLd	-	8	-	"ExternalLoads"	-
 param	^	-	INTEGER	Module_SrvD	-	9	-	"ServoDyn"	-
 param	^	-	INTEGER	Module_SeaSt -	10	-	"SeaState"	-
 param	^	-	INTEGER	Module_HD	-	11	-	"HydroDyn"	-

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -8021,15 +8021,15 @@ END SUBROUTINE FAST_AdvanceToNextTimeStep
 !----------------------------------------------------------------------------------------------------------------------------------
 !> Routine that calls FAST_WriteOutput for one instance of a Turbine data structure. This is a separate subroutine so that the FAST
 !! driver programs do not need to change or operate on the individual module level.
-SUBROUTINE FAST_WriteOutput_T(t_initial, n_t_global, Turbine, ErrStat, ErrMsg )
+SUBROUTINE FAST_WriteOutput_T(t_now, n_t_global, Turbine, ErrStat, ErrMsg )
 
-   REAL(DbKi),               INTENT(IN   ) :: t_initial           !< initial time
+   REAL(DbKi),               INTENT(IN   ) :: t_now               !< current time
    INTEGER(IntKi),           INTENT(IN   ) :: n_t_global          !< loop counter
    TYPE(FAST_TurbineType),   INTENT(INOUT) :: Turbine             !< all data for one instance of a turbine
    INTEGER(IntKi),           INTENT(  OUT) :: ErrStat             !< Error status of the operation
    CHARACTER(*),             INTENT(  OUT) :: ErrMsg              !< Error message if ErrStat /= ErrID_None
 
-      CALL FAST_WriteOutput(t_initial, n_t_global, Turbine%p_FAST, Turbine%y_FAST, Turbine%m_FAST, &
+      CALL FAST_WriteOutput(t_now, n_t_global, Turbine%p_FAST, Turbine%y_FAST, Turbine%m_FAST, &
                   Turbine%ED, Turbine%BD, Turbine%SrvD, Turbine%AD14, Turbine%AD, Turbine%ExtLd, Turbine%IfW, Turbine%ExtInfw, Turbine%SC_DX, &
                   Turbine%SeaSt, Turbine%HD, Turbine%SD, Turbine%ExtPtfm, Turbine%MAP, Turbine%FEAM, Turbine%MD, Turbine%Orca, &
                   Turbine%IceF, Turbine%IceD, Turbine%MeshMapData, ErrStat, ErrMsg )
@@ -8037,10 +8037,10 @@ SUBROUTINE FAST_WriteOutput_T(t_initial, n_t_global, Turbine, ErrStat, ErrMsg )
 END SUBROUTINE FAST_WriteOutput_T
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine writes the outputs at this timestep
-SUBROUTINE FAST_WriteOutput(t_global, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, AD14, AD, ExtLd, IfW, ExtInfw, SC_DX, &
+SUBROUTINE FAST_WriteOutput(t_now, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, AD14, AD, ExtLd, IfW, ExtInfw, SC_DX, &
                   SeaSt, HD, SD, ExtPtfm, MAPp, FEAM, MD, Orca, IceF, IceD, MeshMapData, ErrStat, ErrMsg )
 
-   REAL(DbKi),               INTENT(IN   ) :: t_global            !< initial time
+   REAL(DbKi),               INTENT(IN   ) :: t_now               !< initial time
    INTEGER(IntKi),           INTENT(IN   ) :: n_t_global          !< loop counter
 
    TYPE(FAST_ParameterType), INTENT(IN   ) :: p_FAST              !< Parameters for the glue code
@@ -8087,7 +8087,7 @@ SUBROUTINE FAST_WriteOutput(t_global, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD
    !----------------------------------------------------------------------------------------
    !! Check to see if we should output data this time step:
    !----------------------------------------------------------------------------------------
-   CALL WriteOutputToFile(n_t_global, m_FAST%t_global, p_FAST, y_FAST, ED, BD, AD14, AD, IfW, ExtInfw, SeaSt, HD, SD, ExtPtfm, &
+   CALL WriteOutputToFile(n_t_global, t_now, p_FAST, y_FAST, ED, BD, AD14, AD, IfW, ExtInfw, SeaSt, HD, SD, ExtPtfm, &
                           SrvD, MAPp, FEAM, MD, Orca, IceF, IceD, MeshMapData, ErrStat2, ErrMsg2)
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -60,7 +60,7 @@ IMPLICIT NONE
     INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_BD = 5      ! BeamDyn [-]
     INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_AD14 = 6      ! AeroDyn14 [-]
     INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_AD = 7      ! AeroDyn [-]
-    INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_ExtLd = 8      ! AeroDyn [-]
+    INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_ExtLd = 8      ! ExternalLoads [-]
     INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_SrvD = 9      ! ServoDyn [-]
     INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_SeaSt = 10      ! SeaState [-]
     INTEGER(IntKi), PUBLIC, PARAMETER  :: Module_HD = 11      ! HydroDyn [-]


### PR DESCRIPTION
This is not ready for merging yet.

**Feature or improvement description**
A few minor bugs were discovered after merging #1932.

- Wrong name for the `ExtLoads` module (would show in summary file incorrectly)

During PR #1932, there was some confusion about the use of the `t_initial` value in the `WriteOutputToFile` which was introduced while splitting `FAST_Solution` into multiple routines.  The `FAST_Library.f90` had been calling the `FAST_WriteOutput` with the original `t_initial` which is set to zero, but this would the timestamp in all text files to zero (it did not affect the binary writing).  To get around this, the `m_FAST%t_global` value was used in calling `WriteOutputToFile` in `FAST_Subs.f90`.  But this approach was incorrect - instead the `t_initial` from `FAST_Library` should have been the current time.  To reduce confusion going forward, `t_initial` has been changed to `t_now` in `FAST_Subs` where appropriate.
- change `t_initial` to calculated `t_now` in `FAST_Library` calls to file writing
- change `t_initial` to `t_now` in file writing routines in `FAST_Subs` for consistency
- replace `m_FAST%t_global` with `t_now` in `FAST_Subs::WriteOutputToFile` call

**Related issue, if one exists**
- https://github.com/OpenFAST/openfast/pull/1932#discussion_r1430444257
- https://github.com/OpenFAST/openfast/pull/1932#discussion_r1430454778

**Impacted areas of the software**
- glue code
- summary files from OpenFAST

**Additional supporting information**


**Test results, if applicable**
No test results change with this PR (so far)