### PR TITLE
SeaState: replace `pointer` attribute with `allocatable`

### DIFF
--- a/modules/seastate/src/SeaState_Output.f90
+++ b/modules/seastate/src/SeaState_Output.f90
@@ -428,9 +428,9 @@ subroutine SeaStOut_WriteWaveElev0( Rootname, NStepWave, NGrid, WaveElev1, WaveE
    CHARACTER(*),                  INTENT( IN    )   :: Rootname             ! filename including full path, minus any file extension.
    INTEGER,                       INTENT( IN    )   :: NStepWave            ! Number of time steps for the wave kinematics arrays
    INTEGER,                       INTENT( IN    )   :: NGrid(3)             ! Number of grid points for the wave kinematics arrays
-   REAL(SiKi), pointer,           INTENT( IN    )   :: WaveElev1 (:,:,: )     ! Instantaneous wave elevations at requested locations - 1st order
-   REAL(SiKi), pointer,           INTENT( IN    )   :: WaveElev2 (:,:,: )     ! Instantaneous wave elevations at requested locations - 2nd order
-   REAL(SiKi), pointer,           INTENT( IN    )   :: WaveTime (:    )     ! The time values for the wave kinematics  (time)
+   REAL(SiKi), allocatable,       INTENT( IN    )   :: WaveElev1 (:,:,: )   ! Instantaneous wave elevations at requested locations - 1st order
+   REAL(SiKi), allocatable,       INTENT( IN    )   :: WaveElev2 (:,:,: )   ! Instantaneous wave elevations at requested locations - 2nd order
+   REAL(SiKi), allocatable,       INTENT( IN    )   :: WaveTime (:    )     ! The time values for the wave kinematics  (time)
    INTEGER,                       INTENT(   OUT )   :: ErrStat              ! returns a non-zero value when an error occurs  
    CHARACTER(*),                  INTENT(   OUT )   :: ErrMsg               ! Error message if ErrStat /= ErrID_None
       
@@ -459,12 +459,11 @@ subroutine SeaStOut_WriteWaveElev0( Rootname, NStepWave, NGrid, WaveElev1, WaveE
    ! Write the increments from [0, NStepWave] even though for OpenFAST data, NStepWave = 0, but for arbitrary user data this may not be true.
    ! As a result for WaveMod=5,6 we shouldn't assume periodic waves over the period WaveTMax
    DO m= 0,NStepWave
-      
-            if ( associated(WaveElev2) ) then
-               WRITE(UnWv,Frmt)   WaveTime(m), WaveElev1(m,i,j) + WaveElev2(m,i,j)
-            else
-               WRITE(UnWv,Frmt)   WaveTime(m), WaveElev1(m,i,j)
-            end if 
+      if ( allocated(WaveElev2) ) then
+         WRITE(UnWv,Frmt)   WaveTime(m), WaveElev1(m,i,j) + WaveElev2(m,i,j)
+      else
+         WRITE(UnWv,Frmt)   WaveTime(m), WaveElev1(m,i,j)
+      end if 
    END DO
       
    CLOSE( UnWv, IOSTAT=ErrStat )


### PR DESCRIPTION
**Feature or improvement description**
Fix pointer/allocatable attributes in one SeaState function. At one point in the SeaState evolution, these arrays were pointers, but they later were allocatable. 

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
SeaState, mostly as called from the SeaState driver

**Additional supporting information**
It's possible this was missed because this code isn't called in OpenFAST without changing a hard-coded parameter.

**Test results, if applicable**
Should not change any tests. This will only cause the build to fail on certain compilers.