### PR TITLE
Correct frequency error in AeroDyn driver prescribed motions

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -1105,7 +1105,7 @@ subroutine Dvr_ReadInputFile(fileName, dvr, errStat, errMsg )
       call ParseVar(FileInfo_In, CurLine, 'amplitude'//sWT         , wt%amplitude,       errStat2, errMsg2, unEc); if(Failed()) return
       call ParseVar(FileInfo_In, CurLine, 'frequency'//sWT         , wt%frequency,       errStat2, errMsg2, unEc); if(Failed()) return
       call ParseVar(FileInfo_In, CurLine, 'baseMotionFilename'//sWT, wt%motionFileName,  errStat2, errMsg2, unEc); if(Failed()) return
-      wt%frequency = wt%frequency * 2 *pi ! Hz to rad/s
+      wt%frequency = wt%frequency * 2 * pi ! Hz to rad/s
       if (dvr%analysisType==idAnalysisRegular) then
          if (wt%motionType==idBaseMotionGeneral) then
             call ReadDelimFile(wt%motionFileName, 19, wt%motion, errStat2, errMsg2, priPath=priPath); if(Failed()) return
@@ -1313,7 +1313,7 @@ subroutine setSimpleMotion(wt, rotSpeed, bldPitch, nacYaw, DOF, amplitude, frequ
    integer                       :: i
    wt%degreeofFreedom   = DOF
    wt%amplitude         = amplitude
-   wt%frequency         = frequency * 2 *pi ! Hz to rad/s
+   wt%frequency         = frequency
    wt%nac%motionType    = idNacMotionConstant
    wt%nac%yaw           = nacYaw* PI /180._ReKi ! deg 2 rad
    wt%hub%motionType    = idHubMotionConstant


### PR DESCRIPTION
This pull request is ready to be merged (pending r-test results).

There was an error in the AeroDyn driver script that reads inputs from the driver input file. When prescribing sinusoidal motions, the frequency was multiplied by 2pi in two different places, resulting in inaccurate frequencies being used. The repeated multiplication occurred in the setSimpleMotion subroutine, which was only called for a combined cases analysis or when BasicHAWTFormat was True.

For a surge amplitude of 2 m and period of 6 s, an 18 s simulation gave the following, with 2pi/6 (~1) cycles per second (~18 cycles total):

![Screenshot 2024-08-13 at 1 06 27 PM](https://github.com/user-attachments/assets/ed8bef0a-e8eb-4908-a855-896dbb5d8fdf)

With the bug fix included here, an 18 s simulation gave the following (1/6 cycles per second, total of 3 cycles):

![Screenshot 2024-08-13 at 1 03 48 PM](https://github.com/user-attachments/assets/88e6851e-90da-404f-9754-197975f7ad82)

