### PR TITLE
TurbSim: increase filename to 1024 characters

### DIFF
--- a/modules/turbsim/src/CohStructures.f90
+++ b/modules/turbsim/src/CohStructures.f90
@@ -766,7 +766,7 @@ SUBROUTINE CohStr_WriteEvents( RootName, p_CohStr, e_CohStr, y_CohStr, TScale, U
   CHARACTER(MaxMsgLen)     :: ErrMsg2                         ! Message describing error (local)
 
 
-   CHARACTER(200)          :: InpFile                ! Name of the input file
+   CHARACTER(1024)         :: InpFile                ! Name of the input file
    TYPE (Event), POINTER   :: PtrCurr  => NULL()     ! Pointer to the current event
    TYPE (Event), POINTER   :: PtrPrev  => NULL()     ! Pointer to the previous event (for deallocation purposes)
 

--- a/modules/turbsim/src/Profiles.f90
+++ b/modules/turbsim/src/Profiles.f90
@@ -122,7 +122,7 @@ SUBROUTINE GetChebCoefs(p, UJetMax_IsKnown, ErrStat, ErrMsg)
 
    ! valid only for jet WindProfileType
    
-IMPLICIT                   NONE
+   IMPLICIT                   NONE
 
    TYPE(TurbSim_ParameterType),INTENT(INOUT) :: p                 ! TurbSim parameters
    LOGICAL,                    INTENT(IN)    :: UJetMax_IsKnown   

--- a/modules/turbsim/src/TS_FileIO.f90
+++ b/modules/turbsim/src/TS_FileIO.f90
@@ -72,7 +72,7 @@ SUBROUTINE ReadInputFile(InFile, p, OtherSt_RandNum, ErrStat, ErrMsg)
    LOGICAL                       :: UseDefault                       ! Whether or not to use a default value
    LOGICAL                       :: IsUnusedParameter                ! Whether or not this variable will be ignored
                               
-   CHARACTER(200)                :: Line                             ! An input line
+   CHARACTER(1024)               :: Line                             ! An input line
    CHARACTER(1)                  :: Line1                            ! The first character of an input line
 
    INTEGER(IntKi)                :: ErrStat2                         ! Temporary Error status

--- a/modules/turbsim/src/TurbSim.f90
+++ b/modules/turbsim/src/TurbSim.f90
@@ -82,7 +82,7 @@ REAL(ReKi)                       ::  WSig                   ! Standard deviation
 
 INTEGER(IntKi)                   :: ErrStat                 ! allocation status
 CHARACTER(MaxMsgLen)             :: ErrMsg                  ! error message
-CHARACTER(200)                   :: InFile                  ! Name of the TurbSim input file.
+CHARACTER(1024)                  :: InFile                  ! Name of the TurbSim input file.
 CHARACTER(20)                    :: FlagArg                 ! flag argument from command line
 
 

--- a/modules/turbsim/src/TurbSim_Types.f90
+++ b/modules/turbsim/src/TurbSim_Types.f90
@@ -90,8 +90,8 @@ use NWTC_Library
       REAL(ReKi)                   :: DistScl                                  ! Disturbance scale for AeroDyn coherent turbulence events
    
                   
-      CHARACTER(200)               :: CTEventPath                              ! String used to store the name of the coherent event definition file
-      CHARACTER(200)               :: CTEventFile                              ! String used to store the name of the coherent event definition file
+      CHARACTER(1024)              :: CTEventPath                              ! String used to store the name of the coherent event definition file
+      CHARACTER(1024)              :: CTEventFile                              ! String used to store the name of the coherent event definition file
       CHARACTER(  3)               :: CTExt                                    ! String used to determine the type of coherent structures ("dns" or "les")
 
    END TYPE CohStr_ParameterType
@@ -276,8 +276,8 @@ use NWTC_Library
       INTEGER                          :: US  = -1                    ! I/O unit for summary file.
               
       
-      CHARACTER(200)                   :: DescStr                     ! String used to describe the run (and the first line of the summary file)
-      CHARACTER(197)                   :: RootName                    ! Root name of the I/O files.
+      CHARACTER(1024)                  :: DescStr                     ! String used to describe the run (and the first line of the summary file)
+      CHARACTER(1024)                  :: RootName                    ! Root name of the I/O files.
       TYPE(RandNum_ParameterType)      :: RNG                         ! parameters for random numbers p_RandNum
       TYPE(Grid_ParameterType)         :: grid                        ! parameters for TurbSim (specify grid/frequency size)
       TYPE(Meteorology_ParameterType)  :: met                         ! parameters for TurbSim 


### PR DESCRIPTION
This is ready to merge.

**Feature or improvement description**
On some systems, the file name + path may be more than 200 characters.  When that occurs, the input file can't be found and rather unhelpful error messages occur.

**Impacted areas of the software**
TurbSim

**Additional supporting information**
This became a problem with _WEIS_ where long file paths are common.
@dzalkind notified us of this issue.

**Test results, if applicable**
N/A