### PR TITLE
[Bug] Writing checkpoint files created empty fort.# files

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -774,7 +774,7 @@ jobs:
       - name: Run 5MW tests
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
-          ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_OC3Mnpl_DLL_WTurb_WavesIrr
+          ctest -VV -L openfast -LE "cpp|linear|python" -R 5MW_OC3Mnpl_DLL_WTurb_WavesIrr -j1
       - name: Failing test artifacts
         uses: actions/upload-artifact@v4
         if: failure()

--- a/modules/nwtc-library/src/ModReg.f90
+++ b/modules/nwtc-library/src/ModReg.f90
@@ -190,6 +190,9 @@ contains
       ErrStat = ErrID_None
       ErrMsg = ""
 
+      ! If registry has already been closed, return
+      if (RF%Unit < 0) return
+
       ! Check if there have been any errors while writing to the file
       if (RF%ErrStat /= ErrID_None) then
          call SetErrStat(RF%ErrStat, RF%ErrMsg, ErrStat, ErrMsg, RoutineName)
@@ -204,8 +207,9 @@ contains
          return
       end if
 
-      ! Close the file
+      ! Close the file and set unit to -1 so file won't be closed again
       close (RF%Unit)
+      RF%Unit = -1
 
       ! Deallocate pointer array
       if (allocated(RF%Pointers)) deallocate (RF%Pointers)

--- a/modules/nwtc-library/src/ModReg.f90
+++ b/modules/nwtc-library/src/ModReg.f90
@@ -196,15 +196,13 @@ contains
       ! Check if there have been any errors while writing to the file
       if (RF%ErrStat /= ErrID_None) then
          call SetErrStat(RF%ErrStat, RF%ErrMsg, ErrStat, ErrMsg, RoutineName)
-         return
       end if
 
       ! Write the actual number of pointers
       write (RF%Unit, POS=RF%Offset, iostat=stat) RF%NumPointers
       if (stat /= 0) then
-         ErrStat = ErrID_Fatal
-         write (ErrMsg, *) 'CloseRegFile: Unable to write offset at beginning of file'
-         return
+         call SetErrStat(ErrID_Fatal, 'CloseRegFile: Unable to write offset at beginning of file', &
+                         ErrStat, ErrMsg, RoutineName)
       end if
 
       ! Close the file and set unit to -1 so file won't be closed again

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -9962,16 +9962,14 @@ SUBROUTINE FAST_CreateCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, 
 
    IF ( unOut < 0 ) THEN
 
-      CALL GetNewUnit( unOut, ErrStat2, ErrMsg2 )
-      CALL OpenBOutFile ( unOut, FileName, ErrStat2, ErrMsg2)
-         CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
-         if (ErrStat >= AbortErrLev ) then
-
+      CALL GetNewUnit(unOut, ErrStat2, ErrMsg2)
+      CALL OpenBOutFile (unOut, FileName, ErrStat2, ErrMsg2)
+         CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
+         if (ErrStat >= AbortErrLev)  then
             IF (.NOT. PRESENT(Unit)) THEN
                CLOSE(unOut)
                unOut = -1
             end if
-            call cleanup()
             return
          end if
 
@@ -9985,20 +9983,15 @@ SUBROUTINE FAST_CreateCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, 
 
    ! Initialize the registry file
    call InitRegFile(RF, unOut, ErrStat2, ErrMsg2)
-      call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) return
 
    ! Pack data into the registry file
    call FAST_PackTurbineType(RF, Turbine)
-      call SetErrStat(RF%ErrStat, RF%ErrMsg, ErrStat, ErrMsg, RoutineName )
-      if (ErrStat >= AbortErrLev ) then
-         call cleanup()
-         return
-      end if
 
-   ! Close registry file
+   ! Close registry file and get any errors that occurred while writing
    call CloseRegFile(RF, ErrStat2, ErrMsg2)
-      call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) return
 
    ! If last turbine or no unit, close output unit
@@ -10030,13 +10023,6 @@ SUBROUTINE FAST_CreateCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, 
          Turbine%SrvD%m%dll_data%SimStatus = Turbine%SrvD%m%dll_data%avrSWAP( 1)
       end if
    END IF
-   
-   call cleanup()
-
-contains
-   subroutine cleanup()
-      call CloseRegFile(RF, ErrStat2, ErrMsg2)
-   end subroutine cleanup
 
 END SUBROUTINE FAST_CreateCheckpoint_T
 !----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
This PR is ready to merge.

<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**

This PR fixes a bug in the `dev-unstable-pointers` branch where writing the checkpoint files would cause empty fort.# files to be generated in the same directory as the checkpoint files. This was caused by cleanup code being called on the registry file multiple times. Code was added to return early if the same file is closed multiple times. Also, the cleanup function was removed from FAST_CreateCheckpoint_T as it is no longer needed.

**Impacted areas of the software**
`ModReg.f90` and `Fast_Subs.f90`