### PR TITLE
Registry: add flag to allow integers in InputType

### DIFF
--- a/modules/openfast-registry/src/main.cpp
+++ b/modules/openfast-registry/src/main.cpp
@@ -17,6 +17,7 @@ Options:
     -noextrap         do not generate ModName_Input_ExtrapInterp or ModName_Output_ExtrapInterp routines
     -D<SYM>           define symbol for conditional evaluation inside registry file
     -ccode            generate additional code for interfacing with C/C++
+    -inputintallow    allow integers in InputType
     -keep             do not delete temporary files from registry program
     -shownodes        output a listing of the nodes in registry's AST
   === alternate usage for generating templates ===
@@ -62,6 +63,10 @@ int main(int argc, char *argv[])
         else if ((arg.compare("-ccode")) == 0 || (arg.compare("/ccode")) == 0)
         {
             reg.gen_c_code = true;
+        }
+        else if ((arg.compare("-inputintallow")) == 0 || (arg.compare("/inputintallow")) == 0)
+        {
+            reg.input_int_allow = true;
         }
         else if ((arg.compare("-noextrap")) == 0 || (arg.compare("/noextrap")) == 0)
         {

--- a/modules/openfast-registry/src/registry.hpp
+++ b/modules/openfast-registry/src/registry.hpp
@@ -441,6 +441,7 @@ struct Registry
     bool gen_c_code = false;
     bool no_extrap_interp = false;
     bool gen_inc_subs = false;
+    bool input_int_allow = false;
 
     Registry()
     {

--- a/modules/openfast-registry/src/registry_gen_fortran.cpp
+++ b/modules/openfast-registry/src/registry_gen_fortran.cpp
@@ -133,11 +133,14 @@ void Registry::gen_fortran_module(const Module &mod, const std::string &out_dir)
 
         // If derived data type should only contain reals,
         // verify that it does, otherwise exit with error
-        if ((ddt.interface != nullptr) && ddt.interface->only_reals)
-            if (!ddt.only_contains_reals())
+        if (!this->input_int_allow)
             {
-                std::cerr << "Registry warning: Data type '" << dt_name << "' contains non-real values." << std::endl;
-                exit(EXIT_FAILURE);
+            if ((ddt.interface != nullptr) && ddt.interface->only_reals)
+                if (!ddt.only_contains_reals())
+                {
+                    std::cerr << "Registry warning: Data type '" << dt_name << "' contains non-real values." << std::endl;
+                    exit(EXIT_FAILURE);
+                }
             }
 
         // Write derived type header


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
PR #1973 modified the registry to check for invalid types in the `InputType`.  However, the `ExtLoads` registry includes integers in the `InputType`.  We really don't want integers in that derived type as it breaks with linearization.  

Rather than change the `ExtLoads` registry and potentially break downstream codes that depend on it (AMR-Wind for example), I propose we allow an exception here.  Unless I add such an exception, or force downstream changes, we cannot merge the `dev` branch into the `dev-unstable-pointers` branch.

I added a flag `-inputintallow` to the registry for use in such special cases.

**Impacted areas of the software**
Registry only.

**Test results, if applicable**
None.