### PR TITLE
Backport of PR #2013 and #2016

### DIFF
--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -139,7 +139,7 @@ CONTAINS
       
       INTEGER(IntKi)                   :: ErrStat4
       CHARACTER(120)                   :: ErrMsg4         
-      CHARACTER(120)                   :: Line2
+      CHARACTER(4096)                   :: Line2
 
       CHARACTER(20)                    :: nGridX_string  ! string to temporarily hold the nGridX string from Line2
       CHARACTER(20)                    :: nGridY_string  ! string to temporarily hold the nGridY string from Line3

--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -182,7 +182,7 @@ CONTAINS
          READ(UnCoef,*,IOSTAT=ErrStat4) nGridY_string, nGridY  ! read in the third line as the number of y values in the BathGrid
 
          ! Allocate the bathymetry matrix and associated grid x and y values
-         ALLOCATE(BathGrid(nGridX, nGridY), STAT=ErrStat4)
+         ALLOCATE(BathGrid(nGridY, nGridX), STAT=ErrStat4)
          ALLOCATE(BathGrid_Xs(nGridX), STAT=ErrStat4)
          ALLOCATE(BathGrid_Ys(nGridY), STAT=ErrStat4)
 

--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -563,7 +563,7 @@ CONTAINS
           END IF
         
         ! Point case                            
-        ELSE IF (let1(1:1) == 'P') THEN    ! Look for P?xxx or Point?xxx
+        ELSE IF (let1(1:1) == 'P' .OR. let1(1:1) == 'C') THEN    ! Look for P?xxx or Point?xxx (C?xxx and Con?xxx for backwards compatability)
           p%OutParam(I)%OType = 2                ! Point object type
           qVal = let2                            ! quantity type string
           
@@ -601,7 +601,7 @@ CONTAINS
         ! error
         ELSE
           CALL DenoteInvalidOutput(p%OutParam(I)) ! flag as invalid
-          CALL WrScr('Warning: invalid output specifier '//trim(OutListTmp)//'.  Must start with L, C, R, or B')
+          CALL WrScr('Warning: invalid output specifier '//trim(OutListTmp)//'.  Must start with L, R, or B')
           CYCLE
         END IF
 

--- a/modules/moordyn/src/MoorDyn_Misc.f90
+++ b/modules/moordyn/src/MoorDyn_Misc.f90
@@ -883,7 +883,7 @@ CONTAINS
       else
          dc_dx = 0.0_DbKi   ! maybe this should raise an error
       end if
-      if ( dx > 0.0 ) then
+      if ( dy > 0.0 ) then
          dc_dy = (cx1-cx0)/dy
       else
          dc_dy = 0.0_DbKi   ! maybe this should raise an error

--- a/modules/moordyn/src/MoorDyn_Misc.f90
+++ b/modules/moordyn/src/MoorDyn_Misc.f90
@@ -1297,8 +1297,7 @@ CONTAINS
       REAL(SiKi)                       :: t, Frac
       CHARACTER(1024)                  :: FileName             ! Name of MoorDyn input file  
       CHARACTER(120)                   :: Line
-      CHARACTER(120)                   :: Line2  
-      CHARACTER(120)                   :: entries2  
+      CHARACTER(4096)                  :: entries2  
       INTEGER(IntKi)                   :: coordtype
    
       INTEGER(IntKi)                   :: NStepWave    ! 


### PR DESCRIPTION
This is ready for merging.

**Feature or improvement description**
PR #2013 and #2016 included a few minor corrections to MoorDyn.  These also apply to the 3.5.x series.

**Related issue, if one exists**
PR #2013
PR #2016

**Impacted areas of the software**
_MoorDyn_ bathymetry calculations

**Additional supporting information**
See #2013 
See #2016

**Test results, if applicable**
