### PR TITLE
Bug Fix: UA driver aero-elastic simulation had wrong sign

### DIFF
--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -1416,7 +1416,7 @@ subroutine UA_Init_Outputs(InitInp, p, y, InitOut, errStat, errMsg)
    
    ! --- Write to File
    if ((p%NumOuts > 0) .and. p%UA_OUTS==2) then
-      call WrScr('   UA: Writing separate output file: '//trim((InitInp%OutRootName)//'.out'))
+      call WrScr('   UA: Writing separate output file: '//trim(InitInp%OutRootName)//'.out')
       CALL GetNewUnit( p%unOutFile, ErrStat2, ErrMsg2 )
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
          if (ErrStat >= AbortErrLev) return

--- a/modules/lindyn/src/LinDyn.f90
+++ b/modules/lindyn/src/LinDyn.f90
@@ -293,7 +293,7 @@ subroutine StateMatrices(MM, CC, KK, AA, BB, errStat, errMsg)
    LWORK=nx*nx ! Somehow LWORK = -1 does not work
    allocate(WORK(LWORk))
    call LAPACK_getri(nx, MinvX, IPIV, WORK, LWORK, errStat2, errMsg2); if(Failed()) return
-   BB(nx+1:nq, : ) = -MinvX
+   BB(nx+1:nq, : ) = MinvX
 
 contains
    logical function Failed()

--- a/modules/lindyn/src/LinDyn.f90
+++ b/modules/lindyn/src/LinDyn.f90
@@ -251,6 +251,7 @@ subroutine StateMatrices(MM, CC, KK, AA, BB, errStat, errMsg)
    integer(IntKi)                          :: errStat2    ! Status of error message
    character(1024)                         :: errMsg2     ! Error message if ErrStat /= ErrID_None
    integer                                 :: nx, nq, i
+   
    real(ReKi), dimension(:,:), allocatable :: MLU     ! LU factorization of M matrix
    real(ReKi), dimension(:,:), allocatable :: MinvX   ! Tmp array to store either: M^{-1} C, M^{-1} K , or M^{-1}
    real(ReKi), dimension(:) , allocatable  :: WORK    ! LAPACK variable
@@ -291,10 +292,12 @@ subroutine StateMatrices(MM, CC, KK, AA, BB, errStat, errMsg)
    ! Inverse of M
    MinvX = MLU
    LWORK=nx*nx ! Somehow LWORK = -1 does not work
-   allocate(WORK(LWORk))
+   call AllocAry(WORK, LWORk, 'WORK', errStat2, errMsg2); if(Failed()) return
    call LAPACK_getri(nx, MinvX, IPIV, WORK, LWORK, errStat2, errMsg2); if(Failed()) return
    BB(nx+1:nq, : ) = MinvX
 
+   call CleanUp()
+   
 contains
    logical function Failed()
       call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, 'StateMatrices' )

--- a/modules/lindyn/src/LinDyn.f90
+++ b/modules/lindyn/src/LinDyn.f90
@@ -238,8 +238,8 @@ end subroutine LD_InitInputData
 !----------------------------------------------------------------------------------------------------------------------------------
 !> Compute A and B state matrices for a linear mechanical system
 !! NOTE: Generic function (no derived types), keep it that way
-!! A = [   0        I       ]     B = [0      ]
-!!     [-M^{-1}K   -M^{-1}C ]       = [-M^{-1}]
+!! A = [   0        I       ]     B = [ 0      ]
+!!     [-M^{-1}K   -M^{-1}C ]       = [ M^{-1} ]
 subroutine StateMatrices(MM, CC, KK, AA, BB, errStat, errMsg)
    real(ReKi),              intent(in ) :: MM(:,:)
    real(ReKi),              intent(in ) :: CC(:,:)

--- a/reg_tests/executeUnsteadyAeroRegressionCase.py
+++ b/reg_tests/executeUnsteadyAeroRegressionCase.py
@@ -117,7 +117,7 @@ if not noExec:
 for dvrf in dvrFiles:
     simName = os.path.splitext(os.path.basename(dvrf))[0]
     localOutFile    = os.path.join(testBuildDirectory, simName + '.outb')
-    baselineOutFile = os.path.join(inputsDirectory,    simName + '.out')  # TODO TODO
+    baselineOutFile = os.path.join(inputsDirectory,    simName + '.outb')  # TODO TODO
 
     if not os.path.exists(localOutFile):
         Error('File does not exist: {}'.format(localOutFile))


### PR DESCRIPTION
**Feature or improvement description**
When using the new aero-elastic capabilities in the UA driver, we noticed some simple cases that diverged. Further inspection led us to find a sign error in the LinDyn implementation (see matrix `BB`).

**Related issue, if one exists**
This was discussed in an email chain between Envision Energy and @ebranlard.
 
**Impacted areas of the software**
UA driver, SimMod=3

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
I added a new regression test for UA driver to expose this bug, but the existing cases for the UA driver aren't run in GitHub, so... until that is added, this won't change any regression tests. 
