### PR TITLE
Initialize ED RtHS to zeros

### DIFF
--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -2962,296 +2962,152 @@ SUBROUTINE SetOtherParameters( p, InputFileData, ErrStat, ErrMsg )
 
    CALL Coeff(p, InputFileData, ErrStat, ErrMsg)
    IF ( ErrStat /= ErrID_None ) RETURN
-   
-   
 END SUBROUTINE SetOtherParameters
+
+
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This routine allocates arrays in the RtHndSide data structure.
 !! It requires p\%TwrNodes, p\%NumBl, p\%TipNode, p\%NDOF, p\%BldNodes to be set before calling this routine.
 SUBROUTINE Alloc_RtHS( RtHS, p, ErrStat, ErrMsg  )
-!..................................................................................................................................
-
    TYPE(ED_RtHndSide),       INTENT(INOUT)  :: RtHS                         !< RtHndSide data type
    TYPE(ED_ParameterType),   INTENT(IN)     :: p                            !< Parameters of the structural dynamics module
    INTEGER(IntKi),           INTENT(OUT)    :: ErrStat                      !< Error status
    CHARACTER(*),             INTENT(OUT)    :: ErrMsg                       !< Error message
 
    ! local variables:
+   integer(IntKi)                           :: ErrStat2
+   character(ErrMsgLen)                     :: ErrMsg2
    INTEGER(IntKi),   PARAMETER              :: Dims = 3                     ! The position arrays all must be allocated with a dimension for X,Y,and Z
    CHARACTER(*),     PARAMETER              :: RoutineName = 'Alloc_RtHS'
 
-      ! positions:
-  !CALL AllocAry( RtHS%rZT,       Dims, p%TwrNodes,        'rZT',       ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%rT,        Dims, p%TwrNodes,        'rT',        ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%rT0T,      Dims, p%TwrNodes,        'rT0T',      ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-  !CALL AllocAry( RtHS%rQS,       Dims, p%NumBl,p%TipNode, 'rQS',       ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-  !CALL AllocAry( RtHS%rS,        Dims, p%NumBl,p%TipNode, 'rS',        ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%rS0S,      Dims, p%NumBl,p%TipNode, 'rS0S',      ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%rPS0,      Dims, p%NumBl,           'rPS0',      ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%rSAerCen,  Dims, p%TipNode, p%NumBl,'rSAerCen',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
+   ! positions:
+  !call AllocAry( RtHS%rZT,       Dims, p%TwrNodes,        'rZT',      ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rZT      = 0.0_ReKi
+   call AllocAry( RtHS%rT,        Dims, p%TwrNodes,        'rT',       ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rT       = 0.0_ReKi
+   call AllocAry( RtHS%rT0T,      Dims, p%TwrNodes,        'rT0T',     ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rT0T     = 0.0_ReKi
+  !call AllocAry( RtHS%rQS,       Dims, p%NumBl,p%TipNode, 'rQS',      ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rQS      = 0.0_ReKi
+  !call AllocAry( RtHS%rS,        Dims, p%NumBl,p%TipNode, 'rS',       ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rS       = 0.0_ReKi
+   call AllocAry( RtHS%rS0S,      Dims, p%NumBl,p%TipNode, 'rS0S',     ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rS0S     = 0.0_ReKi
+   call AllocAry( RtHS%rPS0,      Dims, p%NumBl,           'rPS0',     ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rPS0     = 0.0_ReKi
+   call AllocAry( RtHS%rSAerCen,  Dims, p%TipNode, p%NumBl,'rSAerCen', ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%rSAerCen = 0.0_ReKi
   
-      ! tower
-   allocate(RtHS%rZT(      Dims,  0:p%TwrNodes), &
-            RtHS%AngPosEF( Dims,  0:p%TwrNodes), &
-            RtHS%AngPosXF( Dims,  0:p%TwrNodes), &
-            RtHS%AngVelEF( Dims,  0:p%TwrNodes), &
-            RtHS%LinVelET( Dims,  0:p%TwrNodes), &
-            RtHS%AngAccEFt(Dims,  0:p%TwrNodes), &
-            RtHS%LinAccETt(Dims,  0:p%TwrNodes), &
-      STAT=ErrStat)
-      if (ErrStat /= 0) then
-         ErrStat = ErrID_Fatal
-         ErrMsg  = "Error allocating rZT, AngPosEF, AngPosXF, LinVelET, AngVelEF, LinAccETt, and AngAccEFt arrays."
-         RETURN
-      end if
-               
+   ! tower
+   allocate(RtHS%rZT(      Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('rZT      ')) return;   RtHS%rZT       = 0.0_ReKi
+   allocate(RtHS%AngPosEF( Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('AngPosEF ')) return;   RtHS%AngPosEF  = 0.0_ReKi
+   allocate(RtHS%AngPosXF( Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('AngPosXF ')) return;   RtHS%AngPosXF  = 0.0_ReKi
+   allocate(RtHS%AngVelEF( Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('AngVelEF ')) return;   RtHS%AngVelEF  = 0.0_ReKi
+   allocate(RtHS%LinVelET( Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('LinVelET ')) return;   RtHS%LinVelET  = 0.0_ReKi
+   allocate(RtHS%AngAccEFt(Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('AngAccEFt')) return;   RtHS%AngAccEFt = 0.0_ReKi
+   allocate(RtHS%LinAccETt(Dims, 0:p%TwrNodes), STAT=ErrStat2); if (Failed0('LinAccETt')) return;   RtHS%LinAccETt = 0.0_ReKi
       
-      ! blades
-   allocate(RtHS%rS( Dims, p%NumBl,0:p%TipNode), &
-            RtHS%rQS(Dims, p%NumBl,0:p%TipNode), STAT=ErrStat)
-      if (ErrStat /= 0) then
-         ErrStat = ErrID_Fatal
-         ErrMsg  = "Error allocating rS and rQS."
-         RETURN
-      end if
+   ! blades
+   allocate(RtHS%rS( Dims, p%NumBl, 0:p%TipNode), STAT=ErrStat2); if (Failed0('rS ')) return;   RtHS%rS  = 0.0_ReKi
+   allocate(RtHS%rQS(Dims, p%NumBl, 0:p%TipNode), STAT=ErrStat2); if (Failed0('rQS')) return;   RtHS%rQS = 0.0_ReKi
+
+   ! angular velocities (including partial angular velocities):
+   !call AllocAry( RtHS%AngVelEF,  Dims, p%TwrNodes, 'AngVelEF', ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%AngVelEF = 0.0_ReKi
+   !call AllocAry( RtHS%AngPosEF,  Dims, p%TwrNodes, 'AngPosEF', ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%AngPosEF = 0.0_ReKi
+   !call AllocAry( RtHS%AngPosXF,  Dims, p%TwrNodes, 'AngPosXF', ErrStat2, ErrMsg2 );  if (Failed()) return;  RtHS%AngPosXF = 0.0_ReKi
+
+
+   ! These angular velocities are allocated to start numbering a dimension with 0 instead of 1:
+   allocate(RtHS%PAngVelEB(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEB')) return;  RtHS%PAngVelEB = 0.0_ReKi
+   allocate(RtHS%PAngVelER(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelER')) return;  RtHS%PAngVelER = 0.0_ReKi
+   allocate(RtHS%PAngVelEX(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEX')) return;  RtHS%PAngVelEX = 0.0_ReKi
+   allocate(RtHS%PAngVelEA(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEA')) return;  RtHS%PAngVelEA = 0.0_ReKi
+   allocate(RtHS%PAngVelEF(0:p%TwrNodes,       p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEF')) return;  RtHS%PAngVelEF = 0.0_ReKi
+   allocate(RtHS%PAngVelEG(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEG')) return;  RtHS%PAngVelEG = 0.0_ReKi
+   allocate(RtHS%PAngVelEH(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEH')) return;  RtHS%PAngVelEH = 0.0_ReKi
+   allocate(RtHS%PAngVelEL(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEL')) return;  RtHS%PAngVelEL = 0.0_ReKi
+   allocate(RtHS%PAngVelEM(p%NumBl,0:p%TipNode,p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEM')) return;  RtHS%PAngVelEM = 0.0_ReKi
+   allocate(RtHS%PAngVelEN(                    p%NDOF,0:1,Dims), STAT=ErrStat2);  if (Failed0('PAngVelEN')) return;  RtHS%PAngVelEN = 0.0_ReKi
+
+   ! angular accelerations:
+   !CALL AllocAry( RtHS%AngAccEFt, Dims, p%TwrNodes,         'AngAccEFt', ErrStat2, ErrMsg2 ); 
+
+   ! linear velocities (including partial linear velocities):
+   !CALL AllocAry( RtHS%LinVelET,  Dims, p%TwrNodes,         'LinVelET',  ErrStat2, ErrMsg2 ); 
+   !CALL AllocAry( RtHS%LinVelESm2,                 p%NumBl, 'LinVelESm2',ErrStat2, ErrMsg2 );           ! The m2-component (closest to tip) of LinVelES
+   allocate(RtHS%LinVelES( Dims, 0:p%TipNode, p%NumBl), STAT=ErrStat2); if (Failed0('LinVelES')) return; RtHS%LinVelES  = 0.0_ReKi
+   allocate(RtHS%AngVelEM( Dims, 0:p%TipNode, p%NumBl), STAT=ErrStat2); if (Failed0('AngVelEM')) return; RtHS%AngVelEM  = 0.0_ReKi
    
+   ! These linear velocities are allocated to start numbering a dimension with 0 instead of 1:
+   allocate(RtHS%PLinVelEIMU(p%NDOF,0:1,Dims), STAT=ErrStat2);                   if (Failed0('PLinVelEIMU')) return;  RtHS%PLinVelEIMU = 0.0_ReKi;
+   allocate(RtHS%PLinVelEO(p%NDOF,0:1,Dims), STAT=ErrStat2);                     if (Failed0('PLinVelEO  ')) return;  RtHS%PLinVelEO   = 0.0_ReKi;
+   allocate(RtHS%PLinVelES(p%NumBl,0:p%TipNode,p%NDOF,0:1,Dims), STAT=ErrStat2); if (Failed0('PLinVelES  ')) return;  RtHS%PLinVelES   = 0.0_ReKi;
+   allocate(RtHS%PLinVelET(0:p%TwrNodes,p%NDOF,0:1,Dims), STAT=ErrStat2);        if (Failed0('PLinVelET  ')) return;  RtHS%PLinVelET   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEZ(p%NDOF,0:1,Dims), STAT=ErrStat2);                     if (Failed0('PLinVelEZ  ')) return;  RtHS%PLinVelEZ   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEC(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEC  ')) return;  RtHS%PLinVelEC   = 0.0_ReKi;
+   allocate(RtHS%PLinVelED(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelED  ')) return;  RtHS%PLinVelED   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEI(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEI  ')) return;  RtHS%PLinVelEI   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEJ(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEJ  ')) return;  RtHS%PLinVelEJ   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEP(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEP  ')) return;  RtHS%PLinVelEP   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEQ(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEQ  ')) return;  RtHS%PLinVelEQ   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEU(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEU  ')) return;  RtHS%PLinVelEU   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEV(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEV  ')) return;  RtHS%PLinVelEV   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEW(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEW  ')) return;  RtHS%PLinVelEW   = 0.0_ReKi;
+   allocate(RtHS%PLinVelEY(p%NDOF,0:1,3), STAT=ErrStat2);                        if (Failed0('PLinVelEY  ')) return;  RtHS%PLinVelEY   = 0.0_ReKi;
+   allocate(RtHS%LinAccESt(Dims, p%NumBl, 0:p%TipNode), STAT=ErrStat2);          if (Failed0('LinAccESt  ')) return;  RtHS%LinAccESt   = 0.0_ReKi;
+   allocate(RtHS%AngAccEKt(Dims, 0:p%TipNode, p%NumBl), STAT=ErrStat2);          if (Failed0('AngAccEKt  ')) return;  RtHS%AngAccEKt   = 0.0_ReKi;
+   allocate(RtHS%AngPosHM( Dims, p%NumBl, 0:p%TipNode), STAT=ErrStat2);          if (Failed0('AngPosHM   ')) return;  RtHS%AngPosHM    = 0.0_ReKi;
 
-      ! angular velocities (including partial angular velocities):
-   !CALL AllocAry( RtHS%AngVelEF,  Dims, p%TwrNodes,        'AngVelEF',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   !CALL AllocAry( RtHS%AngPosEF,  Dims, p%TwrNodes,        'AngPosEF',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   !CALL AllocAry( RtHS%AngPosXF,  Dims, p%TwrNodes,        'AngPosXF',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
+   !call AllocAry( RtHS%LinAccESt, Dims, p%NumBl, p%TipNode,'LinAccESt', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%LinAccESt  = 0.0_ReKi;
+   !call AllocAry( RtHS%LinAccETt, Dims, p%TwrNodes,        'LinAccETt', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%LinAccETt  = 0.0_ReKi
+   call AllocAry( RtHS%PFrcS0B,   Dims, p%NumBl,p%NDOF,    'PFrcS0B  ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcS0B   = 0.0_ReKi
+   call AllocAry( RtHS%FrcS0Bt,   Dims, p%NumBl,           'FrcS0Bt  ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%FrcS0Bt   = 0.0_ReKi
+   call AllocAry( RtHS%PMomH0B,   Dims, p%NumBl, p%NDOF,   'PMomH0B  ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomH0B   = 0.0_ReKi
+   call AllocAry( RtHS%MomH0Bt,   Dims, p%NumBl,           'MomH0Bt  ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%MomH0Bt   = 0.0_ReKi
+   call AllocAry( RtHS%PFrcPRot,  Dims, p%NDOF,            'PFrcPRot ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcPRot  = 0.0_ReKi
+   call AllocAry( RtHS%PMomLPRot, Dims, p%NDOF,            'PMomLPRot', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomLPRot = 0.0_ReKi
+   call AllocAry( RtHS%PMomNGnRt, Dims, p%NDOF,            'PMomNGnRt', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomNGnRt = 0.0_ReKi
+   call AllocAry( RtHS%PMomNTail, Dims, p%NDOF,            'PMomNTail', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomNTail = 0.0_ReKi
+   call AllocAry( RtHS%PFrcONcRt, Dims, p%NDOF,            'PFrcONcRt', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcONcRt = 0.0_ReKi
+   call AllocAry( RtHS%PMomBNcRt, Dims, p%NDOF,            'PMomBNcRt', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomBNcRt = 0.0_ReKi
+   call AllocAry( RtHS%PFrcT0Trb, Dims, p%NDOF,            'PFrcT0Trb', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcT0Trb = 0.0_ReKi
+   call AllocAry( RtHS%PMomX0Trb, Dims, p%NDOF,            'PMomX0Trb', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomX0Trb = 0.0_ReKi
+   call AllocAry( RtHS%FSAero,    Dims, p%NumBl,p%BldNodes,'FSAero   ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%FSAero    = 0.0_ReKi
+   call AllocAry( RtHS%MMAero,    Dims, p%NumBl,p%BldNodes,'MMAero   ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%MMAero    = 0.0_ReKi
+   call AllocAry( RtHS%FSTipDrag, Dims, p%NumBl,           'FSTipDrag', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%FSTipDrag = 0.0_ReKi
+   call AllocAry( RtHS%PFTHydro,  Dims, p%TwrNodes, p%NDOF,'PFTHydro ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFTHydro  = 0.0_ReKi
+   call AllocAry( RtHS%PMFHydro,  Dims, p%TwrNodes, p%NDOF,'PMFHydro ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMFHydro  = 0.0_ReKi
+   call AllocAry( RtHS%FTHydrot,  Dims, p%TwrNodes,        'FTHydrot ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%FTHydrot  = 0.0_ReKi
+   call AllocAry( RtHS%MFHydrot,  Dims, p%TwrNodes,        'MFHydrot ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%MFHydrot  = 0.0_ReKi
 
+   call AllocAry( RtHS%PFrcVGnRt, Dims, p%NDOF,            'PFrcVGnRt', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcVGnRt = 0.0_ReKi
+   call AllocAry( RtHS%PFrcWTail, Dims, p%NDOF,            'PFrcWTail', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcWTail = 0.0_ReKi
+   call AllocAry( RtHS%PFrcZAll,  Dims, p%NDOF,            'PFrcZAll ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PFrcZAll  = 0.0_ReKi
+   call AllocAry( RtHS%PMomXAll,  Dims, p%NDOF,            'PMomXAll ', ErrStat2, ErrMsg2);  if ( Failed()) return;  RtHS%PMomXAll  = 0.0_ReKi
 
-         ! These angular velocities are allocated to start numbering a dimension with 0 instead of 1:
-   ALLOCATE ( RtHS%PAngVelEB(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEB array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PAngVelER(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelER array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PAngVelEX(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEX array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PAngVelEA(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEA array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PAngVelEF(0:p%TwrNodes, p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEF array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PAngVelEG(                  p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEG array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PAngVelEH(                  p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEH array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PAngVelEL(                  p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEL array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PAngVelEM(p%NumBl,0:p%TipNode,p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEM array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PAngVelEN(                  p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PAngVelEN array.'
-      RETURN
-   ENDIF
-
-      ! angular accelerations:
-   !CALL AllocAry( RtHS%AngAccEFt, Dims, p%TwrNodes,         'AngAccEFt', ErrStat, ErrMsg );  IF ( ErrStat /= ErrID_None ) RETURN
-
-      ! linear velocities (including partial linear velocities):
-   !CALL AllocAry( RtHS%LinVelET,  Dims, p%TwrNodes,         'LinVelET',  ErrStat, ErrMsg );  IF ( ErrStat /= ErrID_None ) RETURN         
-
-   !CALL AllocAry( RtHS%LinVelESm2,                 p%NumBl, 'LinVelESm2',ErrStat, ErrMsg );  IF ( ErrStat /= ErrID_None ) RETURN ! The m2-component (closest to tip) of LinVelES
-   ALLOCATE( RtHS%LinVelES( Dims, 0:p%TipNode, p%NumBl ), &
-             RtHS%AngVelEM( Dims, 0:p%TipNode, p%NumBl ), STAT=ErrStat )
-   IF (ErrStat /= 0 ) THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = RoutineName//":Error allocating LinVelES and AngVelEM."
-      RETURN
-   END IF
-   
-            ! These linear velocities are allocated to start numbering a dimension with 0 instead of 1:
-
-   ALLOCATE ( RtHS%PLinVelEIMU(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEIMU array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PLinVelEO(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEO array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PLinVelES(p%NumBl,0:p%TipNode,p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelES array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PLinVelET(0:p%TwrNodes,p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelET array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PLinVelEZ(p%NDOF,0:1,Dims) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEZ array.'
-      RETURN
-   ENDIF
-
-   ALLOCATE ( RtHS%PLinVelEC(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEC array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PLinVelED(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelED array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PLinVelEI(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEI array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PLinVelEJ(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEJ array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PLinVelEP(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEP array.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%PLinVelEQ(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEQ array.'
-      RETURN
-   ENDIF
-   
-   ALLOCATE ( RtHS%PLinVelEU(p%NDOF,0:1,3) , &
-              RtHS%PLinVelEV(p%NDOF,0:1,3) , &
-              RtHS%PLinVelEW(p%NDOF,0:1,3) , &
-              RtHS%PLinVelEY(p%NDOF,0:1,3) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the PLinVelEU, PLinVelEV, PLinVelEW and PLinVelEY arrays.'
-      RETURN
-   ENDIF
-
-   
-   ALLOCATE( RtHS%LinAccESt( Dims, p%NumBl, 0:p%TipNode ), STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for LinAccESt.'
-      RETURN
-   ENDIF
-   ALLOCATE ( RtHS%AngAccEKt( Dims, 0:p%TipNode, p%NumBl ) , STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for AngAccEKt.'
-      RETURN
-   ENDIF
-
-   ALLOCATE(RtHS%AngPosHM(Dims, p%NumBl, 0:p%TipNode), STAT=ErrStat )
-   IF ( ErrStat /= 0_IntKi )  THEN
-      ErrStat = ErrID_Fatal
-      ErrMsg = ' Error allocating memory for the AngPosHM arrays.'
-      RETURN
-   ENDIF
-
-   !CALL AllocAry( RtHS%LinAccESt, Dims, p%NumBl, p%TipNode,'LinAccESt', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   !CALL AllocAry( RtHS%LinAccETt, Dims, p%TwrNodes,        'LinAccETt', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFrcS0B,   Dims, p%NumBl,p%NDOF,    'PFrcS0B',   ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%FrcS0Bt,   Dims, p%NumBl,           'FrcS0Bt',   ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomH0B,   Dims, p%NumBl, p%NDOF,   'PMomH0B',   ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%MomH0Bt,   Dims, p%NumBl,           'MomH0Bt',   ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFrcPRot,  Dims, p%NDOF,            'PFrcPRot',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomLPRot, Dims, p%NDOF,            'PMomLPRot', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomNGnRt, Dims, p%NDOF,            'PMomNGnRt', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomNTail, Dims, p%NDOF,            'PMomNTail', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFrcONcRt, Dims, p%NDOF,            'PFrcONcRt', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomBNcRt, Dims, p%NDOF,            'PMomBNcRt', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFrcT0Trb, Dims, p%NDOF,            'PFrcT0Trb', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomX0Trb, Dims, p%NDOF,            'PMomX0Trb', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%FSAero,    Dims, p%NumBl,p%BldNodes,'FSAero',    ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%MMAero,    Dims, p%NumBl,p%BldNodes,'MMAero',    ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%FSTipDrag, Dims, p%NumBl,           'FSTipDrag', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFTHydro,  Dims, p%TwrNodes, p%NDOF,'PFTHydro',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMFHydro,  Dims, p%TwrNodes, p%NDOF,'PMFHydro',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%FTHydrot,  Dims, p%TwrNodes,        'FTHydrot',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%MFHydrot,  Dims, p%TwrNodes,        'MFHydrot',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-
-   CALL AllocAry( RtHS%PFrcVGnRt, Dims, p%NDOF,            'PFrcVGnRt', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFrcWTail, Dims, p%NDOF,            'PFrcWTail', ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PFrcZAll,  Dims, p%NDOF,            'PFrcZAll',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-   CALL AllocAry( RtHS%PMomXAll,  Dims, p%NDOF,            'PMomXAll',  ErrStat, ErrMsg );   IF ( ErrStat /= ErrID_None ) RETURN
-
+contains
+   logical function Failed()
+      call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      Failed = ErrStat >= AbortErrLev
+   end function Failed
+   ! check for failed where /= 0 is fatal
+   logical function Failed0(txt)
+      character(*), intent(in) :: txt
+      if (errStat /= 0) then
+         ErrStat2 = ErrID_Fatal
+         ErrMsg2  = "Could not allocate "//trim(txt)
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg2, RoutineName)
+      endif
+      Failed0 = ErrStat >= AbortErrLev
+   end function Failed0
 END SUBROUTINE Alloc_RtHS
+
+
+
 !----------------------------------------------------------------------------------------------------------------------------------
 !> This takes the tower input file data and sets the corresponding tower parameters, performing linear interpolation of the
 !! input data to the specified tower mesh.
 !! It requires p\%TwrFlexL, and p\%TwrNodes to be set first.
-SUBROUTINE SetTowerParameters( p, InputFileData, ErrStat, ErrMsg  )
-!..................................................................................................................................
-
-      ! Passed variables
-
+SUBROUTINE SetTowerParameters( p, InputFileData, ErrStat, ErrMsg )
+   ! Passed variables
    TYPE(ED_ParameterType),   INTENT(INOUT)  :: p                            !< Parameters of the structural dynamics module
    TYPE(ED_InputFile),       INTENT(IN)     :: InputFileData                !< Data stored in the module's input file
    INTEGER(IntKi),           INTENT(OUT)    :: ErrStat                      !< Error status
    CHARACTER(*),             INTENT(OUT)    :: ErrMsg                       !< Error message
 
-      ! Local variables:
-
+   ! Local variables:
    REAL(ReKi)                               :: x                            ! Fractional location between two points in linear interpolation
    INTEGER(IntKi )                          :: J                            ! Index for the node arrays
    INTEGER(IntKi)                           :: InterpInd                    ! Index for the interpolation routine

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -1738,6 +1738,7 @@ SUBROUTINE ReadBladeFile ( BldFile, BladeKInputFileData, UnEc, ErrStat, ErrMsg )
    REAL(ReKi)                   :: AdjEdSt                                         ! Factor to adjust edge stiffness.
    REAL(ReKi)                   :: AdjFlSt                                         ! Factor to adjust flap stiffness.
 
+   TYPE(FileInfoType)           :: InFileInfo                                      !< The derived type for holding the full input file for parsing
    REAL(ReKi)                   :: TmpRAry(17)                                     ! Temporary variable to read table from file (up to 17 columns)
 
    INTEGER(IntKi)               :: I                                               ! A generic DO index.
@@ -1749,7 +1750,12 @@ SUBROUTINE ReadBladeFile ( BldFile, BladeKInputFileData, UnEc, ErrStat, ErrMsg )
 
    ErrStat = ErrID_None
    ErrMsg = ""
-   
+
+     ! read the input file   
+   call ProcessComFile( './tmp.dat', InFileInfo, ErrStat2, ErrMsg2 )
+call Print_FileInfo_Struct(CU, InFileInfo)
+
+ 
    UnIn = -1
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )
 

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -1738,7 +1738,6 @@ SUBROUTINE ReadBladeFile ( BldFile, BladeKInputFileData, UnEc, ErrStat, ErrMsg )
    REAL(ReKi)                   :: AdjEdSt                                         ! Factor to adjust edge stiffness.
    REAL(ReKi)                   :: AdjFlSt                                         ! Factor to adjust flap stiffness.
 
-   TYPE(FileInfoType)           :: InFileInfo                                      !< The derived type for holding the full input file for parsing
    REAL(ReKi)                   :: TmpRAry(17)                                     ! Temporary variable to read table from file (up to 17 columns)
 
    INTEGER(IntKi)               :: I                                               ! A generic DO index.
@@ -1750,11 +1749,6 @@ SUBROUTINE ReadBladeFile ( BldFile, BladeKInputFileData, UnEc, ErrStat, ErrMsg )
 
    ErrStat = ErrID_None
    ErrMsg = ""
-
-     ! read the input file   
-   call ProcessComFile( './tmp.dat', InFileInfo, ErrStat2, ErrMsg2 )
-call Print_FileInfo_Struct(CU, InFileInfo)
-
  
    UnIn = -1
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -1626,7 +1626,7 @@ END SUBROUTINE CheckR8Var
 
    Ch = 0
 
-   DO
+   DO while (Ch + 1 < len(Line))
 
       NextWhite = SCAN( Line(Ch+1:) , ' ,;''"'//Tab )
       Ch        = Ch + NextWhite
@@ -4375,12 +4375,11 @@ END SUBROUTINE CheckR8Var
             ! Deallocate the linked list of file names.
 
           CurrFile => FirstFile
-          NextFile => CurrFile%Next
-          DO
+          DO WHILE(ASSOCIATED(currFile))
+              NextFile => CurrFile%Next
               DEALLOCATE(CurrFile)
               IF ( .NOT. ASSOCIATED( NextFile ) )  EXIT
               CurrFile => NextFile
-              NextFile => CurrFile%Next
           ENDDO
           
 !bjj: this needs to happen elsewhere...
@@ -7867,7 +7866,7 @@ end subroutine ReadR8AryWDefault
    INTEGER                      :: NewLineIndx                                  ! The string index where the NewLine character occurs
 
    CHARACTER(10)                :: Frm                                          ! Format specifier for the output.
-   CHARACTER(LEN(InStr))        :: Str                                          ! The next string to be processed
+   CHARACTER(Len=:),allocatable :: Str                                          ! The next string to be processed
 
 
 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -296,20 +296,16 @@ CONTAINS
 !! If the array is already allocated on entry to this routine, an error will be generated. \n
 !! Use AllocAry (nwtc_io::allocary) instead of directly calling a specific routine in the generic interface.   
    SUBROUTINE AllCAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D CHARACTER array.
 
-      ! This routine allocates a 1-D CHARACTER array.
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    CHARACTER(*), ALLOCATABLE         :: Ary    (:)                                 !< Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !< The size of the first dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !< Brief array description (for error message).
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !< Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !< Error message corresponding to ErrStat
-
    
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
-
 
    IF ( ErrStat /= 0 ) THEN
       ErrStat = ErrID_Fatal
@@ -321,6 +317,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = ''
    END IF
 
    RETURN
@@ -328,20 +325,15 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllCAry2 ( Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D CHARACTER array.
 
-      ! This routine allocates a 2-D CHARACTER array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    CHARACTER(*), ALLOCATABLE         :: Ary    (:,:)                               !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
-
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2) , STAT=ErrStat )
 
@@ -355,21 +347,17 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = ''
    END IF
-
 
    RETURN
    END SUBROUTINE AllCAry2
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllCAry3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 3-D CHARACTER array.
 
-
-      ! This routine allocates a 3-D CHARACTER array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    CHARACTER(*), ALLOCATABLE         :: Ary    (:,:,:)                             !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
@@ -377,7 +365,6 @@ CONTAINS
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
 
@@ -391,27 +378,22 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = ''
    END IF
-
-
 
    RETURN
    END SUBROUTINE AllCAry3
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllI1BAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D INTEGER B1Ki array.
 
-      ! This routine allocates a 1-D INTEGER B1Ki array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER(B1Ki),  ALLOCATABLE :: Ary    (:)                                 ! Array to be allocated
    INTEGER(IntKi), INTENT(IN)  :: AryDim1                                    ! The size of the array
    CHARACTER(*),   INTENT(IN)  :: Descr                                      ! Brief array description
    INTEGER(IntKi), INTENT(OUT) :: ErrStat                                    ! Error status
    CHARACTER(*),   INTENT(OUT) :: ErrMsg                                     ! Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
 
@@ -425,6 +407,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg = ' '
+      Ary = 0_B1Ki
    END IF
 
    RETURN
@@ -432,19 +415,14 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllI2BAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D INTEGER B2Ki array.
 
-
-      ! This routine allocates a 1-D INTEGER B2Ki array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER(B2Ki),  ALLOCATABLE :: Ary    (:)                                 ! Array to be allocated
    INTEGER(IntKi), INTENT(IN)  :: AryDim1                                     ! The size of the array
    CHARACTER(*),   INTENT(IN)  :: Descr                                      ! Brief array description
    INTEGER(IntKi), INTENT(OUT) :: ErrStat                                    ! Error status
    CHARACTER(*),   INTENT(OUT) :: ErrMsg                                     ! Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
 
@@ -458,6 +436,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg = ' '
+      Ary = 0_B2Ki
    END IF
 
    RETURN
@@ -465,19 +444,14 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllI4BAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D INTEGER B1Ki array.
 
-
-      ! This routine allocates a 1-D INTEGER B1Ki array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER(B4Ki),  ALLOCATABLE :: Ary    (:)                                 !  Array to be allocated
    INTEGER(IntKi), INTENT(IN)  :: AryDim1                                     !  The size of the array
    CHARACTER(*),   INTENT(IN)  :: Descr                                      !  Brief array description
    INTEGER(IntKi), INTENT(OUT) :: ErrStat                                    !  Error status
    CHARACTER(*),   INTENT(OUT) :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
 
@@ -491,6 +465,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg = ' '
+      Ary = 0_B4Ki
    END IF
 
    RETURN
@@ -498,20 +473,15 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllIAry2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D INTEGER array.
 
-
-      ! This routine allocates a 2-D INTEGER array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER(IntKi), ALLOCATABLE       :: Ary    (:,:)                               ! Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    ! The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      ! Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    ! Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     ! Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2) , STAT=ErrStat )
 
@@ -525,6 +495,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0_IntKi
    END IF
 
    RETURN
@@ -532,13 +503,9 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllIAry3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 3-D INTEGER array.
 
-
-      ! This routine allocates a 3-D INTEGER array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER(IntKi),  ALLOCATABLE      :: Ary    (:,:,:)                             !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
@@ -546,8 +513,6 @@ CONTAINS
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
 
@@ -561,8 +526,8 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0_IntKi
    END IF
-   
 
    RETURN
    END SUBROUTINE AllIAry3
@@ -573,17 +538,14 @@ CONTAINS
 !! will be deallocated first. \n
 !! Use AllocPAry (nwtc_io::allocpary) instead of directly calling a specific routine in the generic interface.   
    SUBROUTINE AllIPAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D INTEGER array.
 
-      ! This routine allocates a 1-D INTEGER array.
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER,      POINTER             :: Ary    (:)                                 !< Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !< The size of the first dimension of the array.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !< Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !< Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !< Brief array description.
-
 
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
@@ -599,29 +561,23 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
-   
-   Ary = 0
 
    RETURN
    END SUBROUTINE AllIPAry1 
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
    SUBROUTINE AllIPAry2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D INTEGER array.
 
-
-      ! This routine allocates a 2-D INTEGER array.
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    INTEGER,      POINTER             :: Ary    (:,:)                               !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
-
-
 
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
@@ -636,25 +592,23 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
    
-   Ary = 0
    RETURN
    END SUBROUTINE AllIPAry2 
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
    SUBROUTINE AllFPAry1 (  Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D REAL array.
 
-      ! This routine allocates a 1-D REAL array.
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(C_FLOAT), POINTER            :: Ary    (:)                                 !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !< Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
 
-
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
       !ErrStat = ErrID_Warn
@@ -669,25 +623,23 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
    
-   Ary = 0
    RETURN
    END SUBROUTINE AllFPAry1
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
    SUBROUTINE AllDPAry1 (  Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D REAL array.
 
-      ! This routine allocates a 1-D REAL array.
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(C_DOUBLE), POINTER           :: Ary    (:)                                 !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !< Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
 
-
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
       !ErrStat = ErrID_Warn
@@ -702,25 +654,23 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
    
-   Ary = 0
    RETURN
    END SUBROUTINE AllDPAry1
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
    SUBROUTINE AllRPAry2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D REAL array.
 
-      ! This routine allocates a 2-D REAL array.
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(ReKi),   POINTER             :: Ary    (:,:)                               !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
-
 
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
@@ -736,20 +686,17 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
    
-   Ary = 0
    RETURN
    END SUBROUTINE AllRPAry2 
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
    SUBROUTINE AllR4PAry3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg ) 
+   ! This routine allocates a 3-D REAL array.
 
-
-      ! This routine allocates a 3-D REAL array.
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(SiKi),   POINTER             :: Ary    (:,:,:)                             !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
@@ -757,7 +704,6 @@ CONTAINS
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
-
 
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
@@ -773,20 +719,17 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
    
-   Ary = 0
    RETURN
   END SUBROUTINE AllR4PAry3
 !=======================================================================
 !> \copydoc nwtc_io::allipary1
    SUBROUTINE AllR8PAry3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg ) 
+   ! This routine allocates a 3-D REAL array.
 
-
-      ! This routine allocates a 3-D REAL array.
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(R8Ki),   POINTER             :: Ary    (:,:,:)                             !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
@@ -794,7 +737,6 @@ CONTAINS
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
-
 
    IF ( ASSOCIATED(Ary) ) THEN
       DEALLOCATE(Ary)
@@ -810,28 +752,22 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0
    END IF
    
-   Ary = 0
    RETURN
    END SUBROUTINE AllR8PAry3
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllLAry1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D LOGICAL array.
 
-
-      ! This routine allocates a 1-D LOGICAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    LOGICAL,      ALLOCATABLE         :: Ary    (:)                                 !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
-
 
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
 
@@ -846,29 +782,23 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = .FALSE.
    END IF
-
 
    RETURN
    END SUBROUTINE AllLAry1
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllLAry2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D LOGICAL array.
 
-
-      ! This routine allocates a 2-D LOGICAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    LOGICAL,      ALLOCATABLE         :: Ary    (:,:)                               !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2) , STAT=ErrStat )
 
@@ -883,8 +813,8 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = .FALSE.
    END IF
-
 
    RETURN
    END SUBROUTINE AllLAry2
@@ -892,17 +822,14 @@ CONTAINS
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllLAry3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
 
-      ! Argument declarations.
+   ! Argument declarations.
    LOGICAL,      ALLOCATABLE         :: Ary    (:,:,:)                             !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
-
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
 
@@ -917,8 +844,8 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = .FALSE.
    END IF
-
 
    RETURN
    END SUBROUTINE AllLAry3
@@ -926,15 +853,12 @@ CONTAINS
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
 
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(SiKi),      ALLOCATABLE      :: Ary    (:)                                 !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the array.
-
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
 
@@ -948,27 +872,22 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_SiKi
    END IF
-
+ 
    RETURN
    END SUBROUTINE AllR4Ary1
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR8Ary1 ( Ary, AryDim1, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 1-D 8-byte REAL array.
 
-
-      ! This routine allocates a 1-D 8-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(R8Ki),      ALLOCATABLE      :: Ary    (:)                                 !  Array to be allocated
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the array.
-                                                                                     
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
    
    ALLOCATE ( Ary(AryDim1) , STAT=ErrStat )
 
@@ -982,31 +901,25 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_R8Ki
    END IF
-
+ 
    RETURN
    END SUBROUTINE AllR8Ary1
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D 4-Byte REAL array.
 
-
-      ! This routine allocates a 2-D 4-Byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(SiKi), ALLOCATABLE           :: Ary    (:,:)                               !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
 
-
    ALLOCATE ( Ary(AryDim1,AryDim2) , STAT=ErrStat )
-
    
    IF ( ErrStat /= 0 ) THEN
       ErrStat = ErrID_Fatal
@@ -1019,30 +932,23 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_SiKi
    END IF
-
 
    RETURN
    END SUBROUTINE AllR4Ary2
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR8Ary2 (  Ary, AryDim1, AryDim2, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 2-D 8-Byte REAL array.
 
-
-      ! This routine allocates a 2-D 8-Byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(R8Ki), ALLOCATABLE           :: Ary    (:,:)                               !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2) , STAT=ErrStat )
 
@@ -1057,30 +963,24 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_R8Ki
    END IF
-
 
    RETURN
    END SUBROUTINE AllR8Ary2
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 3-D 4-byte REAL array.
 
-
-      ! This routine allocates a 3-D 4-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(SiKi), ALLOCATABLE           :: Ary    (:,:,:)                             !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
 
@@ -1095,6 +995,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_SiKi
    END IF
 
    RETURN
@@ -1102,22 +1003,16 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR8Ary3 (  Ary, AryDim1, AryDim2, AryDim3, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 3-D 8-byte REAL array.
 
-
-      ! This routine allocates a 3-D 8-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(R8Ki), ALLOCATABLE           :: Ary    (:,:,:)                             !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3) , STAT=ErrStat )
 
@@ -1132,6 +1027,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_R8Ki
    END IF
 
    RETURN
@@ -1139,15 +1035,10 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary4 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 4-D 4-byte REAL array.
 
-
-      ! This routine allocates a 4-D 4-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(SiKi),      ALLOCATABLE      :: Ary    (:,:,:,:)                           !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
@@ -1155,7 +1046,6 @@ CONTAINS
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3,AryDim4) , STAT=ErrStat )
 
@@ -1170,6 +1060,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_SiKi
    END IF
 
    RETURN
@@ -1177,15 +1068,10 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR8Ary4 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 4-D 8-byte REAL array.
 
-
-      ! This routine allocates a 4-D 8-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(R8Ki),      ALLOCATABLE      :: Ary    (:,:,:,:)                           !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
@@ -1193,7 +1079,6 @@ CONTAINS
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3,AryDim4) , STAT=ErrStat )
 
@@ -1208,6 +1093,7 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_R8Ki
    END IF
 
    RETURN
@@ -1215,15 +1101,10 @@ CONTAINS
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR4Ary5 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, AryDim5, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 5-D 4-byte REAL array.
 
-
-      ! This routine allocates a 5-D 4-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(SiKi),      ALLOCATABLE      :: Ary    (:,:,:,:,:)                         !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
@@ -1232,7 +1113,6 @@ CONTAINS
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3,AryDim4,AryDim5) , STAT=ErrStat )
 
@@ -1247,24 +1127,18 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_SiKi
    END IF
-
-
 
    RETURN
    END SUBROUTINE AllR4Ary5
 !=======================================================================
 !> \copydoc nwtc_io::allcary1
    SUBROUTINE AllR8Ary5 (  Ary, AryDim1, AryDim2, AryDim3, AryDim4, AryDim5, Descr, ErrStat, ErrMsg )
+   ! This routine allocates a 5-D 8-byte REAL array.
 
-
-      ! This routine allocates a 5-D 8-byte REAL array.
-
-
-      ! Argument declarations.
-
+   ! Argument declarations.
    REAL(R8Ki),      ALLOCATABLE      :: Ary    (:,:,:,:,:)                         !  Array to be allocated
-                                                                                     
    INTEGER,      INTENT(IN)          :: AryDim1                                    !  The size of the first dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim2                                    !< The size of the second dimension of the array.
    INTEGER,      INTENT(IN)          :: AryDim3                                    !< The size of the third dimension of the array.
@@ -1273,7 +1147,6 @@ CONTAINS
    CHARACTER(*), INTENT(IN)          :: Descr                                      !  Brief array description.
    INTEGER,      INTENT(OUT)         :: ErrStat                                    !  Error status; if present, program does not abort on error
    CHARACTER(*), INTENT(OUT)         :: ErrMsg                                     !  Error message corresponding to ErrStat
-
 
    ALLOCATE ( Ary(AryDim1,AryDim2,AryDim3,AryDim4,AryDim5) , STAT=ErrStat )
 
@@ -1288,9 +1161,8 @@ CONTAINS
    ELSE
       ErrStat = ErrID_None
       ErrMsg  = ''
+      Ary = 0.0_R8Ki
    END IF
-
-
 
    RETURN
    END SUBROUTINE AllR8Ary5


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The `RtHS` derived type in _ElastoDyn_ contains many arrays, none of which were initialized to zero during init.  Some of these arrays end up getting used without initializing, so whatever leftover stuff was in memory would then be accessed as values in some of these arrays.

We discovered this issue while converting the parsing of the blade file to use the `FileInfo` data structure and parsing.  If a file of 64 lines long was loaded with the `ProcessCom` command then discarded without use during the `ReadBladeFile` routine, the `5MW_Land_Linear_Aero` case would give the expected results (tested with gcc 12.3.0, double precision release). However, if more lines were present, whatever was written in those memory locations would end up in an `RtHS` array.  We noticed this as incorrect acceleration values for blade 1 nodes in the `y_op` array with values upwards of `1e+294`, which caused issues with linearization.

If line 65 contained `r`, the resulting frequencies would be:
```
46:               Frequency (Hz)                        Damping (%)
46:            ----------------------------         ----------------------------
46:             Ref              New                 Ref              New
46:            0.321115263      0.377324016         0.004761374      0.935368246
46:            0.336468595      0.764882101         0.080286934      0.642368682
46:            0.724206648      0.791899953         0.651774323      0.092775252
46:            0.749265197      1.080146181         0.656903895      0.008118302
46:            0.749326080      1.904270051         0.646239398      0.062853626
46:            1.083362496      1.961998652         0.012309791      0.160466846
46:            1.103154529      1.980423436         0.014866192      0.180651456
46:            1.701439646      2.395306777         0.023216699     -0.521713667
46:            1.928532353      2.618982440         0.180245471      0.577067874
46:            1.945246335      3.155262530         0.177738889      0.021554264
```

If line 65 contained `rrrrrrrr`, the resulting frequencies would be off as follows:
```
46:  Case: 5MW_Land_Linear_Aero:1.lin: :
46:               Frequency (Hz)                        Damping (%)
46:            ----------------------------         ----------------------------
46:             Ref              New                 Ref              New
46:            0.321115263     83.209828452         0.004761374     -0.826506890
46:            0.336468595   8662506957.551628113         0.080286934     -0.000000256
46:            0.724206648   574739393926509749142693497935502516420608.000000000         0.651774323      0.103782929
46:            0.749265197   37471977929674705460798753326446458938499006464.000000000         0.656903895      0.044189924
46:            0.749326080   1596353572817605839899136123782313993697574780928.000000000         0.646239398     -0.221361357
46:            1.083362496   6454645867183894278226561596858301745340078685046177792.000000000         0.012309791     -0.058691704
46:            1.103154529   44775087308082026458361647148189744859863545122018820096.000000000         0.014866192      0.681102728
46:            1.701439646   74380807686665623026286669625369691668842911394732965888.000000000         0.023216699     -0.789905619
46:            1.928532353   301056255025183220231506577309715866922450175489959002112.000000000         0.180245471      0.453293460
46:            1.945246335   3180994479181899036819026195066465440447406087302753026048.000000000         0.177738889      0.017797110
``` 

Explicitly setting all `RtHS` arrays to `0.0_ReKi` during allocation would get rid of this issue.

@deslaughter also found an issue in the `ProcessCom` routine that caused an index issue in Intel compilations.

**Related issue, if one exists**
There may have been some phantom issues caused by this.

**Impacted areas of the software**
ED calculations of blade 1 acceleration values, and perhaps other issues.

