### PR TITLE
GH actions to push docker image to Github container registry

### DIFF
--- a/.github/workflows/build-docker-image-automatic.yml
+++ b/.github/workflows/build-docker-image-automatic.yml
@@ -20,6 +20,9 @@ jobs:
       DOCKERFILE_PATH: share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
       GH_REGISTRY: ghcr.io/nrel/openfast
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -27,18 +30,19 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Commenting out until we get the NREL DockerHub credentials
+      # - name: Log in to DockerHub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
           registry: ${{ env.GH_REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Extract tag from release candidate branch name
         id: extract-tag
@@ -51,8 +55,8 @@ jobs:
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/amd64,linux/aarch64
           tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
             ${{ env.GH_REGISTRY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
+# ${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker-image-automatic.yml
+++ b/.github/workflows/build-docker-image-automatic.yml
@@ -19,6 +19,7 @@ jobs:
     env:
       DOCKERFILE_PATH: share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
+      GH_REGISTRY: ghcr.io/nrel/openfast
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,6 +33,13 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GH_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
+
       - name: Extract tag from release candidate branch name
         id: extract-tag
         run: echo "openfast-tag=$(expr substr "${{ github.head_ref }}" 4 100)" >> $GITHUB_OUTPUT
@@ -42,7 +50,9 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/amd64,linux/aarch64
-          tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
+          tags: |
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
+            ${{ env.GH_REGISTRY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker-image-automatic.yml
+++ b/.github/workflows/build-docker-image-automatic.yml
@@ -19,7 +19,7 @@ jobs:
     env:
       DOCKERFILE_PATH: share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
-      GH_REGISTRY: ghcr.io/nrel/openfast
+      GH_REGISTRY: ghcr.io/OpenFAST/openfast
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/build-docker-image-manual.yml
+++ b/.github/workflows/build-docker-image-manual.yml
@@ -43,7 +43,7 @@ jobs:
         with:
           registry: ${{ env.GH_REGISTRY }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GH_TOKEN }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       # The updated Dockerfile is only available in the repository at the tag v3.5.3 and above. To build versions of
       # OpenFAST that are below this version, the updated Dockerfile from that tag of the repository has to be acquired

--- a/.github/workflows/build-docker-image-manual.yml
+++ b/.github/workflows/build-docker-image-manual.yml
@@ -22,6 +22,7 @@ jobs:
       DOCKERFILE_PATH: share/docker/Dockerfile
       DOCKERFILE_PERMALINK: https://raw.githubusercontent.com/OpenFAST/openfast/main/share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
+      GH_REGISTRY: ghcr.io/nrel/openfast
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -36,6 +37,13 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.GH_REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_TOKEN }}
 
       # The updated Dockerfile is only available in the repository at the tag v3.5.3 and above. To build versions of
       # OpenFAST that are below this version, the updated Dockerfile from that tag of the repository has to be acquired
@@ -52,7 +60,9 @@ jobs:
           context: .
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/amd64,linux/aarch64
-          tags: ${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
+          tags: |
+            ${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
+            ${{ env.GH_REGISTRY }}:${{ github.event.inputs.tag }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker-image-manual.yml
+++ b/.github/workflows/build-docker-image-manual.yml
@@ -23,6 +23,9 @@ jobs:
       DOCKERFILE_PERMALINK: https://raw.githubusercontent.com/OpenFAST/openfast/main/share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
       GH_REGISTRY: ghcr.io/nrel/openfast
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -32,11 +35,12 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
-      - name: Log in to DockerHub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      # Commenting out until we get the NREL DockerHub credentials
+      # - name: Log in to DockerHub
+      #   uses: docker/login-action@v3
+      #   with:
+      #     username: ${{ secrets.DOCKERHUB_USERNAME }}
+      #     password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
@@ -61,8 +65,8 @@ jobs:
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/amd64,linux/aarch64
           tags: |
-            ${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
             ${{ env.GH_REGISTRY }}:${{ github.event.inputs.tag }}
+# ${{ env.DOCKERHUB_REPOSITORY }}:${{ github.event.inputs.tag }}
           push: true
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/.github/workflows/build-docker-image-manual.yml
+++ b/.github/workflows/build-docker-image-manual.yml
@@ -22,7 +22,7 @@ jobs:
       DOCKERFILE_PATH: share/docker/Dockerfile
       DOCKERFILE_PERMALINK: https://raw.githubusercontent.com/OpenFAST/openfast/main/share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
-      GH_REGISTRY: ghcr.io/nrel/openfast
+      GH_REGISTRY: ghcr.io/OpenFAST/openfast
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
This PR adds the GitHub actions to allow publishing the docker images created with #2124 & #2139 on the Github Container Registry. To be merged after #2139.

Tested the actions on a test repository, and successfully published an image in the corresponding registry: https://github.com/mayankchetan/wind-docker/pkgs/container/openfast-test
