### PR TITLE
Upgraded to the latest pFUnit

### DIFF
--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -26,11 +26,6 @@ include(CTest)
 if(NOT ${Python_Interpreter_FOUND})
   message(FATAL_ERROR "CMake did not find a Python interpreter. Python is required for unit tests." )
 endif()
-if (${Python_VERSION} VERSION_GREATER_EQUAL "3.12.0")
-  message(FATAL_ERROR "Unit testing with pfunit not currently possible with Python 3.12 or greater." )
-endif()
-
-
 
 ### pfunit
 include(ExternalProject)


### PR DESCRIPTION
NOTE: The tests are failing because r-test dev branch is required.

**Feature or improvement description**
Now the latest version of pFUnit is considered, which allows to use Python >= 3.12

**Impacted areas of the software**
The tests framework

**Additional supporting information**
You are using a 10 years old pFUnit.

**Test results, if applicable**
```
The following tests FAILED:
         72 - py_ad_5MW_OC4Semi_WSt_WavesWN (Failed)
         73 - py_ad_B1n2_OLAF (Failed)
        102 - py_hd_5MW_OC4Semi_WSt_WavesWN (Failed)
        122 - py_ifw_turbsimff (Failed)
        133 - py_md_5MW_OC4Semi (Failed)
```

The error is always `ModuleNotFoundError: No module named 'aerodyn_inflow_library'`