### PR TITLE
Update SubDyn User Documentation to reflect the removed input parameters

### DIFF
--- a/docs/source/user/subdyn/input_files.rst
+++ b/docs/source/user/subdyn/input_files.rst
@@ -246,10 +246,6 @@ Increasing the number of elements per member may increase accuracy, with
 the trade-off of increased memory usage and computation time. We
 recommend using **NDiv** > 1 when modeling tapered members.
 
-**CBMod** is a flag that specifies whether or not the C-B reduction
-should be carried out by the module. If FALSE, then the full
-finite-element model is retained and **Nmodes** is ignored.
-
 **Nmodes** sets the number of internal C-B modal DOF to retain in the
 C-B reduction. **Nmodes** = 0 corresponds to a Guyan (static)
 reduction. With **Nmodes** < 0 (equivalent to **CBMod** set to FALSE 


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**
Remove the paragraph in the SubDyn documentation on the now deleted input `CBMod` in the SubDyn primary input file.

**Related issue, if one exists**
This is a follow-up to PR #2401.

**Impacted areas of the software**
Documentation only

**Test results, if applicable**
No change to test results