### PR TITLE
Lin tests: increase out precision, error printing full filename, add SD linearization test

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -319,6 +319,7 @@ of_regression_linear("5MW_Land_BD_Linear"           "openfast;linear;beamdyn;ser
 of_regression_linear("5MW_Land_BD_Linear_Aero"      "openfast;linear;beamdyn;servodyn;aerodyn")
 of_regression_linear("5MW_OC4Semi_Linear"           "openfast;linear;hydrodyn;servodyn;map")
 of_regression_linear("5MW_OC4Semi_MD_Linear"        "openfast;linear;hydrodyn;servodyn;moordyn")
+of_regression_linear("5MW_OC3Mnpl_Linear"        "openfast;linear;hydrodyn;servodyn;moordyn")
 of_regression_linear("StC_test_OC4Semi_Linear_Nac"  "openfast;linear;servodyn;stc")
 of_regression_linear("StC_test_OC4Semi_Linear_Tow"  "openfast;linear;servodyn;stc")
 of_regression_linear("5MW_OC3Spar_Linear"           "openfast;linear;map;hydrodyn")

--- a/reg_tests/executeOpenfastLinearRegressionCase.py
+++ b/reg_tests/executeOpenfastLinearRegressionCase.py
@@ -182,9 +182,14 @@ try:
     for i, f in enumerate(localOutFiles):
         local_file = os.path.join(testBuildDirectory, f)
         baseline_file = os.path.join(targetOutputDirectory, f)
+        # Set a prefix for all errors to identify where it comes from
+        basename = os.path.splitext(os.path.basename(local_file))[0]
+        ext2 = os.path.splitext(basename)[1][1:]  #+'.lin' # '.1' or '.AD' '.BD'
+        errPrefix = CasePrefix[:-1]+ext2+': '
+
         if verbose:
-            print(CasePrefix+'ref:', baseline_file)
-            print(CasePrefix+'new:', local_file)
+            print(errPrefix+'ref:', baseline_file)
+            print(errPrefix+'new:', local_file)
 
         # verify both files have the same number of lines
         local_file_line_count = file_line_count(local_file)
@@ -228,8 +233,8 @@ try:
                 v_loc = np.diag(Lambda)
 
                 if verbose:
-                    print(CasePrefix+'val_ref:', v_bas[:7])
-                    print(CasePrefix+'val_new:', v_loc[:7])
+                    print(errPrefix+'val_ref:', v_bas[:7])
+                    print(errPrefix+'val_new:', v_loc[:7])
                 try:
                     np.testing.assert_allclose(v_bas[:10], v_loc[:10], rtol=rtol_f, atol=atol_f)
                 except Exception as e:
@@ -237,10 +242,10 @@ try:
             else:
 
                 #if verbose:
-                print(CasePrefix+'freq_ref:', np.around(freq_bas[:10]    ,5), '[Hz]')
-                print(CasePrefix+'freq_new:', np.around(freq_loc[:10]    ,5), '[Hz]')
-                print(CasePrefix+'damp_ref:', np.around(zeta_bas[:10]*100,5), '[%]')
-                print(CasePrefix+'damp_new:', np.around(zeta_loc[:10]*100,5), '[%]')
+                print(errPrefix+'freq_ref:', np.around(freq_bas[:10]    ,5), '[Hz]')
+                print(errPrefix+'freq_new:', np.around(freq_loc[:10]    ,5), '[Hz]')
+                print(errPrefix+'damp_ref:', np.around(zeta_bas[:10]*100,5), '[%]')
+                print(errPrefix+'damp_new:', np.around(zeta_loc[:10]*100,5), '[%]')
 
                 try:
                     np.testing.assert_allclose(freq_loc[:10], freq_bas[:10], rtol=rtol_f, atol=atol_f)
@@ -266,7 +271,7 @@ try:
             if k not in KEYS or v is None:
                 continue
             if verbose:
-                print(CasePrefix+'key:', k)
+                print(errPrefix+'key:', k)
             # Arrays
             Mloc=np.atleast_2d(floc[k])
             Mbas=np.atleast_2d(fbas[k])


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
Increased the precision in the output for linearization cases.  This should help reduce comparison errors.

Also added printing the full filename during comparison.

Added linearization test with SD.

**Related issue, if one exists**
none

**Impacted areas of the software**
Linearization testing only.

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
The following cases were updated:

- `5MW_Land_BD_Linear_Aero` - input file + results
- `5MW_Land_Linear_Aero` - input file + results
- `5MW_OC3Spar_Linear` - input file + results
- `5MW_OC4Semi_Linear` - input file
- `Fake5MW_AeroLin_B1_UA4_DBEMT3` - input file
- `Fake5MW_AeroLin_B3_UA6` - input file + results
- `StC_test_OC4Semi_Linear_Nac` - input file
- `StC_test_OC4Semi_Linear_Tow` - input file
- `WP_Stationary_Linear` - input file