### PR TITLE
GH actions: remove extraneous "products:" from recipe (added in #2072)

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -651,7 +651,6 @@ jobs:
       - name: Run MATLAB tests and generate artifacts
         uses: matlab-actions/run-tests@v2
         with:
-          products: Simulink
           source-folder: ${{runner.workspace}}/openfast/build/glue-codes/simulink; ${{runner.workspace}}/openfast/glue-codes/simulink/examples
           test-results-junit: test-results/results.xml
           code-coverage-cobertura: code-coverage/coverage.xml


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
PR #2072 fixed some warnings from GitHub actions.  However, an extra "products: Simulink" had been added to the `matlab-actions/run-tests@2` command that should not have been included.  This PR fixes that oversight

**Related issue, if one exists**
PR #2072

**Impacted areas of the software**
Warnings from GitHub actions

