### PR TITLE
VSbuild: set VS version to VS 2017

### DIFF
--- a/vs-build/AeroDyn/AeroDyn_Driver.sln
+++ b/vs-build/AeroDyn/AeroDyn_Driver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33529.622
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "AeroDyn_Driver", "AeroDyn_Driver.vfproj", "{97CEFEB9-1DCB-470E-A231-E1DA2F21A9CE}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/AeroDyn_Inflow_c_binding/AeroDyn_Inflow_c_binding.sln
+++ b/vs-build/AeroDyn_Inflow_c_binding/AeroDyn_Inflow_c_binding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33529.622
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "AeroDyn_Inflow_c_binding", "AeroDyn_Inflow_c_binding.vfproj", "{5D991B19-D4F1-4F29-8A9D-FC36DFF07290}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/BeamDyn/BeamDyn-w-registry.sln
+++ b/vs-build/BeamDyn/BeamDyn-w-registry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "BeamDyn", "BeamDyn.vfproj", "{815C302F-A93D-4C22-9329-7112345113C0}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/FAST-farm/FAST-Farm.sln
+++ b/vs-build/FAST-farm/FAST-Farm.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "FASTlib", "..\FASTlib\FASTlib.vfproj", "{1A440C5B-CBA6-47D9-9CC2-C1CBA8C00BF9}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/FAST/FAST.sln
+++ b/vs-build/FAST/FAST.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "FAST", "FAST.vfproj", "{18AE8067-CCC6-4479-A0DB-C4089EF9FE71}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/HydroDyn/HydroDynDriver.sln
+++ b/vs-build/HydroDyn/HydroDynDriver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30503.244
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "HydroDynDriver", "HydroDynDriver.vfproj", "{815C302F-A93D-4C22-9329-717B085113C0}"
 EndProject

--- a/vs-build/HydroDyn_c_binding/HydroDyn_c_binding.sln
+++ b/vs-build/HydroDyn_c_binding/HydroDyn_c_binding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.30503.244
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "HydroDyn_c_binding", "HydroDyn_c_binding.vfproj", "{FDA4A02B-B3A7-4D06-847C-941BE44E76FB}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/InflowWind/InflowWind_driver.sln
+++ b/vs-build/InflowWind/InflowWind_driver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.33529.622
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "InflowWind_driver", "InflowWind_driver.vfproj", "{3BBE2741-5B28-47BC-9E7F-3E1D172838FB}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/InflowWind_c_binding/InflowWind_c_binding.sln
+++ b/vs-build/InflowWind_c_binding/InflowWind_c_binding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "InflowWind_c_binding", "InflowWind_c_binding.vfproj", "{5D991B19-D4F1-4F29-8A9D-FC36DFF07290}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/MoorDyn/MoorDynDriver.sln
+++ b/vs-build/MoorDyn/MoorDynDriver.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31613.86
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{A1373E92-2C9A-4B4D-BE47-0B46E317E1A8}") = "MoorDynDriver", "MoorDynDriver.vfproj", "{E91DED35-18F8-415F-9719-59DFBA79CB2C}"
 EndProject

--- a/vs-build/MoorDyn_c_binding/MoorDyn_c_binding.sln
+++ b/vs-build/MoorDyn_c_binding/MoorDyn_c_binding.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.31613.86
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "MoorDyn_c_binding", "MoorDyn_c_binding.vfproj", "{25689C95-9A3C-41A1-B0E6-5B292B6EFBE9}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/Registry/FAST_Registry.sln
+++ b/vs-build/Registry/FAST_Registry.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "FAST_Registry", "FAST_Registry.vcxproj", "{DA16A3A6-3297-4628-9E46-C6FA0E3C4D16}"
 EndProject

--- a/vs-build/SC_DLL/SC_DLL.sln
+++ b/vs-build/SC_DLL/SC_DLL.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 2013
-VisualStudioVersion = 12.0.40629.0
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "SC_DLL", "SC_DLL.vfproj", "{183CC593-AD4C-9643-81C1-7D6085A9A5ED}"
 EndProject

--- a/vs-build/SubDyn/SubDyn.sln
+++ b/vs-build/SubDyn/SubDyn.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "SubDyn", "SubDyn.vfproj", "{815C302F-A93D-4C22-9329-717B085113C0}"
 	ProjectSection(ProjectDependencies) = postProject

--- a/vs-build/UnsteadyAero/UnsteadyAero.sln
+++ b/vs-build/UnsteadyAero/UnsteadyAero.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.34031.81
+# Visual Studio 15
+VisualStudioVersion = 15.0.28307.902
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{6989167D-11E4-40FE-8C1A-2192A86A7E90}") = "UnsteadyAero", "UnsteadyAero.vfproj", "{815C302F-A93D-4C22-9329-717B085113C0}"
 	ProjectSection(ProjectDependencies) = postProject


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
We have been intentionally keeping the supported VS version to 2017 to support users on older platforms.  This had recently been updated to 2019, but we want to keep it at 2017 (there is no functional difference in the solution files).

Visual Studio 15
VisualStudioVersion = 15.0.28307.902

**Related issue, if one exists**
#2116 and comment here: https://github.com/OpenFAST/openfast/pull/2121#discussion_r1541497913

**Impacted areas of the software**
VS build solutions only

