### PR TITLE
[BugFix] blank line not handled by InitFileInfo

### DIFF
--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -4111,7 +4111,9 @@ END SUBROUTINE CheckR8Var
          NullLoc = index(FileString(idx:len(FileString)),C_NULL_CHAR)
          ! started indexing at idx, so add that back in for location in FileString
          NullLoc = NullLoc + idx - 1
-         if (NullLoc > idx) then
+         if (NullLoc == idx) then   ! blank line
+            FileStringArray(Line) = ''
+         elseif (NullLoc > idx) then
             FileStringArray(Line) = trim(FileString(idx:NullLoc-1))
          else
             ! If not NULL terminated


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
When an _AeroDyn_ input file is read by `AeroDyn_Init`, it is processed by `ProcessComFile`.  This routine can account for blank lines.

However, if a file is passed as a `c_null` terminated string through the c-bindings interface, it is handled by the `InitFileInfo` routine.  This routine was prematurely exiting when a blank line was found instead of continuing as expected.

This PR updates `InitFileInfo` to correctly handle blank lines and not end prematurely.

**Related issue, if one exists**
PR #1909 ran into unexpected issues with a single blank line in the `AD.dat` of the `py_AD_B1n2_OLAF` regression test. This blank line is present in `AD_B1n2_OLAF`, so we expect the two cases to work identically but the Python case was failing.

**Impacted areas of the software**
Blank lines in input files passed through c-bindings interfaces as `c_null` terminated strings.

**Additional supporting information**

**Test results, if applicable**
Changed the `py_AD_B1n2_OLAF/AD.dat` input file to match `AD_B1n2_OLAF/AD.dat`.