### PR TITLE
Bug in OpenFAST Registry Unpacking Structures with C_obj data

### DIFF
--- a/modules/externalinflow/src/ExternalInflow_Types.f90
+++ b/modules/externalinflow/src/ExternalInflow_Types.f90
@@ -318,7 +318,15 @@ subroutine ExtInfw_UnPackInitInput(RF, OutData)
    call RegUnpack(RF, OutData%NumActForcePtsTower); if (RegCheckErr(RF, RoutineName)) return
    OutData%C_obj%NumActForcePtsTower = OutData%NumActForcePtsTower
    call RegUnpackPtr(RF, OutData%StructBldRNodes); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%StructBldRNodes)) then
+      OutData%C_obj%StructBldRNodes_Len = size(OutData%StructBldRNodes)
+      if (OutData%C_obj%StructBldRNodes_Len > 0) OutData%C_obj%StructBldRNodes = c_loc(OutData%StructBldRNodes(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%StructTwrHNodes); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%StructTwrHNodes)) then
+      OutData%C_obj%StructTwrHNodes_Len = size(OutData%StructTwrHNodes)
+      if (OutData%C_obj%StructTwrHNodes_Len > 0) OutData%C_obj%StructTwrHNodes = c_loc(OutData%StructTwrHNodes(LB(1)))
+   end if
    call RegUnpack(RF, OutData%BladeLength); if (RegCheckErr(RF, RoutineName)) return
    OutData%C_obj%BladeLength = OutData%BladeLength
    call RegUnpack(RF, OutData%TowerHeight); if (RegCheckErr(RF, RoutineName)) return
@@ -1027,7 +1035,15 @@ subroutine ExtInfw_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%NnodesForceTower); if (RegCheckErr(RF, RoutineName)) return
    OutData%C_obj%NnodesForceTower = OutData%NnodesForceTower
    call RegUnpackPtr(RF, OutData%forceBldRnodes); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%forceBldRnodes)) then
+      OutData%C_obj%forceBldRnodes_Len = size(OutData%forceBldRnodes)
+      if (OutData%C_obj%forceBldRnodes_Len > 0) OutData%C_obj%forceBldRnodes = c_loc(OutData%forceBldRnodes(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%forceTwrHnodes); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%forceTwrHnodes)) then
+      OutData%C_obj%forceTwrHnodes_Len = size(OutData%forceTwrHnodes)
+      if (OutData%C_obj%forceTwrHnodes_Len > 0) OutData%C_obj%forceTwrHnodes = c_loc(OutData%forceTwrHnodes(LB(1)))
+   end if
    call RegUnpack(RF, OutData%BladeLength); if (RegCheckErr(RF, RoutineName)) return
    OutData%C_obj%BladeLength = OutData%BladeLength
    call RegUnpack(RF, OutData%TowerHeight); if (RegCheckErr(RF, RoutineName)) return
@@ -1556,22 +1572,90 @@ subroutine ExtInfw_UnPackInput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%pxVel); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pxVel)) then
+      OutData%C_obj%pxVel_Len = size(OutData%pxVel)
+      if (OutData%C_obj%pxVel_Len > 0) OutData%C_obj%pxVel = c_loc(OutData%pxVel(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%pyVel); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pyVel)) then
+      OutData%C_obj%pyVel_Len = size(OutData%pyVel)
+      if (OutData%C_obj%pyVel_Len > 0) OutData%C_obj%pyVel = c_loc(OutData%pyVel(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%pzVel); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pzVel)) then
+      OutData%C_obj%pzVel_Len = size(OutData%pzVel)
+      if (OutData%C_obj%pzVel_Len > 0) OutData%C_obj%pzVel = c_loc(OutData%pzVel(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%pxForce); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pxForce)) then
+      OutData%C_obj%pxForce_Len = size(OutData%pxForce)
+      if (OutData%C_obj%pxForce_Len > 0) OutData%C_obj%pxForce = c_loc(OutData%pxForce(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%pyForce); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pyForce)) then
+      OutData%C_obj%pyForce_Len = size(OutData%pyForce)
+      if (OutData%C_obj%pyForce_Len > 0) OutData%C_obj%pyForce = c_loc(OutData%pyForce(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%pzForce); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pzForce)) then
+      OutData%C_obj%pzForce_Len = size(OutData%pzForce)
+      if (OutData%C_obj%pzForce_Len > 0) OutData%C_obj%pzForce = c_loc(OutData%pzForce(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%xdotForce); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%xdotForce)) then
+      OutData%C_obj%xdotForce_Len = size(OutData%xdotForce)
+      if (OutData%C_obj%xdotForce_Len > 0) OutData%C_obj%xdotForce = c_loc(OutData%xdotForce(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%ydotForce); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%ydotForce)) then
+      OutData%C_obj%ydotForce_Len = size(OutData%ydotForce)
+      if (OutData%C_obj%ydotForce_Len > 0) OutData%C_obj%ydotForce = c_loc(OutData%ydotForce(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%zdotForce); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%zdotForce)) then
+      OutData%C_obj%zdotForce_Len = size(OutData%zdotForce)
+      if (OutData%C_obj%zdotForce_Len > 0) OutData%C_obj%zdotForce = c_loc(OutData%zdotForce(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%pOrientation); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%pOrientation)) then
+      OutData%C_obj%pOrientation_Len = size(OutData%pOrientation)
+      if (OutData%C_obj%pOrientation_Len > 0) OutData%C_obj%pOrientation = c_loc(OutData%pOrientation(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%fx); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fx)) then
+      OutData%C_obj%fx_Len = size(OutData%fx)
+      if (OutData%C_obj%fx_Len > 0) OutData%C_obj%fx = c_loc(OutData%fx(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%fy); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fy)) then
+      OutData%C_obj%fy_Len = size(OutData%fy)
+      if (OutData%C_obj%fy_Len > 0) OutData%C_obj%fy = c_loc(OutData%fy(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%fz); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fz)) then
+      OutData%C_obj%fz_Len = size(OutData%fz)
+      if (OutData%C_obj%fz_Len > 0) OutData%C_obj%fz = c_loc(OutData%fz(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%momentx); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%momentx)) then
+      OutData%C_obj%momentx_Len = size(OutData%momentx)
+      if (OutData%C_obj%momentx_Len > 0) OutData%C_obj%momentx = c_loc(OutData%momentx(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%momenty); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%momenty)) then
+      OutData%C_obj%momenty_Len = size(OutData%momenty)
+      if (OutData%C_obj%momenty_Len > 0) OutData%C_obj%momenty = c_loc(OutData%momenty(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%momentz); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%momentz)) then
+      OutData%C_obj%momentz_Len = size(OutData%momentz)
+      if (OutData%C_obj%momentz_Len > 0) OutData%C_obj%momentz = c_loc(OutData%momentz(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%forceNodesChord); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%forceNodesChord)) then
+      OutData%C_obj%forceNodesChord_Len = size(OutData%forceNodesChord)
+      if (OutData%C_obj%forceNodesChord_Len > 0) OutData%C_obj%forceNodesChord = c_loc(OutData%forceNodesChord(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE ExtInfw_C2Fary_CopyInput(InputData, ErrStat, ErrMsg, SkipPointers)
@@ -2093,8 +2177,20 @@ subroutine ExtInfw_UnPackOutput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%u); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%u)) then
+      OutData%C_obj%u_Len = size(OutData%u)
+      if (OutData%C_obj%u_Len > 0) OutData%C_obj%u = c_loc(OutData%u(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%v); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%v)) then
+      OutData%C_obj%v_Len = size(OutData%v)
+      if (OutData%C_obj%v_Len > 0) OutData%C_obj%v = c_loc(OutData%v(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%w); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%w)) then
+      OutData%C_obj%w_Len = size(OutData%w)
+      if (OutData%C_obj%w_Len > 0) OutData%C_obj%w = c_loc(OutData%w(LB(1)))
+   end if
    call RegUnpackAlloc(RF, OutData%WriteOutput); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 

--- a/modules/extloads/src/ExtLoadsDX_Types.f90
+++ b/modules/extloads/src/ExtLoadsDX_Types.f90
@@ -297,11 +297,35 @@ subroutine ExtLdDX_UnPackInput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%twrDef); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%twrDef)) then
+      OutData%C_obj%twrDef_Len = size(OutData%twrDef)
+      if (OutData%C_obj%twrDef_Len > 0) OutData%C_obj%twrDef = c_loc(OutData%twrDef(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldDef); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldDef)) then
+      OutData%C_obj%bldDef_Len = size(OutData%bldDef)
+      if (OutData%C_obj%bldDef_Len > 0) OutData%C_obj%bldDef = c_loc(OutData%bldDef(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%hubDef); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%hubDef)) then
+      OutData%C_obj%hubDef_Len = size(OutData%hubDef)
+      if (OutData%C_obj%hubDef_Len > 0) OutData%C_obj%hubDef = c_loc(OutData%hubDef(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%nacDef); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%nacDef)) then
+      OutData%C_obj%nacDef_Len = size(OutData%nacDef)
+      if (OutData%C_obj%nacDef_Len > 0) OutData%C_obj%nacDef = c_loc(OutData%nacDef(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldRootDef); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldRootDef)) then
+      OutData%C_obj%bldRootDef_Len = size(OutData%bldRootDef)
+      if (OutData%C_obj%bldRootDef_Len > 0) OutData%C_obj%bldRootDef = c_loc(OutData%bldRootDef(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldPitch); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldPitch)) then
+      OutData%C_obj%bldPitch_Len = size(OutData%bldPitch)
+      if (OutData%C_obj%bldPitch_Len > 0) OutData%C_obj%bldPitch = c_loc(OutData%bldPitch(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE ExtLdDX_C2Fary_CopyInput(InputData, ErrStat, ErrMsg, SkipPointers)
@@ -774,17 +798,65 @@ subroutine ExtLdDX_UnPackParam(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%nBlades); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%nBlades)) then
+      OutData%C_obj%nBlades_Len = size(OutData%nBlades)
+      if (OutData%C_obj%nBlades_Len > 0) OutData%C_obj%nBlades = c_loc(OutData%nBlades(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%nBladeNodes); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%nBladeNodes)) then
+      OutData%C_obj%nBladeNodes_Len = size(OutData%nBladeNodes)
+      if (OutData%C_obj%nBladeNodes_Len > 0) OutData%C_obj%nBladeNodes = c_loc(OutData%nBladeNodes(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%nTowerNodes); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%nTowerNodes)) then
+      OutData%C_obj%nTowerNodes_Len = size(OutData%nTowerNodes)
+      if (OutData%C_obj%nTowerNodes_Len > 0) OutData%C_obj%nTowerNodes = c_loc(OutData%nTowerNodes(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%twrRefPos); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%twrRefPos)) then
+      OutData%C_obj%twrRefPos_Len = size(OutData%twrRefPos)
+      if (OutData%C_obj%twrRefPos_Len > 0) OutData%C_obj%twrRefPos = c_loc(OutData%twrRefPos(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldRefPos); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldRefPos)) then
+      OutData%C_obj%bldRefPos_Len = size(OutData%bldRefPos)
+      if (OutData%C_obj%bldRefPos_Len > 0) OutData%C_obj%bldRefPos = c_loc(OutData%bldRefPos(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%hubRefPos); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%hubRefPos)) then
+      OutData%C_obj%hubRefPos_Len = size(OutData%hubRefPos)
+      if (OutData%C_obj%hubRefPos_Len > 0) OutData%C_obj%hubRefPos = c_loc(OutData%hubRefPos(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%nacRefPos); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%nacRefPos)) then
+      OutData%C_obj%nacRefPos_Len = size(OutData%nacRefPos)
+      if (OutData%C_obj%nacRefPos_Len > 0) OutData%C_obj%nacRefPos = c_loc(OutData%nacRefPos(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldRootRefPos); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldRootRefPos)) then
+      OutData%C_obj%bldRootRefPos_Len = size(OutData%bldRootRefPos)
+      if (OutData%C_obj%bldRootRefPos_Len > 0) OutData%C_obj%bldRootRefPos = c_loc(OutData%bldRootRefPos(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldChord); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldChord)) then
+      OutData%C_obj%bldChord_Len = size(OutData%bldChord)
+      if (OutData%C_obj%bldChord_Len > 0) OutData%C_obj%bldChord = c_loc(OutData%bldChord(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldRloc); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldRloc)) then
+      OutData%C_obj%bldRloc_Len = size(OutData%bldRloc)
+      if (OutData%C_obj%bldRloc_Len > 0) OutData%C_obj%bldRloc = c_loc(OutData%bldRloc(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%twrDia); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%twrDia)) then
+      OutData%C_obj%twrDia_Len = size(OutData%twrDia)
+      if (OutData%C_obj%twrDia_Len > 0) OutData%C_obj%twrDia = c_loc(OutData%twrDia(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%twrHloc); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%twrHloc)) then
+      OutData%C_obj%twrHloc_Len = size(OutData%twrHloc)
+      if (OutData%C_obj%twrHloc_Len > 0) OutData%C_obj%twrHloc = c_loc(OutData%twrHloc(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE ExtLdDX_C2Fary_CopyParam(ParamData, ErrStat, ErrMsg, SkipPointers)
@@ -1163,7 +1235,15 @@ subroutine ExtLdDX_UnPackOutput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%twrLd); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%twrLd)) then
+      OutData%C_obj%twrLd_Len = size(OutData%twrLd)
+      if (OutData%C_obj%twrLd_Len > 0) OutData%C_obj%twrLd = c_loc(OutData%twrLd(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%bldLd); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%bldLd)) then
+      OutData%C_obj%bldLd_Len = size(OutData%bldLd)
+      if (OutData%C_obj%bldLd_Len > 0) OutData%C_obj%bldLd = c_loc(OutData%bldLd(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE ExtLdDX_C2Fary_CopyOutput(OutputData, ErrStat, ErrMsg, SkipPointers)

--- a/modules/map/src/MAP_Types.f90
+++ b/modules/map/src/MAP_Types.f90
@@ -1102,21 +1102,85 @@ subroutine MAP_UnPackOtherState(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%H); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%H)) then
+      OutData%C_obj%H_Len = size(OutData%H)
+      if (OutData%C_obj%H_Len > 0) OutData%C_obj%H = c_loc(OutData%H(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%V); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%V)) then
+      OutData%C_obj%V_Len = size(OutData%V)
+      if (OutData%C_obj%V_Len > 0) OutData%C_obj%V = c_loc(OutData%V(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Ha); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Ha)) then
+      OutData%C_obj%Ha_Len = size(OutData%Ha)
+      if (OutData%C_obj%Ha_Len > 0) OutData%C_obj%Ha = c_loc(OutData%Ha(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Va); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Va)) then
+      OutData%C_obj%Va_Len = size(OutData%Va)
+      if (OutData%C_obj%Va_Len > 0) OutData%C_obj%Va = c_loc(OutData%Va(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%x); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%x)) then
+      OutData%C_obj%x_Len = size(OutData%x)
+      if (OutData%C_obj%x_Len > 0) OutData%C_obj%x = c_loc(OutData%x(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%y); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%y)) then
+      OutData%C_obj%y_Len = size(OutData%y)
+      if (OutData%C_obj%y_Len > 0) OutData%C_obj%y = c_loc(OutData%y(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%z); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%z)) then
+      OutData%C_obj%z_Len = size(OutData%z)
+      if (OutData%C_obj%z_Len > 0) OutData%C_obj%z = c_loc(OutData%z(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%xa); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%xa)) then
+      OutData%C_obj%xa_Len = size(OutData%xa)
+      if (OutData%C_obj%xa_Len > 0) OutData%C_obj%xa = c_loc(OutData%xa(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%ya); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%ya)) then
+      OutData%C_obj%ya_Len = size(OutData%ya)
+      if (OutData%C_obj%ya_Len > 0) OutData%C_obj%ya = c_loc(OutData%ya(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%za); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%za)) then
+      OutData%C_obj%za_Len = size(OutData%za)
+      if (OutData%C_obj%za_Len > 0) OutData%C_obj%za = c_loc(OutData%za(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fx_connect); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fx_connect)) then
+      OutData%C_obj%Fx_connect_Len = size(OutData%Fx_connect)
+      if (OutData%C_obj%Fx_connect_Len > 0) OutData%C_obj%Fx_connect = c_loc(OutData%Fx_connect(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fy_connect); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fy_connect)) then
+      OutData%C_obj%Fy_connect_Len = size(OutData%Fy_connect)
+      if (OutData%C_obj%Fy_connect_Len > 0) OutData%C_obj%Fy_connect = c_loc(OutData%Fy_connect(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fz_connect); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fz_connect)) then
+      OutData%C_obj%Fz_connect_Len = size(OutData%Fz_connect)
+      if (OutData%C_obj%Fz_connect_Len > 0) OutData%C_obj%Fz_connect = c_loc(OutData%Fz_connect(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fx_anchor); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fx_anchor)) then
+      OutData%C_obj%Fx_anchor_Len = size(OutData%Fx_anchor)
+      if (OutData%C_obj%Fx_anchor_Len > 0) OutData%C_obj%Fx_anchor = c_loc(OutData%Fx_anchor(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fy_anchor); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fy_anchor)) then
+      OutData%C_obj%Fy_anchor_Len = size(OutData%Fy_anchor)
+      if (OutData%C_obj%Fy_anchor_Len > 0) OutData%C_obj%Fy_anchor = c_loc(OutData%Fy_anchor(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fz_anchor); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fz_anchor)) then
+      OutData%C_obj%Fz_anchor_Len = size(OutData%Fz_anchor)
+      if (OutData%C_obj%Fz_anchor_Len > 0) OutData%C_obj%Fz_anchor = c_loc(OutData%Fz_anchor(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE MAP_C2Fary_CopyOtherState(OtherStateData, ErrStat, ErrMsg, SkipPointers)
@@ -1645,10 +1709,30 @@ subroutine MAP_UnPackConstrState(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%H); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%H)) then
+      OutData%C_obj%H_Len = size(OutData%H)
+      if (OutData%C_obj%H_Len > 0) OutData%C_obj%H = c_loc(OutData%H(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%V); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%V)) then
+      OutData%C_obj%V_Len = size(OutData%V)
+      if (OutData%C_obj%V_Len > 0) OutData%C_obj%V = c_loc(OutData%V(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%x); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%x)) then
+      OutData%C_obj%x_Len = size(OutData%x)
+      if (OutData%C_obj%x_Len > 0) OutData%C_obj%x = c_loc(OutData%x(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%y); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%y)) then
+      OutData%C_obj%y_Len = size(OutData%y)
+      if (OutData%C_obj%y_Len > 0) OutData%C_obj%y = c_loc(OutData%y(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%z); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%z)) then
+      OutData%C_obj%z_Len = size(OutData%z)
+      if (OutData%C_obj%z_Len > 0) OutData%C_obj%z = c_loc(OutData%z(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE MAP_C2Fary_CopyConstrState(ConstrStateData, ErrStat, ErrMsg, SkipPointers)
@@ -2036,8 +2120,20 @@ subroutine MAP_UnPackInput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%x); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%x)) then
+      OutData%C_obj%x_Len = size(OutData%x)
+      if (OutData%C_obj%x_Len > 0) OutData%C_obj%x = c_loc(OutData%x(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%y); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%y)) then
+      OutData%C_obj%y_Len = size(OutData%y)
+      if (OutData%C_obj%y_Len > 0) OutData%C_obj%y = c_loc(OutData%y(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%z); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%z)) then
+      OutData%C_obj%z_Len = size(OutData%z)
+      if (OutData%C_obj%z_Len > 0) OutData%C_obj%z = c_loc(OutData%z(LB(1)))
+   end if
    call MeshUnpack(RF, OutData%PtFairDisplacement) ! PtFairDisplacement 
 end subroutine
 
@@ -2297,10 +2393,26 @@ subroutine MAP_UnPackOutput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%Fx); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fx)) then
+      OutData%C_obj%Fx_Len = size(OutData%Fx)
+      if (OutData%C_obj%Fx_Len > 0) OutData%C_obj%Fx = c_loc(OutData%Fx(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fy); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fy)) then
+      OutData%C_obj%Fy_Len = size(OutData%Fy)
+      if (OutData%C_obj%Fy_Len > 0) OutData%C_obj%Fy = c_loc(OutData%Fy(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Fz); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Fz)) then
+      OutData%C_obj%Fz_Len = size(OutData%Fz)
+      if (OutData%C_obj%Fz_Len > 0) OutData%C_obj%Fz = c_loc(OutData%Fz(LB(1)))
+   end if
    call RegUnpackAlloc(RF, OutData%WriteOutput); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackPtr(RF, OutData%wrtOutput); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%wrtOutput)) then
+      OutData%C_obj%wrtOutput_Len = size(OutData%wrtOutput)
+      if (OutData%C_obj%wrtOutput_Len > 0) OutData%C_obj%wrtOutput = c_loc(OutData%wrtOutput(LB(1)))
+   end if
    call MeshUnpack(RF, OutData%ptFairleadLoad) ! ptFairleadLoad 
 end subroutine
 

--- a/modules/openfast-registry/src/registry_gen_fortran.cpp
+++ b/modules/openfast-registry/src/registry_gen_fortran.cpp
@@ -838,14 +838,25 @@ void gen_unpack(std::ostream &w, const Module &mod, const DataType::Derived &ddt
 
         // w << indent << "! " << field.name << "";
 
-        // If the field is not derived, is allocatable, is not a pointer,
-        // use RegUnpackAlloc function and continue
+        // If the field is not derived and is allocatable
         if (field.data_type->tag != DataType::Tag::Derived && field.is_allocatable)
         {
             if (field.is_pointer)
             {
                 w << indent << "call RegUnpackPtr(RF, " << var << ")"
                   << "; if (RegCheckErr(RF, RoutineName)) return";
+
+                // If C code is generated, output code to initialize C object
+                if (gen_c_code)
+                {
+                    w << indent << "if (associated("<< var <<")) then";
+                    w << indent << "   " << var_c << "_Len = size(" << var << ")";
+                    w << indent << "   " << "if (" << var_c << "_Len > 0) " << var_c << " = c_loc(" << var << "(";
+                    for (int d = 1; d <= field.rank; d++)
+                        w << (d > 1 ? "," : "") << "LB(" << d << ")";
+                    w << "))";
+                    w << indent << "end if";
+                }
             }
             else
             {
@@ -908,17 +919,6 @@ void gen_unpack(std::ostream &w, const Module &mod, const DataType::Derived &ddt
         if (field.is_pointer)
         {
             w << indent << "RF%Pointers(PtrIdx) = c_loc(" << var << ")";
-        }
-
-        // bjj: this needs to be updated if we've got multiple dimension arrays
-        if (gen_c_code && field.is_pointer &&
-            (field.data_type->tag != DataType::Tag::Derived))
-        {
-            w << indent << var_c << "_Len = size(" << var << ")";
-            w << indent << "if (" << var_c << "_Len > 0) " << var_c << " = c_loc(" << var << "(";
-            for (int d = 1; d <= field.rank; d++)
-                w << (d > 1 ? "," : "") << "LB(" << d << ")";
-            w << "))";
         }
 
         // Call individual routines to unpack data from subtypes:

--- a/modules/supercontroller/src/SCDataEx_Types.f90
+++ b/modules/supercontroller/src/SCDataEx_Types.f90
@@ -419,6 +419,10 @@ subroutine SC_DX_UnPackInput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%toSC); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%toSC)) then
+      OutData%C_obj%toSC_Len = size(OutData%toSC)
+      if (OutData%C_obj%toSC_Len > 0) OutData%C_obj%toSC = c_loc(OutData%toSC(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE SC_DX_C2Fary_CopyInput(InputData, ErrStat, ErrMsg, SkipPointers)
@@ -566,7 +570,15 @@ subroutine SC_DX_UnPackOutput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%fromSC); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fromSC)) then
+      OutData%C_obj%fromSC_Len = size(OutData%fromSC)
+      if (OutData%C_obj%fromSC_Len > 0) OutData%C_obj%fromSC = c_loc(OutData%fromSC(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%fromSCglob); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fromSCglob)) then
+      OutData%C_obj%fromSCglob_Len = size(OutData%fromSCglob)
+      if (OutData%C_obj%fromSCglob_Len > 0) OutData%C_obj%fromSCglob = c_loc(OutData%fromSCglob(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE SC_DX_C2Fary_CopyOutput(OutputData, ErrStat, ErrMsg, SkipPointers)

--- a/modules/supercontroller/src/SuperController_Types.f90
+++ b/modules/supercontroller/src/SuperController_Types.f90
@@ -527,7 +527,15 @@ subroutine SC_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%NumParamTurbine); if (RegCheckErr(RF, RoutineName)) return
    OutData%C_obj%NumParamTurbine = OutData%NumParamTurbine
    call RegUnpackPtr(RF, OutData%ParamGlobal); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%ParamGlobal)) then
+      OutData%C_obj%ParamGlobal_Len = size(OutData%ParamGlobal)
+      if (OutData%C_obj%ParamGlobal_Len > 0) OutData%C_obj%ParamGlobal = c_loc(OutData%ParamGlobal(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%ParamTurbine); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%ParamTurbine)) then
+      OutData%C_obj%ParamTurbine_Len = size(OutData%ParamTurbine)
+      if (OutData%C_obj%ParamTurbine_Len > 0) OutData%C_obj%ParamTurbine = c_loc(OutData%ParamTurbine(LB(1)))
+   end if
    call DLLTypeUnpack(RF, OutData%DLL_Trgt) ! DLL_Trgt 
 end subroutine
 
@@ -717,7 +725,15 @@ subroutine SC_UnPackDiscState(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%Global); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Global)) then
+      OutData%C_obj%Global_Len = size(OutData%Global)
+      if (OutData%C_obj%Global_Len > 0) OutData%C_obj%Global = c_loc(OutData%Global(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%Turbine); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%Turbine)) then
+      OutData%C_obj%Turbine_Len = size(OutData%Turbine)
+      if (OutData%C_obj%Turbine_Len > 0) OutData%C_obj%Turbine = c_loc(OutData%Turbine(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE SC_C2Fary_CopyDiscState(DiscStateData, ErrStat, ErrMsg, SkipPointers)
@@ -1206,7 +1222,15 @@ subroutine SC_UnPackInput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%toSCglob); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%toSCglob)) then
+      OutData%C_obj%toSCglob_Len = size(OutData%toSCglob)
+      if (OutData%C_obj%toSCglob_Len > 0) OutData%C_obj%toSCglob = c_loc(OutData%toSCglob(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%toSC); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%toSC)) then
+      OutData%C_obj%toSC_Len = size(OutData%toSC)
+      if (OutData%C_obj%toSC_Len > 0) OutData%C_obj%toSC = c_loc(OutData%toSC(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE SC_C2Fary_CopyInput(InputData, ErrStat, ErrMsg, SkipPointers)
@@ -1375,7 +1399,15 @@ subroutine SC_UnPackOutput(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpackPtr(RF, OutData%fromSCglob); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fromSCglob)) then
+      OutData%C_obj%fromSCglob_Len = size(OutData%fromSCglob)
+      if (OutData%C_obj%fromSCglob_Len > 0) OutData%C_obj%fromSCglob = c_loc(OutData%fromSCglob(LB(1)))
+   end if
    call RegUnpackPtr(RF, OutData%fromSC); if (RegCheckErr(RF, RoutineName)) return
+   if (associated(OutData%fromSC)) then
+      OutData%C_obj%fromSC_Len = size(OutData%fromSC)
+      if (OutData%C_obj%fromSC_Len > 0) OutData%C_obj%fromSC = c_loc(OutData%fromSC(LB(1)))
+   end if
 end subroutine
 
 SUBROUTINE SC_C2Fary_CopyOutput(OutputData, ErrStat, ErrMsg, SkipPointers)


### PR DESCRIPTION
This PR is ready to merge

**Feature or improvement description**
This fixes a bug in the new OpenFAST registry where C object lengths and pointers weren't being restored in the Unpack routines. The registry logic to generate the necessary code was relocated when the pointer handling was changed. 

**Impacted areas of the software**
- OpenFAST Registry
- MAP
- ExtInflow
- SCDataEx
- ExtLoads
- SuperController


