### PR TITLE
Handling of Paths for SrvD UserSubs Input Files

### DIFF
--- a/modules/servodyn/src/ServoDyn.f90
+++ b/modules/servodyn/src/ServoDyn.f90
@@ -158,6 +158,8 @@ SUBROUTINE SrvD_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitO
    CALL DispNVD( SrvD_Ver )
    CALL GetPath( InitInp%InputFile, PriPath )     ! Input files will be relative to the path where the primary input file is located.
 
+    p%PriPath = PriPath
+
       !............................................................................................
       ! Read the input file and validate the data
       ! (note p%NumBl and p%RootName must be set first!)
@@ -5241,7 +5243,7 @@ SUBROUTINE CalculateStandardYaw(t, u, p, m, YawPosCom, YawRateCom, YawPosComInt,
 
          CASE ( ControlMode_USER )              ! User-defined from routine UserYawCont().
 
-            CALL UserYawCont ( u%Yaw, u%YawRate, u%WindDir, u%YawErr, p%NumBl, t, p%DT, p%RootName, YawPosCom, YawRateCom )
+            CALL UserYawCont ( u%Yaw, u%YawRate, u%WindDir, u%YawErr, p%NumBl, t, p%DT, p%PriPath, YawPosCom, YawRateCom )
 
          CASE ( ControlMode_EXTERN )              ! User-defined from Simulink or LabVIEW
 
@@ -5380,7 +5382,7 @@ SUBROUTINE Pitch_CalcOutput( t, u, p, x, xd, z, OtherState, BlPitchCom, ElecPwr,
 
          CASE ( ControlMode_USER )              ! User-defined from routine PitchCntrl().
 
-            CALL PitchCntrl ( u%BlPitch, ElecPwr, u%LSS_Spd, u%TwrAccel, p%NumBl, t, p%DT, p%RootName, BlPitchCom )
+            CALL PitchCntrl ( u%BlPitch, ElecPwr, u%LSS_Spd, u%TwrAccel, p%NumBl, t, p%DT, p%PriPath, BlPitchCom )
 
          CASE ( ControlMode_EXTERN )              ! User-defined from Simulink or LabVIEW.
 
@@ -5733,7 +5735,7 @@ SUBROUTINE Torque_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrM
 
          CASE ( ControlMode_USER )                   ! User-defined HSS brake model.
 
-            CALL UserHSSBr ( y%GenTrq, y%ElecPwr, u%HSS_Spd, p%NumBl, t, p%DT, p%RootName, HSSBrFrac )
+            CALL UserHSSBr ( y%GenTrq, y%ElecPwr, u%HSS_Spd, p%NumBl, t, p%DT, p%PriPath, HSSBrFrac )
 
             IF ( ( HSSBrFrac < 0.0_ReKi ) .OR. ( HSSBrFrac > 1.0_ReKi ) )  THEN   ! 0 (off) <= HSSBrFrac <= 1 (full); else Abort.
                ErrStat = ErrID_Fatal
@@ -5938,8 +5940,8 @@ SUBROUTINE CalculateTorque( t, u, p, m, GenTrq, ElecPwr, ErrStat, ErrMsg )
                   CASE ( ControlMode_USER )                          ! User-defined generator model.
 
 
-            !        CALL UserGen ( u%HSS_Spd, u%LSS_Spd, p%NumBl, t, DT, p%GenEff, DelGenTrq, DirRoot, GenTrq, ElecPwr )
-                     CALL UserGen ( u%HSS_Spd, u%LSS_Spd, p%NumBl, t, p%DT, p%GenEff, 0.0_ReKi, p%RootName, GenTrq, ElecPwr )
+                     CALL UserGen ( u%HSS_Spd, u%LSS_Spd, p%NumBl, t, p%DT, p%GenEff, 0.0_ReKi, p%PriPath, GenTrq, ElecPwr )
+
 
                END SELECT
 
@@ -5974,7 +5976,7 @@ SUBROUTINE CalculateTorque( t, u, p, m, GenTrq, ElecPwr, ErrStat, ErrMsg )
             CASE ( ControlMode_USER )                              ! User-defined variable-speed control for routine UserVSCont().
 
 
-               CALL UserVSCont ( u%HSS_Spd, u%LSS_Spd, p%NumBl, t, p%DT, p%GenEff, 0.0_ReKi, p%RootName, GenTrq, ElecPwr )
+               CALL UserVSCont ( u%HSS_Spd, u%LSS_Spd, p%NumBl, t, p%DT, p%GenEff, 0.0_ReKi, p%PriPath, GenTrq, ElecPwr )
 
             CASE ( ControlMode_DLL )                                ! User-defined variable-speed control from Bladed-style DLL
 

--- a/modules/servodyn/src/ServoDyn_Registry.txt
+++ b/modules/servodyn/src/ServoDyn_Registry.txt
@@ -439,6 +439,7 @@ typedef	^	ParameterType	IntKi	StCCmode	-	-	-	"Structural control control mode {0
 typedef	^	ParameterType	IntKi	NumOuts	-	-	-	"Number of parameters in the output list (number of outputs requested)"	-
 typedef	^	ParameterType	IntKi	NumOuts_DLL	-	-	-	"Number of logging channels output from the DLL (set at initialization)"	-
 typedef	^	ParameterType	CHARACTER(1024)	RootName	-	-	-	"RootName for writing output files"	-
+typedef	^	ParameterType	CHARACTER(1024)	PriPath  	-	-	-	"Path of the primary SD input file "	-
 typedef	^	ParameterType	OutParmType	OutParam	{:}	-	-	"Names and units (and other characteristics) of all requested output parameters"	-
 typedef	^	ParameterType	CHARACTER(1)	Delim	-	-	-	"Column delimiter for output text files"	-
 # parameters for Bladed Interface (dynamic-link library)

--- a/modules/servodyn/src/ServoDyn_Types.f90
+++ b/modules/servodyn/src/ServoDyn_Types.f90
@@ -450,6 +450,7 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: NumOuts      !< Number of parameters in the output list (number of outputs requested) [-]
     INTEGER(IntKi)  :: NumOuts_DLL      !< Number of logging channels output from the DLL (set at initialization) [-]
     CHARACTER(1024)  :: RootName      !< RootName for writing output files [-]
+    CHARACTER(1024)  :: PriPath      !< Path of the primary SD input file  [-]
     TYPE(OutParmType) , DIMENSION(:), ALLOCATABLE  :: OutParam      !< Names and units (and other characteristics) of all requested output parameters [-]
     CHARACTER(1)  :: Delim      !< Column delimiter for output text files [-]
     LOGICAL  :: UseBladedInterface      !< Flag that determines if BladedInterface was used [-]
@@ -12645,6 +12646,7 @@ ENDIF
     DstParamData%NumOuts = SrcParamData%NumOuts
     DstParamData%NumOuts_DLL = SrcParamData%NumOuts_DLL
     DstParamData%RootName = SrcParamData%RootName
+    DstParamData%PriPath = SrcParamData%PriPath
 IF (ALLOCATED(SrcParamData%OutParam)) THEN
   i1_l = LBOUND(SrcParamData%OutParam,1)
   i1_u = UBOUND(SrcParamData%OutParam,1)
@@ -13247,6 +13249,7 @@ ENDIF
       Int_BufSz  = Int_BufSz  + 1  ! NumOuts
       Int_BufSz  = Int_BufSz  + 1  ! NumOuts_DLL
       Int_BufSz  = Int_BufSz  + 1*LEN(InData%RootName)  ! RootName
+      Int_BufSz  = Int_BufSz  + 1*LEN(InData%PriPath)  ! PriPath
   Int_BufSz   = Int_BufSz   + 1     ! OutParam allocated yes/no
   IF ( ALLOCATED(InData%OutParam) ) THEN
     Int_BufSz   = Int_BufSz   + 2*1  ! OutParam upper/lower bounds for each dimension
@@ -13731,6 +13734,10 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     DO I = 1, LEN(InData%RootName)
       IntKiBuf(Int_Xferred) = ICHAR(InData%RootName(I:I), IntKi)
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    DO I = 1, LEN(InData%PriPath)
+      IntKiBuf(Int_Xferred) = ICHAR(InData%PriPath(I:I), IntKi)
       Int_Xferred = Int_Xferred + 1
     END DO ! I
   IF ( .NOT. ALLOCATED(InData%OutParam) ) THEN
@@ -14619,6 +14626,10 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     DO I = 1, LEN(OutData%RootName)
       OutData%RootName(I:I) = CHAR(IntKiBuf(Int_Xferred))
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    DO I = 1, LEN(OutData%PriPath)
+      OutData%PriPath(I:I) = CHAR(IntKiBuf(Int_Xferred))
       Int_Xferred = Int_Xferred + 1
     END DO ! I
   IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! OutParam not allocated


### PR DESCRIPTION
**Feature or improvement description**

In Issue #2059, @rdamiani pointed out that the existing method for handling file paths with `UserSubs` is difficult as it requires putting all the user input files in the same location as the ServoDyn file.  This PR gives a method that from @rdamiani for a method he has had good success with.  

This PR is entirely @rdamini's work merely copied into a PR by me.  

Co-authored-by:rdamiani <r.damiani@RRDengineering.com>


**Related issue, if one exists**
Closes #2059 

**Impacted areas of the software**
_ServoDyn_ controls where the `UserSubs` option is used (`PCMode`, `VSContrl`, `HSSBrMode`, or `YCMode` =3).

**Additional supporting information**
The usage of the affected routines is a very specialized case that we don't directly support, but certainly want to make life easier for users of these features.

**Test results, if applicable**
None.