### PR TITLE
Vis: Fix bug with vtk writing of non-square wave surface

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -8686,7 +8686,7 @@ SUBROUTINE WrVTK_WaveElevVisGrid(t_global, p_FAST, y_FAST, SeaSt)
 
    do ix=1,p_FAST%VTK_surface%NWaveElevPts(1)-1
       do iy=1,p_FAST%VTK_surface%NWaveElevPts(2)-1
-         n = p_FAST%VTK_surface%NWaveElevPts(1)*(ix-1)+iy - 1 ! points start at 0
+         n = p_FAST%VTK_surface%NWaveElevPts(2)*(ix-1)+iy - 1 ! points start at 0
 
          WRITE(Un,'(3(i7))') n,   n+1,                                    n+p_FAST%VTK_surface%NWaveElevPts(2)
          WRITE(Un,'(3(i7))') n+1, n+1+p_FAST%VTK_surface%NWaveElevPts(2), n+p_FAST%VTK_surface%NWaveElevPts(2)


### PR DESCRIPTION


**Feature or improvement description**

When a rectangular _SeaState_ grid was used, the connection list in the vtk file was incorrectly generated due to an indexing error.  The list would contain points beyond the total number of points in the point list.

For a 5x3 _SeaState_ grid (Nx=3, Ny=2) there are a total of 15 points (0 to 14). The connection list was being incorrectly generated as
```
        <DataArray type="Int32" Name="connectivity" format="ascii">
      0      1      3
      1      4      3
      1      2      4
      2      5      4
      5      6      8
      6      9      8
      6      7      9
      7     10      9
     10     11     13
     11     14     13
     11     12     14
     12     15     14
     15     16     18
     16     19     18
     16     17     19
     17     20     19
```

The connection list should be
```
        <DataArray type="Int32" Name="connectivity" format="ascii">
      0      1      3
      1      4      3
      1      2      4
      2      5      4
      3      4      6
      4      7      6
      4      5      7
      5      8      7
      6      7      9
      7     10      9
      7      8     10
      8     11     10
      9     10     12
     10     13     12
     10     11     13
     11     14     13
```

**Related issue, if one exists**
This should be backported to 3.5.4

**Impacted areas of the software**
Visualization of rectangular wave surfaces only.

**Additional supporting information**
Thanks to @luwang00 for finding this.

**Test results, if applicable**
This is not part of the regression tests (we don't output vtk in regression tests due to data size).