### PR TITLE
MD: replace "save" variable with logical in MD_Point

### DIFF
--- a/modules/moordyn/src/MoorDyn_Point.f90
+++ b/modules/moordyn/src/MoorDyn_Point.f90
@@ -383,7 +383,9 @@ CONTAINS
       REAL(DbKi),       INTENT(INOUT)    :: rdEnd(3)
       
       Integer(IntKi)    :: l,m,J
-      Integer(IntKi)    :: found = 0
+      logical           :: found
+
+      found = .false.
       
       DO l = 1,Point%nAttached    ! look through attached lines
       
@@ -409,13 +411,13 @@ CONTAINS
                EXIT
             END DO
             
-            found = 1
+            found = .true.
          
          END IF
          
       END DO
 
-      IF (found == 0) THEN   ! detect if line not found TODO: fix this, its wrong. If pointNnattached is oprginally 2, then it will be 1 after one run of the loop and l will also be 1
+      IF (found) THEN   ! detect if line not found TODO: fix this, its wrong. If pointNnattached is oprginally 2, then it will be 1 after one run of the loop and l will also be 1
          CALL WrScr("Error: failed to find line to remove during RemoveLine call to Point "//trim(num2lstr(Point%IdNum))//". Line "//trim(num2lstr(lineID)))
       END IF
       


### PR DESCRIPTION
See comments on PR #2214 for details

**Feature or improvement description**
PR #2214 accidentally introduce a "save" variable that is persistent between calls to a routine in the `MoorDyn_Point.f90` source.

**Related issue, if one exists**
#2214 

**Impacted areas of the software**
_MoorDyn_

**Additional supporting information**
We don't allow "save" variables in the code for portability and parrallelization reasons.

**Test results, if applicable**
No changes