### PR TITLE
Fix restart file index and nc write

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -2479,7 +2479,7 @@ void fast::OpenFAST::readRestartFile(int iTurbLoc, int n_t_global) {
     //Find the file and open it in append mode
     std::stringstream rstfile_ss;
     rstfile_ss << "turb_" ;
-    rstfile_ss << std::setfill('0') << std::setw(2) << turbineMapProcToGlob[iTurbLoc];
+    rstfile_ss << std::setfill('0') << std::setw(2) << turbineData[iTurbLoc].TurbID;
     rstfile_ss << "_rst.nc";
     std::string rst_filename = rstfile_ss.str();
     int ierr = nc_open(rst_filename.c_str(), NC_NOWRITE, &ncid);

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -2903,7 +2903,7 @@ void fast::OpenFAST::writeRestartFile(int iTurbLoc, int n_t_global) {
     //Find the file and open it in append mode
     std::stringstream rstfile_ss;
     rstfile_ss << "turb_" ;
-    rstfile_ss << std::setfill('0') << std::setw(2) << turbineMapProcToGlob[iTurbLoc];
+    rstfile_ss << std::setfill('0') << std::setw(2) << turbineData[iTurbLoc].TurbID;
     rstfile_ss << "_rst.nc";
     std::string rst_filename = rstfile_ss.str();
     int ierr = nc_open(rst_filename.c_str(), NC_WRITE, &ncid);


### PR DESCRIPTION
Trying to fix the restart of fsi simulations from precursor when there are multiple separate turbines (and hoping this contributes to being able to restart multiple turbines)