### PR TITLE
New registry needs C++14

### DIFF
--- a/modules/openfast-registry/CMakeLists.txt
+++ b/modules/openfast-registry/CMakeLists.txt
@@ -23,7 +23,7 @@ add_executable(openfast_registry
   src/registry.hpp
   src/templates.hpp
 )
-target_compile_features(openfast_registry PRIVATE cxx_std_11)
+target_compile_features(openfast_registry PRIVATE cxx_std_14)
 
 set_target_properties(openfast_registry PROPERTIES
   RUNTIME_OUTPUT_DIRECTORY_DEBUG ${CMAKE_BINARY_DIR}/modules/openfast-registry


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This pull request is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

The new registry uses std::quoted for parsing the registry files. This feature was added in C++14, not C++11. This commit changes the required C++ standard in the openfast_registry CMakeLists.txt file to the appropriate standard.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

#2204 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`modules/openfast-registry/CMakeLists.txt`
