### PR TITLE
Add linearization regression tests

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -21,6 +21,7 @@ env:
   C_COMPILER: gcc-12
   GCOV_EXE: gcov-12
   CMAKE_BUILD_PARALLEL_LEVEL: 8
+  CTEST_PARALLEL_LEVEL: 2
 
 
 jobs:
@@ -589,7 +590,7 @@ jobs:
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
-          ctest -VV -j4 \
+          ctest -VV \
           -L openfast \
           -LE "cpp|linear|python|fastlib" \
           -E "5MW_OC4Semi_WSt_WavesWN|5MW_OC3Mnpl_DLL_WTurb_WavesIrr|5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth|5MW_OC3Trpd_DLL_WSt_WavesReg|5MW_Land_BD_DLL_WTurb"
@@ -892,7 +893,7 @@ jobs:
       - name: Run OpenFAST linearization tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
-          ctest -VV -j4 -L linear
+          ctest -VV -L linear
       - name: Failing test artifacts
         uses: actions/upload-artifact@v3
         if: failure()

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -36,11 +36,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -87,7 +87,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install dependencies
@@ -122,11 +122,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -168,11 +168,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -226,7 +226,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-postlib-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -264,7 +264,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-postlib-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -302,7 +302,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-postlib-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -338,11 +338,11 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout
-        uses: actions/checkout@main
+        uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -404,7 +404,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-drivers-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -460,7 +460,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-all-debug-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -519,7 +519,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-interfaces-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -567,7 +567,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -620,7 +620,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -670,7 +670,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -720,7 +720,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -770,7 +770,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -820,7 +820,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -870,7 +870,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-openfast-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
@@ -920,7 +920,7 @@ jobs:
           path: ${{runner.workspace}}
           key: build-fastfarm-release-${{ github.sha }}
       - name: Setup Python
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -383,7 +383,7 @@ jobs:
           ctest -VV -R "^ua_" 
 
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-uadriver
@@ -442,7 +442,7 @@ jobs:
       - name: Run SubDyn tests
         uses: ./.github/actions/tests-module-subdyn
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-module-drivers
@@ -500,7 +500,7 @@ jobs:
       - name: Run VersionInfo tests
         uses: ./.github/actions/tests-module-version
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-modules-debug
@@ -543,7 +543,7 @@ jobs:
         run: |
           ctest -VV -L "cpp|python|fastlib"
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-interfaces
@@ -595,7 +595,7 @@ jobs:
           -LE "cpp|linear|python|fastlib" \
           -E "5MW_OC4Semi_WSt_WavesWN|5MW_OC3Mnpl_DLL_WTurb_WavesIrr|5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth|5MW_OC3Trpd_DLL_WSt_WavesReg|5MW_Land_BD_DLL_WTurb"
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF
@@ -645,7 +645,7 @@ jobs:
         run: |
           ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_OC4Semi_WSt_WavesWN
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF-5MW_OC4Semi_WSt_WavesWN
@@ -695,7 +695,7 @@ jobs:
         run: |
           ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_OC3Mnpl_DLL_WTurb_WavesIrr
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF-5MW_OC3Mnpl_DLL_WTurb_WavesIrr
@@ -745,7 +745,7 @@ jobs:
         run: |
           ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF-5MW_OC4Jckt_DLL_WTurb_WavesIrr_MGrowth
@@ -795,7 +795,7 @@ jobs:
         run: |
           ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_OC3Trpd_DLL_WSt_WavesReg
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF-5MW_OC3Trpd_DLL_WSt_WavesReg
@@ -845,7 +845,7 @@ jobs:
         run: |
           ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_Land_BD_DLL_WTurb
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF-5MW_Land_BD_DLL_WTurb
@@ -895,7 +895,7 @@ jobs:
         run: |
           ctest -VV -L linear
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-OF-linearization
@@ -947,7 +947,7 @@ jobs:
           set OMP_NUM_THREADS=2
           ctest -VV -L fastfarm --verbose
       - name: Failing test artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: rtest-FF

--- a/modules/hydrodyn/src/HydroDyn.f90
+++ b/modules/hydrodyn/src/HydroDyn.f90
@@ -3567,39 +3567,35 @@ SUBROUTINE HD_Perturb_x( p, n, perturb_sign, x, dx )
    
 
    ! local variables
-   integer(intKi)                                      :: i, offset1, offset2, n2
+   integer(intKi)                                      :: i, j, k
   
    if ( p%totalStates == 0 ) return
    
    !Note: All excitation states for all bodies are stored 1st, then all radiation states
    dx = p%dx(n)
-   offset1 = 1
-   if ( n <= p%totalExctnStates ) then
+   k = 1
       
-      ! Find body index for exctn states
-      do i=1,p%nWAMITObj 
-         offset2 = offset1 + p%WAMIT(i)%SS_Exctn%numStates
-         if ( n >= offset1 .and. n < offset2) then
-            n2 = n - offset1 + 1
-            x%WAMIT(i)%SS_Exctn%x( n2 ) = x%WAMIT(i)%SS_Exctn%x( n2 ) + dx * perturb_sign 
-            exit
+   ! Find body index for exctn states
+   do i = 1, p%nWAMITObj 
+      do j = 1, p%WAMIT(i)%SS_Exctn%numStates
+         if (n == k) then
+            x%WAMIT(i)%SS_Exctn%x(j) = x%WAMIT(i)%SS_Exctn%x(j) + dx * perturb_sign 
+            return
          end if
-         offset1 = offset2
+         k = k + 1
       end do
+   end do
       
-   else
-      offset1 = p%totalExctnStates + 1
-      ! Find body index for rdtn states
-      do i=1,p%nWAMITObj
-         offset2 = offset1 + p%WAMIT(i)%SS_Exctn%numStates
-         if ( n >= offset1 .and. n < offset2) then
-            n2 = n - offset1 + 1
-            x%WAMIT(i)%SS_Rdtn%x( n2 ) = x%WAMIT(i)%SS_Rdtn%x( n2 ) + dx * perturb_sign 
-            exit
+   ! Find body index for rdtn states
+   do i = 1, p%nWAMITObj
+      do j = 1, p%WAMIT(i)%SS_Rdtn%numStates
+         if (n == k) then
+            x%WAMIT(i)%SS_Rdtn%x(j) = x%WAMIT(i)%SS_Rdtn%x(j) + dx * perturb_sign 
+            return
          end if
-         offset1 = offset2
+         k = k + 1
       end do
-   end if
+   end do
                                                 
 END SUBROUTINE HD_Perturb_x
 

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -314,8 +314,11 @@ of_regression_linear("Fake5MW_AeroLin_B3_UA6"        "openfast;linear;elastodyn"
 of_regression_linear("WP_Stationary_Linear"         "openfast;linear;elastodyn")
 of_regression_linear("Ideal_Beam_Fixed_Free_Linear" "openfast;linear;beamdyn")
 of_regression_linear("Ideal_Beam_Free_Free_Linear"  "openfast;linear;beamdyn")
+of_regression_linear("5MW_Land_Linear_Aero"         "openfast;linear;elastodyn;servodyn;aerodyn")
 of_regression_linear("5MW_Land_BD_Linear"           "openfast;linear;beamdyn;servodyn")
-of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn")
+of_regression_linear("5MW_Land_BD_Linear_Aero"      "openfast;linear;beamdyn;servodyn;aerodyn")
+of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn;map")
+of_regression_linear("5MW_OC4Semi_MD_Linear"        "openfast;linear;hydrodyn;servodyn;moordyn")
 of_regression_linear("StC_test_OC4Semi_Linear_Nac"  "openfast;linear;servodyn;stc")
 of_regression_linear("StC_test_OC4Semi_Linear_Tow"  "openfast;linear;servodyn;stc")
 

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -321,6 +321,7 @@ of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;se
 of_regression_linear("5MW_OC4Semi_MD_Linear"        "openfast;linear;hydrodyn;servodyn;moordyn")
 of_regression_linear("StC_test_OC4Semi_Linear_Nac"  "openfast;linear;servodyn;stc")
 of_regression_linear("StC_test_OC4Semi_Linear_Tow"  "openfast;linear;servodyn;stc")
+of_regression_linear("5MW_OC3Spar_Linear"           "openfast;linear;map;hydrodyn")
 
 # FAST Farm regression tests
 if(BUILD_FASTFARM)

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -237,22 +237,20 @@ try:
             else:
 
                 #if verbose:
-                print(CasePrefix+'freq_ref:', np.around(freq_bas[:8]    ,5), '[Hz]')
-                print(CasePrefix+'freq_new:', np.around(freq_loc[:8]    ,5),'[Hz]')
-                print(CasePrefix+'damp_ref:', np.around(zeta_bas[:8]*100,5), '[%]')
-                print(CasePrefix+'damp_new:', np.around(zeta_loc[:8]*100,5), '[%]')
+                print(CasePrefix+'freq_ref:', np.around(freq_bas[:10]    ,5), '[Hz]')
+                print(CasePrefix+'freq_new:', np.around(freq_loc[:10]    ,5), '[Hz]')
+                print(CasePrefix+'damp_ref:', np.around(zeta_bas[:10]*100,5), '[%]')
+                print(CasePrefix+'damp_new:', np.around(zeta_loc[:10]*100,5), '[%]')
 
                 try:
                     np.testing.assert_allclose(freq_loc[:10], freq_bas[:10], rtol=rtol_f, atol=atol_f)
                 except Exception as e:
                     raise Exception('Failed to compare A-matrix frequencies\n\tLinfile: {}.\n\tException: {}'.format(local_file, indent(e.args[0])))
 
-
                 if caseName=='Ideal_Beam_Free_Free_Linear':
-                    # The free-free case is a bit weird, smae frequencies but dampings are +/- a value
-                    zeta_loc=np.abs(zeta_loc)
-                    zeta_bas=np.abs(zeta_bas)
-
+                    # The free-free case is a bit weird, same frequencies but damping values are +/- a value
+                    zeta_loc = np.abs(zeta_loc)
+                    zeta_bas = np.abs(zeta_bas)
 
                 try:
                     # Note: damping ratios in [%]
@@ -294,17 +292,17 @@ try:
                 except Exception as e:
                     sElem = f'Element [{i+1},{j+1}], new: {Mloc[i,j]}, baseline: {Mbas[i,j]}'
                     if k in ['dXdx', 'A', 'dXdu', 'B']:
-                        sElem += '\n  row:', fbas['x_info']['Description'][i]
+                        sElem += '\n\t\t  row: ' + fbas['x_info']['Description'][i]
                     if k in ['dYdx', 'C', 'dYdu', 'D']:
-                        sElem += '\n  row:', fbas['y_info']['Description'][i]
+                        sElem += '\n\t\t  row: ' + fbas['y_info']['Description'][i]
                     if k in ['dUdu', 'dUdy']:
-                        sElem += '\n  row:', fbas['u_info']['Description'][i]
+                        sElem += '\n\t\t  row: ' + fbas['u_info']['Description'][i]
                     if k in ['dXdx', 'A', 'dYdx', 'C']:
-                        sElem += '\n  col:', fbas['x_info']['Description'][j]
+                        sElem += '\n\t\t  col: ' + fbas['x_info']['Description'][j]
                     if k in ['dXdu', 'B', 'dYdu', 'D', 'dUdu']:
-                        sElem += '\n  col:', fbas['u_info']['Description'][j]
+                        sElem += '\n\t\t  col: ' + fbas['u_info']['Description'][j]
                     if k in ['dUdy']:
-                        sElem += '\n  col:', fbas['y_info']['Description'][j]
+                        sElem += '\n\t\t  col: ' + fbas['y_info']['Description'][j]
                     raise Exception('Failed to compare matrix `{}`, {} \n\tLinfile: {}.\n\tException: {}'.format(k, sElem, local_file, indent(e.args[0])))
 
 


### PR DESCRIPTION
This PR needs review of results before merging.

**Feature or improvement description**
The number of linearization cases has been somewhat limited and did not fully cover the code.  This PR adds the following regression tesrts:

- `5MW_Land_BD_Linear_Aero` -- based on the `5MW_Land_BD_Linear` case, but with the addition of aero damping
- `5MW_Land_Linear_Aero` -- based on `5MW_Land_BD_Linear_Aero`, but with _ElastoDyn_ for the blades
- `5MW_OC4Semi_MD_Linear` -- based on `5MW_OC4Semi_MD_Linear`, but with _MoorDyn_ instead of _MAP_
- `5MW_OC3Spar_Linear` -- a very simple linearization of the `5MW_OC3Spar_DLL_WTurb_WavesIrr` case with no aero, no controls, and no inflow.

**Related issue, if one exists**
None.

**Impacted areas of the software**
Regression tests cover aero and more hydro for comparisons during glue-code reorganization.

**Additional supporting information**
During the development of the tight-coupling (for OF v5.0), the linearization must be refactored from the implementation in v3.5 and v4.0.  It has proven difficult to check that all the modules are correctly implemented in the new code without linearization models that included aero.

**Test results, if applicable**
Test results below.