### PR TITLE
SubDyn documentation: Member Cosine Matrices

### DIFF
--- a/docs/source/user/subdyn/input_files.rst
+++ b/docs/source/user/subdyn/input_files.rst
@@ -555,9 +555,12 @@ Member Cosine Matrices COSM (i,j)
 to be provided. Each row of the table will list the nine entries of the
 direction cosine matrices (COSM11, COSM12,…COSM33) for matrix elements.
 Each row is a vector in the global coordinate system for principal axes 
-in the x, y and z directions respectively. These vectors need to be 
-specified with an extremely high level of precision for results to be
-equivalent to an internal calculation.
+in the x (COSM11, COSM12, COSM13), y (COSM21, COSM22, COSM23) and 
+z (COSM31, COSM32, COSM33) directions respectively. Internally, SubDyn 
+transposes this provided matrix to make it consistent with the definition 
+of direction cosine matrix :math:`[ \mathbf{D_c} ]` used in SubDyn (Eq. :eq:`Dc`). 
+The vectors provided need to be specified with an extremely high level of 
+precision for results to be equivalent to an internal calculation.
 
 Joint Additional Concentrated Masses
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
I believe this pull request is ready to be merged.

**Feature or improvement description**
The current documentation is quite confusing about how the user should define the member cosine matrices in SubDyn.

The documentation shows the calculation of direction cosine matrix as: (https://openfast.readthedocs.io/en/dev/source/user/subdyn/theory.html#local-to-global-transformation):
![image](https://github.com/user-attachments/assets/39ddc33d-5459-41f8-b5d8-beb7b9293e4c)
 
In this case, the vectors x, y, and z correspond to the columns of the direction cosine matrix.

However, when the user provides the direction cosine matrix as input (https://openfast.readthedocs.io/en/dev/source/user/subdyn/input_files.html#member-cosine-matrices-cosm-i-j) for example to define the directions for a spring element (https://openfast.readthedocs.io/en/dev/source/user/subdyn/theory.html#spring-elements), it has to provide the vectors x, y, and z as the rows of the direction cosine matrix (not the columns as shown in the above [Dc]).

Internally, SubDyn computes the transpose of the matrix provided by the user. Making the direction cosine matrix consistent with the definition of [Dc]. This may be very confusing for a user if it doesn't look in detail in the source code.

The same issue would be faced in the future when defining rectangular members in SubDyn.

I illustrate this with an example taking advantage of the USFLOWT project. The image below shows the top view of the substructure.
![image](https://github.com/user-attachments/assets/7a91c998-c40a-4f2e-8d4e-1bde2a06b1d7)

The member cosine matrix for the vectors that I show in the above picture, would correspond to:
```
---------------------- MEMBER COSINE MATRICES COSM(i,j) ------------------------
             1   NCOSMs      - Number of unique cosine matrices (i.e., of unique member alignments including principal axis rotations); ignored if NXPropSets=0   or 9999 in any element below
COSMID    COSM11    COSM12    COSM13    COSM21    COSM22    COSM23    COSM31    COSM32    COSM33
 (-)       (-)       (-)       (-)       (-)       (-)       (-)       (-)       (-)       (-)
 1       -0.5      0.866       0      -0.866     -0.5        0         0         0         1
```

where the direction 1 (x_e) is defined by (COSM11, COSM12, COSM12); the direction 2 (y_e) is defined by (COSM21, COSM22, COSM23); and the direction 3 (z_e) is defined by (COSM31, COSM32, COSM33).

**Impacted areas of the software**
Only documentation.