### PR TITLE
Minor changes to FF input descriptions, re-enable test cases, update Simulink string compare

### DIFF
--- a/glue-codes/fast-farm/src/FAST_Farm_IO.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_IO.f90
@@ -1046,13 +1046,13 @@ SUBROUTINE Farm_ValidateInput( p, WD_InitInp, AWAE_InitInp, SC_InitInp, ErrStat,
    IF (WD_InitInp%C_vAmb_FMin <  0.0_Reki .or. WD_InitInp%C_vAmb_FMin > 1.0_Reki) CALL SetErrStat(ErrID_Fatal,'k_vAmb(2) (FMin) must be between 0 and 1 (inclusive).',ErrStat,ErrMsg,RoutineName)
    IF (WD_InitInp%C_vAmb_DMin <  0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vAmb(3) (DMin) must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF (WD_InitInp%C_vAmb_DMax <= WD_InitInp%C_vAmb_DMin)                          CALL SetErrStat(ErrID_Fatal,'k_vAmb(4) (DMax) must be larger than DMin.',ErrStat,ErrMsg,RoutineName)
-   IF (WD_InitInp%C_vAmb_Exp  <= 0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vAmb(5) (e) must be positive.',ErrStat,ErrMsg,RoutineName)
+   IF (WD_InitInp%C_vAmb_Exp  <  0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vAmb(5) (e) must be >=0.',ErrStat,ErrMsg,RoutineName)
 
    IF (WD_InitInp%k_vShr      <  0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vShr(1) (k_vShr) must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF (WD_InitInp%C_vShr_FMin <  0.0_Reki .or. WD_InitInp%C_vShr_FMin > 1.0_ReKi) CALL SetErrStat(ErrID_Fatal,'k_vShr(2) (FMin) must be between 0 and 1 (inclusive).',ErrStat,ErrMsg,RoutineName)
    IF (WD_InitInp%C_vShr_DMin <  0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vShr(3) (DMin) must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF (WD_InitInp%C_vShr_DMax <= WD_InitInp%C_vShr_DMin)                          CALL SetErrStat(ErrID_Fatal,'k_vShr(4) (DMax) must be larger than DMin.',ErrStat,ErrMsg,RoutineName)
-   IF (WD_InitInp%C_vShr_Exp  <= 0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vShr(5) (e) must be positive.',ErrStat,ErrMsg,RoutineName)
+   IF (WD_InitInp%C_vShr_Exp  <  0.0_Reki)                                        CALL SetErrStat(ErrID_Fatal,'k_vShr(5) (e) must be >=0.',ErrStat,ErrMsg,RoutineName)
 
    IF (WD_InitInp%Mod_WakeDiam < WakeDiamMod_RotDiam .or. WD_InitInp%Mod_WakeDiam > WakeDiamMod_MtmFlux) THEN
       call SetErrStat(ErrID_Fatal,'Wake diameter calculation model, Mod_WakeDiam, must be 1 (rotor diameter), 2 (velocity-based), 3 (mass-flux based), 4 (momentum-flux based) or DEFAULT.',ErrStat,ErrMsg,RoutineName)
@@ -1085,13 +1085,13 @@ SUBROUTINE Farm_ValidateInput( p, WD_InitInp, AWAE_InitInp, SC_InitInp, ErrStat,
       if (WD_InitInp%WAT_k_Def_FMin <  0.0_ReKi .or. WD_InitInp%WAT_k_Def_FMin > 1.0_ReKi) call SetErrStat(ErrID_Fatal,'WAT_k_Def(2) (f_min) must be >=0 and <=1.',ErrStat,ErrMsg,RoutineName)
       if (WD_InitInp%WAT_k_Def_DMin <  0.0_ReKi)                                           call SetErrStat(ErrID_Fatal,'WAT_k_Def(3) (D_min) must be >=0.',ErrStat,ErrMsg,RoutineName)
       if (WD_InitInp%WAT_k_Def_DMax <= WD_InitInp%WAT_k_Def_DMin)                          call SetErrStat(ErrID_Fatal,'WAT_k_Def(4) (D_max) must be greater than D_min.',ErrStat,ErrMsg,RoutineName)
-      if (WD_InitInp%WAT_k_Def_Exp  <  0.0_ReKi)                                           call SetErrStat(ErrID_Fatal,'WAT_k_Def(5) (e) must be >0.',ErrStat,ErrMsg,RoutineName)
+      if (WD_InitInp%WAT_k_Def_Exp  <  0.0_ReKi)                                           call SetErrStat(ErrID_Fatal,'WAT_k_Def(5) (e) must be >=0.',ErrStat,ErrMsg,RoutineName)
       ! Tests on k_Grad
       if (WD_InitInp%WAT_k_Grad_k_c  <= 0.0_ReKi)                                            call SetErrStat(ErrID_Fatal,'WAT_k_Grad(1) (k_def) must be >0.',ErrStat,ErrMsg,RoutineName)
       if (WD_InitInp%WAT_k_Grad_FMin <  0.0_ReKi .or. WD_InitInp%WAT_k_Grad_FMin > 1.0_ReKi) call SetErrStat(ErrID_Fatal,'WAT_k_Grad(2) (f_min) must be >=0 and <=1.',ErrStat,ErrMsg,RoutineName)
       if (WD_InitInp%WAT_k_Grad_DMin <  0.0_ReKi)                                            call SetErrStat(ErrID_Fatal,'WAT_k_Grad(3) (D_min) must be >=0.',ErrStat,ErrMsg,RoutineName)
       if (WD_InitInp%WAT_k_Grad_DMax <= WD_InitInp%WAT_k_Grad_DMin)                          call SetErrStat(ErrID_Fatal,'WAT_k_Grad(4) (D_max) must be greater than D_min.',ErrStat,ErrMsg,RoutineName)
-      if (WD_InitInp%WAT_k_Grad_Exp  <  0.0_ReKi)                                            call SetErrStat(ErrID_Fatal,'WAT_k_Grad(5) (e) must be >0.',ErrStat,ErrMsg,RoutineName)
+      if (WD_InitInp%WAT_k_Grad_Exp  <  0.0_ReKi)                                            call SetErrStat(ErrID_Fatal,'WAT_k_Grad(5) (e) must be >=0.',ErrStat,ErrMsg,RoutineName)
       ! summary table
       call WrScr('  Wake-Added Turbulence (WAT): coefficients:')
       call WrScr('                k_c      f_min    D_min    D_max    e')

--- a/glue-codes/simulink/examples/Test01_SIG.mdl
+++ b/glue-codes/simulink/examples/Test01_SIG.mdl
@@ -1828,7 +1828,7 @@ Model {
       ZOrder		      -3
       BlockMirror	      on
       NameLocation	      "top"
-      Expr		      "u(strmatch('LSSGagVxa',OutList))"
+      Expr		      "u(strcmpi('LSSGagVxa',OutList))"
     }
     Block {
       BlockType		      SubSystem

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -343,8 +343,8 @@ of_regression_py("EllipticalWing_OLAF_py"                    "openfast;fastlib;p
 of_regression_aeroacoustic("IEA_LB_RWT-AeroAcoustics"  "openfast;aerodyn15;aeroacoustics")
 
 # Linearized OpenFAST regression tests
-#of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-highpass=0.05"  "openfast;linear;elastodyn;aerodyn")  #segfault currently -- fixed in next PR
-#of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-highpass=0.05"  "openfast;linear;elastodyn;aerodyn")  #segfault currently -- fixed in next PR
+of_regression_linear("Fake5MW_AeroLin_B1_UA4_DBEMT3"  "-highpass=0.05"  "openfast;linear;elastodyn;aerodyn")
+of_regression_linear("Fake5MW_AeroLin_B3_UA6"         "-highpass=0.05"  "openfast;linear;elastodyn;aerodyn")
 of_regression_linear("WP_Stationary_Linear"           ""                "openfast;linear;elastodyn")
 of_regression_linear("Ideal_Beam_Fixed_Free_Linear"   "-highpass=0.10"  "openfast;linear;beamdyn")
 of_regression_linear("Ideal_Beam_Free_Free_Linear"    "-highpass=0.10"  "openfast;linear;beamdyn")


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
* minor language update on limits and language for the `k_vAmb_Exp` (and similar) inputs for FAST.Farm
* Re-enable the `Fake5MW_` linearization regression tests (these should have been enabled after merging #2014 
* change `strmatch` to `strcmpi` in Simulink regression test (`strmatch` is deprecated).  See comment https://github.com/OpenFAST/openfast/issues/2232#issuecomment-2150923531

**Related issue, if one exists**
none

