### PR TITLE
Increase number of unit numbers available for OMP file opening

### DIFF
--- a/modules/awae/src/AWAE_IO.f90
+++ b/modules/awae/src/AWAE_IO.f90
@@ -135,12 +135,13 @@ end subroutine WriteDisWindFiles
 !----------------------------------------------------------------------------------------------------------------------------------   
 !> This subroutine 
 !!
-subroutine ReadLowResWindFile(n, p, Vamb_Low, errStat, errMsg)
+subroutine ReadLowResWindFile(n, p, Vamb_Low, errStat, errMsg, UnStart)
    integer(IntKi),                 intent(in   )  :: n            !< Current simulation timestep increment (zero-based)
    type(AWAE_ParameterType),       intent(in   )  :: p            !< Parameters
    real(SiKi),                     intent(inout)  :: Vamb_Low(:,0:,0:,0:)         !< Array which will contain the low resolution grid of ambient wind velocities
    integer(IntKi),                 intent(  out)  :: errStat      !< Error status of the operation
    character(*),                   intent(  out)  :: errMsg       !< Error message if errStat /= ErrID_None
+   integer(IntKi), optional,       intent(in   )  :: UnStart      !< Optional start unit -- for parrallelization we may want to start each turbine at n*100 to clobbering openings
   
    integer(IntKi)           :: dims(3)              !  dimension of the 3D grid (nX,nY,nZ)
    real(ReKi)               :: origin(3)            !  the lower-left corner of the 3D grid (X0,Y0,Z0)
@@ -154,8 +155,12 @@ subroutine ReadLowResWindFile(n, p, Vamb_Low, errStat, errMsg)
    errMsg  = ""
   
    FileName = trim(p%WindFilePath)//trim(PathSep)//"Low"//trim(PathSep)//"Amb.t"//trim(num2lstr(n))//".vtk"
-   Un = 0; ! Initialization different from -1, important to prevent file closing 
-   call ReadVTK_SP_info( FileName, descr, dims, origin, gridSpacing, vecLabel, Un, ErrStat, ErrMsg ) 
+   if (present(UnStart)) then
+      Un = max(UnStart,0)
+   else
+      Un = 0; ! Initialization different from -1, important to prevent file closing
+   endif
+   call ReadVTK_SP_info( FileName, descr, dims, origin, gridSpacing, vecLabel, Un, ErrStat, ErrMsg )
       if (ErrStat >= AbortErrLev) return
    call ReadVTK_SP_vectors( FileName, Un, dims, Vamb_Low, ErrStat, ErrMsg )
       
@@ -168,7 +173,7 @@ end subroutine ReadLowResWindFile
 !----------------------------------------------------------------------------------------------------------------------------------   
 !> This subroutine 
 !!
-subroutine ReadHighResWindFile(nt, n, p, Vamb_high, errStat, errMsg)
+subroutine ReadHighResWindFile(nt, n, p, Vamb_high, errStat, errMsg, UnStart)
 
    integer(IntKi),                 intent(in   )  :: nt
    integer(IntKi),                 intent(in   )  :: n                       !< high-res time increment
@@ -176,6 +181,7 @@ subroutine ReadHighResWindFile(nt, n, p, Vamb_high, errStat, errMsg)
    real(SiKi),                     intent(inout)  :: Vamb_high(:,0:,0:,0:)         !< Array which will contain the low resolution grid of ambient wind velocities
    integer(IntKi),                 intent(  out)  :: errStat      !< Error status of the operation
    character(*),                   intent(  out)  :: errMsg       !< Error message if errStat /= ErrID_None
+   integer(IntKi), optional,       intent(in   )  :: UnStart      !< Optional start unit -- for parrallelization we may want to start each turbine at n*100 to clobbering openings
   
    
    integer(IntKi)           :: dims(3)              !  dimension of the 3D grid (nX,nY,nZ)
@@ -190,7 +196,11 @@ subroutine ReadHighResWindFile(nt, n, p, Vamb_high, errStat, errMsg)
    errMsg  = ""
    
    FileName = trim(p%WindFilePath)//trim(PathSep)//"HighT"//trim(num2lstr(nt))//trim(PathSep)//"Amb.t"//trim(num2lstr(n))//".vtk"
-   Un = 0; ! Initialization different from -1, important to prevent file closing 
+   if (present(UnStart)) then
+      Un = max(UnStart,0)
+   else
+      Un = 0; ! Initialization different from -1, important to prevent file closing
+   endif
    call ReadVTK_SP_info( FileName, descr, dims, origin, gridSpacing, vecLabel, Un, ErrStat, ErrMsg ) 
       if (ErrStat >= AbortErrLev) return
    call ReadVTK_SP_vectors( FileName, Un, dims, Vamb_high, ErrStat, ErrMsg ) 

--- a/modules/nwtc-library/src/VTK.f90
+++ b/modules/nwtc-library/src/VTK.f90
@@ -158,7 +158,11 @@ contains
          closeOnReturn = .FALSE.
       END IF
       
-      CALL GetNewUnit( Un, ErrStat, ErrMsg )      
+      if (Un > 0) then
+         CALL GetNewUnit( Un, ErrStat, ErrMsg, Un )      ! Optional argument to start at a much higher unit number
+      else
+         CALL GetNewUnit( Un, ErrStat, ErrMsg )
+      endif
       CALL OpenFInpFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
          if (ErrStat >= AbortErrLev) return
       
@@ -358,7 +362,7 @@ contains
       INTEGER(IntKi)  , INTENT(  OUT)        :: ErrStat              !< error level/status of OpenFOutFile operation
       CHARACTER(*)    , INTENT(  OUT)        :: ErrMsg               !< message when error occurs
    
-      CALL GetNewUnit( Un, ErrStat, ErrMsg )      
+      CALL GetNewUnit( Un, ErrStat, ErrMsg )
       CALL OpenFOutFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
          if (ErrStat >= AbortErrLev) return
       


### PR DESCRIPTION
Needs testing and approval by @rthedin before merging

**Feature or improvement description**

We were having problems with the `!OMP` directives around high resolution file reading in AWAE.f90. Since the file reading starts with a call to `GetNewUnit` before starting the opening, parallel calls to `GetNewUnit` could result in the same unit number handed out to two processes.  The first process would open the file and start reading, but then the second process would open a different file with the same unit number causing read errors for both processes as they attempted to read the same file at the same time.

To resolve this, an optional start unit number is added to `GtNewUnit`.  This optional argument is propagated up through to the calls within the `!OMP` loop where a `N*100` is used as the starting unit number for the search (where `N` is the turbine number).  Theoretically this will solve the parallel file reading issue from AWAE.

Routine changes:

`GetNewUnit`
 - Increased maximum unit from 1024 to 64k (likely won't be an issue since most times where more than 1024 files are needed will be on supercomputers where the unit number limit is really high)
 - optional argument for starting unit number.  Defaults to old behaviour when not present. `ReadLowResWindFile`
 - optional argument for starting unit number.  Defaults to old behaviour when not present. `ReadHighResWindFile`
 - optional argument for starting unit number.  Defaults to old behaviour when not present. AWAE `UpdateStates`
 - call to `ReadHighResWindFile` includes `nt*100` as the start unit number

**Related issue, if one exists**
There may be several _FAST.Farm_ issues related to this, but it is unknown at the moment.

**Impacted areas of the software**
_FAST.Farm_ `AWAE` module file reading of high-res VTK files inside the `!OMP` directive in `UpdateStates`

**Additional supporting information**
