### PR TITLE
Fix typo in logic from PR #2400

### DIFF
--- a/modules/moordyn/src/MoorDyn_Point.f90
+++ b/modules/moordyn/src/MoorDyn_Point.f90
@@ -417,7 +417,7 @@ CONTAINS
          
       END DO
 
-      IF (found) THEN   ! detect if line not found TODO: fix this, its wrong. If pointNnattached is oprginally 2, then it will be 1 after one run of the loop and l will also be 1
+      IF (.not. found) THEN   ! detect if line not found TODO: fix this, its wrong. If pointNnattached is oprginally 2, then it will be 1 after one run of the loop and l will also be 1
          CALL WrScr("Error: failed to find line to remove during RemoveLine call to Point "//trim(num2lstr(Point%IdNum))//". Line "//trim(num2lstr(lineID)))
       END IF
       


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
PR #2400 removed a `SAVE` variable.  But I got the logic wrong.  This PR fixes the logic.

**Related issue, if one exists**
See comment here: https://github.com/OpenFAST/openfast/pull/2400/files#r1742242238

**Impacted areas of the software**
_MoorDyn_ only

