### PR TITLE
Backward compatibility for the AXIAL COEFFICIENTS section of the HydroDyn input file

### DIFF
--- a/modules/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules/hydrodyn/src/HydroDyn_Input.f90
@@ -364,9 +364,19 @@ SUBROUTINE HydroDyn_ParseInput( InputFileName, OutRootName, FileInfo_In, InputFi
       END IF
           
       DO I = 1,InputFileData%Morison%NAxCoefs
-            ! read the table entries   AxCoefID   CdAx  CaAx    in the HydroDyn input file
+         ! read the table entries AxCoefID, AxCd, AxCa, AxCp, AxFdMod, AxVnCOff, AxFDLoFSc in the HydroDyn input file
+         ! Try reading in 7 entries first
          call ParseAry( FileInfo_In, CurLine, ' axial coefficients line '//trim( Int2LStr(I)), tmpReArray, size(tmpReArray), ErrStat2, ErrMsg2, UnEc )
-            if (Failed())  return;
+         if ( ErrStat2 /= 0 ) then ! Try reading in 5 entries
+            tmpReArray(6) = -1.0  ! AxVnCoff
+            tmpReArray(7) =  1.0  ! AxFDLoFSc
+            call ParseAry( FileInfo_In, CurLine, ' axial coefficients line '//trim( Int2LStr(I)), tmpReArray(1:5), 5, ErrStat2, ErrMsg2, UnEc )
+            if ( ErrStat2 /= 0 ) then ! Try reading in 4 entries
+               tmpReArray(5) =  0.0  ! AxFdMod
+               call ParseAry( FileInfo_In, CurLine, ' axial coefficients line '//trim( Int2LStr(I)), tmpReArray(1:4), 4, ErrStat2, ErrMsg2, UnEc )
+               if (Failed())  return;
+            end if
+         end if
          InputFileData%Morison%AxialCoefs(I)%AxCoefID = NINT(tmpReArray(1))
          InputFileData%Morison%AxialCoefs(I)%AxCd     =      tmpReArray(2)
          InputFileData%Morison%AxialCoefs(I)%AxCa     =      tmpReArray(3)


### PR DESCRIPTION
**Feature or improvement description**
This PR adds backward compatibility to the AXIAL COEFFICIENTS section of the HydroDyn input file. The new inputs added to Ver. 4.0 are made optional. 

For each line of axial-coefficient input, users can:
1. provide AxCoefID, AxCd, AxCa, and AxCp as in Version 3.5.x,
2. also specify AxFdMod in addition to the four parameters above, or
3. also specify AxVnCOff and AxFDLoFSc for a total of seven parameters.

Each line can have a different number of input parameters following one of the three options above. When optional parameters are omitted, default values are used that effectively disable the corresponding new features. With Option 1 above, the axial load modeling from Version 3.5.x is recovered.

**Impacted areas of the software**
HydroDyn

**Test results, if applicable**
No change to existing test results