### PR TITLE
Always build openfastcpplib as shared. Use BUILD_OPENFAST_CPP_DRIVER to disable openfastcpp executable

### DIFF
--- a/glue-codes/openfast-cpp/CMakeLists.txt
+++ b/glue-codes/openfast-cpp/CMakeLists.txt
@@ -27,9 +27,8 @@ find_package(MPI REQUIRED)
 find_package(LibXml2 REQUIRED)
 find_package(ZLIB REQUIRED)
 find_package(HDF5 REQUIRED COMPONENTS C HL)
-find_package(yaml-cpp REQUIRED)
 
-add_library(openfastcpplib src/OpenFAST.cpp src/SC.cpp)
+add_library(openfastcpplib SHARED src/OpenFAST.cpp src/SC.cpp)
 set_property(TARGET openfastcpplib PROPERTY POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(openfastcpplib
   openfastlib
@@ -48,28 +47,41 @@ target_include_directories(openfastcpplib PUBLIC
 )
 set_target_properties(openfastcpplib PROPERTIES PUBLIC_HEADER "src/OpenFAST.H;src/SC.h")
 
-add_executable(openfastcpp src/FAST_Prog.cpp)
-target_link_libraries(openfastcpp 
-  ${YAML_CPP_LIBRARIES}
-  openfastcpplib 
-)
-target_include_directories(openfastcpp PRIVATE ${YAML_CPP_INCLUDE_DIR})
-set_target_properties(openfastcpp PROPERTIES LINKER_LANGUAGE CXX)
-
-if(MPI_COMPILE_FLAGS)
-  set_target_properties(openfastcpp PROPERTIES
-    COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
-endif(MPI_COMPILE_FLAGS)
-
-if(MPI_LINK_FLAGS)
-  set_target_properties(openfastcpp PROPERTIES
-    LINK_FLAGS "${MPI_LINK_FLAGS}")
-endif(MPI_LINK_FLAGS)
-
-install(TARGETS openfastcpp openfastcpplib
+install(TARGETS openfastcpplib
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION lib
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
   PUBLIC_HEADER DESTINATION include
 )
+
+# Build driver if requested
+if (BUILD_OPENFAST_CPP_DRIVER)
+
+  find_package(yaml-cpp REQUIRED)
+  add_executable(openfastcpp src/FAST_Prog.cpp)
+  target_link_libraries(openfastcpp 
+    ${YAML_CPP_LIBRARIES}
+    openfastcpplib 
+  )
+  target_include_directories(openfastcpp PRIVATE ${YAML_CPP_INCLUDE_DIR})
+  set_target_properties(openfastcpp PROPERTIES LINKER_LANGUAGE CXX)
+
+  if(MPI_COMPILE_FLAGS)
+    set_target_properties(openfastcpp PROPERTIES
+      COMPILE_FLAGS "${MPI_COMPILE_FLAGS}")
+  endif(MPI_COMPILE_FLAGS)
+
+  if(MPI_LINK_FLAGS)
+    set_target_properties(openfastcpp PROPERTIES
+      LINK_FLAGS "${MPI_LINK_FLAGS}")
+  endif(MPI_LINK_FLAGS)
+
+  install(TARGETS openfastcpp 
+    EXPORT "${CMAKE_PROJECT_NAME}Libraries"
+    RUNTIME DESTINATION lib
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    PUBLIC_HEADER DESTINATION include
+  )
+endif()


### PR DESCRIPTION
This PR is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR makes `openfastcpplib` always build as a shared library so `BUILD_SHARED_LIBS=ON` is not needed for AMR-WIND. This PR also uses `BUILD_OPENFAST_CPP_DRIVER` to control whether `openfastcpp` is built or not. Setting `BUILD_OPENFAST_CPP_DRIVER=OFF` and `BUILD_OPENFAST_CPP_API=ON` will allow `openfastcpplib` to be built for AMR-WIND without needing `yaml-cpp` which has been a problem on some platforms like Kestrel.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

Only the openfast-cpp CMakeLists.txt was changed.

**Additional supporting information**
<!-- Add any other context about the problem here. -->

This change reuses `BUILD_OPENFAST_CPP_DRIVER` which previously only controlled if `openfast_cpp_driver` was built. It may be better to use a separate flag, but it would be difficult to find a better name since both of these executables are C++ drivers. Also, `openfastcpp` is only built when `BUILD_OPENFAST_CPP_API=ON`.

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

No tests were affected