### PR TITLE
Fix bug in new UA driver

### DIFF
--- a/modules/aerodyn/src/UA_Dvr_Subs.f90
+++ b/modules/aerodyn/src/UA_Dvr_Subs.f90
@@ -131,7 +131,7 @@ module UA_Dvr_Subs
       real(ReKi) :: twist_full      !< Full twist (includes initial twist, potential pitch, and torsion)
       integer    :: iU0Last = 1     !< Index for faster interpolation of wind speed
       integer    :: iPALast = 1     !< Index for faster interpolation of prescribed aero
-      real(ReKi) :: uPA(4)          !< Prescribed Aero inputs
+      real(ReKi) :: uPA(3)          !< Prescribed Aero inputs
    end type Dvr_Misc
 
    type Dvr_Data


### PR DESCRIPTION
**Feature or improvement description**
The code was setting an array of size 4 equal to an array of size 3, causing an issue in the debugger.

**Related issue, if one exists**
This was introduced in https://github.com/OpenFAST/openfast/pull/1910

**Impacted areas of the software**
The new UA driver

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
This likely won't change results; I don't think this particular part of UA driver has a regression test.

