### PR TITLE
CMake: OpenMP turned on only if requested

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -110,13 +110,8 @@ include(${CMAKE_SOURCE_DIR}/cmake/set_rpath.cmake)
 # OpenMP
 #-------------------------------------------------------------------------------
 
-if (OPENMP OR BUILD_FASTFARM OR BUILD_OPENFAST_CPP_API)
-  if (OPENMP)
-    FIND_PACKAGE(OpenMP REQUIRED)
-  else()
-    # Optional for FF or the CPP interface
-    FIND_PACKAGE(OpenMP)
-  endif()
+if (OPENMP)
+  FIND_PACKAGE(OpenMP REQUIRED)
   if (OpenMP_Fortran_FOUND)
     set(CMAKE_Fortran_FLAGS "${CMAKE_Fortran_FLAGS} ${OpenMP_Fortran_FLAGS}")
     link_libraries("${OpenMP_Fortran_LIBRARIES}")


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
Previously OpenMP would be turned on by default for CPP interface and FAST.Farm.

As requested by @jrood-nrel 


**Impacted areas of the software**
CMake build systems

**Additional supporting information**
Having `OpenMP` on with the _CPP_ interface has been a headache for the CFD integration.

