### PR TITLE
SeaState: fix grid size in wave surface visualization

### DIFF
--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -76,8 +76,9 @@ typedef	^	FAST_VTK_SurfaceType	SiKi	GroundRad	-	-	-	"radius for plotting circle 
 typedef	^	FAST_VTK_SurfaceType	SiKi	NacelleBox	{3}{8}	-	-	"X-Y-Z locations of 8 points that define the nacelle box, relative to the nacelle position"	m
 typedef	^	FAST_VTK_SurfaceType	SiKi	TowerRad	{:}	-	-	"radius of each ED tower node"	m
 typedef	^	FAST_VTK_SurfaceType	IntKi	NWaveElevPts	{2}	-	-	"number of points for wave elevation visualization"	-
-typedef	^	FAST_VTK_SurfaceType	SiKi	WaveElevXY	{:}{:}	-	-	"X-Y locations for WaveElev output (for visualization).  First dimension is the X (1) and Y (2) coordinate.  Second dimension is the point number."	"m,-"
-typedef	^	FAST_VTK_SurfaceType	SiKi	WaveElev	{:}{:}	-	-	"wave elevation at WaveElevXY; first dimension is time step; second dimension is point number"	"m,-"
+typedef	^	FAST_VTK_SurfaceType	SiKi	WaveElevVisX	{:}	-	-	"X locations for WaveElev output (for visualization)."	"m,-"
+typedef	^	FAST_VTK_SurfaceType	SiKi	WaveElevVisY	{:}	-	-	"Y locations for WaveElev output (for visualization)."	"m,-"
+typedef	^	FAST_VTK_SurfaceType	SiKi	WaveElevVisGrid	{:}{:}{:}	-	-	"wave elevation at WaveElevVis{XY}; first dimension is time step; second/third dimensions are grid of elevations"	"m,-"
 typedef	^	FAST_VTK_SurfaceType	FAST_VTK_BLSurfaceType	BladeShape	{:}	-	-	"AirfoilCoords for each blade"	m
 typedef	^	FAST_VTK_SurfaceType	SiKi	MorisonVisRad	{:}	-	-	"radius of each Morison node"	m
 

--- a/modules/seastate/src/SeaState.txt
+++ b/modules/seastate/src/SeaState.txt
@@ -73,13 +73,15 @@ typedef   ^                  ^                      ReKi                     def
 typedef   ^                  ^                      ReKi                     defWtrDpth                      -          -          -         "Default water depth from the driver; may be overwritten                        "  "m"
 typedef   ^                  ^                      ReKi                     defMSL2SWL                      -          -          -         "Default mean sea level to still water level from the driver; may be overwritten"  "m"
 typedef   ^                  ^                      DbKi                     TMax                            -          -          -         "Supplied by Driver:  The total simulation time"    "(sec)"
-typedef   ^                  ^                      SiKi                     WaveElevXY                      {:}{:}     -          -         "Supplied by Driver:  X-Y locations for WaveElevation output (for visualization).  First dimension is the X (1) and Y (2) coordinate.  Second dimension is the point number."    "m,-"
 typedef   ^                  ^                      INTEGER                  WaveFieldMod                    -          -          -         "Wave field handling (-) (switch) 0: use individual SeaState inputs without adjustment, 1: adjust wave phases based on turbine offsets from farm origin"   -
 typedef   ^                  ^                      ReKi                     PtfmLocationX                   -          -          -         "Supplied by Driver:  X coordinate of platform location in the wave field"    "m"
 typedef   ^                  ^                      ReKi                     PtfmLocationY                   -          -          -         "Supplied by Driver:  Y coordinate of platform location in the wave field"    "m"
 typedef   ^                  ^                      IntKi                    WrWvKinMod                      -          0          -         "0,1, or 2 indicating whether we are going to write out kinematics files.  [ignored if WaveMod = 6, if 1 or 2 then files are written using the outrootname]" -
 typedef   ^                  ^                      LOGICAL                  HasIce                          -          -          -         "Supplied by Driver:  Whether this simulation has ice loading (flag)"    -
 typedef   ^                  ^                      Logical                  Linearize                       -     .FALSE.         -         "Flag that tells this module if the glue code wants to linearize."	-
+typedef   ^                  ^                      Logical                  SurfaceVis                      -     .FALSE.         -         "Turn on grid surface visualization outputs" -
+typedef   ^                  ^                      IntKi                    SurfaceVisNx                    -          0          -         "Number of points in X direction to output for visualization grid.  Use 0 or negative to set to SeaState resolution." -
+typedef   ^                  ^                      IntKi                    SurfaceVisNy                    -          0          -         "Number of points in Y direction to output for visualization grid.  Use 0 or negative to set to SeaState resolution." -
 
 #
 #
@@ -89,8 +91,11 @@ typedef   ^                  InitOutputType         CHARACTER(ChanLen)       Wri
 typedef   ^                  ^                      CHARACTER(ChanLen)       WriteOutputUnt    {:}     -      -  "The is the list of all HD-related output channel unit strings (includes all sub-module channels)"    -
 typedef   ^                  ^                      ProgDesc                 Ver                -      -      -  "Version of SeaState"
 typedef   ^                  ^                      LOGICAL                  InvalidWithSSExctn -      -      -  "Whether SeaState configuration is invalid with HydroDyn's state-space excitation (ExctnMod=2)" (-)
-typedef   ^                  ^                      SiKi                     WaveElevSeries    {:}{:}  -      -  "Wave elevation time-series at each of the points given by WaveElevXY.  First dimension is the timestep. Second dimension is XY point number corresponding to second dimension of WaveElevXY." (m)
+typedef   ^                  ^                      SiKi                     WaveElevVisX       {:}     -      -  "X locations of grid output"    "m,-"
+typedef   ^                  ^                      SiKi                     WaveElevVisY       {:}     -      -  "X locations of grid output"    "m,-"
+typedef   ^                  ^                      SiKi                     WaveElevVisGrid    {:}{:}{:}  -   -  "Wave elevation time-series at each of the points given by WaveElevXY.  First dimension is the timestep. Second/third dimensions are the grid of points." (m)
 typedef   ^                  ^                      SeaSt_WaveFieldType     *WaveField          -      -      -  "Pointer to wave field"
+
 #                            
 #                            
 # ..... States ....................................................................................................................

--- a/modules/seastate/src/SeaState_Types.f90
+++ b/modules/seastate/src/SeaState_Types.f90
@@ -94,13 +94,15 @@ IMPLICIT NONE
     REAL(ReKi)  :: defWtrDpth = 0.0_ReKi      !< Default water depth from the driver; may be overwritten                         [m]
     REAL(ReKi)  :: defMSL2SWL = 0.0_ReKi      !< Default mean sea level to still water level from the driver; may be overwritten [m]
     REAL(DbKi)  :: TMax = 0.0_R8Ki      !< Supplied by Driver:  The total simulation time [(sec)]
-    REAL(SiKi) , DIMENSION(:,:), ALLOCATABLE  :: WaveElevXY      !< Supplied by Driver:  X-Y locations for WaveElevation output (for visualization).  First dimension is the X (1) and Y (2) coordinate.  Second dimension is the point number. [m,-]
     INTEGER(IntKi)  :: WaveFieldMod = 0_IntKi      !< Wave field handling (-) (switch) 0: use individual SeaState inputs without adjustment, 1: adjust wave phases based on turbine offsets from farm origin [-]
     REAL(ReKi)  :: PtfmLocationX = 0.0_ReKi      !< Supplied by Driver:  X coordinate of platform location in the wave field [m]
     REAL(ReKi)  :: PtfmLocationY = 0.0_ReKi      !< Supplied by Driver:  Y coordinate of platform location in the wave field [m]
     INTEGER(IntKi)  :: WrWvKinMod = 0      !< 0,1, or 2 indicating whether we are going to write out kinematics files.  [ignored if WaveMod = 6, if 1 or 2 then files are written using the outrootname] [-]
     LOGICAL  :: HasIce = .false.      !< Supplied by Driver:  Whether this simulation has ice loading (flag) [-]
     LOGICAL  :: Linearize = .FALSE.      !< Flag that tells this module if the glue code wants to linearize. [-]
+    LOGICAL  :: SurfaceVis = .FALSE.      !< Turn on grid surface visualization outputs [-]
+    INTEGER(IntKi)  :: SurfaceVisNx = 0      !< Number of points in X direction to output for visualization grid.  Use 0 or negative to set to SeaState resolution. [-]
+    INTEGER(IntKi)  :: SurfaceVisNy = 0      !< Number of points in Y direction to output for visualization grid.  Use 0 or negative to set to SeaState resolution. [-]
   END TYPE SeaSt_InitInputType
 ! =======================
 ! =========  SeaSt_InitOutputType  =======
@@ -109,7 +111,9 @@ IMPLICIT NONE
     CHARACTER(ChanLen) , DIMENSION(:), ALLOCATABLE  :: WriteOutputUnt      !< The is the list of all HD-related output channel unit strings (includes all sub-module channels) [-]
     TYPE(ProgDesc)  :: Ver      !< Version of SeaState [-]
     LOGICAL  :: InvalidWithSSExctn = .false.      !< Whether SeaState configuration is invalid with HydroDyn's state-space excitation (ExctnMod=2) [(-)]
-    REAL(SiKi) , DIMENSION(:,:), ALLOCATABLE  :: WaveElevSeries      !< Wave elevation time-series at each of the points given by WaveElevXY.  First dimension is the timestep. Second dimension is XY point number corresponding to second dimension of WaveElevXY. [(m)]
+    REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: WaveElevVisX      !< X locations of grid output [m,-]
+    REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: WaveElevVisY      !< X locations of grid output [m,-]
+    REAL(SiKi) , DIMENSION(:,:,:), ALLOCATABLE  :: WaveElevVisGrid      !< Wave elevation time-series at each of the points given by WaveElevXY.  First dimension is the timestep. Second/third dimensions are the grid of points. [(m)]
     TYPE(SeaSt_WaveFieldType) , POINTER :: WaveField => NULL()      !< Pointer to wave field [-]
   END TYPE SeaSt_InitOutputType
 ! =======================
@@ -445,7 +449,6 @@ subroutine SeaSt_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, Err
    integer(IntKi),  intent(in   ) :: CtrlCode
    integer(IntKi),  intent(  out) :: ErrStat
    character(*),    intent(  out) :: ErrMsg
-   integer(B8Ki)                  :: LB(2), UB(2)
    integer(IntKi)                 :: ErrStat2
    character(ErrMsgLen)           :: ErrMsg2
    character(*), parameter        :: RoutineName = 'SeaSt_CopyInitInput'
@@ -462,24 +465,15 @@ subroutine SeaSt_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, Err
    DstInitInputData%defWtrDpth = SrcInitInputData%defWtrDpth
    DstInitInputData%defMSL2SWL = SrcInitInputData%defMSL2SWL
    DstInitInputData%TMax = SrcInitInputData%TMax
-   if (allocated(SrcInitInputData%WaveElevXY)) then
-      LB(1:2) = lbound(SrcInitInputData%WaveElevXY, kind=B8Ki)
-      UB(1:2) = ubound(SrcInitInputData%WaveElevXY, kind=B8Ki)
-      if (.not. allocated(DstInitInputData%WaveElevXY)) then
-         allocate(DstInitInputData%WaveElevXY(LB(1):UB(1),LB(2):UB(2)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstInitInputData%WaveElevXY.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstInitInputData%WaveElevXY = SrcInitInputData%WaveElevXY
-   end if
    DstInitInputData%WaveFieldMod = SrcInitInputData%WaveFieldMod
    DstInitInputData%PtfmLocationX = SrcInitInputData%PtfmLocationX
    DstInitInputData%PtfmLocationY = SrcInitInputData%PtfmLocationY
    DstInitInputData%WrWvKinMod = SrcInitInputData%WrWvKinMod
    DstInitInputData%HasIce = SrcInitInputData%HasIce
    DstInitInputData%Linearize = SrcInitInputData%Linearize
+   DstInitInputData%SurfaceVis = SrcInitInputData%SurfaceVis
+   DstInitInputData%SurfaceVisNx = SrcInitInputData%SurfaceVisNx
+   DstInitInputData%SurfaceVisNy = SrcInitInputData%SurfaceVisNy
 end subroutine
 
 subroutine SeaSt_DestroyInitInput(InitInputData, ErrStat, ErrMsg)
@@ -493,9 +487,6 @@ subroutine SeaSt_DestroyInitInput(InitInputData, ErrStat, ErrMsg)
    ErrMsg  = ''
    call NWTC_Library_DestroyFileInfoType(InitInputData%PassedFileData, ErrStat2, ErrMsg2)
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
-   if (allocated(InitInputData%WaveElevXY)) then
-      deallocate(InitInputData%WaveElevXY)
-   end if
 end subroutine
 
 subroutine SeaSt_PackInitInput(RF, Indata)
@@ -512,13 +503,15 @@ subroutine SeaSt_PackInitInput(RF, Indata)
    call RegPack(RF, InData%defWtrDpth)
    call RegPack(RF, InData%defMSL2SWL)
    call RegPack(RF, InData%TMax)
-   call RegPackAlloc(RF, InData%WaveElevXY)
    call RegPack(RF, InData%WaveFieldMod)
    call RegPack(RF, InData%PtfmLocationX)
    call RegPack(RF, InData%PtfmLocationY)
    call RegPack(RF, InData%WrWvKinMod)
    call RegPack(RF, InData%HasIce)
    call RegPack(RF, InData%Linearize)
+   call RegPack(RF, InData%SurfaceVis)
+   call RegPack(RF, InData%SurfaceVisNx)
+   call RegPack(RF, InData%SurfaceVisNy)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -526,9 +519,6 @@ subroutine SeaSt_UnPackInitInput(RF, OutData)
    type(RegFile), intent(inout)    :: RF
    type(SeaSt_InitInputType), intent(inout) :: OutData
    character(*), parameter            :: RoutineName = 'SeaSt_UnPackInitInput'
-   integer(B8Ki)   :: LB(2), UB(2)
-   integer(IntKi)  :: stat
-   logical         :: IsAllocAssoc
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpack(RF, OutData%InputFile); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%UseInputFile); if (RegCheckErr(RF, RoutineName)) return
@@ -539,13 +529,15 @@ subroutine SeaSt_UnPackInitInput(RF, OutData)
    call RegUnpack(RF, OutData%defWtrDpth); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%defMSL2SWL); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%TMax); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%WaveElevXY); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%WaveFieldMod); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%PtfmLocationX); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%PtfmLocationY); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%WrWvKinMod); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%HasIce); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%Linearize); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%SurfaceVis); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%SurfaceVisNx); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%SurfaceVisNy); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine SeaSt_CopyInitOutput(SrcInitOutputData, DstInitOutputData, CtrlCode, ErrStat, ErrMsg)
@@ -554,7 +546,7 @@ subroutine SeaSt_CopyInitOutput(SrcInitOutputData, DstInitOutputData, CtrlCode, 
    integer(IntKi),  intent(in   ) :: CtrlCode
    integer(IntKi),  intent(  out) :: ErrStat
    character(*),    intent(  out) :: ErrMsg
-   integer(B8Ki)                  :: LB(2), UB(2)
+   integer(B8Ki)                  :: LB(3), UB(3)
    integer(IntKi)                 :: ErrStat2
    character(ErrMsgLen)           :: ErrMsg2
    character(*), parameter        :: RoutineName = 'SeaSt_CopyInitOutput'
@@ -588,17 +580,41 @@ subroutine SeaSt_CopyInitOutput(SrcInitOutputData, DstInitOutputData, CtrlCode, 
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
    DstInitOutputData%InvalidWithSSExctn = SrcInitOutputData%InvalidWithSSExctn
-   if (allocated(SrcInitOutputData%WaveElevSeries)) then
-      LB(1:2) = lbound(SrcInitOutputData%WaveElevSeries, kind=B8Ki)
-      UB(1:2) = ubound(SrcInitOutputData%WaveElevSeries, kind=B8Ki)
-      if (.not. allocated(DstInitOutputData%WaveElevSeries)) then
-         allocate(DstInitOutputData%WaveElevSeries(LB(1):UB(1),LB(2):UB(2)), stat=ErrStat2)
+   if (allocated(SrcInitOutputData%WaveElevVisX)) then
+      LB(1:1) = lbound(SrcInitOutputData%WaveElevVisX, kind=B8Ki)
+      UB(1:1) = ubound(SrcInitOutputData%WaveElevVisX, kind=B8Ki)
+      if (.not. allocated(DstInitOutputData%WaveElevVisX)) then
+         allocate(DstInitOutputData%WaveElevVisX(LB(1):UB(1)), stat=ErrStat2)
          if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstInitOutputData%WaveElevSeries.', ErrStat, ErrMsg, RoutineName)
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstInitOutputData%WaveElevVisX.', ErrStat, ErrMsg, RoutineName)
             return
          end if
       end if
-      DstInitOutputData%WaveElevSeries = SrcInitOutputData%WaveElevSeries
+      DstInitOutputData%WaveElevVisX = SrcInitOutputData%WaveElevVisX
+   end if
+   if (allocated(SrcInitOutputData%WaveElevVisY)) then
+      LB(1:1) = lbound(SrcInitOutputData%WaveElevVisY, kind=B8Ki)
+      UB(1:1) = ubound(SrcInitOutputData%WaveElevVisY, kind=B8Ki)
+      if (.not. allocated(DstInitOutputData%WaveElevVisY)) then
+         allocate(DstInitOutputData%WaveElevVisY(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstInitOutputData%WaveElevVisY.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstInitOutputData%WaveElevVisY = SrcInitOutputData%WaveElevVisY
+   end if
+   if (allocated(SrcInitOutputData%WaveElevVisGrid)) then
+      LB(1:3) = lbound(SrcInitOutputData%WaveElevVisGrid, kind=B8Ki)
+      UB(1:3) = ubound(SrcInitOutputData%WaveElevVisGrid, kind=B8Ki)
+      if (.not. allocated(DstInitOutputData%WaveElevVisGrid)) then
+         allocate(DstInitOutputData%WaveElevVisGrid(LB(1):UB(1),LB(2):UB(2),LB(3):UB(3)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstInitOutputData%WaveElevVisGrid.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstInitOutputData%WaveElevVisGrid = SrcInitOutputData%WaveElevVisGrid
    end if
    DstInitOutputData%WaveField => SrcInitOutputData%WaveField
 end subroutine
@@ -620,8 +636,14 @@ subroutine SeaSt_DestroyInitOutput(InitOutputData, ErrStat, ErrMsg)
    end if
    call NWTC_Library_DestroyProgDesc(InitOutputData%Ver, ErrStat2, ErrMsg2)
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
-   if (allocated(InitOutputData%WaveElevSeries)) then
-      deallocate(InitOutputData%WaveElevSeries)
+   if (allocated(InitOutputData%WaveElevVisX)) then
+      deallocate(InitOutputData%WaveElevVisX)
+   end if
+   if (allocated(InitOutputData%WaveElevVisY)) then
+      deallocate(InitOutputData%WaveElevVisY)
+   end if
+   if (allocated(InitOutputData%WaveElevVisGrid)) then
+      deallocate(InitOutputData%WaveElevVisGrid)
    end if
    nullify(InitOutputData%WaveField)
 end subroutine
@@ -636,7 +658,9 @@ subroutine SeaSt_PackInitOutput(RF, Indata)
    call RegPackAlloc(RF, InData%WriteOutputUnt)
    call NWTC_Library_PackProgDesc(RF, InData%Ver) 
    call RegPack(RF, InData%InvalidWithSSExctn)
-   call RegPackAlloc(RF, InData%WaveElevSeries)
+   call RegPackAlloc(RF, InData%WaveElevVisX)
+   call RegPackAlloc(RF, InData%WaveElevVisY)
+   call RegPackAlloc(RF, InData%WaveElevVisGrid)
    call RegPack(RF, associated(InData%WaveField))
    if (associated(InData%WaveField)) then
       call RegPackPointer(RF, c_loc(InData%WaveField), PtrInIndex)
@@ -651,7 +675,7 @@ subroutine SeaSt_UnPackInitOutput(RF, OutData)
    type(RegFile), intent(inout)    :: RF
    type(SeaSt_InitOutputType), intent(inout) :: OutData
    character(*), parameter            :: RoutineName = 'SeaSt_UnPackInitOutput'
-   integer(B8Ki)   :: LB(2), UB(2)
+   integer(B8Ki)   :: LB(3), UB(3)
    integer(IntKi)  :: stat
    logical         :: IsAllocAssoc
    integer(B8Ki)   :: PtrIdx
@@ -661,7 +685,9 @@ subroutine SeaSt_UnPackInitOutput(RF, OutData)
    call RegUnpackAlloc(RF, OutData%WriteOutputUnt); if (RegCheckErr(RF, RoutineName)) return
    call NWTC_Library_UnpackProgDesc(RF, OutData%Ver) ! Ver 
    call RegUnpack(RF, OutData%InvalidWithSSExctn); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%WaveElevSeries); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%WaveElevVisX); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%WaveElevVisY); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%WaveElevVisGrid); if (RegCheckErr(RF, RoutineName)) return
    if (associated(OutData%WaveField)) deallocate(OutData%WaveField)
    call RegUnpack(RF, IsAllocAssoc); if (RegCheckErr(RF, RoutineName)) return
    if (IsAllocAssoc) then


### PR DESCRIPTION
This PR is ready to merge.

**Feature or improvement description**
When the _SeaState_ module was introduced, the grid used for wave surface visualization was based on interpolated data from the _SeaState_ wave grid stored in the _WaveField_ data.  The wave surface size was hard-coded to be 4x the blade length of the turbine being modeled.  This resulted in clamping any parts of the wave surface outside the _WaveField_ data.  As result, the visualization looks a bit strange.


***Before***
![Screenshot 2024-01-17 at 5 52 33 PM](https://github.com/OpenFAST/openfast/assets/2745453/c616c01b-831a-40a4-8fa3-bd27042b6f3d)
Figure 1: before modification, wave surfaces beyond the _WaveField_ data would be set to the value of the nearest edge of the _WaveField_ data.  The _WaveField_ edges are shown as pink vertical boundaries.  In the original formulation, 25x25 data points were interpolated from the _WaveField_ data and stored.  For this visualization, the `5MW_OC4Semi_WSt_WavesWN` regression test was modified with `WaveHs=55`, `WaveTp=4`, `WaveDir=30`, `WaveDirMod=1`, `WaveDirSpread=1`, `WaveNDir=75`, `WaveDirRange=60`, and second order turned off.


***After***
![Screenshot 2024-01-17 at 5 55 24 PM](https://github.com/OpenFAST/openfast/assets/2745453/f640012d-60d1-40dd-9553-fb88374dc421)
Figure 2: after modification, the wave surfaces for visualization are bounded by the `WaveField` data set and use the native _WaveField_ grid resolution specified in the _SeaState_ input file (6 nodes in each half-width direction).  The same _WaveField_ is used here as in the original case above.

**Related issue, if one exists**
None.

**Impacted areas of the software**
Visualization of wave surface.

**Additional supporting information**
Before the addition of the _SeaState_ module, the grid had been set to 25x25 points.  The sea surface at each point was calculated from the FFT of the wave spectral data.  After the addition of the _SeaState_ module, each point requested was interpolated from the _WaveField_ data.  It would be nice to someday restore the ability to calculate an arbitrary number of points for the sea surface from the FFT of the wave spectral data for that location, but I don't have time right now to modify this.

**Test results, if applicable**
None.