### PR TITLE
HD: Initialization of the low-pass-filtered displacements of potential-flow bodies when ExctnDisp = 2

### DIFF
--- a/modules/hydrodyn/src/HydroDyn_DriverCode.f90
+++ b/modules/hydrodyn/src/HydroDyn_DriverCode.f90
@@ -239,18 +239,20 @@ PROGRAM HydroDynDriver
       CALL SetHDInputs(0.0_R8Ki, n, u(1), mappingData, drvrData, ErrStat, ErrMsg);   CALL CheckError()
    END IF
 
-   IF ( (p%PotMod == 1_IntKi) .AND. (p%WAMIT(1)%ExctnDisp == 2_IntKi) ) THEN
-      ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
-      IF (p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
-         DO i = 1,p%NBody
-            xd%WAMIT(1)%BdyPosFilt(1,i,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
-            xd%WAMIT(1)%BdyPosFilt(2,i,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
-         END DO
-      ELSE IF (p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
-         DO i = 1,p%NBody
-            xd%WAMIT(i)%BdyPosFilt(1,1,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
-            xd%WAMIT(i)%BdyPosFilt(2,1,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
-         END DO
+   IF ( p%PotMod == 1_IntKi ) THEN
+      IF ( p%WAMIT(1)%ExctnDisp == 2_IntKi ) THEN
+         ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
+         IF (p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
+            DO i = 1,p%NBody
+               xd%WAMIT(1)%BdyPosFilt(1,i,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
+               xd%WAMIT(1)%BdyPosFilt(2,i,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
+            END DO
+         ELSE IF (p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
+            DO i = 1,p%NBody
+               xd%WAMIT(i)%BdyPosFilt(1,1,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
+               xd%WAMIT(i)%BdyPosFilt(2,1,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
+            END DO
+         END IF
       END IF
    END IF
 
@@ -289,10 +291,11 @@ PROGRAM HydroDynDriver
       Time = (n-1) * drvrData%TimeInterval
       InputTime(1) = Time
 
+      IF (( drvrData%PRPInputsMod == 2 ) .OR. ( drvrData%PRPInputsMod < 0 )) THEN
          ! Modify u (likely from the outputs of another module or a set of test conditions) here:
-      call SetHDInputs(Time, n, u(1), mappingData, drvrData, ErrStat, ErrMsg);  CALL CheckError()
-      ! SeaState has no inputs, so no need to set them.
-      
+         call SetHDInputs(Time, n, u(1), mappingData, drvrData, ErrStat, ErrMsg);  CALL CheckError()
+         ! SeaState has no inputs, so no need to set them.
+      END IF
      
       if (n==1 .and. drvrData%Linearize) then
          ! we set u(1)%PRPMesh motions, so we should assume that EDRP changed similarly: 

--- a/modules/hydrodyn/src/HydroDyn_DriverCode.f90
+++ b/modules/hydrodyn/src/HydroDyn_DriverCode.f90
@@ -239,15 +239,15 @@ PROGRAM HydroDynDriver
       CALL SetHDInputs(0.0_R8Ki, n, u(1), mappingData, drvrData, ErrStat, ErrMsg);   CALL CheckError()
    END IF
 
+   ! Set the initial low-pass-filtered displacements of potential-flow bodies if ExctnDisp = 2
    IF ( p%PotMod == 1_IntKi ) THEN
       IF ( p%WAMIT(1)%ExctnDisp == 2_IntKi ) THEN
-         ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
          IF (p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
             DO i = 1,p%NBody
                xd%WAMIT(1)%BdyPosFilt(1,i,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
                xd%WAMIT(1)%BdyPosFilt(2,i,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
             END DO
-         ELSE IF (p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
+         ELSE IF (p%NBodyMod > 1_IntKi) THEN ! NBody instances of WAMIT with one body each
             DO i = 1,p%NBody
                xd%WAMIT(i)%BdyPosFilt(1,1,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
                xd%WAMIT(i)%BdyPosFilt(2,1,:) = u(1)%WAMITMesh%TranslationDisp(2,i)

--- a/modules/hydrodyn/src/HydroDyn_DriverCode.f90
+++ b/modules/hydrodyn/src/HydroDyn_DriverCode.f90
@@ -239,7 +239,7 @@ PROGRAM HydroDynDriver
       CALL SetHDInputs(0.0_R8Ki, n, u(1), mappingData, drvrData, ErrStat, ErrMsg);   CALL CheckError()
    END IF
 
-   IF ( p%PotMod == 1_IntKi ) THEN
+   IF ( (p%PotMod == 1_IntKi) .AND. (p%WAMIT(1)%ExctnDisp == 2_IntKi) ) THEN
       ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
       IF (p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
          DO i = 1,p%NBody

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1554,9 +1554,9 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
       ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
       CALL SmllRotTrans( 'initial platform rotation ', &
-                          Init%OutData_ED%PlatformPos(4), &
-                          Init%OutData_ED%PlatformPos(5), &
-                          Init%OutData_ED%PlatformPos(6), &
+                          REAL(Init%OutData_ED%PlatformPos(4),R8Ki), &
+                          REAL(Init%OutData_ED%PlatformPos(5),R8Ki), &
+                          REAL(Init%OutData_ED%PlatformPos(6),R8Ki), &
                           ED%y%PlatformPtMesh%Orientation(:,:,1), '', ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       ED%y%PlatformPtMesh%TranslationDisp(1,1) = ED%y%PlatformPtMesh%TranslationDisp(1,1) + ED%y%PlatformPtMesh%Orientation(3,1,1) * ED%p%PtfmRefzt

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1547,37 +1547,39 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
          ErrMsg = ""
       END IF
 
-   ! -------------------------------------------------------------------------
+   ! ----------------------------------------------------------------------------
    ! Initialize low-pass-filtered displacements of HydroDyn potential-flow bodies
-   ! -------------------------------------------------------------------------
-   IF ( (p_FAST%CompHydro == Module_HD) .AND. (HD%p%PotMod == 1_IntKi) .AND. (HD%p%WAMIT(1)%ExctnDisp == 2_IntKi) ) THEN
-      ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
-      ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
-      CALL SmllRotTrans( 'initial platform rotation ', &
-                          REAL(Init%OutData_ED%PlatformPos(4),R8Ki), &
-                          REAL(Init%OutData_ED%PlatformPos(5),R8Ki), &
-                          REAL(Init%OutData_ED%PlatformPos(6),R8Ki), &
-                          ED%y%PlatformPtMesh%Orientation(:,:,1), '', ErrStat2, ErrMsg2 )
-      CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
-      ED%y%PlatformPtMesh%TranslationDisp(1,1) = ED%y%PlatformPtMesh%TranslationDisp(1,1) + ED%y%PlatformPtMesh%Orientation(3,1,1) * ED%p%PtfmRefzt
-      ED%y%PlatformPtMesh%TranslationDisp(2,1) = ED%y%PlatformPtMesh%TranslationDisp(2,1) + ED%y%PlatformPtMesh%Orientation(3,2,1) * ED%p%PtfmRefzt
-      ED%y%PlatformPtMesh%TranslationDisp(3,1) = ED%y%PlatformPtMesh%TranslationDisp(3,1) + ED%y%PlatformPtMesh%Orientation(3,3,1) * ED%p%PtfmRefzt - ED%p%PtfmRefzt
-      CALL Transfer_PlatformMotion_to_HD( ED%y%PlatformPtMesh, HD%Input(1), MeshMapData, ErrStat2, ErrMsg2 )
-      CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
-      IF (ErrStat >= AbortErrLev) THEN
-         CALL Cleanup()
-         RETURN
-      END IF
-      IF (HD%p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
-         DO i = 1,HD%p%NBody
-            HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(1,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
-            HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(2,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
-         END DO
-      ELSE IF (HD%p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
-         DO i = 1,HD%p%NBody
-            HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(1,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
-            HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(2,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
-         END DO
+   ! ----------------------------------------------------------------------------
+   IF ( (p_FAST%CompHydro == Module_HD) .AND. (HD%p%PotMod == 1_IntKi) ) THEN
+      IF ( HD%p%WAMIT(1)%ExctnDisp == 2_IntKi ) THEN
+         ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
+         ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
+         CALL SmllRotTrans( 'initial platform rotation ', &
+                             REAL(Init%OutData_ED%PlatformPos(4),R8Ki), &
+                             REAL(Init%OutData_ED%PlatformPos(5),R8Ki), &
+                             REAL(Init%OutData_ED%PlatformPos(6),R8Ki), &
+                             ED%y%PlatformPtMesh%Orientation(:,:,1), '', ErrStat2, ErrMsg2 )
+         CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+         ED%y%PlatformPtMesh%TranslationDisp(1,1) = ED%y%PlatformPtMesh%TranslationDisp(1,1) + ED%y%PlatformPtMesh%Orientation(3,1,1) * ED%p%PtfmRefzt
+         ED%y%PlatformPtMesh%TranslationDisp(2,1) = ED%y%PlatformPtMesh%TranslationDisp(2,1) + ED%y%PlatformPtMesh%Orientation(3,2,1) * ED%p%PtfmRefzt
+         ED%y%PlatformPtMesh%TranslationDisp(3,1) = ED%y%PlatformPtMesh%TranslationDisp(3,1) + ED%y%PlatformPtMesh%Orientation(3,3,1) * ED%p%PtfmRefzt - ED%p%PtfmRefzt
+         CALL Transfer_PlatformMotion_to_HD( ED%y%PlatformPtMesh, HD%Input(1), MeshMapData, ErrStat2, ErrMsg2 )
+         CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+         IF (ErrStat >= AbortErrLev) THEN
+            CALL Cleanup()
+            RETURN
+         END IF
+         IF (HD%p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
+            DO i = 1,HD%p%NBody
+               HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(1,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
+               HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(2,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
+            END DO
+         ELSE IF (HD%p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
+            DO i = 1,HD%p%NBody
+               HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(1,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
+               HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(2,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
+            END DO
+         END IF
       END IF
    END IF
 

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1574,7 +1574,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
                HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(1,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
                HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(2,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
             END DO
-         ELSE IF (HD%p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
+         ELSE IF (HD%p%NBodyMod > 1_IntKi) THEN ! NBody instances of WAMIT with one body each
             DO i = 1,HD%p%NBody
                HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(1,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
                HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(2,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1550,7 +1550,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
    ! -------------------------------------------------------------------------
    ! Initialize low-pass-filtered displacements of HydroDyn potential-flow bodies
    ! -------------------------------------------------------------------------
-   IF ( p_FAST%CompHydro == Module_HD .AND. HD%p%PotMod) THEN
+   IF ( (p_FAST%CompHydro == Module_HD) .AND. (HD%p%PotMod == 1_IntKi) ) THEN
       ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
       ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
       CALL SmllRotTrans( 'initial platform rotation ', &

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1548,6 +1548,40 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       END IF
 
    ! -------------------------------------------------------------------------
+   ! Initialize low-pass-filtered displacements of HydroDyn potential-flow bodies
+   ! -------------------------------------------------------------------------
+   IF ( p_FAST%CompHydro == Module_HD .AND. HD%p%PotMod) THEN
+      ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
+      ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
+      CALL SmllRotTrans( 'initial platform rotation ', &
+                          Init%OutData_ED%PlatformPos(4), &
+                          Init%OutData_ED%PlatformPos(5), &
+                          Init%OutData_ED%PlatformPos(6), &
+                          ED%y%PlatformPtMesh%Orientation(:,:,1), '', ErrStat2, ErrMsg2 )
+      CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      ED%y%PlatformPtMesh%TranslationDisp(1,1) = ED%y%PlatformPtMesh%TranslationDisp(1,1) + ED%y%PlatformPtMesh%Orientation(3,1,1) * ED%p%PtfmRefzt
+      ED%y%PlatformPtMesh%TranslationDisp(2,1) = ED%y%PlatformPtMesh%TranslationDisp(2,1) + ED%y%PlatformPtMesh%Orientation(3,2,1) * ED%p%PtfmRefzt
+      ED%y%PlatformPtMesh%TranslationDisp(3,1) = ED%y%PlatformPtMesh%TranslationDisp(3,1) + ED%y%PlatformPtMesh%Orientation(3,3,1) * ED%p%PtfmRefzt - ED%p%PtfmRefzt
+      CALL Transfer_PlatformMotion_to_HD( ED%y%PlatformPtMesh, HD%Input(1), MeshMapData, ErrStat2, ErrMsg2 )
+      CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      IF (ErrStat >= AbortErrLev) THEN
+         CALL Cleanup()
+         RETURN
+      END IF
+      IF (HD%p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
+         DO i = 1,HD%p%NBody
+            HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(1,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
+            HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(2,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
+         END DO
+      ELSE IF (HD%p%NBodyMod > 1_IntKi) THEN ! NBody instance of WAMIT with one body each
+         DO i = 1,HD%p%NBody
+            HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(1,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
+            HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(2,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
+         END DO
+      END IF
+   END IF
+
+   ! -------------------------------------------------------------------------
    ! Initialize for linearization or computing aero maps:
    ! -------------------------------------------------------------------------
    if ( p_FAST%Linearize .or. p_FAST%CompAeroMaps) then

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1550,7 +1550,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
    ! -------------------------------------------------------------------------
    ! Initialize low-pass-filtered displacements of HydroDyn potential-flow bodies
    ! -------------------------------------------------------------------------
-   IF ( (p_FAST%CompHydro == Module_HD) .AND. (HD%p%PotMod == 1_IntKi) ) THEN
+   IF ( (p_FAST%CompHydro == Module_HD) .AND. (HD%p%PotMod == 1_IntKi) .AND. (HD%p%WAMIT(1)%ExctnDisp == 2_IntKi) ) THEN
       ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
       ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
       CALL SmllRotTrans( 'initial platform rotation ', &


### PR DESCRIPTION
**This PR should be ready to merge after review**

**Feature or improvement description**
This PR allows HydroDyn to automatically initialize the low-pass-filtered surge and sway displacements of potential-flow bodies based on either the driver PRP motion input if running HydroDyn standalone or based on the initial platform position from ElastoDyn when running OpenFAST. This change only affects the solution when `ExctnDisp = 2`. This is helpful if the simulation starts with a large platform displacement from the origin. Previously, HydroDyn always initialize the low-pass-filtered displacements to zero.

**Impacted areas of the software**
Glue-codes and HydroDyn

**Test results, if applicable**
All existing tests with `ExctnDisp = 2` all start from zero platform displacement, so this PR has no effect.