### PR TITLE
Improvements to linearization regression testing

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -108,7 +108,7 @@ function(of_fastlib_regression TESTNAME LABEL)
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast")
   # extra flag in call to "regression" on next line sets the ${TESTDIR}
-  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " "${TESTNAME}_fastlib" "${LABEL}" ${TESTNAME} " ")
+  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " "${TESTNAME}_fastlib" "${LABEL}" " " ${TESTNAME})
 endfunction(of_fastlib_regression)
 
 # openfast aeroacoustic 
@@ -342,11 +342,11 @@ of_regression_py("EllipticalWing_OLAF_py"                    "openfast;fastlib;p
 of_regression_aeroacoustic("IEA_LB_RWT-AeroAcoustics"  "openfast;aerodyn15;aeroacoustics")
 
 # Linearized OpenFAST regression tests
-#of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
-#of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
+#of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-highpass=0.05"  "openfast;linear;elastodyn;aerodyn")
+#of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-highpass=0.05"  "openfast;linear;elastodyn;aerodyn")
 of_regression_linear("WP_Stationary_Linear"           ""                "openfast;linear;elastodyn")
-of_regression_linear("Ideal_Beam_Fixed_Free_Linear"   "-lowpass=0.05"   "openfast;linear;beamdyn")
-of_regression_linear("Ideal_Beam_Free_Free_Linear"    "-lowpass=0.05"   "openfast;linear;beamdyn")
+of_regression_linear("Ideal_Beam_Fixed_Free_Linear"   "-highpass=0.05"  "openfast;linear;beamdyn")
+of_regression_linear("Ideal_Beam_Free_Free_Linear"    "-highpass=0.05"  "openfast;linear;beamdyn")
 of_regression_linear("5MW_Land_BD_Linear"             ""                "openfast;linear;beamdyn;servodyn")
 of_regression_linear("5MW_OC4Semi_Linear"             ""                "openfast;linear;hydrodyn;servodyn")
 of_regression_linear("StC_test_OC4Semi_Linear_Nac"    ""                "openfast;linear;servodyn;stc")

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -18,7 +18,7 @@
 # Generic test functions
 #===============================================================================
 
-function(regression TEST_SCRIPT EXECUTABLE SOURCE_DIRECTORY BUILD_DIRECTORY STEADYSTATE_FLAG TESTNAME LABEL)
+function(regression TEST_SCRIPT EXECUTABLE SOURCE_DIRECTORY BUILD_DIRECTORY STEADYSTATE_FLAG TESTNAME LABEL OTHER_FLAGS)
 
   file(TO_NATIVE_PATH "${EXECUTABLE}" EXECUTABLE)
   file(TO_NATIVE_PATH "${TEST_SCRIPT}" TEST_SCRIPT)
@@ -57,6 +57,10 @@ function(regression TEST_SCRIPT EXECUTABLE SOURCE_DIRECTORY BUILD_DIRECTORY STEA
     set(STEADYSTATE_FLAG "")
   endif()
   
+  if(OTHER_FLAGS STREQUAL " ")
+    set(OTHER_FLAGS "")
+  endif()
+  
   add_test(
     ${TESTNAME} ${Python_EXECUTABLE}
        ${TEST_SCRIPT}
@@ -70,6 +74,7 @@ function(regression TEST_SCRIPT EXECUTABLE SOURCE_DIRECTORY BUILD_DIRECTORY STEA
        ${RUN_VERBOSE_FLAG}              # empty or "-v"
        ${NO_RUN_FLAG}                   # empty or "-n"
        ${STEADYSTATE_FLAG}              # empty or "-steadystate"
+       ${OTHER_FLAGS}
   )
   # limit each test to 90 minutes: 5400s
   set_tests_properties(${TESTNAME} PROPERTIES TIMEOUT 5400 WORKING_DIRECTORY "${CMAKE_CURRENT_BINARY_DIR}" LABELS "${LABEL}")
@@ -85,7 +90,7 @@ function(of_regression TESTNAME LABEL)
   set(OPENFAST_EXECUTABLE "${CTEST_OPENFAST_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast")
-  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(of_regression)
 
 function(of_aeromap_regression TESTNAME LABEL)
@@ -94,7 +99,7 @@ function(of_aeromap_regression TESTNAME LABEL)
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast")
   set(STEADYSTATE_FLAG "-steadystate")
-  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} ${STEADYSTATE_FLAG} ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} ${STEADYSTATE_FLAG} ${TESTNAME} "${LABEL}" " ")
 endfunction(of_aeromap_regression)
 
 function(of_fastlib_regression TESTNAME LABEL)
@@ -103,7 +108,7 @@ function(of_fastlib_regression TESTNAME LABEL)
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast")
   # extra flag in call to "regression" on next line sets the ${TESTDIR}
-  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " "${TESTNAME}_fastlib" "${LABEL}" ${TESTNAME})
+  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " "${TESTNAME}_fastlib" "${LABEL}" ${TESTNAME} " ")
 endfunction(of_fastlib_regression)
 
 # openfast aeroacoustic 
@@ -112,7 +117,7 @@ function(of_regression_aeroacoustic TESTNAME LABEL)
   set(OPENFAST_EXECUTABLE "${CTEST_OPENFAST_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast")
-  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(of_regression_aeroacoustic)
 
 # FAST Farm
@@ -121,16 +126,17 @@ function(ff_regression TESTNAME LABEL)
   set(FASTFARM_EXECUTABLE "${CTEST_FASTFARM_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/fast-farm")
-  regression(${TEST_SCRIPT} ${FASTFARM_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${FASTFARM_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(ff_regression)
 
 # openfast linearized
-function(of_regression_linear TESTNAME LABEL)
+function(of_regression_linear TESTNAME OTHER_FLAGS LABEL)
   set(TEST_SCRIPT "${CMAKE_CURRENT_LIST_DIR}/executeOpenfastLinearRegressionCase.py")
   set(OPENFAST_EXECUTABLE "${CTEST_OPENFAST_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast")
-  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  set(OTHER_FLAGS "${OTHER_FLAGS}")
+  regression(${TEST_SCRIPT} ${OPENFAST_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" "${OTHER_FLAGS}")
 endfunction(of_regression_linear)
 
 # openfast C++ interface
@@ -139,7 +145,7 @@ function(of_cpp_interface_regression TESTNAME LABEL)
   set(OPENFAST_CPP_EXECUTABLE "${CTEST_OPENFASTCPP_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/openfast-cpp")
-  regression(${TEST_SCRIPT} ${OPENFAST_CPP_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${OPENFAST_CPP_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(of_cpp_interface_regression)
 
 # openfast Python-interface
@@ -148,7 +154,7 @@ function(of_regression_py TESTNAME LABEL)
   set(EXECUTABLE "None")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/glue-codes/python")
-  regression(${TEST_SCRIPT} ${EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(of_regression_py)
 
 # aerodyn
@@ -157,7 +163,7 @@ function(ad_regression TESTNAME LABEL)
   set(AERODYN_EXECUTABLE "${CTEST_AERODYN_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/aerodyn")
-  regression(${TEST_SCRIPT} ${AERODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${AERODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(ad_regression)
 
 # aerodyn-Py
@@ -166,7 +172,7 @@ function(py_ad_regression TESTNAME LABEL)
   set(AERODYN_EXECUTABLE "${Python_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/aerodyn")
-  regression(${TEST_SCRIPT} ${AERODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${AERODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(py_ad_regression)
 
 
@@ -176,7 +182,7 @@ function(ua_regression TESTNAME LABEL)
   set(AERODYN_EXECUTABLE "${CTEST_UADRIVER_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/unsteadyaero")
-  regression(${TEST_SCRIPT} ${AERODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${AERODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(ua_regression)
 
 
@@ -186,7 +192,7 @@ function(bd_regression TESTNAME LABEL)
   set(BEAMDYN_EXECUTABLE "${CTEST_BEAMDYN_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/beamdyn")
-  regression(${TEST_SCRIPT} ${BEAMDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${BEAMDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(bd_regression)
 
 # hydrodyn
@@ -195,7 +201,7 @@ function(hd_regression TESTNAME LABEL)
   set(HYDRODYN_EXECUTABLE "${CTEST_HYDRODYN_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/hydrodyn")
-  regression(${TEST_SCRIPT} ${HYDRODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${HYDRODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(hd_regression)
 
 # py_hydrodyn
@@ -204,7 +210,7 @@ function(py_hd_regression TESTNAME LABEL)
   set(HYDRODYN_EXECUTABLE "${Python_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/hydrodyn")
-  regression(${TEST_SCRIPT} ${HYDRODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${HYDRODYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(py_hd_regression)
 
 # subdyn
@@ -213,7 +219,7 @@ function(sd_regression TESTNAME LABEL)
   set(SUBDYN_EXECUTABLE "${CTEST_SUBDYN_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/subdyn")
-  regression(${TEST_SCRIPT} ${SUBDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${SUBDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(sd_regression)
 
 # inflowwind
@@ -222,7 +228,7 @@ function(ifw_regression TESTNAME LABEL)
   set(INFLOWWIND_EXECUTABLE "${CTEST_INFLOWWIND_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/inflowwind")
-  regression(${TEST_SCRIPT} ${INFLOWWIND_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${INFLOWWIND_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(ifw_regression)
 
 # py_inflowwind
@@ -231,7 +237,7 @@ function(py_ifw_regression TESTNAME LABEL)
   set(INFLOWWIND_EXECUTABLE "${Python_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/inflowwind")
-  regression(${TEST_SCRIPT} ${INFLOWWIND_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${INFLOWWIND_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(py_ifw_regression)
 
 # seastate
@@ -240,7 +246,7 @@ function(seast_regression TESTNAME LABEL)
   set(SEASTATE_EXECUTABLE "${CTEST_SEASTATE_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/seastate")
-  regression(${TEST_SCRIPT} ${SEASTATE_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${SEASTATE_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(seast_regression)
 
 # moordyn
@@ -249,7 +255,7 @@ function(md_regression TESTNAME LABEL)
   set(MOORDYN_EXECUTABLE "${CTEST_MOORDYN_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/moordyn")
-  regression(${TEST_SCRIPT} ${MOORDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${MOORDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(md_regression)
 
 # py_moordyn c-bindings interface
@@ -258,7 +264,7 @@ function(py_md_regression TESTNAME LABEL)
   set(MOORDYN_EXECUTABLE "${Python_EXECUTABLE}")
   set(SOURCE_DIRECTORY "${CMAKE_CURRENT_LIST_DIR}/..")
   set(BUILD_DIRECTORY "${CTEST_BINARY_DIR}/modules/moordyn")
-  regression(${TEST_SCRIPT} ${MOORDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}")
+  regression(${TEST_SCRIPT} ${MOORDYN_EXECUTABLE} ${SOURCE_DIRECTORY} ${BUILD_DIRECTORY} " " ${TESTNAME} "${LABEL}" " ")
 endfunction(py_md_regression)
 
 # # Python-based OpenFAST Library tests
@@ -336,15 +342,15 @@ of_regression_py("EllipticalWing_OLAF_py"                    "openfast;fastlib;p
 of_regression_aeroacoustic("IEA_LB_RWT-AeroAcoustics"  "openfast;aerodyn15;aeroacoustics")
 
 # Linearized OpenFAST regression tests
-# of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3" "openfast;linear;elastodyn") #Also: aerodyn
-# of_regression_linear("Fake5MW_AeroLin_B3_UA6"        "openfast;linear;elastodyn") #Also: aerodyn
-of_regression_linear("WP_Stationary_Linear"         "openfast;linear;elastodyn")
-of_regression_linear("Ideal_Beam_Fixed_Free_Linear" "openfast;linear;beamdyn")
-of_regression_linear("Ideal_Beam_Free_Free_Linear"  "openfast;linear;beamdyn")
-of_regression_linear("5MW_Land_BD_Linear"           "openfast;linear;beamdyn;servodyn")
-of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn")
-of_regression_linear("StC_test_OC4Semi_Linear_Nac"  "openfast;linear;servodyn;stc")
-of_regression_linear("StC_test_OC4Semi_Linear_Tow"  "openfast;linear;servodyn;stc")
+of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
+of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
+of_regression_linear("WP_Stationary_Linear"           ""                "openfast;linear;elastodyn")
+of_regression_linear("Ideal_Beam_Fixed_Free_Linear"   "-lowpass=0.05"   "openfast;linear;beamdyn")
+of_regression_linear("Ideal_Beam_Free_Free_Linear"    "-lowpass=0.05"   "openfast;linear;beamdyn")
+of_regression_linear("5MW_Land_BD_Linear"             ""                "openfast;linear;beamdyn;servodyn")
+of_regression_linear("5MW_OC4Semi_Linear"             ""                "openfast;linear;hydrodyn;servodyn")
+of_regression_linear("StC_test_OC4Semi_Linear_Nac"    ""                "openfast;linear;servodyn;stc")
+of_regression_linear("StC_test_OC4Semi_Linear_Tow"    ""                "openfast;linear;servodyn;stc")
 
 # FAST Farm regression tests
 if(BUILD_FASTFARM)

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -342,8 +342,8 @@ of_regression_py("EllipticalWing_OLAF_py"                    "openfast;fastlib;p
 of_regression_aeroacoustic("IEA_LB_RWT-AeroAcoustics"  "openfast;aerodyn15;aeroacoustics")
 
 # Linearized OpenFAST regression tests
-of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
-of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
+#of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
+#of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-lowpass=0.05"   "openfast;linear;elastodyn;aerodyn")
 of_regression_linear("WP_Stationary_Linear"           ""                "openfast;linear;elastodyn")
 of_regression_linear("Ideal_Beam_Fixed_Free_Linear"   "-lowpass=0.05"   "openfast;linear;beamdyn")
 of_regression_linear("Ideal_Beam_Free_Free_Linear"    "-lowpass=0.05"   "openfast;linear;beamdyn")

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -67,6 +67,7 @@ parser.add_argument("atol", metavar="Absolute-Tolerance", type=float, nargs=1, h
 parser.add_argument("-p", "-plot", dest="plot", action='store_true', help="bool to include plots in failed cases")
 parser.add_argument("-n", "-no-exec", dest="noExec", action='store_true', help="bool to prevent execution of the test cases")
 parser.add_argument("-v", "-verbose", dest="verbose", action='store_true', help="bool to include verbose system output")
+parser.add_argument("-lowpass", dest='lowpass', metavar="LowPass-Filter", type=float, nargs='?', default=0.0,  help="low pass filter on linearization frequencies to compare")
 
 args = parser.parse_args()
 
@@ -79,6 +80,7 @@ atol = args.atol[0]
 plotError = args.plot
 noExec = args.noExec
 verbose = args.verbose
+lowpass = args.lowpass
 
 # --- Tolerances for matrix comparison
 # Outputs of lin matrices have 3 decimal digits leading to minimum error of 0.001  
@@ -212,6 +214,14 @@ def compareLin(f,file_freq_ref,file_freq_new):
             print(msg)
         Errors.append(msg)
 
+    def ApplyLowPass(freq,zeta):
+        freqL=np.array([])
+        zetaL=np.array([])
+        for i in range(len(freq)):
+            if freq[i]>lowpass:
+                freqL = np.append(freqL,freq[i])
+                zetaL = np.append(zetaL,zeta[i])
+        return freqL,zetaL
 
 
 
@@ -249,6 +259,9 @@ def compareLin(f,file_freq_ref,file_freq_new):
         # Note: we could potentially reorder states like MBC does, but no need for freq/damping
         _, zeta_bas, _, freq_bas = eigA(Abas, nq=None, nq1=None, sort=True, fullEV=True)
         _, zeta_loc, _, freq_loc = eigA(Aloc, nq=None, nq1=None, sort=True, fullEV=True)
+
+        freq_bas, zeta_bas = ApplyLowPass( freq_bas, zeta_bas )
+        freq_loc, zeta_loc = ApplyLowPass( freq_loc, zeta_loc )
 
         if len(freq_bas)==0:
             # We use complex eigenvalues instead of frequencies/damping

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -98,6 +98,10 @@ atol_f=1e-2
 rtol_d=1e-2
 atol_d=1e-1  
 
+# --- Filenames for frequency info
+fileNameFreqRef="frequencies_ref.txt"
+fileNameFreqNew="frequencies_new.txt"
+
 
 CasePrefix=' Case: {}: '.format(caseName)
 def exitWithError(msg):
@@ -120,6 +124,8 @@ moduleDirectory = os.path.join(rtest, "glue-codes", "openfast")
 inputsDirectory = os.path.join(moduleDirectory, caseName)
 targetOutputDirectory = os.path.join(inputsDirectory)
 testBuildDirectory = os.path.join(buildDirectory, caseName)
+fNameFreqRef = os.path.join(testBuildDirectory, fileNameFreqRef)
+fNameFreqNew = os.path.join(testBuildDirectory, fileNameFreqNew)
 
 # verify all the required directories exist
 if not os.path.isdir(rtest):
@@ -183,7 +189,7 @@ if len(localOutFiles) != len(baselineOutFiles):
 
 ### test for regression (compare lin files only)
 
-def compareLin(f):
+def compareLin(f,file_freq_ref,file_freq_new):
     Errors     = []
     ElemErrors = []
 
@@ -261,12 +267,44 @@ def compareLin(f):
                 Err='Failed to compare A-matrix frequencies\n\tLinfile: {}.\n\tException: {}'.format(local_file2, indent(e.args[0]))
                 newError(Err)
         else:
-
             #if verbose:
-            print(errPrefix+'freq_ref:', np.around(freq_bas[:8]    ,5), '[Hz]')
-            print(errPrefix+'freq_new:', np.around(freq_loc[:8]    ,5),'[Hz]')
-            print(errPrefix+'damp_ref:', np.around(zeta_bas[:8]*100,5), '[%]')
-            print(errPrefix+'damp_new:', np.around(zeta_loc[:8]*100,5), '[%]')
+            print('\n'+errPrefix+':')
+            print('              Frequency (Hz)                        Damping (%)')
+            print('           ----------------------------         ----------------------------')
+            print('            Ref              New                 Ref              New')
+
+            #write frequencies to file
+            try:
+                file_freq_ref.write('\n'+errPrefix+':\n')
+                file_freq_ref.write('            Freq (Hz)        Damp (%)\n')
+                file_freq_new.write('\n'+errPrefix+':\n')
+                file_freq_new.write('            Freq (Hz)        Damp (%)\n')
+            except Exception:
+                pass    # ignore all writing errors
+
+
+            for j in range(min(10,max(len(freq_bas),len(freq_loc)))):
+                if j<len(freq_bas):
+                    str_freq_bas='{:14.9f}'.format(freq_bas[j])
+                    str_zeta_bas='{:14.9f}'.format(zeta_bas[j])
+                else:
+                    str_freq_bas='              '
+                    str_zeta_bas='              '
+                if j<len(freq_loc):
+                    str_freq_loc='{:14.9f}'.format(freq_loc[j])
+                    str_zeta_loc='{:14.9f}'.format(zeta_loc[j])
+                else:
+                    str_freq_loc='              '
+                    str_zeta_loc='              '
+                print('        '+str_freq_bas+'   '+str_freq_loc+'      '+str_zeta_bas+'   '+str_zeta_loc)
+
+                #write frequencies to file
+                try:
+                    file_freq_ref.write('        '+str_freq_bas+'   '+str_zeta_bas+'\n')
+                    file_freq_new.write('        '+str_freq_loc+'   '+str_zeta_loc+'\n')
+                except Exception:
+                    pass
+
 
             try:
                 np.testing.assert_allclose(freq_loc[:10], freq_bas[:10], rtol=rtol_f, atol=atol_f)
@@ -331,12 +369,50 @@ def compareLin(f):
                         ElemErrors.append(Err)
     return Errors, ElemErrors
 
+
+# Header for file containing all frequency information
+def freqFileHdr():
+    Err=[]
+    file_freq_ref=[]
+    file_freq_new=[]
+    try:
+        file_freq_ref=open(fNameFreqRef,"w")
+    except Exception as e:
+        Err = 'Could not open file '+fileNameFreqRef+' for writing'
+
+    try:
+        file_freq_new=open(fNameFreqNew,"w")
+    except Exception as e:
+        Err = 'Could not open file '+fileNameFreqNew+' for writing'
+
+    return Err,file_freq_ref,file_freq_new
+
+# close files with frequency info
+def freqFileClose(file_freq_ref,file_freq_new):
+    try:
+        file_ref.close()
+    except Exception:
+        pass
+    try:
+        file_new.close()
+    except Exception:
+        pass
+
+
+# Compare
 Errors=[]
+
+ErrorsLoc,ff1,ff2 = freqFileHdr()
+Errors += ErrorsLoc
+
 for i, f in enumerate(localOutFiles):
-    ErrorsLoc, ElemErrorsLoc = compareLin(f)
+    ErrorsLoc, ElemErrorsLoc = compareLin(f,ff1,ff2)
     Errors += ErrorsLoc
     if len(ElemErrorsLoc)>0:
         Errors += ElemErrorsLoc[:3] # Just a couple of them
+
+freqFileClose(ff1,ff2)
+
 
 if len(Errors)>0:
     exitWithError('See errors below: \n'+'\n'.join(Errors))

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -67,7 +67,7 @@ parser.add_argument("atol", metavar="Absolute-Tolerance", type=float, nargs=1, h
 parser.add_argument("-p", "-plot", dest="plot", action='store_true', help="bool to include plots in failed cases")
 parser.add_argument("-n", "-no-exec", dest="noExec", action='store_true', help="bool to prevent execution of the test cases")
 parser.add_argument("-v", "-verbose", dest="verbose", action='store_true', help="bool to include verbose system output")
-parser.add_argument("-lowpass", dest='lowpass', metavar="LowPass-Filter", type=float, nargs='?', default=0.0,  help="low pass filter on linearization frequencies to compare")
+parser.add_argument("-highpass", dest='highpass', metavar="LowPass-Filter", type=float, nargs='?', default=0.0, help="high pass filter on linearization frequencies to compare")
 
 args = parser.parse_args()
 
@@ -80,7 +80,7 @@ atol = args.atol[0]
 plotError = args.plot
 noExec = args.noExec
 verbose = args.verbose
-lowpass = args.lowpass
+highpass = args.highpass
 
 # --- Tolerances for matrix comparison
 # Outputs of lin matrices have 3 decimal digits leading to minimum error of 0.001  
@@ -214,11 +214,11 @@ def compareLin(f,file_freq_ref,file_freq_new):
             print(msg)
         Errors.append(msg)
 
-    def ApplyLowPass(freq,zeta):
+    def ApplyHighPass(freq,zeta):
         freqL=np.array([])
         zetaL=np.array([])
         for i in range(len(freq)):
-            if freq[i]>lowpass:
+            if freq[i]>highpass:
                 freqL = np.append(freqL,freq[i])
                 zetaL = np.append(zetaL,zeta[i])
         return freqL,zetaL
@@ -260,8 +260,8 @@ def compareLin(f,file_freq_ref,file_freq_new):
         _, zeta_bas, _, freq_bas = eigA(Abas, nq=None, nq1=None, sort=True, fullEV=True)
         _, zeta_loc, _, freq_loc = eigA(Aloc, nq=None, nq1=None, sort=True, fullEV=True)
 
-        freq_bas, zeta_bas = ApplyLowPass( freq_bas, zeta_bas )
-        freq_loc, zeta_loc = ApplyLowPass( freq_loc, zeta_loc )
+        freq_bas, zeta_bas = ApplyHighPass( freq_bas, zeta_bas )
+        freq_loc, zeta_loc = ApplyHighPass( freq_loc, zeta_loc )
 
         if len(freq_bas)==0:
             # We use complex eigenvalues instead of frequencies/damping


### PR DESCRIPTION
This ready to merge.

**Feature or improvement description**
Add two updates to the linearization regression testing method:

1. add tables for comparison of frequencies and damping. Export these to files `frequencies_ref.txt` and `frequencies_new.txt`
2. add an optional high-pass filter to the frequency comparisons.  There had been some cases where extra very low frequencies might appear in certain linearization checks (this was causing test `Fake5MW_AeroLin_B1_UA4_DBEMT3` to fail when a frequency of ~0.00159 Hz - see below).  The high-pass filter is set as an optional argument in the `CTestList.cmake` file (_i.e._ `of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-highpass=0.05"   "openfast;linear;elastodyn;aerodyn")`)


*Comparison tables*
The new table format for the frequency comparisons appears as:

```
43:  Case: Ideal_Beam_Fixed_Free_Linear:1.lin: :
43:               Frequency (Hz)                        Damping (%)
43:            ----------------------------         ----------------------------
43:             Ref              New                 Ref              New
43:            0.570963420      0.570963420         0.000000000      0.000000000
43:            0.570963426      0.570963426        -0.000000000     -0.000000000
43:            3.546155606      3.546155606        -0.000000000     -0.000000000
43:            3.546155608      3.546155608         0.000000000      0.000000000
43:            9.763888291      9.763888291         0.000000000      0.000000000
43:            9.763888291      9.763888291        -0.000000000     -0.000000000
43:           18.694578736     18.694578736        -0.000000000     -0.000000000
43:           18.694578736     18.694578736        -0.000000000     -0.000000000
43:           33.978106303     33.978106303         0.000000000      0.000000000
43:           33.978106303     33.978106303         0.000000000      0.000000000
43:
43:  Case: Ideal_Beam_Fixed_Free_Linear:BD1.lin: :
43:               Frequency (Hz)                        Damping (%)
43:            ----------------------------         ----------------------------
43:             Ref              New                 Ref              New
43:            0.570963420      0.570963420         0.000000000      0.000000000
43:            0.570963426      0.570963426        -0.000000000     -0.000000000
43:            3.546155606      3.546155606        -0.000000000     -0.000000000
43:            3.546155608      3.546155608         0.000000000      0.000000000
43:            9.763888291      9.763888291         0.000000000      0.000000000
43:            9.763888291      9.763888291        -0.000000000     -0.000000000
43:           18.694578736     18.694578736        -0.000000000     -0.000000000
43:           18.694578736     18.694578736        -0.000000000     -0.000000000
43:           33.978106303     33.978106303         0.000000000      0.000000000
43:           33.978106303     33.978106303         0.000000000      0.000000000
```

*High-pass filter*
Before adding the high-pass filter, the case `Fake5MW_AeroLin_B1_UA4_DBEMT3` would fail with an extra low frequency value sometimes appearing at 0.001591549 Hz.  For this case, this frequency doesn't make much sense.  The high-pass filter allows us to ignore it.

```
40:  Case: Fake5MW_AeroLin_B1_UA4_DBEMT3:1.lin: :
40:               Frequency (Hz)                        Damping (%)
40:            ----------------------------         ----------------------------
40:             Ref              New                 Ref              New
40:            0.618153481      0.001591549         0.077632352      1.000000000
40:            2.542444969      0.618023953         0.960695174      0.077577325
40:                             2.542505004                          0.960671433
```

**Related issue, if one exists**
The `Fake5MW_AeroLin_B1_UA4_DBEMT3` regression test was added at commit 202bfe7d, then removed 2 months later with commit 8e7e0b94.  Between these commits, no changes were made to anything related to linearization.

This might be a candidate for inclusion in a v3.5.3 release.

NOTE: there is a bug in the AD15 linearization that is currently being fixed by PR #2014.  So the `Fake5MW_AeroLin_B*` cases are currently disabled even though they are the reason for this PR.

**Impacted areas of the software**
Linearization.

**Additional supporting information**

**Test results, if applicable**
Test results do not change, but the comparison for linearization cases is slightly more robust.