### PR TITLE
GH actions: build docker on release instead of merge

### DIFF
--- a/.github/workflows/build-docker-image-automatic.yml
+++ b/.github/workflows/build-docker-image-automatic.yml
@@ -5,15 +5,12 @@
 name: build-docker-image-automatic
 
 on:
-  pull_request:
+  release:
     types:
-      - closed
-    branches:
-      - main
+      - released
 
 jobs:
   build-and-push:
-    if: ${{ (github.event.pull_request.merged == true) && startsWith(github.head_ref, 'rc-') }}
     runs-on: ubuntu-latest
     timeout-minutes: 300
     env:


### PR DESCRIPTION
Maybe ready to merge.

**Feature or improvement description**
Instead of building docker images on a merge commit, build based on a release.  This will ensure correct tagging (probably).

**Related issue, if one exists**
#2124
#2129 
#2141 

**Impacted areas of the software**
Automated docker builds only.

**Other info**
This may require some refinement to get it to trigger correctly.

https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#release

https://docs.github.com/en/webhooks/webhook-events-and-payloads?actionType=released#release