### PR TITLE
Add !$ OMP critical around file opening for VTK

### DIFF
--- a/modules/nwtc-library/src/VTK.f90
+++ b/modules/nwtc-library/src/VTK.f90
@@ -158,8 +158,10 @@ contains
          closeOnReturn = .FALSE.
       END IF
       
+      !$OMP critical
       CALL GetNewUnit( Un, ErrStat, ErrMsg )      
       CALL OpenFInpFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
+      !$OMP end critical
          if (ErrStat >= AbortErrLev) return
       
        CALL ReadCom( Un, FileName, 'File header: Module Version (line 1)', ErrStat2, ErrMsg2, 0 )
@@ -358,8 +360,10 @@ contains
       INTEGER(IntKi)  , INTENT(  OUT)        :: ErrStat              !< error level/status of OpenFOutFile operation
       CHARACTER(*)    , INTENT(  OUT)        :: ErrMsg               !< message when error occurs
    
+      !$OMP critical
       CALL GetNewUnit( Un, ErrStat, ErrMsg )      
       CALL OpenFOutFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
+      !$OMP end critical
          if (ErrStat >= AbortErrLev) return
       
       WRITE(Un,'(A)')  '# vtk DataFile Version 3.0'


### PR DESCRIPTION
This is the preferred alternate approach to PR #2339.  If this works, this PR will be merged in and the other closed.

**Feature or improvement description**
We were having problems with the `!OMP` directives around high resolution file reading in AWAE.f90. Since the file reading starts with a call to `GetNewUnit` before starting the opening, parallel calls to `GetNewUnit` could result in the same unit number handed out to two processes.  The first process would open the file and start reading, but then the second process would open a different file with the same unit number causing read errors for both processes as they attempted to read the same file at the same time.

Adding `$OMP critical` around the `GetNewUnit` and following `OpenFile...` calls so that in theory these cannot be done in parallel.

**Related issue, if one exists**
#2339 

**Impacted areas of the software**
VTK file reading within `!$OMP` loops

**Additional supporting information**

**Test results, if applicable**
@rthedin will report on testing with many turbines in a _FAST.Farm_ simulation.