### PR TITLE
Change input string size for bathgrid and waterkin input files

### DIFF
--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -139,7 +139,7 @@ CONTAINS
       
       INTEGER(IntKi)                   :: ErrStat4
       CHARACTER(120)                   :: ErrMsg4         
-      CHARACTER(120)                   :: Line2
+      CHARACTER(4096)                   :: Line2
 
       CHARACTER(20)                    :: nGridX_string  ! string to temporarily hold the nGridX string from Line2
       CHARACTER(20)                    :: nGridY_string  ! string to temporarily hold the nGridY string from Line3

--- a/modules/moordyn/src/MoorDyn_Misc.f90
+++ b/modules/moordyn/src/MoorDyn_Misc.f90
@@ -1300,8 +1300,7 @@ CONTAINS
       REAL(SiKi)                       :: t, Frac
       CHARACTER(1024)                  :: FileName             ! Name of MoorDyn input file  
       CHARACTER(120)                   :: Line
-!      CHARACTER(120)                   :: Line2  
-      CHARACTER(120)                   :: entries2  
+      CHARACTER(4096)                  :: entries2  
       INTEGER(IntKi)                   :: coordtype
    
       INTEGER(IntKi)                   :: NStepWave    ! 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Increases allocated string length for reading in the Water Kinematics file and the Bathymetry Grid file to allow for larger grids to be defined. Previously only 16 grid points were allowed when supplied values were formatted as XXX.XX.

Removes unused Line2 variable from MoorDyn_Misc.f90

Based on work currently being done by @luwang00. 

**Related issue, if one exists**
n/a

**Impacted areas of the software**
MoorDyn
Corresponding docs update: FloatingArrayDesign/MoorDyn@89eddea

**Test results, if applicable**
n/a

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
