### PR TITLE
Minor MD bug fixes: Bathymetry

### DIFF
--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -567,7 +567,7 @@ CONTAINS
           END IF
         
         ! Point case                            
-        ELSE IF (let1(1:1) == 'P') THEN    ! Look for P?xxx or Point?xxx
+        ELSE IF (let1(1:1) == 'P' .OR. let1(1:1) == 'C') THEN    ! Look for P?xxx or Point?xxx (C?xxx and Con?xxx for backwards compatability)
           p%OutParam(I)%OType = 2                ! Point object type
           qVal = let2                            ! quantity type string
           
@@ -605,7 +605,7 @@ CONTAINS
         ! error
         ELSE
           CALL DenoteInvalidOutput(p%OutParam(I)) ! flag as invalid
-          CALL WrScr('Warning: invalid output specifier '//trim(OutListTmp)//'.  Must start with L, C, R, or B')
+          CALL WrScr('Warning: invalid output specifier '//trim(OutListTmp)//'.  Must start with L, R, or B')
           CYCLE
         END IF
 

--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -182,7 +182,7 @@ CONTAINS
          READ(UnCoef,*,IOSTAT=ErrStat4) nGridY_string, nGridY  ! read in the third line as the number of y values in the BathGrid
 
          ! Allocate the bathymetry matrix and associated grid x and y values
-         ALLOCATE(BathGrid(nGridX, nGridY), STAT=ErrStat4)
+         ALLOCATE(BathGrid(nGridY, nGridX), STAT=ErrStat4)
          ALLOCATE(BathGrid_Xs(nGridX), STAT=ErrStat4)
          ALLOCATE(BathGrid_Ys(nGridY), STAT=ErrStat4)
 

--- a/modules/moordyn/src/MoorDyn_Misc.f90
+++ b/modules/moordyn/src/MoorDyn_Misc.f90
@@ -885,7 +885,7 @@ CONTAINS
       else
          dc_dx = 0.0_DbKi   ! maybe this should raise an error
       end if
-      if ( dx > 0.0 ) then
+      if ( dy > 0.0 ) then
          dc_dy = (cx1-cx0)/dy
       else
          dc_dy = 0.0_DbKi   ! maybe this should raise an error


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Fixes typos in warnings printed when reading Input files. Adds backwards compatibility for older MD input files that still use Connection/Con instead of Point in output channels. Fixes two bugs in bathymetry files with MD: allocating the bathymetry grid now matches the input file format (Y = rows, X = columns), fixed a typo in the logic that calculates the normal to the seabed slope which was causing nan's. 

**Related issue, if one exists**
n/a

**Impacted areas of the software**
MoorDyn

**Additional supporting information**
As discussed with @mattEhall and @luwang00.

Note that bathymetry bugs are also present in v 3.5.2 and should be back ported into 3.5.3 release.

**Test results, if applicable**
n/a

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
