### PR TITLE
Initialize mass matrix to zeros in Moordyn

### DIFF
--- a/modules/moordyn/src/MoorDyn_Body.f90
+++ b/modules/moordyn/src/MoorDyn_Body.f90
@@ -63,7 +63,7 @@ CONTAINS
 !      INTEGER(4)                          :: K             ! Generic index
 !      INTEGER(IntKi)                      :: N
 
-      REAL(DbKi)                          :: Mtemp(6,6)   
+      REAL(DbKi)                          :: Mtemp(6,6) = 0.0_DbKi  ! temporary mass matrix
       
       ErrStat = ErrID_None
       ErrMsg = ""


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
Ready to be merged.

<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
All tests pass.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
Initialized the 6x6 temporary mass matrix to avoid setting them to NaNs, which crashed `moordyn_driver` for certain compilers such as gcc-8, 10, 12. The fix was tested with gcc-12.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
None

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
Moordyn

**Additional supporting information**
<!-- Add any other context about the problem here. -->
N/A

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
N/A

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
