### PR TITLE
Fix crash in MAP_End when using Intel's new icx compiler and disable caching in setup-python GH action

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -128,7 +128,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -173,7 +173,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -226,7 +226,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -263,7 +263,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -300,7 +300,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -339,7 +339,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -400,7 +400,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -455,7 +455,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -513,7 +513,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -560,7 +560,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -612,7 +612,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -661,7 +661,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -710,7 +710,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -759,7 +759,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -808,7 +808,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -857,7 +857,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -906,7 +906,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
+          # cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/modules/map/src/mapinit.c
+++ b/modules/map/src/mapinit.c
@@ -2304,7 +2304,14 @@ MAP_ERROR_CODE push_variable_to_output_list(OutputList* y_list, const int i, dou
   size = list_size(&y_list->out_list_ptr);
   iter_vartype = (VarTypePtr*)list_get_at(&y_list->out_list_ptr, size-1);
   iter_vartype->value = variable_ref;
-  iter_vartype->name = bformat("%s[%d]", alias, i);
+  if (i >= 0)
+  {
+    iter_vartype->name = bformat("%s[%d]", alias, i);
+  }
+  else
+  {
+    iter_vartype->name = bformat(alias);
+  }
   iter_vartype->units = bformat("%s", units);      
 
   return MAP_SAFE;
@@ -2325,49 +2332,50 @@ MAP_ERROR_CODE set_output_list(Domain* domain, MAP_InitOutputType_t* io_type, ch
     line_iter = (Line*)list_iterator_next(&domain->line);    
     
     if (line_iter->options.gx_anchor_pos_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->anchor->position_ptr.x);      
+      success = push_variable_to_output_list(y_list, -1, line_iter->anchor->position_ptr.x.value, line_iter->anchor->position_ptr.x.name->data, line_iter->anchor->position_ptr.x.units->data);      
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.gy_anchor_pos_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->anchor->position_ptr.y);
+      success = push_variable_to_output_list(y_list, -1, line_iter->anchor->position_ptr.x.value, line_iter->anchor->position_ptr.x.name->data, line_iter->anchor->position_ptr.x.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.gz_anchor_pos_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->anchor->position_ptr.z);
+      success = push_variable_to_output_list(y_list, -1, line_iter->anchor->position_ptr.x.value, line_iter->anchor->position_ptr.x.name->data, line_iter->anchor->position_ptr.x.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.gx_pos_flag) {
       list_append(&y_list->out_list_ptr, &line_iter->fairlead->position_ptr.x);
+      success = push_variable_to_output_list(y_list, -1, line_iter->fairlead->position_ptr.x.value, line_iter->fairlead->position_ptr.x.name->data, line_iter->fairlead->position_ptr.x.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.gy_pos_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->fairlead->position_ptr.y);
+      success = push_variable_to_output_list(y_list, -1, line_iter->fairlead->position_ptr.y.value, line_iter->fairlead->position_ptr.y.name->data, line_iter->fairlead->position_ptr.y.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.gz_pos_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->fairlead->position_ptr.z);
+      success = push_variable_to_output_list(y_list, -1, line_iter->fairlead->position_ptr.z.value, line_iter->fairlead->position_ptr.z.name->data, line_iter->fairlead->position_ptr.z.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.H_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->H);
+      success = push_variable_to_output_list(y_list, -1, line_iter->H.value, line_iter->H.name->data, line_iter->H.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };
 
     if (line_iter->options.V_flag) {
-      list_append(&y_list->out_list_ptr, &line_iter->V);
+      success = push_variable_to_output_list(y_list, -1, line_iter->V.value, line_iter->V.name->data, line_iter->V.units->data);
       io_type->writeOutputHdr_Len++;
       io_type->writeOutputUnt_Len++;
     };


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**
This PR provides two fixes:
1. Fixes a crash in MAP during module shutdown (`MAP_End`) caused by double freeing memory related to strings. This crash only occurred when using the new Intel icx compiler.
2. Adjusting the settings in the `setup-python` Github Action to disable caching of Python modules. This should fix the issue where regression tests fail because `setup-python` can't find `requirements.txt`. 

**Related issue, if one exists**
PR #2129 was a previous attempt to fix the issue with `setup-python` and the regression tests which didn't succeed. 

**Impacted areas of the software**
- MAP
- Github Actions

**Additional supporting information**
The issue with MAP trying to free the memory twice looks like it has been around since the module was added. The problem stemmed from several nodes being added to the `OutputList` by directly copying the data. These nodes contained pointers to strings which were allocated. These pointers were shared with nodes in other lists which were freed earlier in `MAP_End`. When the `OutputList` nodes were freed, the code tried to free the same pointers again, resulting in a crash. The issue was resolved by creating new nodes in `OutputList` with a copy of the data instead of reusing the existing pointers. The amount of data copied is very small so this was a simpler solution than trying to track the pointer usage.

This fix will need to be migrated to the other branches once approved.
