### PR TITLE
Minor bugfix: ED blade file parsing (no PichAxis column), AD warnings

### DIFF
--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -1140,6 +1140,11 @@ SUBROUTINE ParsePrimaryFileInfo( PriPath, InitInp, InputFile, RootName, NumBlade
       endif
    endif
 
+   !====== Print new and old inputs =====================================================================
+   if (wakeModProvided .or. frozenWakeProvided .or. skewModProvided .or. AFAeroModProvided .or. UAModProvided) then
+      call printNewOldInputs()
+   endif
+
    !======  Nodal Outputs  ==============================================================================
       ! In case there is something ill-formed in the additional nodal outputs section, we will simply ignore it.
       ! Expecting at least 5 more lines in the input file for this section
@@ -1172,11 +1177,6 @@ SUBROUTINE ParsePrimaryFileInfo( PriPath, InitInp, InputFile, RootName, NumBlade
    ! Prevent segfault when no blades specified.  All logic tests on BldNd_NumOuts at present.
    if (InputFileData%BldNd_BladesOut <= 0)   InputFileData%BldNd_NumOuts = 0
 
-
-   !====== Print new and old inputs =====================================================================
-   if (wakeModProvided .or. frozenWakeProvided .or. skewModProvided .or. AFAeroModProvided .or. UAModProvided) then
-   call printNewOldInputs()
-   endif
 
    !====== Advanced Options =============================================================================
    if ((CurLine) >= size(FileInfo_In%Lines)) RETURN
@@ -1224,7 +1224,6 @@ CONTAINS
          InputFileData%BldNd_BladesOut = 0
          InputFileData%BldNd_NumOuts = 0
          call wrscr( trim(ErrMsg_NoAllBldNdOuts) )
-         call printNewOldInputs()
       endif
    end function FailedNodal
    subroutine LegacyWarning(Message)

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -1798,7 +1798,7 @@ SUBROUTINE ReadBladeFile ( BldFile, BladeKInputFileData, UnEc, ErrStat, ErrMsg )
       CurLine = CurLine - 1   ! Backup one line to read entire table
       call ParseTable6Col(ErrStat2, ErrMsg2); if (Failed()) return;
    else                                ! no PitchAxis input
-      CurLine = CurLine - 1   ! Backup one line to read entire table
+      ! NOTE: don't backup a line as a failed ParesAry above won't increment the current line
       call ParseTable5Col(ErrStat2, ErrMsg2); if (Failed()) return;
    endif
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
PR #2267 allows skipping the `PitchAxis` column in ED blade file. However, there was a logic error that prevented that feature from working.

If a new format _AeroDyn_ input file was used that did not have the nodal outputs section, the `printNewOldInputs` routine was being called anyhow to print out the new inputs.  This has been corrected

**Related issue, if one exists**

**Impacted areas of the software**
ED file parsing, and AD messages only.

**Additional supporting information**
Thanks to @RBergua for catching these issues.

**Test results, if applicable**
No changes