### PR TITLE
Update to rotation matrix comments in NWTC Library

### DIFF
--- a/modules/nwtc-library/src/NWTC_Num.f90
+++ b/modules/nwtc-library/src/NWTC_Num.f90
@@ -1687,8 +1687,8 @@ CONTAINS
 
    END FUNCTION EqualRealNos8
 !=======================================================================
-!> This function creates a rotation matrix, M, from a 1-2-3 rotation
-!! sequence of the 3 Euler angles, \f$\theta_x\f$, \f$\theta_y\f$, and \f$\theta_z\f$, in radians.
+!> This function creates a rotation matrix, M, from a 3-2-1 intrinsic rotation
+!! sequence of the 3 Tait-Bryan angles (1-2-3 extrinsic rotation), \f$\theta_x\f$, \f$\theta_y\f$, and \f$\theta_z\f$, in radians.
 !! M represents a change of basis (from global to local coordinates; 
 !! not a physical rotation of the body). It is the inverse of EulerExtract (nwtc_num::eulerextract).
 !!
@@ -1752,8 +1752,8 @@ CONTAINS
 !> \copydoc nwtc_num::eulerconstructr4
    FUNCTION EulerConstructR8(theta) result(M)
    
-      ! this function creates a rotation matrix, M, from a 1-2-3 rotation
-      ! sequence of the 3 Euler angles, theta_x, theta_y, and theta_z, in radians.
+      ! this function creates a rotation matrix, M, from a 3-2-1 intrinsic rotation
+!! sequence of the 3 Tait-Bryan angles (1-2-3 extrinsic rotation), theta_x, theta_y, and theta_z, in radians.
       ! M represents a change of basis (from global to local coordinates; 
       ! not a physical rotation of the body). it is the inverse of EulerExtract (nwtc_num::eulerextract).
       !


### PR DESCRIPTION
**Feature or improvement description**
Updating the comments in the NWTC library for rotation matrices to reflect what is in the code. This caused some confusion in https://github.com/FloatingArrayDesign/MoorDyn/pull/233#issuecomment-2211313485

**Related issue, if one exists**
n/a

**Impacted areas of the software**
NWTC library
