### PR TITLE
FileInfoType: increase line length allowed

### DIFF
--- a/modules/nwtc-library/src/NWTC_Base.f90
+++ b/modules/nwtc-library/src/NWTC_Base.f90
@@ -40,7 +40,7 @@ MODULE NWTC_Base
    
    INTEGER(IntKi), PARAMETER     :: MinChanLen = 10                               !< The min allowable length of channel names (i.e., width of output columns), used because some modules (like Bladed DLL outputs) have excessively long names
    INTEGER(IntKi), PARAMETER     :: LinChanLen = 200                              !< The allowable length of row/column names in linearization files
-   INTEGER(IntKi), PARAMETER     :: MaxFileInfoLineLen = 1024                     !< The allowable length of an input line stored in FileInfoType%Lines
+   INTEGER(IntKi), PARAMETER     :: MaxFileInfoLineLen = 8192                     !< The allowable length of an input line stored in FileInfoType%Lines
 
    INTEGER(IntKi), PARAMETER     :: NWTC_Verbose = 10                             !< The maximum level of verbosity
    INTEGER(IntKi), PARAMETER     :: NWTC_VerboseLevel = 5                         !< a number in [0, NWTC_Verbose]: 0 = no output; NWTC_Verbose=verbose; 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The `FileInfoType` used to store input files read into memory has a line length limit of 1024 characters.  With the ability to add many input fields in some input file tables -- such as when HydroDyn when 14+ floating bodies are specified.   Increasing this to 8192 characters to future proof a little.  We may still hit limits with this again later, but perhaps we can migrate to a different input file format before then (wishful thinking I know).

**Related issue, if one exists**
In trying to diagnose an issue brought up on the forum, we initially thought this might be the issue (apparently it isn't in that particular case).  https://forums.nrel.gov/t/hydrodyn-nbody-maximum-limit/7418

**Impacted areas of the software**
All modules using the `FileInfoType` parsing.

**Tests**
No tests are affected.