### PR TITLE
Fix use of uninitialized variables in FAST.Farm and increase stack size in Visual Studio

### DIFF
--- a/modules/aerodyn/src/AeroDyn_AllBldNdOuts_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_AllBldNdOuts_IO.f90
@@ -301,7 +301,7 @@ SUBROUTINE Calc_WriteAllBldNdOutput( p, p_AD, u, m, m_AD, x, y, OtherState, Indx
    nNd = p%NumBlNds
    R_li => m%R_li                     ! inertial to local-polar
    R_wi => m%orientationAnnulus       ! inertial to without-sweep-pitch-twist or orientation annulus (TODO: deprecate me)
-   W2B => p_AD%FVW%Bld2Wings(iRot, :) ! From Wing index to blade index
+   if (p_AD%WakeMod == WakeMod_FVW) W2B => p_AD%FVW%Bld2Wings(iRot, :) ! From Wing index to blade index
 
          ! Initialize some things
       ErrMsg = ''

--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -958,6 +958,9 @@ subroutine AWAE_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitO
       IfW_InitInp%lidar%HubPosition = 0.0_ReKi
       IfW_InitInp%lidar%SensorType  = SensorType_None
       IfW_InitInp%Use4Dext          = .false.
+      IfW_InitInp%MHK               = 0   !FIXME: after merge to dev, change this test to use MHK_None
+      IfW_InitInp%WtrDpth           = 0.0_ReKi
+      IfW_InitInp%MSL2SWL           = 0.0_ReKi
 
       if (      p%Mod_AmbWind == 2 ) then ! one InflowWind module
 

--- a/vs-build/FAST-farm/FAST-Farm.vfproj
+++ b/vs-build/FAST-farm/FAST-Farm.vfproj
@@ -6,7 +6,7 @@
 	<Configurations>
 		<Configuration Name="Debug|Win32" OutputDirectory="..\..\build\bin\" TargetName="FAST.Farm_$(PlatformName)_Debug">
 				<Tool Name="VFFortranCompilerTool" AdditionalOptions="/fpe-all:0" SuppressStartupBanner="true" DebugInformationFormat="debugEnabled" Optimization="optimizeDisabled" Preprocess="preprocessYes" PreprocessorDefinitions="&quot;GIT_INCLUDE_FILE='$(ProjectDir)\..\gitVersionInfo.h'&quot;" StandardWarnings="standardWarningsF03" DisableSpecificDiagnostics="5268,5199" WarnInterfaces="true" Traceback="true" RuntimeLibrary="rtMultiThreadedDebug" UseMkl="mklSequential"/>
-				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateManifest="false" GenerateDebugInformation="true" SubSystem="subSystemConsole" StackReserveSize="9999999" LargeAddressAware="addrAwareLarge"/>
+				<Tool Name="VFLinkerTool" LinkIncremental="linkIncrementalNo" SuppressStartupBanner="true" GenerateManifest="false" GenerateDebugInformation="true" SubSystem="subSystemConsole" StackReserveSize="19999999" LargeAddressAware="addrAwareLarge"/>
 				<Tool Name="VFResourceCompilerTool"/>
 				<Tool Name="VFMidlTool" SuppressStartupBanner="true"/>
 				<Tool Name="VFCustomBuildTool"/>


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged

**Feature or improvement description**
This PR fixes the use of uninitialized variables when running FAST.Farm. Initialization of `IfW_InitInp%MHK`, `IfW_InitInp%WtrDpth`, and `IfW_InitInp%MSL2SWL` were added to AWAE. Slicing of an unallocated array was also fixed in `AeroDyn_AllBldNdOuts_IO.f90`. This PR also increases the stack size when building with Visual Studio.

**Related issue, if one exists**
#2053 

**Impacted areas of the software**
`AeroDyn_AllBldNdOuts_IO.f90`
`AWAE.f90`


