### PR TITLE
Use AD tower diameter for VTK visualization + minor improvements

### DIFF
--- a/modules/aerodyn/src/AirfoilInfo.f90
+++ b/modules/aerodyn/src/AirfoilInfo.f90
@@ -424,7 +424,7 @@ CONTAINS
             RETURN
          END IF
          
-         ! RelThickness, default is 0.2 if user doesn't know it, only used for Boing-Vertol UA model = 7
+         ! RelThickness, default is 0.2 if user doesn't know it, only used for Boeing-Vertol UA model = 7
       CALL ParseVarWDefault ( FileInfo, CurLine, 'RelThickness', p%RelThickness, 0.2_ReKi, ErrStat2, ErrMsg2, UnEc )
          if (ErrStat2 >= AbortErrLev) then ! if the line is missing, set RelThickness = -1 and move on...
             p%RelThickness=-1 ! To trigger an error

--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -28,7 +28,7 @@
 !        Development plan for the aerodynamic linearization in OpenFAST
 !        Unpublished
 !
-!   [70] User Documentation / AeroDyn / Unsteady Aerodynamics / Boing-Vertol model
+!   [70] User Documentation / AeroDyn / Unsteady Aerodynamics / Boeing-Vertol model
 !        https://openfast.readthedocs.io/
 !
 !   [other] R. Damiani and G. Hayman (2017)
@@ -1424,7 +1424,7 @@ subroutine UA_ValidateInput(InitInp, ErrStat, ErrMsg)
 
    if (InitInp%UAMod < UA_Gonzalez .or. InitInp%UAMod > UA_BV ) call SetErrStat( ErrID_Fatal, &
       "In this version, UAMod must be 2 (Gonzalez's variant), 3 (Minnema/Pierce variant), 4 (continuous HGM model), 5 (HGM with vortex), &
-      &6 (Oye), 7 (Boing-Vertol)", ErrStat, ErrMsg, RoutineName )  ! NOTE: for later-  1 (baseline/original) 
+      &6 (Oye), 7 (Boeing-Vertol)", ErrStat, ErrMsg, RoutineName )  ! NOTE: for later-  1 (baseline/original) 
       
    if (.not. InitInp%FLookUp ) call SetErrStat( ErrID_Fatal, 'FLookUp must be TRUE for this version.', ErrStat, ErrMsg, RoutineName )
    
@@ -1664,7 +1664,7 @@ subroutine UA_TurnOff_param(p, AFInfo, ErrStat, ErrMsg)
 
 end subroutine UA_TurnOff_param
 !============================================================================== 
-!> Update discrete states for Boieng Vertol model
+!> Update discrete states for Boeing Vertol model
 subroutine UA_UpdateDiscOtherState_BV( i, j, u, p, xd, OtherState, AFInfo, m, ErrStat, ErrMsg )   
    integer   ,                   intent(in   )  :: i           !< node index within a blade
    integer   ,                   intent(in   )  :: j           !< blade index    
@@ -3756,7 +3756,7 @@ subroutine UA_CalcOutput( i, j, t, u_in, p, x, xd, OtherState, AFInfo, y, misc, 
 #endif
 
 contains 
-   !> Calc Outputs for Boieng-Vertol dynamic stall
+   !> Calc Outputs for Boeing-Vertol dynamic stall
    !! See BV_DynStall.f95 of CACTUS, and [70], notations kept more or less consistent
    subroutine BV_CalcOutput()
       real(ReKi) :: alpha_50

--- a/modules/hydrodyn/src/HydroDyn.txt
+++ b/modules/hydrodyn/src/HydroDyn.txt
@@ -21,7 +21,6 @@ usefrom   WAMIT.txt
 usefrom   WAMIT2.txt
 usefrom   Morison.txt
 usefrom   SeaSt_WaveField.txt
-usefrom   SeaState.txt
 
 param     HydroDyn/HydroDyn            unused                        INTEGER                  MaxHDOutputs                    -          510        -         "The maximum number of output channels supported by this module"    -
 param     HydroDyn/HydroDyn            unused                        INTEGER                  MaxUserOutputs                  -         5150        -         " Total possible number of output channels:  SS_Excitation = 7 + SS_Radiation = 7 + Morison= 4626 + HydroDyn=510   =  5150" -

--- a/modules/hydrodyn/src/HydroDyn_Types.f90
+++ b/modules/hydrodyn/src/HydroDyn_Types.f90
@@ -37,7 +37,6 @@ USE SS_Excitation_Types
 USE WAMIT_Types
 USE WAMIT2_Types
 USE Morison_Types
-USE SeaState_Types
 USE NWTC_Library
 IMPLICIT NONE
     INTEGER(IntKi), PUBLIC, PARAMETER  :: MaxHDOutputs = 510      ! The maximum number of output channels supported by this module [-]

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -726,7 +726,7 @@ CONTAINS
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
    IF ( ErrStat /= 0 ) THEN
       ErrStat = ErrID_Fatal
-      ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_REAL))//&
+      ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_R4Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
    ELSE
       ErrStat = ErrID_None
@@ -763,7 +763,7 @@ CONTAINS
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
    IF ( ErrStat /= 0 ) THEN
       ErrStat = ErrID_Fatal
-      ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_REAL))//&
+      ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_R8Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
    ELSE
       ErrStat = ErrID_None
@@ -901,7 +901,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*BYTES_IN_SiKi))//' bytes of memory for the '//TRIM( Descr )//' array.'
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*BYTES_IN_R4Ki))//' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
       ErrStat = ErrID_None
@@ -971,7 +971,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*BYTES_IN_SiKi))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*BYTES_IN_R4Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
@@ -1047,7 +1047,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_REAL))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_R4Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
@@ -1084,7 +1084,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_REAL))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*BYTES_IN_R8Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
@@ -1122,7 +1122,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*BYTES_IN_REAL))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*BYTES_IN_R4Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
@@ -1160,7 +1160,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*BYTES_IN_REAL))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*BYTES_IN_R8Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
@@ -1199,7 +1199,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*AryDim5*BYTES_IN_REAL))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*AryDim5*BYTES_IN_R4Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE
@@ -1240,7 +1240,7 @@ CONTAINS
       IF ( ALLOCATED(Ary) ) THEN ! or Sttus=151 on IVF
          ErrMsg = 'Error allocating memory for the '//TRIM( Descr )//' array; array was already allocated.'
       ELSE
-         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*AryDim5*BYTES_IN_REAL))//&
+         ErrMsg = 'Error allocating '//TRIM(Num2LStr(AryDim1*AryDim2*AryDim3*AryDim4*AryDim5*BYTES_IN_R8Ki))//&
                   ' bytes of memory for the '//TRIM( Descr )//' array.'
       END IF
    ELSE

--- a/modules/nwtc-library/src/Registry_NWTC_Library.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library.txt
@@ -24,10 +24,10 @@ typedef     ^             ^                 CHARACTER(ChanLen)       Name   - - 
 typedef     ^             ^                 CHARACTER(ChanLen)       Units  - - - "Units this channel is specified in"
 typedef     ^             ^                 IntKi                    SignM  - - - "Multiplier for output channel; usually -1 (minus) or 0 (invalid channel)"
 
-typedef   NWTC_Library  FileInfoType        IntKi                    NumLines
-typedef     ^             ^                 IntKi                    NumFiles
-typedef     ^             ^                 IntKi                    FileLine  {:}
-typedef     ^             ^                 IntKi                    FileIndx  {:}
+typedef   NWTC_Library  FileInfoType        IntKi                          NumLines
+typedef     ^             ^                 IntKi                          NumFiles
+typedef     ^             ^                 IntKi                          FileLine  {:}
+typedef     ^             ^                 IntKi                          FileIndx  {:}
 typedef     ^             ^                 CHARACTER(MaxFileInfoLineLen)  FileList  {:}
 typedef     ^             ^                 CHARACTER(MaxFileInfoLineLen)  Lines     {:}
 
@@ -35,9 +35,9 @@ typedef   NWTC_Library  Quaternion          ReKi                     q0
 typedef     ^             ^                 ReKi                     v  {3}
 
 typedef   NWTC_Library  NWTC_RandomNumber_ParameterType   IntKi                pRNG
-typedef     ^             ^                     IntKi                RandSeed          {3}
-typedef     ^             ^                     IntKi                RandSeedAry       {:}
-typedef     ^             ^              CHARACTER(6)                RNG_type
+typedef     ^             ^                               IntKi                RandSeed          {3}
+typedef     ^             ^                               IntKi                RandSeedAry       {:}
+typedef     ^             ^                        CHARACTER(6)                RNG_type
 
 # This file defines types that may be  used from the NWTC_Library
 # include this into a component registry file if you wish to use these types
@@ -76,6 +76,6 @@ typedef     ^               ^               R8Ki                     DisplacedPo
 typedef     ^               ^               R8Ki                     LoadLn2_A_Mat     {:}{:}    - - "The 3-components of the forces for each node of an element in the point-to-line load mapping (for each element)"
 typedef     ^               ^               R8Ki                     LoadLn2_F         {:}{:}    - - "The 6-by-6 matrix that makes up the diagonal of the [A 0; B A] matrix in the point-to-line load mapping"
 typedef     ^               ^               R8Ki                     LoadLn2_M         {:}{:}    - - "The 3-components of the moments for each node of an element in the point-to-line load mapping (for each element)"
-typedef     ^             ^                 MeshMapLinearizationType dM
-#typedef     ^               ^               MeshType                 Lumped_Points_Dest -        - - "temporary mesh for debugging the lumped values in the line2-to-line2"
+typedef     ^               ^               MeshMapLinearizationType dM
+#typedef    ^               ^               MeshType                 Lumped_Points_Dest -        - - "temporary mesh for debugging the lumped values in the line2-to-line2"
 

--- a/modules/nwtc-library/src/SysIVF.f90
+++ b/modules/nwtc-library/src/SysIVF.f90
@@ -193,18 +193,18 @@ END SUBROUTINE Get_CWD
 !> This routine creates a given directory if it does not already exist.
 SUBROUTINE MKDIR ( new_directory_path )
 
+   USE IFPORT, ONLY: MAKEDIRQQ
    implicit none
 
    character(*), intent(in) :: new_directory_path
-   character(1024)          :: make_command
    logical                  :: directory_exists
+   logical                  :: success
 
    ! Check if the directory exists first
    inquire( directory=trim(new_directory_path), exist=directory_exists )
 
    if ( .NOT. directory_exists ) then
-      make_command = 'mkdir "'//trim(new_directory_path)//'"'
-      call system( make_command )
+      success = MAKEDIRQQ( trim(new_directory_path) )
    endif
 
 END SUBROUTINE MKDIR

--- a/modules/nwtc-library/src/SysMatlabWindows.f90
+++ b/modules/nwtc-library/src/SysMatlabWindows.f90
@@ -47,7 +47,6 @@ MODULE SysSubs
 !=======================================================================
 
 
-   INTEGER, PARAMETER            :: ConRecL     = 120                               ! The record length for console output.
    INTEGER, PARAMETER            :: CU          = 6                                 ! The I/O unit for the console.
    INTEGER, PARAMETER            :: MaxWrScrLen = 98                                ! The maximum number of characters allowed to be written to a line in WrScr
 

--- a/modules/nwtc-library/src/VTK.f90
+++ b/modules/nwtc-library/src/VTK.f90
@@ -12,8 +12,8 @@ module VTK
 
    implicit none
 
-   character(8), parameter :: RFMT='E17.8E3'
-   character(8), parameter :: IFMT='I7'
+   character(*), parameter :: RFMT='E17.8E3'
+   character(*), parameter :: IFMT='I7'
 
    ! Internal type to ensure the same options are used in between calls for the functions vtk_*
    TYPE, PUBLIC :: VTK_Misc

--- a/modules/nwtc-library/src/readme.txt
+++ b/modules/nwtc-library/src/readme.txt
@@ -1,8 +1,0 @@
-The two NWTC_Library-related types files cannot be generated through the registry.  At the moment it is a manual process.
-   
-The NWTC registry input file gets split into two sections: one for the mesh mapping and everything else. 
-It's not an automatic process since you have to copy the SetErrStat routine into NWTC_Library_Types.f90, 
-and you have to copy the mesh-related types/routines into the ModMesh_Types.f90 file. 
-Originally, we also had to change some other parts, too, but I've hard-coded some stuff 
-in the registry source code for when it is trying to generate types for the NWTC_Library module. 
-We could hard-code the registry to generate SetErrStat() at some point, too.

--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -2275,8 +2275,6 @@ SUBROUTINE Linear_SD_InputSolve_du( p_FAST, y_FAST, SrvD, u_SD, y_SD, y_ED, HD, 
          ! Transfer MAP loads to ED PlatformPtmesh input:
          ! we're mapping loads, so we also need the sibling meshes' displacements:
 
-      MAP_Start = y_FAST%Lin%Modules(MODULE_MAP)%Instance(1)%LinStartIndx(LIN_INPUT_COL)
-   
          MAP_Start = y_FAST%Lin%Modules(MODULE_MAP)%Instance(1)%LinStartIndx(LIN_INPUT_COL)
       
          ! NOTE: Assumes at least one MAP Fairlead point    

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -3974,7 +3974,7 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_AD, InitInData_S
 
 
    IF ( p_FAST%CompAero == Module_AD .and. allocated(InitOutData_AD%rotors) .and. allocated(AD%y%rotors) ) THEN  ! These meshes may have tower diameter data associated with nodes
-      UseADtwr = allocated(InitOutData_AD%rotors(1)%TowerRad)
+      UseADtwr = allocated(InitOutData_AD%rotors(1)%TwrDiam)
    ELSE
       UseADtwr = .false.
    END IF
@@ -3984,7 +3984,7 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_AD, InitInData_S
          ! This assumes a vertical tower (i.e., we deal only with z component of position)
       Indx = 1
       do k=1,TowerMotionMesh%NNodes
-         p_FAST%VTK_Surface%TowerRad(k) = InterpStp( TowerMotionMesh%Position(3,k), AD%y%rotors(1)%TowerLoad%Position(3,:), InitOutData_AD%rotors(1)%TowerRad, Indx, AD%y%rotors(1)%TowerLoad%NNodes )
+         p_FAST%VTK_Surface%TowerRad(k) = InterpStp( TowerMotionMesh%Position(3,k), AD%y%rotors(1)%TowerLoad%Position(3,:), InitOutData_AD%rotors(1)%TwrDiam, Indx, AD%y%rotors(1)%TowerLoad%NNodes ) / 2.0_ReKi
       end do
    
    else

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -3984,7 +3984,7 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_AD, InitInData_S
          ! This assumes a vertical tower (i.e., we deal only with z component of position)
       Indx = 1
       do k=1,TowerMotionMesh%NNodes
-         p_FAST%VTK_Surface%TowerRad(k) = InterpStp( TowerMotionMesh%Position(3,k), AD%y%rotors(1)%TowerLoad%Position(3,:), InitOutData_AD%rotors(1)%TwrDiam, Indx, AD%y%rotors(1)%TowerLoad%NNodes ) / 2.0_ReKi
+         p_FAST%VTK_Surface%TowerRad(k) = InterpStp( TowerMotionMesh%Position(3,k), InitOutData_AD%rotors(1)%TwrElev, InitOutData_AD%rotors(1)%TwrDiam, Indx, size(InitOutData_AD%rotors(1)%TwrElev) ) / 2.0_ReKi
       end do
    
    else

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1127,7 +1127,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       Init%InData_FEAM%NStepWave   = 1                          ! an arbitrary number > 0 (to set the size of the wave data, which currently contains all zero values)     
       Init%InData_FEAM%gravity     = p_FAST%Gravity     ! This need to be according to g from driver
       Init%InData_FEAM%WtrDens     = Init%OutData_SeaSt%WaveField%WtrDens     ! This needs to be set according to seawater density in SeaState
-!      Init%InData_FEAM%depth       =  Init%OutData_SeaSt%WtrDpth    ! This need to be set according to the water depth in SeaState
+!      Init%InData_FEAM%depth       =  Init%OutData_SeaSt%WaveField%WtrDpth    ! This need to be set according to the water depth in SeaState
 
       CALL FEAM_Init( Init%InData_FEAM, FEAM%Input(1), FEAM%p,  FEAM%x(STATE_CURR), FEAM%xd(STATE_CURR), FEAM%z(STATE_CURR), &
                       FEAM%OtherSt(STATE_CURR), FEAM%y, FEAM%m, p_FAST%dt_module( MODULE_FEAM ), Init%OutData_FEAM, ErrStat2, ErrMsg2 )
@@ -3853,7 +3853,7 @@ SUBROUTINE SetVTKParameters_B4SeaSt(p_FAST, InitOutData_ED, InitInData_SeaSt, BD
       n = 1
       do i=1,p_FAST%VTK_surface%NWaveElevPts(1)
          do j=1,p_FAST%VTK_surface%NWaveElevPts(2)
-            InitInData_SeaSt%WaveElevXY(1,n) = dx*(i-1) - WidthBy2 !+ p_FAST%TurbinePos(1) ! HD takes p_FAST%TurbinePos into account already
+            InitInData_SeaSt%WaveElevXY(1,n) = dx*(i-1) - WidthBy2 !+ p_FAST%TurbinePos(1) ! SeaSt takes p_FAST%TurbinePos into account already
             InitInData_SeaSt%WaveElevXY(2,n) = dy*(j-1) - WidthBy2 !+ p_FAST%TurbinePos(2)
             n = n+1
          end do

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -6362,7 +6362,7 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD, IfW
 
 
    logical, parameter                      :: OutputFields = .FALSE. ! due to confusion about what fields mean on a surface, we are going to just output the basic meshes if people ask for fields
-   INTEGER(IntKi)                          :: NumBl, k, l
+   INTEGER(IntKi)                          :: NumBl, k, L
    INTEGER(IntKi)                          :: ErrStat2
    CHARACTER(ErrMsgLen)                    :: ErrMSg2
    CHARACTER(*), PARAMETER                 :: RoutineName = 'WrVTK_Surfaces'
@@ -6451,18 +6451,18 @@ SUBROUTINE WrVTK_Surfaces(t_global, p_FAST, y_FAST, MeshMapData, ED, BD, AD, IfW
    if ( p_FAST%CompMooring == Module_MD ) THEN
       !call MeshWrVTK(p_FAST%TurbinePos, MD%Input(1)%CoupledKinematics, trim(p_FAST%VTK_OutFileRoot)//'.MD_PtFair_motion', y_FAST%VTK_count, OutputFields, ErrStat2, ErrMsg2 )        
       if (allocated(MD%y%VisLinesMesh)) then
-         do l=1,size(MD%y%VisLinesMesh)
-            if (MD%y%VisLinesMesh(l)%Committed) then  ! No orientation data, so surface representation not possible
-               call MeshWrVTK(p_FAST%TurbinePos, MD%y%VisLinesMesh(l), trim(p_FAST%VTK_OutFileRoot)//'.MD_Line'//trim(Num2LStr(l)), y_FAST%VTK_count, p_FAST%VTK_fields, &
+         do L=1,size(MD%y%VisLinesMesh)
+            if (MD%y%VisLinesMesh(L)%Committed) then  ! No orientation data, so surface representation not possible
+               call MeshWrVTK(p_FAST%TurbinePos, MD%y%VisLinesMesh(L), trim(p_FAST%VTK_OutFileRoot)//'.MD_Line'//trim(Num2LStr(L)), y_FAST%VTK_count, p_FAST%VTK_fields, &
                      ErrSTat2, ErrMsg2, p_FAST%VTK_tWidth )
             endif
          enddo
       endif
       if (allocated(MD%y%VisRodsMesh)) then
-         do l=1,size(MD%y%VisRodsMesh)
-            if (MD%y%VisRodsMesh(l)%Committed) then  ! No orientation data, so surface representation not possible
-               call MeshWrVTK_Ln2Surface(p_FAST%TurbinePos, MD%y%VisRodsMesh(l), trim(p_FAST%VTK_OutFileRoot)//'.MD_Rod'//trim(Num2LStr(l))//'Surface', y_FAST%VTK_count, p_FAST%VTK_fields, &
-                     ErrSTat2, ErrMsg2, p_FAST%VTK_tWidth, NumSegments=p_FAST%VTK_Surface%NumSectors, Radius=MD%p%VisRodsDiam(l)%Diam )
+         do L=1,size(MD%y%VisRodsMesh)
+            if (MD%y%VisRodsMesh(L)%Committed) then  ! No orientation data, so surface representation not possible
+               call MeshWrVTK_Ln2Surface(p_FAST%TurbinePos, MD%y%VisRodsMesh(L), trim(p_FAST%VTK_OutFileRoot)//'.MD_Rod'//trim(Num2LStr(L))//'Surface', y_FAST%VTK_count, p_FAST%VTK_fields, &
+                     ErrSTat2, ErrMsg2, p_FAST%VTK_tWidth, NumSegments=p_FAST%VTK_Surface%NumSectors, Radius=MD%p%VisRodsDiam(L)%Diam )
             endif
          enddo
       endif

--- a/modules/openfast-registry/src/registry_gen_fortran.cpp
+++ b/modules/openfast-registry/src/registry_gen_fortran.cpp
@@ -116,7 +116,10 @@ void Registry::gen_fortran_module(const Module &mod, const std::string &out_dir)
         // verify that it does, otherwise exit with error
         if ((ddt.interface != nullptr) && ddt.interface->only_reals)
             if (!ddt.only_contains_reals())
+            {
+                std::cerr << "Registry warning: Data type '" << dt_name << "' contains non-real values." << std::endl;
                 exit(EXIT_FAILURE);
+            }
 
         // Write derived type header
         w << "! =========  " << ddt.type_fortran << (this->gen_c_code ? "_C" : "") << "  =======\n";


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
- If AeroDyn has tower diameter information, that is used for VTK visualization of the tower surface. Otherwise, it will use a tower diameter based on the NREL 5MW turbine (like it did before).
- The Registry now prints an error message before ending if a data type that should only contain reals finds an invalid type.
- Removed unnecessary dependency on SeaState in HydroDyn.
- Fixed some typos:
   - The word "Boeing" was misspelled in a few places.
   - The NWTC Library was potentially using the wrong number of bytes in some of its error messages if an array couldn't be allocated.
   - A line computing an index was repeated twice in FAST_Lin (likely a result of a merge).
   - I changed the case of the variable "l" to "L" for readability (it's easy to confuse lower-case l with the number 1 in some fonts)

**Related issue, if one exists**
None

**Impacted areas of the software**
- Tower surface VTK visualization
- Some error messages throughout the code

**Test results, if applicable**
This does not change any test-case results. Only cases with AeroDyn tower diameter with VTK surfaces would look any different, but we don't have those kinds of tests.
