### PR TITLE
Fix cache failure in Github Actions caused by setup-python

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -46,8 +46,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
       - name: Setup workspace
@@ -132,8 +131,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
       - name: Setup workspace
@@ -178,8 +176,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev  # gcovr
@@ -232,8 +229,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -270,8 +266,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -308,8 +303,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -348,8 +342,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev
       - name: Setup workspace
@@ -410,8 +403,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -466,8 +458,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -525,8 +516,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3" vtk
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -573,8 +563,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -626,8 +615,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -676,8 +664,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -726,8 +713,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -776,8 +762,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -826,8 +811,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -876,8 +860,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev
@@ -926,8 +909,7 @@ jobs:
           cache: 'pip'
       - name: Install dependencies
         run: |
-          python -m pip install --upgrade pip
-          pip install numpy "Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3"
+          pip install -r requirements.txt
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libopenmpi-dev libyaml-cpp-dev

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,15 +1,3 @@
-# This file was added to work around an issue with setup-python for non-Python projects, 
-# which fails with this error:
-#
-#   Run actions/setup-python@v5.0.0
-#     with:
-#       python-version: 3.12
-#       cache: pip
-#   Installed versions
-#     Successfully set up CPython (3.12.1)
-#   Error: No file in /home/runner/work/awesome-iam/awesome-iam matched to
-#   [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository
-#
-# This has been reported at: https://github.com/actions/setup-python/issues/807
-# In the future this might be addressed by: https://github.com/actions/setup-python/pull/762
-# or https://github.com/actions/setup-python/issues/751
+# Python dependencies used for testing
+numpy 
+Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 # Python dependencies used for testing
 numpy 
+vtk
 Bokeh>=2.4,!=3.0.0,!=3.0.1,!=3.0.2,!=3.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,15 @@
+# This file was added to work around an issue with setup-python for non-Python projects, 
+# which fails with this error:
+#
+#   Run actions/setup-python@v5.0.0
+#     with:
+#       python-version: 3.12
+#       cache: pip
+#   Installed versions
+#     Successfully set up CPython (3.12.1)
+#   Error: No file in /home/runner/work/awesome-iam/awesome-iam matched to
+#   [**/requirements.txt or **/pyproject.toml], make sure you have checked out the target repository
+#
+# This has been reported at: https://github.com/actions/setup-python/issues/807
+# In the future this might be addressed by: https://github.com/actions/setup-python/pull/762
+# or https://github.com/actions/setup-python/issues/751


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

Adds requirements.txt in root of repository to work around setup-python issue where it can't find a `requirements.txt` in a non-python repo, which caused the actions to fail. The Python packages used in running the regression tests in the Github Actions were then moved into this file and the actions were updated to use it. Using `requirements.txt` simplifies the Github Actions and provides one location to specify the required Python packages.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

This cache failure problem is known to the setup-python developers and documented in actions/setup-python#807.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

Github Actions `automated-dev-tests.yml`
