### PR TITLE
Bug Fix: AeroDyn driver output files contained wrong channel names

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Driver_Registry.txt
+++ b/modules/aerodyn/src/AeroDyn_Driver_Registry.txt
@@ -15,7 +15,7 @@ usefrom    AeroDyn_Registry.txt
 usefrom    AeroDyn_Inflow_Registry.txt
 #
 # ..... Table of combined cases to run .......................................................................................................
-typedef   AeroDyn_Driver/AD_Dvr Dvr_Case   ReKi                   HWindSpeed       -      -     -   "Hub wind speed" "m/s"
+typedef   AeroDyn_Driver/AD_Dvr Dvr_Case          ReKi                   HWindSpeed       -      -     -   "Hub wind speed" "m/s"
 typedef   ^                         ^             ReKi                   PLExp            -      -     -   "Power law wind-shear exponent" "-"
 typedef   ^                         ^             ReKi                   rotSpeed         -      -     -   "Rotor speed" "rad/s"
 typedef   ^                         ^             ReKi                   bldPitch         -      -     -   "Pitch angle" "rad"
@@ -36,7 +36,7 @@ typedef    ^    DvrVTK_SurfaceType    SiKi    BaseBox       {3}{8}    -    -    
 # typedef    ^    DvrVTK_SurfaceType    DvrVTK_BLSurfaceType    BladeShape    {:}    -    -    "AirfoilCoords for each blade"    m
 
 # ..... Data for driver output file .......................................................................................................
-typedef   AeroDyn_Driver/AD_Dvr  Dvr_Outputs ProgDesc          AD_ver           -      -     -   "AeroDyn version information" -
+typedef   AeroDyn_Driver/AD_Dvr  Dvr_Outputs      ProgDesc               AD_ver           -      -     -   "AeroDyn version information" -
 typedef   ^                         ^             IntKi                  unOutFile        :      -     -   "unit number for writing output file for each rotor" "-"
 typedef   ^                         ^             IntKi                  ActualChanLen    -      -     -   "Actual length of channels written to text file (less than or equal to ChanLen)" "-"
 typedef   ^                         ^             IntKi                  nDvrOutputs      -      -     -   "Number of outputs for the driver (without AD and IW)" "-"

--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -358,7 +358,7 @@ subroutine Dvr_EndCase(dvr, ADI, initialized, errStat, errMsg)
             else
                sWT = ''
             endif
-            call WrBinFAST(trim(dvr%out%Root)//trim(sWT)//'.outb', FileFmtID_ChanLen_In, 'AeroDynDriver', dvr%out%WriteOutputHdr, dvr%out%WriteOutputUnt, (/0.0_DbKi, dvr%dt/), dvr%out%storage(:,:,iWT), errStat2, errMsg2)
+            call WrBinFAST(trim(dvr%out%Root)//trim(sWT)//'.outb', FileFmtID_ChanLen_In, GetVersion(version), dvr%out%WriteOutputHdr, dvr%out%WriteOutputUnt, (/0.0_DbKi, dvr%dt/), dvr%out%storage(:,:,iWT), errStat2, errMsg2)
             call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
          enddo
       endif
@@ -1452,7 +1452,7 @@ subroutine Dvr_InitializeOutputs(nWT, out, numSteps, errStat, errMsg)
             end if
             call OpenFOutFile ( out%unOutFile(iWT), trim(out%Root)//trim(sWT)//'.out', errStat, errMsg )
             if ( errStat >= AbortErrLev ) return
-            write (out%unOutFile(iWT),'(/,A)')  'Predictions were generated on '//CurDate()//' at '//CurTime()//' using '//trim( TRIM(GetVersion(version)) )
+            write (out%unOutFile(iWT),'(/,A)')  'Predictions were generated on '//CurDate()//' at '//CurTime()//' using '//trim( GetVersion(version) )
             write (out%unOutFile(iWT),'(1X,A)') trim(GetNVD(out%AD_ver))
             write (out%unOutFile(iWT),'()' )    !print a blank line
             write (out%unOutFile(iWT),'()' )    !print a blank line

--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -516,7 +516,8 @@ subroutine Init_ADI_ForDriver(iCase, ADI, dvr, FED, dt, errStat, errMsg)
       enddo
 
       call ADI_Init(InitInp, ADI%u(1), ADI%p, ADI%x(1), ADI%xd(1), ADI%z(1), ADI%OtherState(1), ADI%y, ADI%m, dt, InitOut, errStat, errMsg)
-
+      dvr%out%AD_ver = InitOut%Ver
+      
       ! Set output headers
       if (iCase==1) then
          call concatOutputHeaders(dvr%out%WriteOutputHdr, dvr%out%WriteOutputUnt, InitOut%WriteOutputHdr, InitOut%WriteOutputUnt, errStat2, errMsg2); if(Failed()) return
@@ -548,7 +549,7 @@ contains
       if (errStat /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'Dvr_InitCase')
+         call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'Init_ADI_ForDriver')
       endif
       Failed0 = errStat >= AbortErrLev
       if(Failed0) call cleanUp()
@@ -1451,7 +1452,7 @@ subroutine Dvr_InitializeOutputs(nWT, out, numSteps, errStat, errMsg)
             end if
             call OpenFOutFile ( out%unOutFile(iWT), trim(out%Root)//trim(sWT)//'.out', errStat, errMsg )
             if ( errStat >= AbortErrLev ) return
-            write (out%unOutFile(iWT),'(/,A)')  'Predictions were generated on '//CurDate()//' at '//CurTime()//' using '//trim( version%Name )
+            write (out%unOutFile(iWT),'(/,A)')  'Predictions were generated on '//CurDate()//' at '//CurTime()//' using '//trim( TRIM(GetVersion(version)) )
             write (out%unOutFile(iWT),'(1X,A)') trim(GetNVD(out%AD_ver))
             write (out%unOutFile(iWT),'()' )    !print a blank line
             write (out%unOutFile(iWT),'()' )    !print a blank line
@@ -1667,8 +1668,8 @@ subroutine Dvr_WriteOutputs(nt, t, dvr, out, yADI, errStat, errMsg)
          out%outLine(1:nDV)         = dvr%wt(iWT)%WriteOutput(1:nDV)  ! Driver Write Outputs
          ! out%outLine(11)            = dvr%WT(iWT)%hub%azimuth       ! azimuth already stored a nt-1
 
-         out%outLine(nDV+1:nDV+nAD) = yADI%AD%rotors(iWT)%WriteOutput     ! AeroDyn WriteOutputs
-         out%outLine(nDV+nAD+1:)    = yADI%IW_WriteOutput                 ! InflowWind WriteOutputs
+         out%outLine(nDV+1:nDV+nIW) = yADI%IW_WriteOutput                 ! InflowWind WriteOutputs
+         out%outLine(nDV+nIW+1:)    = yADI%AD%rotors(iWT)%WriteOutput     ! AeroDyn WriteOutputs
 
          if (out%fileFmt==idFmtBoth .or. out%fileFmt == idFmtAscii) then
             ! ASCII
@@ -1681,7 +1682,7 @@ subroutine Dvr_WriteOutputs(nt, t, dvr, out, yADI, errStat, errMsg)
          endif
          if (out%fileFmt==idFmtBoth .or. out%fileFmt == idFmtBinary) then
             ! Store for binary
-            out%storage(1:nDV+nAD+nIW, nt, iWT) = out%outLine(1:nDV+nAD+nIW)
+            out%storage(1:nDV+nIW+nAD, nt, iWT) = out%outLine(1:nDV+nIW+nAD)
          endif
       endif
    enddo


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
The AeroDyn driver code uses AeroDyn_Inflow (ADI). ADI concatenates the output headers from InflowWind and AeroDyn's first rotor into one array at initialization. However, at each time step, it makes the driver code concatenate the `WriteOutput` arrays. The AeroDyn driver concatenated AeroDyn's outputs from the first rotor and InflowWind output channels (the opposite order of ADI), so all of the AD and IfW channels were mislabeled if both modules were used. 

I changed the order of the `WriteOutput` channels in the AeroDyn driver so that they now match the order of the concatenated headers from ADI. It likely would have caused fewer issues with the regression tests if I had just relabeled the columns, but since ADI is used elsewhere (I think), this seemed like it was less likely to cause issues with other codes that use ADI.

It seems like ADI should handle the concatenation of arrays instead of the driver. If it does it at initialization, it should do it at each time step, too. This would make sure only one code (ADI) needs to be concerned about the internal order of the columns. However, I will leave this as an exercise for someone else to do later.

I also fixed a problem where AD driver was attempting to print the AD version in the text output file, but not initializing the variable it uses. This left a bunch of non-printable characters in the text file.

Finally, I am printing the git hash (version info) in the output files generated by the AeroDyn driver. This applies to both the text and binary files.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
AeroDyn driver

**Test results, if applicable**
All of the AeroDyn driver tests that contain outputs from both AD and InflowWind will fail due to the outputs being in a different order.

```
The following tests FAILED:
	 57 - ad_EllipticalWingInf_OLAF (Failed)
	 58 - ad_HelicalWakeInf_OLAF (Failed)
	 59 - ad_Kite_OLAF (Failed)
	 60 - ad_MultipleHAWT (Failed)
	 67 - ad_BAR_SineMotion (Failed)
	 68 - ad_BAR_SineMotion_UA4_DBEMT3 (Failed)
```