### PR TITLE
Option to turn off unit_tests from cmake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,7 +67,10 @@ endif()
 option(BUILD_TESTING "Build the testing tree." OFF)
 if(BUILD_TESTING)
   option(CODECOVERAGE "Enable infrastructure for measuring code coverage." OFF)
-  set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DUNIT_TEST")
+  option(BUILD_UNIT_TESTING "Enable unit testing" ON)
+  if(BUILD_UNIT_TESTING)
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -DUNIT_TEST")
+  endif()
 endif()
 
 # Setup Fortran Compiler options based on architecture/compiler
@@ -276,8 +279,10 @@ if(BUILD_TESTING)
   add_subdirectory(reg_tests)
 
   # unit tests
-  if(NOT (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Flang"))
-    add_subdirectory(unit_tests)
+  if(BUILD_UNIT_TESTING)
+    if(NOT (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Flang"))
+      add_subdirectory(unit_tests)
+    endif()
   endif()
 endif()
 

--- a/docs/source/testing/unit_test.rst
+++ b/docs/source/testing/unit_test.rst
@@ -12,7 +12,8 @@ Unit testing in OpenFAST modules is accomplished through `pFUnit <https://github
 This framework provides a Fortran abstraction to the popular
 `xUnit <https://en.wikipedia.org/wiki/XUnit>`__ structure. pFUnit is compiled
 along with OpenFAST through CMake when the CMake variable ``BUILD_TESTING`` is
-turned on.
+turned on (default off) and the CMake variable ``BUILD_UNIT_TESTING`` is on
+(turned on by default when ``BUILD_TEST`` is on).
 
 The BeamDyn and NWTC Library modules contain some sample unit tests and should
 serve as a reference for future development and testing.
@@ -21,7 +22,7 @@ Dependencies
 ------------
 The following packages are required for unit testing:
 
-- Python 3.7+
+- Python 3.7+, <3.12
 - CMake
 - pFUnit - Included in OpenFAST repo through a git-submodule
 


### PR DESCRIPTION
This PR is ready to merge.

**Feature or improvement description**
Previously anytime the `BUILD_TESTING` option in CMake was turned on, unit tests would also be run.  However, Kestrel cannot currently run the unit testing, so an option to turn that off separately is needed.

A new CMake variable `BUILD_UNIT_TESTING` is now turned on if `BUILD_TESTING` is on.  This option can be separately specified for scenarios where pfunit used in testing is not available.

**Related issue, if one exists**
#1948

**Impacted areas of the software**
Unit testing.

**Additional supporting information**
We are currently using `pfunit` version 3.2.10, which is 6+ years old (current version is 4.8).  We don't have resources at present to deploy the newer `pfunit` or fix the issues on Kestrel, so a workaround is needed for these rare cases.

**Test results, if applicable**
