### PR TITLE
Move flag for WriteThisStep to FAST_PreWork

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -7392,9 +7392,6 @@ SUBROUTINE FAST_Solution(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, 
    ErrMsg  = ""
 
    n_t_global_next = n_t_global+1
-   t_global_next = t_initial + n_t_global_next*p_FAST%DT  ! = m_FAST%t_global + p_FAST%dt
-
-   y_FAST%WriteThisStep = NeedWriteOutput(n_t_global_next, t_global_next, p_FAST)
 
    !++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
    !! ## Step 1.a: set some variables and Extrapolate Inputs
@@ -7486,6 +7483,7 @@ SUBROUTINE FAST_Prework(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, S
    CHARACTER(*),             INTENT(  OUT) :: ErrMsg              !< Error message if ErrStat /= ErrID_None
 
    ! local variables
+   INTEGER(IntKi)                          :: n_t_global_next     ! n_t_global + 1
    REAL(DbKi)                              :: t_global_next       ! next simulation time (m_FAST%t_global + p_FAST%dt)
    INTEGER(IntKi)                          :: j_pc                ! predictor-corrector loop counter
    INTEGER(IntKi)                          :: NumCorrections      ! number of corrections for this time step
@@ -7501,7 +7499,11 @@ SUBROUTINE FAST_Prework(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, S
    ErrStat = ErrID_None
    ErrMsg  = ""
 
-   t_global_next = t_initial + (n_t_global+1)*p_FAST%DT  ! = m_FAST%t_global + p_FAST%dt
+   n_t_global_next = n_t_global+1
+   t_global_next = t_initial + n_t_global_next*p_FAST%DT  ! = m_FAST%t_global + p_FAST%dt
+
+   ! set flag for writing output at time t_global_next
+   y_FAST%WriteThisStep = NeedWriteOutput(n_t_global_next, t_global_next, p_FAST)
 
       !! determine if the Jacobian should be calculated this time
    IF ( m_FAST%calcJacobian ) THEN ! this was true (possibly at initialization), so we'll advance the time for the next calculation of the Jacobian


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
In the glue code, a flag `WriteThisStep` indicates when to write output to files (or store outputs).  This had been in `FAST_Solution`, but should be located in `FAST_PreWork` (it was left in `FAST_Solution` when that routine was split into several parts).

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/pull/1932/files#r1513534370

**Impacted areas of the software**
Potential impacts on writing to file when an external code directly calls the OpenFAST routines called by `FAST_Solution` (for example, _AMR-Wind_).

**Additional supporting information**
When `FAST_Solution` was split into multiple routines during the addition of the `ExtLoads` module, this statement should have been included in the new `FAST_PreWork` routine, but was not.
