### PR TITLE
switch from -fpic to -fPIC for all gfortran builds

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -109,9 +109,9 @@ endmacro(check_f2008_features)
 #
 macro(set_fast_gfortran)
   if(NOT WIN32)
-    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fpic ")
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fpic")
-    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fpic")
+    set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} -fPIC ")
+    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fPIC")
+    set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fPIC")
   endif(NOT WIN32)
 
   # Fix free-form compilation for OpenFAST


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Changing Fortran flags from `-fpic` to `-fPIC` for all `gfortran` builds.  Doing so enables compilation on Linux ARM64/AARCH64 architectures, which is used by Docker.
<!-- A clear and concise description of the new code. -->

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
See [PR](https://github.com/conda-forge/openfast-feedstock/pull/48#issuecomment-1900966636) discussion for conda-forge packaging.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
Anticipating no impact to model.  There is a chance that the compiled file sizes will get a bit bigger and code may run a hair slower with `gfortran`.

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

