### PR TITLE
Remove pfunit as a submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,3 @@
 [submodule "reg_tests/r-test"]
 	path = reg_tests/r-test
 	url = https://github.com/OpenFAST/r-test.git
-[submodule "unit_tests/pfunit"]
-	path = unit_tests/pfunit
-	url = https://github.com/Goddard-Fortran-Ecosystem/pFUnit.git


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This PR removes pfUnit as a submodule. The code that was using this submodule was removed in #2276, so this shouldn't be necessary anymore. 

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/pull/2276

**Impacted areas of the software**
This shouldn't affect anything other than not keeping an unused copy of pfUnit around.

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
No changes