### PR TITLE
GH actions: update matlab-actions version

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -46,6 +46,8 @@ jobs:
           cache: 'pip'
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
+        with:
+          products: Simulink
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -181,6 +183,8 @@ jobs:
           cache: 'pip'
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
+        with:
+          products: Simulink
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -635,6 +639,8 @@ jobs:
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev libopenblas-dev libopenblas-openmp-dev
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v2
+        with:
+          products: Simulink
       - name: Build FAST_SFunc
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
@@ -645,6 +651,7 @@ jobs:
       - name: Run MATLAB tests and generate artifacts
         uses: matlab-actions/run-tests@v2
         with:
+          products: Simulink
           source-folder: ${{runner.workspace}}/openfast/build/glue-codes/simulink; ${{runner.workspace}}/openfast/glue-codes/simulink/examples
           test-results-junit: test-results/results.xml
           code-coverage-cobertura: code-coverage/coverage.xml

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -45,7 +45,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -180,7 +180,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
@@ -634,7 +634,7 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev libopenblas-dev libopenblas-openmp-dev
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
       - name: Build FAST_SFunc
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
@@ -643,7 +643,7 @@ jobs:
             ${GITHUB_WORKSPACE}
           cmake --build . --target FAST_SFunc
       - name: Run MATLAB tests and generate artifacts
-        uses: matlab-actions/run-tests@v1
+        uses: matlab-actions/run-tests@v2
         with:
           source-folder: ${{runner.workspace}}/openfast/build/glue-codes/simulink; ${{runner.workspace}}/openfast/glue-codes/simulink/examples
           test-results-junit: test-results/results.xml


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
We were receiving errors about node.js 16 deprecation:
<img width="551" alt="Screenshot 2024-03-05 at 3 16 09 PM" src="https://github.com/OpenFAST/openfast/assets/2745453/7f125ca7-8a34-4659-9a63-532f850b3d9b">


Update matlab-actions from v1 to v2
node.js 16 is getting deprecated.  Matlab-actions v2 uses node.js 20


**Impacted areas of the software**
Testing on GitHub only.
