### PR TITLE
Fix bug in BD linearization resulting from reference rotation change

### DIFF
--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -932,6 +932,7 @@ subroutine SetParameters(InitInp, InputFileData, p, OtherState, ErrStat, ErrMsg)
 
 
    p%RotStates      = InputFileData%RotStates      ! Rotate states in linearization?
+   if (ChangeRefFrame) p%RotStates = .true.
    p%RelStates      = InputFileData%RelStates      ! Define states relative to root motion in linearization?
    
    p%rhoinf         = InputFileData%rhoinf         ! Numerical damping coefficient: [0,1].  No numerical damping if rhoinf = 1; maximum numerical damping if rhoinf = 0.
@@ -6025,7 +6026,8 @@ SUBROUTINE BD_JacobianPInput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrM
       end if
       
       if (p%RotStates) then
-         RotateStates = matmul( u%RootMotion%Orientation(:,:,1), transpose( u%RootMotion%RefOrientation(:,:,1) ) )
+         ! Calculate difference between input root orientation and root reference orientation
+         RotateStates = matmul( u%RootMotion%Orientation(:,:,1), OtherState%GlbRot )
          do i=1,size(dXdu,1),3
             dXdu(i:i+2, :) = matmul( RotateStates, dXdu(i:i+2, :) )
          end do
@@ -6121,7 +6123,8 @@ SUBROUTINE BD_JacobianPContState( t, u, p, x, xd, z, OtherState, y, m, ErrStat, 
    call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
    
    if (p%RotStates) then
-      RotateStates          = matmul( u%RootMotion%Orientation(:,:,1), transpose( u%RootMotion%RefOrientation(:,:,1) ) )
+      ! Calculate difference between input root orientation and root reference orientation
+      RotateStates          = matmul( u%RootMotion%Orientation(:,:,1), OtherState%GlbRot )
       RotateStatesTranspose = transpose( RotateStates )
 
       if ( present(StateRotation) ) then


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This pull request is ready to be merged

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR fixes a bug in the BeamDyn Jacobian calculations related to rotating the states. When RotStates (input file) and ChangeRefFrame (BeamDyn.f90) were both True, the state Jacobians were rotated by the wrong amount leading to incorrect linearization results. This has been updated by setting RotStates to True when ChangeRefFrame is True and updating the way the difference in rotation is calculated for rotating the state Jacobians.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
`BeamDyn.f90`

**Additional supporting information**
<!-- Add any other context about the problem here. -->

When the change in reference frame was implemented in v3.5.0, it effectively changed the states to be in the rotating frame. The existing method for putting the state Jacobians into the rotating frame involved calculating the difference in rotation between the root mesh reference orientation and the root mesh current orientation. Originally, the reference orientation always aligned with the blade root reference orientation inside BeamDyn. However, this is not a valid assumption when ChangeRefFrame = .true. as the blade root reference is updated by UpdateStates at every step.

This commit changes two things: first, if ChangeRefFrame is true, then p%RotStates is also set to true because the states are in the rotating frame; second, the Jacobian is now rotated by the difference between the root mesh current orientation and BeamDyn's root reference orientation. These orientations will be the same after UpdateStates, but the correction is still applied in case the Jacobian routines are called with a different root mesh orientation.

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
No test results were affected. However, it would be good to change the `5MW_Land_BD_Linear` regression test to not linearize at time 0 so the blades have a chance to move away from their reference position/orientation. This issue was not discovered sooner because the tests passed since there was no difference between the root orientation and the reference orientation.
