### PR TITLE
nwtc lib: SetErrStat ref'd incorrectly in VTK

### DIFF
--- a/modules/nwtc-library/src/VTK.f90
+++ b/modules/nwtc-library/src/VTK.f90
@@ -5,10 +5,9 @@
 module VTK
 
    use Precision, only: IntKi, SiKi, ReKi
-   use NWTC_Base, only: ErrID_None, ErrID_Fatal, AbortErrLev, ErrMsgLen
+   use NWTC_Base, only: ErrID_None, ErrID_Fatal, AbortErrLev, ErrMsgLen, SetErrStat
    use NWTC_IO, only: GetNewUnit, NewLine, WrScr, ReadStr, OpenFOutFile
    use NWTC_IO, only: OpenFinpFile, ReadCom, Conv2UC
-   use NWTC_IO, only: SetErrStat
 
    implicit none
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The `SetErrStat` was moved to `NWTC_Base.f90` from `NWTC_IO.f90`.  This was not updated in `VTK.f90`.  Somehow GH actions and all the setups I was using for compiling did not error on this.

**Related issue, if one exists**
NA

**Impacted areas of the software**
Compilation on a few systems.

**Additional supporting information**
Thanks to @RyanDavies19 for finding this!