### PR TITLE
Support cross-compiling with Mingw 

### DIFF
--- a/modules/map/src/mapsys.h
+++ b/modules/map/src/mapsys.h
@@ -33,7 +33,7 @@
 
 
 #if defined(_WIN32) || defined(_WIN64)
-#  include <Windows.h>
+#  include <windows.h>
 #  include <tchar.h>
 #else
 #  include <unistd.h>


### PR DESCRIPTION

<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
_Support cross-compiling openfast in Linux (to build a Windows version)_

I'm using Mingw compiler on Linux to cross-compile openfast and build a Windows version (yes, geek but useful for me ...)  
Unfortunately the mingw windows header file is "windows.h". In a case-sensitive system (like linux) the build fails in this line, as it's trying to include the header "Windows.h" ('W' upper-case)

Changing the include line to `#include <windows.h>` solves my problem and I'm able to cross-compile openfast. The change should not affect the windows native build, as this is a case-insensitive system.


**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
None 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
None

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
