### PR TITLE
Send actual filename to checkpoint creator

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -1360,7 +1360,7 @@ void fast::OpenFAST::advance_to_next_driver_time_step(bool writeFiles) {
       for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
           int tStepRatio = time_step_ratio(dtFAST, dtDriver);
           if ( (restartFreq_*tStepRatio > 0) && (((nt_global - ntStart) % (restartFreq_*tStepRatio)) == 0 )  && (nt_global != ntStart) ) {
-              turbineData[iTurb].FASTRestartFileName = " "; // if blank, it will use FAST convention <RootName>.nt_global
+                turbineData[iTurb].FASTRestartFileName = turbineData[iTurb].outFileRoot + "." + std::to_string(nt_global); // if blank, it will use FAST convention <RootName>.nt_global
               FAST_CreateCheckpoint(&iTurb, turbineData[iTurb].FASTRestartFileName.data(), &ErrStat, ErrMsg);
               checkError(ErrStat, ErrMsg);
               writeRestartFile(iTurb, nt_global);
@@ -1521,7 +1521,7 @@ void fast::OpenFAST::step(bool writeFiles) {
         int tStepRatio = time_step_ratio(dtFAST, dtDriver);
         for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
             if ( (((nt_global - ntStart) % (restartFreq_ * tStepRatio)) == 0 )  && (nt_global != ntStart) ) {
-                turbineData[iTurb].FASTRestartFileName = " "; // if blank, it will use FAST convention <RootName>.nt_global
+                turbineData[iTurb].FASTRestartFileName = turbineData[iTurb].outFileRoot + "." + std::to_string(nt_global); // if blank, it will use FAST convention <RootName>.nt_global
                 FAST_CreateCheckpoint(&iTurb, turbineData[iTurb].FASTRestartFileName.data(), &ErrStat, ErrMsg);
                 checkError(ErrStat, ErrMsg);
                 writeRestartFile(iTurb, nt_global);


### PR DESCRIPTION
Exploring the weirdness with checkpoint files on non-precursor checkpoint creation.

Problem:
During the precursor openfastcpp run, the code knows about all the turbines and so can properly write out turbine ids and openfast filenames, but this doesn't happen on subsequent restarts when each nalu instance only knows about a single turbine.
