### PR TITLE
SrvD: Fix seg fault if blade StC used while writing summary file

### DIFF
--- a/docs/changelogs/v3.5.3.md
+++ b/docs/changelogs/v3.5.3.md
@@ -103,6 +103,7 @@ Other notable improvements include corrections to turbine indexing when coupled 
 ### ServoDyn
 
 #2079 Handling of Paths for SrvD UserSubs Input Files (@rdamiani)
+#2134 Bugfix seg fault if blade StC used while writing summary file (@aplatt)
 
 
 ### TurbSim

--- a/modules/servodyn/src/ServoDyn.f90
+++ b/modules/servodyn/src/ServoDyn.f90
@@ -1486,7 +1486,7 @@ subroutine StC_Blade_Setup(SrvD_InitInp,SrvD_p,InputFileData,SrvD_u,SrvD_y,SrvD_
          ! A little bit of information about the StC location
          if (unsum >0) then
             write(UnSum, '(A24,i2)')                  '    Blade StC instance: ',j
-            write(UnSum, '(10x,A)')                   'Input file: '//trim(InputFileData%NStCfiles(j))
+            write(UnSum, '(10x,A)')                   'Input file: '//trim(InputFileData%BStCfiles(j))
             do k=1,StC_InitInp%NumMeshPts
                write(UnSum, '(10x,A6,I1,A29)')        'Blade ',k,' location (global/inertial): '
                write(UnSum, '(20x,3(2x,ES10.3e2))')   u(1,j)%Mesh(k)%Position(1:3,1)


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
A segmentation fault could occur while writing the _ServoDyn_ summary file if the blade StC was enabled.

**Related issue, if one exists**
None

**Impacted areas of the software**
_ServoDyn_ module

**Additional supporting information**
This was a copy paste error during development of the structural controls

**Test results, if applicable**
None affected.