### PR TITLE
CMake: openmp optional for FF and CPP if not explicitly requested (correction)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,11 +110,13 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_rpath.cmake)
 # OpenMP
 #-------------------------------------------------------------------------------
 
-if (OPENMP)
+if (OPENMP OR BUILD_FASTFARM OR BUILD_OPENFAST_CPP_API)
+  if (OPENMP)
     FIND_PACKAGE(OpenMP REQUIRED)
-endif()
-if (BUILD_FASTFARM OR BUILD_OPENFAST_CPP_API)
-   FIND_PACKAGE(OpenMP)
+  else()
+    # Optional for FF or the CPP interface
+    FIND_PACKAGE(OpenMP)
+  endif()
   if (OpenMP_Fortran_FOUND)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
     link_libraries("${OpenMP_Fortran_LIBRARIES}")


### PR DESCRIPTION
This is ready to merge.  

**Feature or improvement description**
PR #2120 had a mistake in it. The `OpenMP` logic in `CMakeLists.txt` would only be applied if building FAST.Farm or the C++ API, but not when `OpenMP` is explicitly set.

**Related issue, if one exists**
#2120 

**Impacted areas of the software**
CMake builds with `OpenMP` only.

**Test results, if applicable**
No test results change.