### PR TITLE
Turn off "#Restoring here" messages in .out files during linearization visualization sims

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -10212,8 +10212,8 @@ SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turb
    ! deal with files that were open:
    IF (Turbine%p_FAST%WrTxtOutFile) THEN
       CALL OpenFunkFileAppend ( Turbine%y_FAST%UnOu, TRIM(Turbine%p_FAST%OutFileRoot)//'.out', ErrStat2, ErrMsg2)
-      IF ( ErrStat2 >= AbortErrLev ) RETURN
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      IF ( ErrStat2 >= AbortErrLev ) RETURN
       CALL WrFileNR ( Turbine%y_FAST%UnOu, '#Restarting here')
       WRITE(Turbine%y_FAST%UnOu, '()')
    END IF

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -10221,7 +10221,7 @@ SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turb
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat2 >= AbortErrLev ) RETURN
       if (present(silent)) then
-         if (silent) then
+         if (.not. silent) then
             CALL WrFileNR ( Turbine%y_FAST%UnOu, '#Restarting here')
             WRITE(Turbine%y_FAST%UnOu, '()')
          endif

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -10057,7 +10057,7 @@ SUBROUTINE FAST_CreateCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, 
 END SUBROUTINE FAST_CreateCheckpoint_T
 !----------------------------------------------------------------------------------------------------------------------------------
 !> Routine that calls FAST_RestoreFromCheckpoint_T for an array of Turbine data structures.
-SUBROUTINE FAST_RestoreFromCheckpoint_Tary(t_initial, n_t_global, Turbine, CheckpointRoot, ErrStat, ErrMsg  )
+SUBROUTINE FAST_RestoreFromCheckpoint_Tary(t_initial, n_t_global, Turbine, CheckpointRoot, ErrStat, ErrMsg, silent )
 
    REAL(DbKi),               INTENT(IN   ) :: t_initial           !< initial time (for comparing with time from checkpoint file)
    INTEGER(IntKi),           INTENT(  OUT) :: n_t_global          !< loop counter
@@ -10065,6 +10065,7 @@ SUBROUTINE FAST_RestoreFromCheckpoint_Tary(t_initial, n_t_global, Turbine, Check
    CHARACTER(*),             INTENT(IN   ) :: CheckpointRoot      !< Rootname of checkpoint file
    INTEGER(IntKi),           INTENT(  OUT) :: ErrStat             !< Error status of the operation
    CHARACTER(*),             INTENT(  OUT) :: ErrMsg              !< Error message if ErrStat /= ErrID_None
+   logical,        optional, intent(in   ) :: silent              !< optional to not write "#Restarting here" info
 
       ! local variables
    REAL(DbKi)                              :: t_initial_out
@@ -10087,7 +10088,11 @@ SUBROUTINE FAST_RestoreFromCheckpoint_Tary(t_initial, n_t_global, Turbine, Check
       ! Restore data from checkpoint file
    Unit = -1
    DO i_turb = 1,NumTurbines
-      CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(i_turb), CheckpointRoot, ErrStat2, ErrMsg2, Unit )
+      if (present(silent)) then
+         CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(i_turb), CheckpointRoot, ErrStat2, ErrMsg2, Unit, silent )
+      else
+         CALL FAST_RestoreFromCheckpoint_T(t_initial_out, n_t_global, NumTurbines_out, Turbine(i_turb), CheckpointRoot, ErrStat2, ErrMsg2, Unit )
+      endif
          CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
          IF (t_initial_out /= t_initial) CALL SetErrStat(ErrID_Fatal, "invalid value of t_initial.", ErrStat, ErrMsg, RoutineName )
@@ -10102,7 +10107,7 @@ END SUBROUTINE FAST_RestoreFromCheckpoint_Tary
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine is the inverse of FAST_CreateCheckpoint_T. It reads data from a checkpoint file and populates data structures for
 !! the turbine instance.
-SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, CheckpointRoot, ErrStat, ErrMsg, Unit )
+SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, CheckpointRoot, ErrStat, ErrMsg, Unit, silent )
    USE BladedInterface, ONLY: CallBladedDLL  ! Hack for Bladed-style DLL
    USE BladedInterface, ONLY: GH_DISCON_STATUS_RESTARTING
 
@@ -10114,6 +10119,7 @@ SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turb
    INTEGER(IntKi),           INTENT(  OUT) :: ErrStat             !< Error status of the operation
    CHARACTER(*),             INTENT(  OUT) :: ErrMsg              !< Error message if ErrStat /= ErrID_None
    INTEGER(IntKi), OPTIONAL, INTENT(INOUT) :: Unit                !< unit number for output file
+   logical,        optional, intent(in   ) :: silent              !< optional to not write "#Restarting here" info
 
       ! local variables:
    type(RegFile)                           :: RF
@@ -10214,8 +10220,12 @@ SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turb
       CALL OpenFunkFileAppend ( Turbine%y_FAST%UnOu, TRIM(Turbine%p_FAST%OutFileRoot)//'.out', ErrStat2, ErrMsg2)
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat2 >= AbortErrLev ) RETURN
-      CALL WrFileNR ( Turbine%y_FAST%UnOu, '#Restarting here')
-      WRITE(Turbine%y_FAST%UnOu, '()')
+      if (present(silent)) then
+         if (silent) then
+            CALL WrFileNR ( Turbine%y_FAST%UnOu, '#Restarting here')
+            WRITE(Turbine%y_FAST%UnOu, '()')
+         endif
+      endif
    END IF
 
    ! (ignoring for now; will have fort.x files if any were open [though I printed a warning about not outputting binary files earlier])
@@ -10256,7 +10266,7 @@ SUBROUTINE FAST_RestoreForVTKModeShape_Tary(t_initial, Turbine, InputFileName, E
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       if (ErrStat >= AbortErrLev) return
 
-   CALL FAST_RestoreFromCheckpoint_Tary( t_initial, n_t_global, Turbine, trim(Turbine(1)%p_FAST%VTK_modes%CheckpointRoot), ErrStat2, ErrMsg2 )
+   CALL FAST_RestoreFromCheckpoint_Tary( t_initial, n_t_global, Turbine, trim(Turbine(1)%p_FAST%VTK_modes%CheckpointRoot), ErrStat2, ErrMsg2, silent=.true. )
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
When mode shape visualization is used during linearization, the `.out` file has lines with `#Restarting here` at each linearization.  This creates issues with some readers.

**Related issue, if one exists**
The `#Restarting here` comment was added with #158 for use with AMR-Wind.  Unfortunately this also affected the mode shape visualization restarts.

**Impacted areas of the software**
ASCII output files from mode shape visualization during linearization only.
