### PR TITLE
SD: Remove the misleading CBMod input

### DIFF
--- a/docs/source/user/subdyn/input_files.rst
+++ b/docs/source/user/subdyn/input_files.rst
@@ -229,13 +229,6 @@ static gravity and buoyancy loads, and high-frequency loads transferred
 from the turbine. Recommended to set to True.
 
 
-**GuyanLoadCorrection** is a flag to specify whether the extra moment due to 
-the lever arm from the Guyan deflection of the structure is to be added to the loads
-passed to SubDyn, and, whether the FEM representation should be expressed in the rotating 
-frame in the floating case (the rotation is induced by the rigid body Guyan modes).
-See section :numref:`SD_Loads` for details. Recommended to set to True.
-
-
 FEA and Craig-Bampton Parameters
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -257,12 +250,11 @@ recommend using **NDiv** > 1 when modeling tapered members.
 should be carried out by the module. If FALSE, then the full
 finite-element model is retained and **Nmodes** is ignored.
 
-**Nmodes** sets the number of internal C-B modal DOFs to retain in the
+**Nmodes** sets the number of internal C-B modal DOF to retain in the
 C-B reduction. **Nmodes** = 0 corresponds to a Guyan (static)
-reduction. **Nmodes** is ignored if **CBMod** is set to FALSE,
-meaning the full finite-element model is retained by keeping all modes
-(i.e. a modal analysis is still done, and all the modes are used as DOFs)  .
-
+reduction. With **Nmodes** < 0 (equivalent to **CBMod** set to FALSE 
+in previous versions), SubDyn will retain all C-B modes, leading to the 
+same number of DOF as the full finite-element model.
 
 **JDampings** specifies value(s) of damping coefficients as a
 percentage of critical damping for the retained C-B modes. Distinct

--- a/docs/source/user/subdyn/theory.rst
+++ b/docs/source/user/subdyn/theory.rst
@@ -1780,7 +1780,7 @@ Corrections to the baseline formulation ("GuyanLoadCorrection")
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 The baseline FEM implementation needs to be corrected to account for the fact that loads are provided to SubDyn at the displaced positions, and to account for the rigid body motions in the floating case.
-The corrections are activated by setting the parameter **GuyanLoadCorrection** to True.
+In previous versions of SubDyn, the corrections are activated by setting the parameter **GuyanLoadCorrection** to True. This input parameter has been removed from the SubDyn primary input file, and the load corrections will always be used in current and future versions of SubDyn.
 
 
 


### PR DESCRIPTION
**Feature or improvement description**
This pull request slightly modifies the SubDyn input file by removing the `CBMod` T/F switch. This input can be misleading because irrespective of `CBMod`, SubDyn always transforms the equations of motion to be in terms of Guyan and Craig-Bampton modes. Setting `CBMod` to false simply lets SubDyn retain all Craig-Bampton modes.

To better reflect how SubDyn actually functions, the `CBMod` switch is removed. Instead, if `Nmodes`>=0, SubDyn will function as if `CBMod` is true in previous versions. Alternatively, setting `Nmodes`<0 will let SubDyn retain all Craig-Bampton modes, recovering the same behavior with `CBMod` set to false in previous versions.

The user documentation for SubDyn is updated to reflect the removal of `CBMod` from the primary input file. The removal of `GuyanLoadCorrection` from the input file is also briefly explained (see PR #2203). 

**Impacted areas of the software**
SubDyn, Docs

**Test results, if applicable**
There is no change to existing test results. All r-test SubDyn input files are updated by removing `CBMod`.
