### PR TITLE
ZMQ runtime communication with FAST

### DIFF
--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -226,6 +226,22 @@ typedef	^	FAST_ParameterType	ReKi	WS_TSR	{:}	-	-	"List of WindSpeed or TSRs (dep
 typedef	^	FAST_ParameterType	ReKi	Pitch	{:}	-	-	"List of pitch angles for aeromap generation"	"(rad)"
 typedef	^	FAST_ParameterType	IntKi	GearBox_index	-	-	-	"Index to gearbox rotation in state array (for steady-state calculations)"   -
 
+# ................................................... ZMQ PROTOCOL ........................................................... 
+typedef	^	FAST_ParameterType	LOGICAL	            ZmqOn	                -	.false.	    -	"zmq activation flag"     -  
+typedef	^	FAST_ParameterType	CHARACTER(1024)	    ZmqInAddress            -	-	        -	"address for ZMQ REQ-REP protocol" - 
+typedef	^	FAST_ParameterType	IntKi	            ZmqInNbr                -	-	        -	"number of ZMQ REQ-REP channels" - 
+typedef	^	FAST_ParameterType	CHARACTER(ChanLen)	ZmqInChannels           {:}	-	        -	"address for ZMQ REQ-REP protocol" - 
+
+typedef	^	FAST_ParameterType	CHARACTER(1024)	    ZmqOutAddress           -	-	        -	"address for ZMQ PUB-SUB protocol" - 
+typedef	^	FAST_ParameterType	IntKi	            ZmqOutNbr               -	-	        -	"number of ZMQ PUB-SUB channels" - 
+
+typedef	^	FAST_ParameterType	CHARACTER(ChanLen)	ZmqOutChannels          {:}	-	        -	"variables to pass ZMQ PUB-SUB protocol" - 
+typedef ^   FAST_ParameterType	IntKi           	ZmqOutChnlsIdx          {:}	-	        -	"indexes of channels to be broadcasted" - 
+
+typedef	^	FAST_ParameterType	CHARACTER(ChanLen)	ZmqOutChannelsNames     {:}	-	        -	"names for ZMQ PUB-SUB protocol" -  
+typedef	^	FAST_ParameterType	ReKi	            ZmqOutChannelsAry       {:}	-	        -	"array to pass ZMQ PUB-SUB protocol" - 
+# ............................................................................................................................
+
 
 # SAVED OPERATING POINT DATA FOR VTKLIN (visualization of mode shapes from linearization analysis)
 # ..... IceDyn OP data .......................................................................................................

--- a/modules/openfast-library/src/FAST_SS_Subs.f90
+++ b/modules/openfast-library/src/FAST_SS_Subs.f90
@@ -115,12 +115,13 @@ SUBROUTINE FAST_SteadyState_T( Turbine, ErrStat, ErrMsg )
    CHARACTER(*),             INTENT(  OUT) :: ErrMsg              !< Error message if ErrStat /= ErrID_None
    
       CALL FAST_SteadyState( Turbine%p_FAST, Turbine%y_FAST, Turbine%m_FAST, &
-                  Turbine%ED, Turbine%BD, Turbine%AD, Turbine%MeshMapData, ErrStat, ErrMsg )
+                  Turbine%ED, Turbine%BD, Turbine%AD, Turbine%MeshMapData, &
+                  Turbine%TurbID, ErrStat, ErrMsg )
                   
 END SUBROUTINE FAST_SteadyState_T
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine takes data from n_t_global and gets values at n_t_global + 1
-SUBROUTINE FAST_SteadyState(p_FAST, y_FAST, m_FAST, ED, BD, AD, MeshMapData, ErrStat, ErrMsg )
+SUBROUTINE FAST_SteadyState(p_FAST, y_FAST, m_FAST, ED, BD, AD, MeshMapData, TurbID, ErrStat, ErrMsg )
 
    TYPE(FAST_ParameterType), INTENT(IN   ) :: p_FAST              !< Parameters for the glue code
    TYPE(FAST_OutputFileType),INTENT(INOUT) :: y_FAST              !< Output variables for the glue code
@@ -149,6 +150,7 @@ SUBROUTINE FAST_SteadyState(p_FAST, y_FAST, m_FAST, ED, BD, AD, MeshMapData, Err
    CHARACTER(MaxWrScrLen), PARAMETER       :: BlankLine = " "
    
    CHARACTER(*), PARAMETER                 :: RoutineName = 'FAST_SteadyState'
+   INTEGER(IntKi)                          :: TurbID             !< Turbine ID for consistent zmq comms.
    
    ErrStat = ErrID_None
    ErrMsg = ""
@@ -219,7 +221,8 @@ SUBROUTINE FAST_SteadyState(p_FAST, y_FAST, m_FAST, ED, BD, AD, MeshMapData, Err
       
       CALL WrOutputLine( n_global, p_FAST, y_FAST, UnusedAry, UnusedAry, ED%y%WriteOutput, &
             AD%y, UnusedAry, UnusedAry, UnusedAry, UnusedAry, UnusedAry, UnusedAry, &
-            UnusedAry, UnusedAry, UnusedAry, UnusedAry, y_IceD, BD%y, ErrStat2, ErrMsg2 )
+            UnusedAry, UnusedAry, UnusedAry, UnusedAry, y_IceD, BD%y, &
+            p_FAST%ZmqOutChannelsAry, TurbID, ErrStat2, ErrMsg2 )
 
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
          if (ErrStat >= AbortErrLev) then

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1805,7 +1805,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
    ! ........................
 
    CALL FAST_InitOutput( p_FAST, y_FAST, Init, p_FAST%ZmqOutChnlsIdx, p_FAST%ZmqOutChannelsNames, p_FAST%ZmqOutChannelsAry, ErrStat2, ErrMsg2 )
-      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+      CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName) ! zmq integration ok 
 
 
    ! -------------------------------------------------------------------------
@@ -2487,64 +2487,64 @@ SUBROUTINE ValidateInputData(p, m_FAST, ErrStat, ErrMsg)
       END IF
    END IF
 
-   if (p%CompAeroMaps) then
+   ! if (p%CompAeroMaps) then
 
-      if (p%NumSSCases < 0) then
-         CALL SetErrStat( ErrID_Fatal, 'NumSSCases must be at least 1 to compute steady-state solve.', ErrStat, ErrMsg, RoutineName )
-      else
-         do i=1,p%NumSSCases
-            if (p%RotSpeed(i) < 0.0_ReKi) then
-               CALL SetErrStat( ErrID_Fatal, 'RotSpeed must be positive for the steady-state solver.', ErrStat, ErrMsg, RoutineName )
-            end if
-         end do
+   !    if (p%NumSSCases < 0) then
+   !       CALL SetErrStat( ErrID_Fatal, 'NumSSCases must be at least 1 to compute steady-state solve.', ErrStat, ErrMsg, RoutineName )
+   !    else
+   !       do i=1,p%NumSSCases
+   !          if (p%RotSpeed(i) < 0.0_ReKi) then
+   !             CALL SetErrStat( ErrID_Fatal, 'RotSpeed must be positive for the steady-state solver.', ErrStat, ErrMsg, RoutineName )
+   !          end if
+   !       end do
 
-         do i=1,p%NumSSCases
-            if (p%WS_TSR(i) < EPSILON(p%WS_TSR(1))) then
-               CALL SetErrStat( ErrID_Fatal, 'WindSpeed and TSR must be positive numbers for the steady-state solver.', ErrStat, ErrMsg, RoutineName ) ! at least, they can't be zero!
-            end if
-         end do
+   !       do i=1,p%NumSSCases
+   !          if (p%WS_TSR(i) < EPSILON(p%WS_TSR(1))) then
+   !             CALL SetErrStat( ErrID_Fatal, 'WindSpeed and TSR must be positive numbers for the steady-state solver.', ErrStat, ErrMsg, RoutineName ) ! at least, they can't be zero!
+   !          end if
+   !       end do
 
-      end if
+   !    end if
 
-   end if
+   ! end if
    
-   ! Query of ZMQ broadcast channels idx
+   ! ! Query of ZMQ broadcast channels idx
 
-   if (p_FAST%ZmqOn) then
-      CALL AllocAry( ZmqOutChnlsIdx, p_FAST%ZmqOutNbr, 'ZmqOutChnlsIdx', ErrStat, ErrMsg )
-      CALL AllocAry( ZmqOutChannelsNames, p_FAST%ZmqOutNbr + 2, 'ZmqOutChannelNames', ErrStat, ErrMsg )
+   ! if (p_FAST%ZmqOn) then
+   !    CALL AllocAry( ZmqOutChnlsIdx, p_FAST%ZmqOutNbr, 'ZmqOutChnlsIdx', ErrStat, ErrMsg )
+   !    CALL AllocAry( ZmqOutChannelsNames, p_FAST%ZmqOutNbr + 2, 'ZmqOutChannelNames', ErrStat, ErrMsg )
 
-      ZmqOutChnlsIdx    = 0_IntKi
+   !    ZmqOutChnlsIdx    = 0_IntKi
 
-      do i = 1, SIZE(ZmqOutChnlsIdx) 
-         tmp_string = p_FAST%ZmqOutChannels(i)
-         call Conv2UC(tmp_string)
+   !    do i = 1, SIZE(ZmqOutChnlsIdx) 
+   !       tmp_string = p_FAST%ZmqOutChannels(i)
+   !       call Conv2UC(tmp_string)
 
-         do j = 1, SIZE(y_FAST%ChannelNames)
-            tmp_string2 = y_FAST%ChannelNames(j)
-            call Conv2UC(tmp_string2)
+   !       do j = 1, SIZE(y_FAST%ChannelNames)
+   !          tmp_string2 = y_FAST%ChannelNames(j)
+   !          call Conv2UC(tmp_string2)
 
-            if (trim(tmp_string) == trim(tmp_string2)) then 
-               ZmqOutChnlsIdx(i) = j 
-               exit 
-            end if 
+   !          if (trim(tmp_string) == trim(tmp_string2)) then 
+   !             ZmqOutChnlsIdx(i) = j 
+   !             exit 
+   !          end if 
 
-         end do 
-      end do 
+   !       end do 
+   !    end do 
 
-      if (minval(ZmqOutChnlsIdx) == 0) then 
-         call WrScr('Warning: one channel requested from ZMQ was not identified') ! CU = unit number for the output 
-      end if 
+   !    if (minval(ZmqOutChnlsIdx) == 0) then 
+   !       call WrScr('Warning: one channel requested from ZMQ was not identified') ! CU = unit number for the output 
+   !    end if 
 
-      ! Augmenting ZMQ output to handle wind turbine id and current time stamp
-      ZmqOutChannelsNames(1) = 'TurbId'
-      ZmqOutChannelsNames(2) = 'Time'
+   !    ! Augmenting ZMQ output to handle wind turbine id and current time stamp
+   !    ZmqOutChannelsNames(1) = 'TurbId'
+   !    ZmqOutChannelsNames(2) = 'Time'
 
-      do i = 1,p_FAST%ZmqOutNbr
-         ZmqOutChannelsNames(2 + i) = trim(y_FAST%ChannelNames(ZmqOutChnlsIdx(i))) ! Up to here everything OK! 
-      end do
+   !    do i = 1,p_FAST%ZmqOutNbr
+   !       ZmqOutChannelsNames(2 + i) = trim(y_FAST%ChannelNames(ZmqOutChnlsIdx(i))) ! Up to here everything OK! 
+   !    end do
 
-   end if 
+   ! end if 
 
 END SUBROUTINE ValidateInputData
 !----------------------------------------------------------------------------------------------------------------------------------
@@ -7791,7 +7791,9 @@ END SUBROUTINE FAST_Solution_T
 SUBROUTINE FAST_Solution(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, AD14, AD, ExtLd, IfW, ExtInfw, SC_DX, SeaSt, HD, SD, ExtPtfm, &
                          MAPp, FEAM, MD, Orca, IceF, IceD, MeshMapData, ZmqOutChannelsAry, TurbID, ErrStat, ErrMsg )
 
-   REAL(DbKi),               INTENT(IN   ) :: t_initial           !< initial time
+   
+   use iso_c_binding
+                         REAL(DbKi),               INTENT(IN   ) :: t_initial           !< initial time
    INTEGER(IntKi),           INTENT(IN   ) :: n_t_global          !< loop counter
 
    TYPE(FAST_ParameterType), INTENT(IN   ) :: p_FAST              !< Parameters for the glue code
@@ -7831,7 +7833,8 @@ SUBROUTINE FAST_Solution(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, 
    INTEGER(IntKi), parameter               :: MaxCorrections = 20 ! maximum number of corrections allowed
    LOGICAL                                 :: WriteThisStep       ! Whether WriteOutput values will be printed
 
-   INTEGER(IntKi)                          :: I, k                ! generic loop counters
+   INTEGER(IntKi)                          :: I, k, idx                ! generic loop counters
+
 
    !REAL(ReKi)                              :: ControlInputGuess   ! value of controller inputs
 
@@ -7842,9 +7845,9 @@ SUBROUTINE FAST_Solution(t_initial, n_t_global, p_FAST, y_FAST, m_FAST, ED, BD, 
    INTEGER(IntKi)                          :: TurbID                    !< Grab Turbine ID for messages-tagging purposes (ZMQ)
 
    ! ! -----------------------------------------------------------------------------
-   ! REAL(DbKi), allocatable, intent(inout)           :: ZmqOutChannelsAry(:)
-   ! REAL(DbKi)                                       :: ZmqInChannelsAry(p_FAST%ZmqInNbr)
-   ! character(len=1024)                              :: tmp_str 
+   REAL(DbKi), allocatable, intent(inout)           :: ZmqOutChannelsAry(:)
+   REAL(DbKi)                                       :: ZmqInChannelsAry(p_FAST%ZmqInNbr)
+   character(len=1024)                              :: tmp_str 
    ! ! -----------------------------------------------------------------------------
 
 

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -232,6 +232,16 @@ IMPLICIT NONE
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: WS_TSR      !< List of WindSpeed or TSRs (depending on WindSpeedOrTSR setting) for aeromap generation [(m/s or -)]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: Pitch      !< List of pitch angles for aeromap generation [(rad)]
     INTEGER(IntKi)  :: GearBox_index      !< Index to gearbox rotation in state array (for steady-state calculations) [-]
+    LOGICAL  :: ZmqOn = .false.      !< zmq activation flag [-]
+    CHARACTER(1024)  :: ZmqInAddress      !< address for ZMQ REQ-REP protocol [-]
+    INTEGER(IntKi)  :: ZmqInNbr      !< number of ZMQ REQ-REP channels [-]
+    CHARACTER(ChanLen) , DIMENSION(:), ALLOCATABLE  :: ZmqInChannels      !< address for ZMQ REQ-REP protocol [-]
+    CHARACTER(1024)  :: ZmqOutAddress      !< address for ZMQ PUB-SUB protocol [-]
+    INTEGER(IntKi)  :: ZmqOutNbr      !< number of ZMQ PUB-SUB channels [-]
+    CHARACTER(ChanLen) , DIMENSION(:), ALLOCATABLE  :: ZmqOutChannels      !< variables to pass ZMQ PUB-SUB protocol [-]
+    INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: ZmqOutChnlsIdx      !< indexes of channels to be broadcasted [-]
+    CHARACTER(ChanLen) , DIMENSION(:), ALLOCATABLE  :: ZmqOutChannelsNames      !< names for ZMQ PUB-SUB protocol [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: ZmqOutChannelsAry      !< array to pass ZMQ PUB-SUB protocol [-]
   END TYPE FAST_ParameterType
 ! =======================
 ! =========  FAST_LinStateSave  =======
@@ -2541,6 +2551,71 @@ IF (ALLOCATED(SrcParamData%Pitch)) THEN
     DstParamData%Pitch = SrcParamData%Pitch
 ENDIF
     DstParamData%GearBox_index = SrcParamData%GearBox_index
+    DstParamData%ZmqOn = SrcParamData%ZmqOn
+    DstParamData%ZmqInAddress = SrcParamData%ZmqInAddress
+    DstParamData%ZmqInNbr = SrcParamData%ZmqInNbr
+IF (ALLOCATED(SrcParamData%ZmqInChannels)) THEN
+  i1_l = LBOUND(SrcParamData%ZmqInChannels,1)
+  i1_u = UBOUND(SrcParamData%ZmqInChannels,1)
+  IF (.NOT. ALLOCATED(DstParamData%ZmqInChannels)) THEN 
+    ALLOCATE(DstParamData%ZmqInChannels(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%ZmqInChannels.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%ZmqInChannels = SrcParamData%ZmqInChannels
+ENDIF
+    DstParamData%ZmqOutAddress = SrcParamData%ZmqOutAddress
+    DstParamData%ZmqOutNbr = SrcParamData%ZmqOutNbr
+IF (ALLOCATED(SrcParamData%ZmqOutChannels)) THEN
+  i1_l = LBOUND(SrcParamData%ZmqOutChannels,1)
+  i1_u = UBOUND(SrcParamData%ZmqOutChannels,1)
+  IF (.NOT. ALLOCATED(DstParamData%ZmqOutChannels)) THEN 
+    ALLOCATE(DstParamData%ZmqOutChannels(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%ZmqOutChannels.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%ZmqOutChannels = SrcParamData%ZmqOutChannels
+ENDIF
+IF (ALLOCATED(SrcParamData%ZmqOutChnlsIdx)) THEN
+  i1_l = LBOUND(SrcParamData%ZmqOutChnlsIdx,1)
+  i1_u = UBOUND(SrcParamData%ZmqOutChnlsIdx,1)
+  IF (.NOT. ALLOCATED(DstParamData%ZmqOutChnlsIdx)) THEN 
+    ALLOCATE(DstParamData%ZmqOutChnlsIdx(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%ZmqOutChnlsIdx.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%ZmqOutChnlsIdx = SrcParamData%ZmqOutChnlsIdx
+ENDIF
+IF (ALLOCATED(SrcParamData%ZmqOutChannelsNames)) THEN
+  i1_l = LBOUND(SrcParamData%ZmqOutChannelsNames,1)
+  i1_u = UBOUND(SrcParamData%ZmqOutChannelsNames,1)
+  IF (.NOT. ALLOCATED(DstParamData%ZmqOutChannelsNames)) THEN 
+    ALLOCATE(DstParamData%ZmqOutChannelsNames(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%ZmqOutChannelsNames.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%ZmqOutChannelsNames = SrcParamData%ZmqOutChannelsNames
+ENDIF
+IF (ALLOCATED(SrcParamData%ZmqOutChannelsAry)) THEN
+  i1_l = LBOUND(SrcParamData%ZmqOutChannelsAry,1)
+  i1_u = UBOUND(SrcParamData%ZmqOutChannelsAry,1)
+  IF (.NOT. ALLOCATED(DstParamData%ZmqOutChannelsAry)) THEN 
+    ALLOCATE(DstParamData%ZmqOutChannelsAry(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+      CALL SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%ZmqOutChannelsAry.', ErrStat, ErrMsg,RoutineName)
+      RETURN
+    END IF
+  END IF
+    DstParamData%ZmqOutChannelsAry = SrcParamData%ZmqOutChannelsAry
+ENDIF
  END SUBROUTINE FAST_CopyParam
 
  SUBROUTINE FAST_DestroyParam( ParamData, ErrStat, ErrMsg, DEALLOCATEpointers )
@@ -2576,6 +2651,21 @@ IF (ALLOCATED(ParamData%WS_TSR)) THEN
 ENDIF
 IF (ALLOCATED(ParamData%Pitch)) THEN
   DEALLOCATE(ParamData%Pitch)
+ENDIF
+IF (ALLOCATED(ParamData%ZmqInChannels)) THEN
+  DEALLOCATE(ParamData%ZmqInChannels)
+ENDIF
+IF (ALLOCATED(ParamData%ZmqOutChannels)) THEN
+  DEALLOCATE(ParamData%ZmqOutChannels)
+ENDIF
+IF (ALLOCATED(ParamData%ZmqOutChnlsIdx)) THEN
+  DEALLOCATE(ParamData%ZmqOutChnlsIdx)
+ENDIF
+IF (ALLOCATED(ParamData%ZmqOutChannelsNames)) THEN
+  DEALLOCATE(ParamData%ZmqOutChannelsNames)
+ENDIF
+IF (ALLOCATED(ParamData%ZmqOutChannelsAry)) THEN
+  DEALLOCATE(ParamData%ZmqOutChannelsAry)
 ENDIF
  END SUBROUTINE FAST_DestroyParam
 
@@ -2763,6 +2853,36 @@ ENDIF
       Re_BufSz   = Re_BufSz   + SIZE(InData%Pitch)  ! Pitch
   END IF
       Int_BufSz  = Int_BufSz  + 1  ! GearBox_index
+      Int_BufSz  = Int_BufSz  + 1  ! ZmqOn
+      Int_BufSz  = Int_BufSz  + 1*LEN(InData%ZmqInAddress)  ! ZmqInAddress
+      Int_BufSz  = Int_BufSz  + 1  ! ZmqInNbr
+  Int_BufSz   = Int_BufSz   + 1     ! ZmqInChannels allocated yes/no
+  IF ( ALLOCATED(InData%ZmqInChannels) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! ZmqInChannels upper/lower bounds for each dimension
+      Int_BufSz  = Int_BufSz  + SIZE(InData%ZmqInChannels)*LEN(InData%ZmqInChannels)  ! ZmqInChannels
+  END IF
+      Int_BufSz  = Int_BufSz  + 1*LEN(InData%ZmqOutAddress)  ! ZmqOutAddress
+      Int_BufSz  = Int_BufSz  + 1  ! ZmqOutNbr
+  Int_BufSz   = Int_BufSz   + 1     ! ZmqOutChannels allocated yes/no
+  IF ( ALLOCATED(InData%ZmqOutChannels) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! ZmqOutChannels upper/lower bounds for each dimension
+      Int_BufSz  = Int_BufSz  + SIZE(InData%ZmqOutChannels)*LEN(InData%ZmqOutChannels)  ! ZmqOutChannels
+  END IF
+  Int_BufSz   = Int_BufSz   + 1     ! ZmqOutChnlsIdx allocated yes/no
+  IF ( ALLOCATED(InData%ZmqOutChnlsIdx) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! ZmqOutChnlsIdx upper/lower bounds for each dimension
+      Int_BufSz  = Int_BufSz  + SIZE(InData%ZmqOutChnlsIdx)  ! ZmqOutChnlsIdx
+  END IF
+  Int_BufSz   = Int_BufSz   + 1     ! ZmqOutChannelsNames allocated yes/no
+  IF ( ALLOCATED(InData%ZmqOutChannelsNames) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! ZmqOutChannelsNames upper/lower bounds for each dimension
+      Int_BufSz  = Int_BufSz  + SIZE(InData%ZmqOutChannelsNames)*LEN(InData%ZmqOutChannelsNames)  ! ZmqOutChannelsNames
+  END IF
+  Int_BufSz   = Int_BufSz   + 1     ! ZmqOutChannelsAry allocated yes/no
+  IF ( ALLOCATED(InData%ZmqOutChannelsAry) ) THEN
+    Int_BufSz   = Int_BufSz   + 2*1  ! ZmqOutChannelsAry upper/lower bounds for each dimension
+      Re_BufSz   = Re_BufSz   + SIZE(InData%ZmqOutChannelsAry)  ! ZmqOutChannelsAry
+  END IF
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -3137,6 +3257,101 @@ ENDIF
   END IF
     IntKiBuf(Int_Xferred) = InData%GearBox_index
     Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = TRANSFER(InData%ZmqOn, IntKiBuf(1))
+    Int_Xferred = Int_Xferred + 1
+    DO I = 1, LEN(InData%ZmqInAddress)
+      IntKiBuf(Int_Xferred) = ICHAR(InData%ZmqInAddress(I:I), IntKi)
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    IntKiBuf(Int_Xferred) = InData%ZmqInNbr
+    Int_Xferred = Int_Xferred + 1
+  IF ( .NOT. ALLOCATED(InData%ZmqInChannels) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%ZmqInChannels,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%ZmqInChannels,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%ZmqInChannels,1), UBOUND(InData%ZmqInChannels,1)
+        DO I = 1, LEN(InData%ZmqInChannels)
+          IntKiBuf(Int_Xferred) = ICHAR(InData%ZmqInChannels(i1)(I:I), IntKi)
+          Int_Xferred = Int_Xferred + 1
+        END DO ! I
+      END DO
+  END IF
+    DO I = 1, LEN(InData%ZmqOutAddress)
+      IntKiBuf(Int_Xferred) = ICHAR(InData%ZmqOutAddress(I:I), IntKi)
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    IntKiBuf(Int_Xferred) = InData%ZmqOutNbr
+    Int_Xferred = Int_Xferred + 1
+  IF ( .NOT. ALLOCATED(InData%ZmqOutChannels) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%ZmqOutChannels,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%ZmqOutChannels,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%ZmqOutChannels,1), UBOUND(InData%ZmqOutChannels,1)
+        DO I = 1, LEN(InData%ZmqOutChannels)
+          IntKiBuf(Int_Xferred) = ICHAR(InData%ZmqOutChannels(i1)(I:I), IntKi)
+          Int_Xferred = Int_Xferred + 1
+        END DO ! I
+      END DO
+  END IF
+  IF ( .NOT. ALLOCATED(InData%ZmqOutChnlsIdx) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%ZmqOutChnlsIdx,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%ZmqOutChnlsIdx,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%ZmqOutChnlsIdx,1), UBOUND(InData%ZmqOutChnlsIdx,1)
+        IntKiBuf(Int_Xferred) = InData%ZmqOutChnlsIdx(i1)
+        Int_Xferred = Int_Xferred + 1
+      END DO
+  END IF
+  IF ( .NOT. ALLOCATED(InData%ZmqOutChannelsNames) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%ZmqOutChannelsNames,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%ZmqOutChannelsNames,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%ZmqOutChannelsNames,1), UBOUND(InData%ZmqOutChannelsNames,1)
+        DO I = 1, LEN(InData%ZmqOutChannelsNames)
+          IntKiBuf(Int_Xferred) = ICHAR(InData%ZmqOutChannelsNames(i1)(I:I), IntKi)
+          Int_Xferred = Int_Xferred + 1
+        END DO ! I
+      END DO
+  END IF
+  IF ( .NOT. ALLOCATED(InData%ZmqOutChannelsAry) ) THEN
+    IntKiBuf( Int_Xferred ) = 0
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    IntKiBuf( Int_Xferred ) = 1
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf( Int_Xferred    ) = LBOUND(InData%ZmqOutChannelsAry,1)
+    IntKiBuf( Int_Xferred + 1) = UBOUND(InData%ZmqOutChannelsAry,1)
+    Int_Xferred = Int_Xferred + 2
+
+      DO i1 = LBOUND(InData%ZmqOutChannelsAry,1), UBOUND(InData%ZmqOutChannelsAry,1)
+        ReKiBuf(Re_Xferred) = InData%ZmqOutChannelsAry(i1)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
  END SUBROUTINE FAST_PackParam
 
  SUBROUTINE FAST_UnPackParam( ReKiBuf, DbKiBuf, IntKiBuf, Outdata, ErrStat, ErrMsg )
@@ -3560,6 +3775,116 @@ ENDIF
   END IF
     OutData%GearBox_index = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1
+    OutData%ZmqOn = TRANSFER(IntKiBuf(Int_Xferred), OutData%ZmqOn)
+    Int_Xferred = Int_Xferred + 1
+    DO I = 1, LEN(OutData%ZmqInAddress)
+      OutData%ZmqInAddress(I:I) = CHAR(IntKiBuf(Int_Xferred))
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    OutData%ZmqInNbr = IntKiBuf(Int_Xferred)
+    Int_Xferred = Int_Xferred + 1
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! ZmqInChannels not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%ZmqInChannels)) DEALLOCATE(OutData%ZmqInChannels)
+    ALLOCATE(OutData%ZmqInChannels(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%ZmqInChannels.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%ZmqInChannels,1), UBOUND(OutData%ZmqInChannels,1)
+        DO I = 1, LEN(OutData%ZmqInChannels)
+          OutData%ZmqInChannels(i1)(I:I) = CHAR(IntKiBuf(Int_Xferred))
+          Int_Xferred = Int_Xferred + 1
+        END DO ! I
+      END DO
+  END IF
+    DO I = 1, LEN(OutData%ZmqOutAddress)
+      OutData%ZmqOutAddress(I:I) = CHAR(IntKiBuf(Int_Xferred))
+      Int_Xferred = Int_Xferred + 1
+    END DO ! I
+    OutData%ZmqOutNbr = IntKiBuf(Int_Xferred)
+    Int_Xferred = Int_Xferred + 1
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! ZmqOutChannels not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%ZmqOutChannels)) DEALLOCATE(OutData%ZmqOutChannels)
+    ALLOCATE(OutData%ZmqOutChannels(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%ZmqOutChannels.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%ZmqOutChannels,1), UBOUND(OutData%ZmqOutChannels,1)
+        DO I = 1, LEN(OutData%ZmqOutChannels)
+          OutData%ZmqOutChannels(i1)(I:I) = CHAR(IntKiBuf(Int_Xferred))
+          Int_Xferred = Int_Xferred + 1
+        END DO ! I
+      END DO
+  END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! ZmqOutChnlsIdx not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%ZmqOutChnlsIdx)) DEALLOCATE(OutData%ZmqOutChnlsIdx)
+    ALLOCATE(OutData%ZmqOutChnlsIdx(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%ZmqOutChnlsIdx.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%ZmqOutChnlsIdx,1), UBOUND(OutData%ZmqOutChnlsIdx,1)
+        OutData%ZmqOutChnlsIdx(i1) = IntKiBuf(Int_Xferred)
+        Int_Xferred = Int_Xferred + 1
+      END DO
+  END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! ZmqOutChannelsNames not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%ZmqOutChannelsNames)) DEALLOCATE(OutData%ZmqOutChannelsNames)
+    ALLOCATE(OutData%ZmqOutChannelsNames(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%ZmqOutChannelsNames.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%ZmqOutChannelsNames,1), UBOUND(OutData%ZmqOutChannelsNames,1)
+        DO I = 1, LEN(OutData%ZmqOutChannelsNames)
+          OutData%ZmqOutChannelsNames(i1)(I:I) = CHAR(IntKiBuf(Int_Xferred))
+          Int_Xferred = Int_Xferred + 1
+        END DO ! I
+      END DO
+  END IF
+  IF ( IntKiBuf( Int_Xferred ) == 0 ) THEN  ! ZmqOutChannelsAry not allocated
+    Int_Xferred = Int_Xferred + 1
+  ELSE
+    Int_Xferred = Int_Xferred + 1
+    i1_l = IntKiBuf( Int_Xferred    )
+    i1_u = IntKiBuf( Int_Xferred + 1)
+    Int_Xferred = Int_Xferred + 2
+    IF (ALLOCATED(OutData%ZmqOutChannelsAry)) DEALLOCATE(OutData%ZmqOutChannelsAry)
+    ALLOCATE(OutData%ZmqOutChannelsAry(i1_l:i1_u),STAT=ErrStat2)
+    IF (ErrStat2 /= 0) THEN 
+       CALL SetErrStat(ErrID_Fatal, 'Error allocating OutData%ZmqOutChannelsAry.', ErrStat, ErrMsg,RoutineName)
+       RETURN
+    END IF
+      DO i1 = LBOUND(OutData%ZmqOutChannelsAry,1), UBOUND(OutData%ZmqOutChannelsAry,1)
+        OutData%ZmqOutChannelsAry(i1) = ReKiBuf(Re_Xferred)
+        Re_Xferred = Re_Xferred + 1
+      END DO
+  END IF
  END SUBROUTINE FAST_UnPackParam
 
  SUBROUTINE FAST_CopyLinStateSave( SrcLinStateSaveData, DstLinStateSaveData, CtrlCode, ErrStat, ErrMsg )

--- a/modules/openfast-library/src/zmq_client.c
+++ b/modules/openfast-library/src/zmq_client.c
@@ -1,0 +1,482 @@
+// ||  ----- ZeroMQ Client (re-adapted from ROSCO) ------ ||
+// ||            Real-time interactor for FAST            ||
+// || --------------------------------------------------- ||
+
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <math.h>
+#include <zmq.h>
+#include </home/cJSON/cJSON.h>
+
+// Initializing publisher and requester as global variables
+
+void *publisher = NULL;
+void *requester = NULL;
+
+void printString(const char *str) {
+    printf("String: ");
+    
+    // Print each character of the string including the null terminator
+    for (int i = 0; str[i] != '\0'; ++i) {
+        printf("%c", str[i]);
+    }
+    printf("\\0");
+}
+
+
+// float *zmq_req_rep(const char *socket_address, const char *request) {
+//     // add null-termination from Fortran strings inputs 
+
+//     // printf("received request from fortran in C: %s \n\n", request);
+
+//     size_t socket_len = strlen(socket_address);
+//     size_t request_len = strlen(request);
+
+//     int send_status_req;
+//     int send_status_data;
+//     // Allocate memory for null-terminated strings
+//     // char *socket_copy = malloc(socket_len + 1);
+//     // char *request_copy = malloc(request_len + 1);
+
+//     // // Copy received strings and null-terminate them
+//     // strncpy(socket_copy, socket_address, socket_len);
+//     // socket_copy[socket_len +1] = '\0';
+
+//     // strncpy(request_copy, request, request_len);
+//     // request_copy[request_len +1] = '\0';
+
+//     void *context = zmq_ctx_new();
+
+//     if (context == NULL) {
+//         perror("Error in opening ZMQ comm");
+//         return NULL; // Return NULL to indicate failure
+//     }
+
+//     void *requester = zmq_socket(context, ZMQ_REQ);
+//     if (requester == NULL) {
+//         perror("Error in opening ZMQ comm");
+//         zmq_ctx_destroy(context);
+//         return NULL; // Return NULL to indicate failure
+//     }
+//     // printf("Connecting...");
+
+//     int rc = zmq_connect(requester, socket_address);
+
+//     if (rc != 0) {
+//         perror("Error in connecting to specified address");
+//         fprintf(stderr, "Address: %s\n", socket_address);
+//         zmq_close(requester);
+//         zmq_ctx_destroy(context);
+//         return NULL; // Return NULL to indicate failure
+//     }
+
+//     // printf("C: Sending request %s to socket... \n", request);
+//     send_status_req = zmq_send(requester, request, strlen(request), 0);
+
+//     if (send_status_req >= 0) {
+//         printf("C: Request sent successfully.\n");
+//     } else {
+//         printf("C: Error sending request: %s\n", zmq_strerror(errno));
+//     }
+
+//     float *received_value = (float *)malloc(sizeof(float));
+
+//     int recv_size = zmq_recv(requester, (char *)received_value, sizeof(float), 0);
+//     if (recv_size == sizeof(float)) {
+//         printf("C: Received float value: %f\n", *received_value);
+//         return received_value; // Return pointer to received float data
+
+//     } else {
+//         free(received_value); // Free the allocated memory in case of failure
+//         printf("C: Error receiving float value\n");
+//         zmq_close(requester);
+//         zmq_ctx_destroy(context);
+
+//         return NULL;
+//     }
+
+//     zmq_close(requester);
+//     zmq_ctx_destroy(context);
+//     free(socket_address);
+//     free(request);
+
+//     return NULL; // Return NULL to indicate failure
+// }
+// String manipulation before passing to ZMQ
+
+
+char **split(const char *str, char delimiter, int *count) {
+    int token_count = 0;
+    int str_len = strlen(str);
+
+    // Count the number of tokens
+    for (int i = 0; i < str_len; i++) {
+        if (str[i] == delimiter) {
+            token_count++;
+        }
+    }
+    token_count++;  // Add one for the last token
+
+    char **tokens = malloc(token_count * sizeof(char *));
+    if (tokens == NULL) {
+        *count = 0;
+        return NULL;
+    }
+
+    int token_index = 0;
+    int token_start = 0;
+    for (int i = 0; i <= str_len; i++) {
+        if (str[i] == delimiter || str[i] == '\0') {
+            int token_length = i - token_start;
+            tokens[token_index] = malloc((token_length + 1) * sizeof(char));
+            if (tokens[token_index] == NULL) {
+                *count = token_index;
+                for (int j = 0; j < token_index; j++) {
+                    free(tokens[j]);
+                }
+                free(tokens);
+                return NULL;
+            }
+            strncpy(tokens[token_index], str + token_start, token_length);
+            tokens[token_index][token_length] = '\0';
+            token_index++;
+            token_start = i + 1;
+        }
+    }
+
+    *count = token_count;
+    return tokens;
+}
+
+char *createJSONString(const char *data, const char *names) {
+    cJSON *root = cJSON_CreateObject();
+    
+    int data_count, names_count;
+    char **data_tokens = split(data, ';', &data_count);
+    char **names_tokens = split(names, ';', &names_count);
+
+    if (root && data_tokens && names_tokens && data_count == names_count) {
+        for (int i = 0; i < data_count; i++) {
+            // Check for empty string in names before adding to JSON
+            if (strcmp(names_tokens[i], "") != 0) {
+                cJSON_AddItemToObject(root, names_tokens[i], cJSON_CreateNumber(atof(data_tokens[i])));
+            }
+            free(data_tokens[i]);
+            free(names_tokens[i]);
+        }
+        free(data_tokens);
+        free(names_tokens);
+
+        char *jsonString = cJSON_Print(root);
+        cJSON_Delete(root);
+        return jsonString;
+    } else {
+        cJSON_Delete(root);
+        if (data_tokens) {
+            for (int i = 0; i < data_count; i++) {
+                free(data_tokens[i]);
+            }
+            free(data_tokens);
+        }
+        if (names_tokens) {
+            for (int i = 0; i < names_count; i++) {
+                free(names_tokens[i]);
+            }
+            free(names_tokens);
+        }
+        return NULL;
+    }
+}
+
+char *cJSON_keys_to_string(cJSON *json, const char *delimiter) {
+    char *result = NULL;
+    cJSON *child = json->child;
+    size_t total_len = 0;
+
+    // Calculate the total length needed for the keys string
+    while (child != NULL) {
+        total_len += strlen(child->string) + strlen(delimiter) + 1; // +1 for delimiter
+
+        child = child->next;
+    }
+
+    // Allocate memory for the keys string
+    result = (char *)malloc(total_len + 1); // +1 for null terminator
+    if (result == NULL) {
+        return NULL;
+    }
+
+    // Build the keys string separated by the delimiter
+    child = json->child;
+    result[0] = '\0'; // Initialize the string
+    while (child != NULL) {
+        strcat(result, child->string);
+        if (child->next != NULL) {
+            strcat(result, delimiter);
+        }
+        child = child->next;
+    }
+
+    return result;
+}
+
+char *cJSON_values_to_string(cJSON *json, const char *delimiter) {
+    char *result = NULL;
+    cJSON *child = json->child;
+    size_t total_len = 0;
+
+    // Calculate the total length needed for the values string
+    while (child != NULL) {
+        total_len += strlen(cJSON_Print(child)) + strlen(delimiter) + 1; // +1 for delimiter
+
+        child = child->next;
+    }
+
+    // Allocate memory for the values string
+    result = (char *)malloc(total_len + 1); // +1 for null terminator
+    if (result == NULL) {
+        return NULL;
+    }
+
+    // Build the values string separated by the delimiter
+    child = json->child;
+    result[0] = '\0'; // Initialize the string
+    while (child != NULL) {
+        strcat(result, cJSON_Print(child));
+        if (child->next != NULL) {
+            strcat(result, delimiter);
+        }
+        child = child->next;
+    }
+
+    return result;
+}
+
+float *process_received_data(const char *received_data) {
+    // Parse received JSON data
+    cJSON *root = cJSON_Parse(received_data);
+    if (!root) {
+        fprintf(stderr, "Error parsing JSON\n");
+        return NULL; // Handle the error appropriately
+    }
+
+    // Extract values from JSON and create an array of floats
+    cJSON *array = cJSON_GetObjectItem(root, "array_key"); // Replace "array_key" with your JSON key
+    if (!array || !cJSON_IsArray(array)) {
+        fprintf(stderr, "JSON array not found or invalid\n");
+        cJSON_Delete(root);
+        return NULL; // Handle the error appropriately
+    }
+
+    int num_elements = cJSON_GetArraySize(array);
+    float *float_array = (float *)malloc(num_elements * sizeof(float));
+
+    for (int i = 0; i < num_elements; ++i) {
+        cJSON *item = cJSON_GetArrayItem(array, i);
+        if (cJSON_IsNumber(item)) {
+            float_array[i] = (float)item->valuedouble;
+        } else {
+            fprintf(stderr, "Non-numeric value found in JSON array\n");
+            free(float_array);
+            cJSON_Delete(root);
+            return NULL; // Handle the error appropriately
+        }
+    }
+
+    cJSON_Delete(root);
+    return float_array;
+}
+
+
+// ------------------------------- Key ZMQ Helpers ------------------------- //
+int zmq_init_pub(const char *req_address) {
+    void *context = zmq_ctx_new();
+    publisher = zmq_socket(context, ZMQ_PUB);
+
+    int rc = zmq_connect(publisher, req_address);
+
+    if (rc != 0) {
+        printf("Error binding at %s : %s\n", req_address, zmq_strerror(errno));
+        zmq_close(publisher);
+        zmq_ctx_destroy(context);
+        return -1; // Return error code if binding fails
+    }
+
+    printf("Established PUB - SUB connection at address %s \n", req_address);
+    return 0; // Return success
+}
+
+
+int zmq_init_req_rep(const char *req_address) {
+    void *context = zmq_ctx_new();
+    requester = zmq_socket(context, ZMQ_REQ);
+
+    int rc = zmq_connect(requester, req_address);
+
+    if (rc != 0) {
+        printf("Error binding at %s : %s\n", req_address, zmq_strerror(errno));
+        zmq_close(requester);
+        zmq_ctx_destroy(context);
+        return -1; // Return error code if binding fails
+    }
+
+    printf("Established REQ - REP connection at address %s \n", req_address);
+    return 0; // Return success
+}
+
+int zmq_broadcast(const char *data, const char *names) {
+    if (publisher == NULL) {
+        printf("Socket not initialized. Call zmq_initialize_publisher first.\n");
+        return -1; // Return error if socket is not initialized
+    }
+    // printf("inside C broadcasting routine.... \n");
+
+    size_t size = 0;
+
+    // printf("Received names: %s\n", names);
+    // printf("Received string: %s\n", data);
+
+    char *jsonString = createJSONString(data, names);
+
+    if (jsonString) {
+        // printf("JSON String ready to be published: %s\n", jsonString);
+        zmq_send(publisher, jsonString, strlen(jsonString), 0);
+        free(jsonString); 
+    } else {
+        printf("Failed to create JSON string\n");
+    }
+
+    return 0; // Success
+}
+
+int count_semicolons(const char *request) {
+    int semicolon_count = 0;
+    for (int i = 0; request[i] != '\0'; i++) {
+        if (request[i] == ';') {
+            semicolon_count++;
+        }
+    }
+    return semicolon_count;
+}
+
+
+float *zmq_req_rep(const char *socket_address, const char *request) {
+    
+    if (requester == NULL) {
+        printf("Socket not initialized. Call zmq_initialize_requester first.\n");
+        return -1; // Return error if socket is not initialized
+    }
+
+    int req_count, send_status_req;
+    int max_floats = count_semicolons(request); 
+
+    // char **reqtoken = split(request, ';', &req_count);
+
+    // printf("C: Sending request %s to socket... \n", request);
+    send_status_req = zmq_send(requester, request, strlen(request), 0);
+
+    // char received_data[max_floats * sizeof(float)];
+
+    // Receive data via ZeroMQ
+    char buffer[1024];  
+    zmq_recv(requester, buffer, sizeof(buffer), 0);
+
+    // Process received string
+    int count = 0;
+    const char delim[] = ";";
+    char* token;
+    float* float_array;
+
+    // Count the number of floats
+    char* copy = strdup(buffer);
+    token = strtok(copy, delim);
+    while (token != NULL) {
+        count++;
+        token = strtok(NULL, delim);
+    }
+    free(copy);
+
+    // Allocate memory for the float array
+    float_array = (float*)malloc(count * sizeof(float));
+
+    // Convert string tokens to floats
+    token = strtok(buffer, delim);
+    for (int i = 0; i < count; ++i) {
+        float_array[i] = strtof(token, NULL);
+        token = strtok(NULL, delim);
+    }
+
+    printf("Received float array:");
+    for (int i = 0; i < count; ++i) {
+        printf(" %.4f", float_array[i]);
+    }
+    printf("\n");
+
+    return float_array;
+}
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+    // const int max_data_size = 1024;
+
+    // Receive data via ZeroMQ
+    // char* received_data = (char*)malloc(max_data_size * sizeof(char));
+
+    // Receive data via ZeroMQ
+    // int recv_size = zmq_recv(requester, received_data, max_data_size - 1, 0);
+    
+    // if (recv_size > 0) {
+    //     received_data[recv_size] = '\0'; // Null-terminate at the correct position
+    //     printf("Received data: %s\n", received_data);
+
+    //     return received_data;
+    // } else {
+    //     fprintf(stderr, "Error receiving data\n");
+    //     free(received_data);
+    //     return NULL;
+    // }
+    // }
+
+
+
+
+//     float *received_value = (float *)malloc(sizeof(float));
+
+//     // int recv_size = zmq_recv(requester, (char *)received_value, max_floats * sizeof(float), 0);
+//     int recv_size = zmq_recv(requester, (char *)&received_value, sizeof(float *), 0);
+
+//     if (recv_size > 0 && recv_size == sizeof(float *)) {
+//         printf("Received pointer to array\n");
+//         return received_value; // Return pointer to the received float array
+//     } 
+//     else 
+//     {
+//         printf("C: Error receiving float array\n");
+//         return NULL;
+//     }
+// }
+
+//     free(socket_address);
+//     free(request);
+
+//     return NULL; // Return NULL to indicate failure
+// }


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
ZMQ integration in the solver for real-time communication.

Code re-arranged from OpenFAST 3.5.0, now to be harmonized in new `dev` branch. 
**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
Mainly FAST Subs and FAST solution. Possibility to communicate at runtime.
**Additional supporting information**
<!-- Add any other context about the problem here. -->
currently well integrated with 1 wind turbine only, under testing. Given with python accompanying code.
**Test results, if applicable**
- docs and joss paper under preparation; 
- added functionalities with python tbd
- to be re-arranged and re-tested to fit new openfast dev 
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
