### PR TITLE
Correct issues with SED

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -783,17 +783,28 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
       Init%InData_AD%MSL2SWL            = p_FAST%MSL2SWL
 
 
-      Init%InData_AD%rotors(1)%HubPosition        = ED%y%HubPtMotion%Position(:,1)
-      Init%InData_AD%rotors(1)%HubOrientation     = ED%y%HubPtMotion%RefOrientation(:,:,1)
-      Init%InData_AD%rotors(1)%NacellePosition    = ED%y%NacelleMotion%Position(:,1)
-      Init%InData_AD%rotors(1)%NacelleOrientation = ED%y%NacelleMotion%RefOrientation(:,:,1)
+      if (p_FAST%CompElast == Module_SED) then
+         Init%InData_AD%rotors(1)%HubPosition        = SED%y%HubPtMotion%Position(:,1)
+         Init%InData_AD%rotors(1)%HubOrientation     = SED%y%HubPtMotion%RefOrientation(:,:,1)
+         Init%InData_AD%rotors(1)%NacellePosition    = SED%y%NacelleMotion%Position(:,1)
+         Init%InData_AD%rotors(1)%NacelleOrientation = SED%y%NacelleMotion%RefOrientation(:,:,1)
+         do k=1,NumBl
+            Init%InData_AD%rotors(1)%BladeRootPosition(:,k)      = SED%y%BladeRootMotion(k)%Position(:,1)
+            Init%InData_AD%rotors(1)%BladeRootOrientation(:,:,k) = SED%y%BladeRootMotion(k)%RefOrientation(:,:,1)
+         end do
+      elseif (p_FAST%CompElast == Module_ED .or. p_FAST%CompElast == Module_BD) then
+         Init%InData_AD%rotors(1)%HubPosition        = ED%y%HubPtMotion%Position(:,1)
+         Init%InData_AD%rotors(1)%HubOrientation     = ED%y%HubPtMotion%RefOrientation(:,:,1)
+         Init%InData_AD%rotors(1)%NacellePosition    = ED%y%NacelleMotion%Position(:,1)
+         Init%InData_AD%rotors(1)%NacelleOrientation = ED%y%NacelleMotion%RefOrientation(:,:,1)
+         do k=1,NumBl
+            Init%InData_AD%rotors(1)%BladeRootPosition(:,k)      = ED%y%BladeRootMotion(k)%Position(:,1)
+            Init%InData_AD%rotors(1)%BladeRootOrientation(:,:,k) = ED%y%BladeRootMotion(k)%RefOrientation(:,:,1)
+         end do
+      endif
+
       ! Note: not passing tailfin position and orientation at init
       Init%InData_AD%rotors(1)%AeroProjMod        = APM_BEM_NoSweepPitchTwist
-
-      do k=1,NumBl
-         Init%InData_AD%rotors(1)%BladeRootPosition(:,k)      = ED%y%BladeRootMotion(k)%Position(:,1)
-         Init%InData_AD%rotors(1)%BladeRootOrientation(:,:,k) = ED%y%BladeRootMotion(k)%RefOrientation(:,:,1)
-      end do
 
       ! Set pointers to flowfield
       IF (p_FAST%CompInflow == Module_IfW) Init%InData_AD%FlowField => Init%OutData_IfW%FlowField

--- a/modules/simple-elastodyn/src/SED.f90
+++ b/modules/simple-elastodyn/src/SED.f90
@@ -30,7 +30,7 @@ MODULE SED
 
    implicit none
    private
-   type(ProgDesc), parameter :: SED_Ver = ProgDesc( 'SED', 'v1.00.00', '15-Feb-2022' )
+   type(ProgDesc), parameter :: SED_Ver = ProgDesc( 'SED', '', '' )
 
    public :: SED_Init
    public :: SED_End

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -335,6 +335,9 @@ of_regression("MHK_RM1_Floating"                       "openfast;elastodyn;aerod
 of_regression("MHK_RM1_Floating_wNacDrag"              "openfast;elastodyn;aerodyn;hydrodyn;moordyn;mhk")
 of_regression("Tailfin_FreeYaw1DOF_PolarBased"         "openfast;elastodyn;aerodyn")
 of_regression("Tailfin_FreeYaw1DOF_Unsteady"           "openfast;elastodyn;aerodyn")
+of_regression("5MW_Land_DLL_WTurb_ADsk"                "openfast;elastodyn;aerodisk")
+of_regression("5MW_Land_DLL_WTurb_ADsk_SED"            "openfast;simple-elastodyn;aerodisk")
+of_regression("5MW_Land_DLL_WTurb_SED"                 "openfast;simple-elastodyn;aerodyn")
 
 of_aeromap_regression("5MW_Land_AeroMap"               "aeromap;elastodyn;aerodyn")
 


### PR DESCRIPTION
Ready to merge after regression test updates

**Feature or improvement description**
Somewhere during final updates of the reduced order models (_SED_ and _ADsk_), an incorrect merge resulted in missing logic in `FAST_Subs.f90` for the _SED_ + _AD_ combination, which resulted in segmentation faults.  This is now fixed.

Also, _SED_ was carrying version info while no other modules apart from _MoorDyn_ carry version info anymore (the module version is now the _OpenFAST_ version), so version info was dropped.

The following regression tests are now turned on in GH actions and have changed very slightly from the original baselines 18 months ago (changes are minimal and due entirely to other changes in the code).

-  `5MW_Land_DLL_WTurb_ADsk`
- `5MW_Land_DLL_WTurb_ADsk_SED`
- `5MW_Land_DLL_WTurb_SED`

**Related issue, if one exists**
PR #1295 

**Impacted areas of the software**
The new module _SED_ now works with _AD_.

@mayankchetan, please review.