### PR TITLE
Install also the Map++ API headers

### DIFF
--- a/glue-codes/simulink/CMakeLists.txt
+++ b/glue-codes/simulink/CMakeLists.txt
@@ -27,7 +27,7 @@ set(MEX_LIBS
   $<TARGET_FILE:hydrodynlib>
   $<TARGET_FILE:icedynlib>
   $<TARGET_FILE:icefloelib>
-  $<TARGET_FILE:maplib>
+  $<TARGET_FILE:mappplib>
   $<TARGET_FILE:moordynlib>
   $<TARGET_FILE:orcaflexlib>
   $<TARGET_FILE:sctypeslib>

--- a/modules/map/CMakeLists.txt
+++ b/modules/map/CMakeLists.txt
@@ -39,6 +39,16 @@ add_library(mappplib STATIC
   src/MAP_Fortran_Types.f90
   ${MAP_CLIB_SOURCES}
 )
+target_sources(
+  mappplib
+  PUBLIC
+    $<INSTALL_INTERFACE:MAP_Types.h>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/MAP_Types.h>
+    $<INSTALL_INTERFACE:mapsys.h>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/mapsys.h>
+    $<INSTALL_INTERFACE:mapapi.h>
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/mapapi.h>
+)
 target_link_libraries(mappplib nwtclibs)
 target_include_directories(mappplib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bstring>
@@ -47,9 +57,8 @@ target_include_directories(mappplib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/simclist>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
-set_target_properties(mappplib PROPERTIES PUBLIC_HEADER src/MAP_Types.h
-                                                        src/mapsys.h
-                                                        src/mapapi.h)
+get_target_property(MAPPP_PUBLIC_HEADERS mappplib INTERFACE_SOURCES)
+set_target_properties(mappplib PROPERTIES PUBLIC_HEADER "${MAPPP_PUBLIC_HEADERS}")
 
 install(TARGETS mappplib
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"

--- a/modules/map/CMakeLists.txt
+++ b/modules/map/CMakeLists.txt
@@ -33,26 +33,28 @@ endif()
 file(GLOB MAP_CLIB_SOURCES src/*.c src/*.cc src/*/*.c src/*/*.cc)
 file(GLOB MAP_C_HEADERS src/*.h src/*/*.h)
 
-add_library(maplib STATIC
+add_library(mappplib STATIC
   src/map.f90
   src/MAP_Types.f90
   src/MAP_Fortran_Types.f90
   ${MAP_CLIB_SOURCES}
 )
-target_link_libraries(maplib nwtclibs)
-target_include_directories(maplib PUBLIC
+target_link_libraries(mappplib nwtclibs)
+target_include_directories(mappplib PUBLIC
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/bstring>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/cminpack>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/lapack>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/simclist>
   $<BUILD_INTERFACE:${CMAKE_CURRENT_BINARY_DIR}>
 )
-set_target_properties(maplib PROPERTIES PUBLIC_HEADER src/MAP_Types.h)
+set_target_properties(mappplib PROPERTIES PUBLIC_HEADER src/MAP_Types.h
+                                                        src/mapsys.h
+                                                        src/mapapi.h)
 
-install(TARGETS maplib
+install(TARGETS mappplib
   EXPORT "${CMAKE_PROJECT_NAME}Libraries"
   RUNTIME DESTINATION bin
   ARCHIVE DESTINATION lib
   LIBRARY DESTINATION lib
-  PUBLIC_HEADER DESTINATION include
+  PUBLIC_HEADER DESTINATION include/mappp
 )

--- a/modules/openfast-library/CMakeLists.txt
+++ b/modules/openfast-library/CMakeLists.txt
@@ -54,7 +54,7 @@ target_link_libraries(openfast_prelib
   icedynlib
   icefloelib
   ifwlib
-  maplib
+  mappplib
   moordynlib
   orcaflexlib
   sctypeslib


### PR DESCRIPTION
**Feature or improvement description**
This PR just adds all the needed files to use the produced MAP++ library by 3rd parties.

On top of that, it renames the library as mappplib (Map++ library) and guard the header files under a mappp folder. Otherwise one might expect collisions with some other packages installed on the system (maplib, mapsys and mapapi seem like names that might happen even as system files on exotic OSs)

**Related issue, if one exists**
None

**Impacted areas of the software**
Map++ and the related CMake files

**Additional supporting information**
Not much else to say

**Test results, if applicable**
Nothing changed actually

- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll