### PR TITLE
Vis: Fix another bug with vtk writing of non-square wave surface

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -8673,7 +8673,7 @@ SUBROUTINE WrVTK_WaveElevVisGrid(t_global, p_FAST, y_FAST, SeaSt)
 
    do ix=1,p_FAST%VTK_surface%NWaveElevPts(1)
       do iy=1,p_FAST%VTK_surface%NWaveElevPts(2)
-         WRITE(Un,VTK_AryFmt) p_FAST%VTK_surface%WaveElevVisX(ix), p_FAST%VTK_surface%WaveElevVisX(iy), p_FAST%VTK_surface%WaveElevVisGrid(y_FAST%VTK_LastWaveIndx,ix,iy)
+         WRITE(Un,VTK_AryFmt) p_FAST%VTK_surface%WaveElevVisX(ix), p_FAST%VTK_surface%WaveElevVisY(iy), p_FAST%VTK_surface%WaveElevVisGrid(y_FAST%VTK_LastWaveIndx,ix,iy)
       end do
    end do
 


### PR DESCRIPTION
**Feature or improvement description**
The y-coordinates of the VTK points were incorrect. This PR fixes this bug.

**Related issue, if one exists**
Another issue with the visualization of rectangular wave field was fixed with PR #2338

**Impacted areas of the software**
Visualization of rectangular wave surfaces only.

**Test results, if applicable**
This is not part of the regression tests (we don't output vtk in regression tests due to data size).