### PR TITLE
Lidar bug fix + other minor changes

### DIFF
--- a/glue-codes/simulink/src/FAST_SFunc.c
+++ b/glue-codes/simulink/src/FAST_SFunc.c
@@ -189,9 +189,6 @@ static void mdlInitializeSizes(SimStruct *S)
              InitInputAry[i] = AdditionalInitInputs[i + 1];
           }
        }
-       else{
-          InitInputAry[0] = SensorType_None; // tell it not to use lidar (shouldn't be necessary, but we'll cover our bases)
-       }
 
        // set this before possibility of error in Fortran library:
 

--- a/modules/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules/hydrodyn/src/HydroDyn_Input.f90
@@ -385,11 +385,11 @@ SUBROUTINE HydroDyn_ParseInput( InputFileName, OutRootName, FileInfo_In, InputFi
          ! read the table entries AxCoefID, AxCd, AxCa, AxCp, AxFdMod, AxVnCOff, AxFDLoFSc in the HydroDyn input file
          ! Try reading in 7 entries first
          call ParseAry( FileInfo_In, CurLine, ' axial coefficients line '//trim( Int2LStr(I)), tmpReArray, size(tmpReArray), ErrStat2, ErrMsg2, UnEc )
-         if ( ErrStat2 /= 0 ) then ! Try reading in 5 entries
+         if ( ErrStat2 /= ErrID_None ) then ! Try reading in 5 entries
             tmpReArray(6) = -1.0  ! AxVnCoff
             tmpReArray(7) =  1.0  ! AxFDLoFSc
             call ParseAry( FileInfo_In, CurLine, ' axial coefficients line '//trim( Int2LStr(I)), tmpReArray(1:5), 5, ErrStat2, ErrMsg2, UnEc )
-            if ( ErrStat2 /= 0 ) then ! Try reading in 4 entries
+            if ( ErrStat2 /= ErrID_None ) then ! Try reading in 4 entries
                tmpReArray(5) =  0.0  ! AxFdMod
                call ParseAry( FileInfo_In, CurLine, ' axial coefficients line '//trim( Int2LStr(I)), tmpReArray(1:4), 4, ErrStat2, ErrMsg2, UnEc )
                if (Failed())  return;

--- a/modules/hydrodyn/src/YawOffset.f90
+++ b/modules/hydrodyn/src/YawOffset.f90
@@ -18,7 +18,7 @@ INTERFACE GetRotAngs
    MODULE PROCEDURE GetRotAngsD
 END INTERFACE GetRotAngs
 
-INTERFACE WrapToPi
+INTERFACE WrapToPi  ! See NWTC_Num.f90:: mpi2pi()
    MODULE PROCEDURE WrapToPiR
    MODULE PROCEDURE WrapToPiD
 END INTERFACE WrapToPi
@@ -238,7 +238,7 @@ FUNCTION WrapTo180R(angle)
 
    REAL(SiKi),    INTENT(IN) :: angle
    REAL(SiKi)                :: WrapTo180R
-   WrapTo180R = modulo(angle + 180.0, 360.0) - 180.0
+   WrapTo180R = modulo(angle + 180.0_SiKi, 360.0_SiKi) - 180.0_SiKi
 
 END FUNCTION WrapTo180R
 
@@ -246,7 +246,7 @@ FUNCTION WrapTo180D(angle)
 
    REAL(R8Ki),    INTENT(IN) :: angle
    REAL(R8Ki)                :: WrapTo180D
-   WrapTo180D = modulo(angle + 180.0, 360.0) - 180.0
+   WrapTo180D = modulo(angle + 180.0_R8Ki, 360.0_R8Ki) - 180.0_R8Ki
 
 END FUNCTION WrapTo180D
 
@@ -254,7 +254,7 @@ FUNCTION WrapToPiR(angle)
 
    REAL(SiKi),    INTENT(IN) :: angle
    REAL(SiKi)                :: WrapToPiR
-   WrapToPiR = modulo(angle + PI, TwoPi) - PI
+   WrapToPiR = modulo(angle + Pi_R4, TwoPi) - Pi_R4
 
 END FUNCTION WrapToPiR
 
@@ -262,7 +262,7 @@ FUNCTION WrapToPiD(angle)
 
    REAL(R8Ki),    INTENT(IN) :: angle
    REAL(R8Ki)                :: WrapToPiD
-   WrapToPiD = modulo(angle + PI, TwoPi) - PI
+   WrapToPiD = modulo(angle + Pi_R8, TwoPi) - Pi_R8
 
 END FUNCTION WrapToPiD
 

--- a/modules/hydrodyn/src/YawOffset.f90
+++ b/modules/hydrodyn/src/YawOffset.f90
@@ -254,7 +254,7 @@ FUNCTION WrapToPiR(angle)
 
    REAL(SiKi),    INTENT(IN) :: angle
    REAL(SiKi)                :: WrapToPiR
-   WrapToPiR = modulo(angle + Pi_R4, TwoPi) - Pi_R4
+   WrapToPiR = modulo(angle + Pi_R4, TwoPi_R4) - Pi_R4
 
 END FUNCTION WrapToPiR
 
@@ -262,7 +262,7 @@ FUNCTION WrapToPiD(angle)
 
    REAL(R8Ki),    INTENT(IN) :: angle
    REAL(R8Ki)                :: WrapToPiD
-   WrapToPiD = modulo(angle + Pi_R8, TwoPi) - Pi_R8
+   WrapToPiD = modulo(angle + Pi_R8, TwoPi_R8) - Pi_R8
 
 END FUNCTION WrapToPiD
 

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -490,22 +490,18 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
   
       ! LIDAR Sensor Type
    CALL ParseVar( InFileInfo, CurLine, "SensorType", InputFileData%SensorType, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
 
      ! Number of Range Gates
    CALL ParseVar( InFileInfo, CurLine, "NumPulseGate", InputFileData%NumPulseGate, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
      
      ! Pulse Gate Spacing
    CALL ParseVar( InFileInfo, CurLine, "PulseSpacing", InputFileData%PulseSpacing, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
 
      ! NumBeam: Number of points to output the lidar measured wind velocity (1 to 5)
    CALL ParseVar( InFileInfo, CurLine, "NumBeam", InputFileData%NumBeam, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    if (Failed()) return
 
      ! Before proceeding, make sure that NumBeam makes sense
@@ -515,53 +511,42 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
       RETURN   
    ELSE   
             ! Allocate space for the output location arrays:
-      CALL AllocAry( InputFileData%FocalDistanceX, InputFileData%NumBeam, 'NumBeam', TmpErrStat, TmpErrMsg )
-      CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
-      CALL AllocAry( InputFileData%FocalDistanceY, InputFileData%NumBeam, 'NumBeam', TmpErrStat, TmpErrMsg )
-      CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
-      CALL AllocAry( InputFileData%FocalDistanceZ, InputFileData%NumBeam, 'NumBeam', TmpErrStat, TmpErrMsg )
-      CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
+      CALL AllocAry( InputFileData%FocalDistanceX, InputFileData%NumBeam, 'FocalDistanceX', TmpErrStat, TmpErrMsg ); CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
+      CALL AllocAry( InputFileData%FocalDistanceY, InputFileData%NumBeam, 'FocalDistanceY', TmpErrStat, TmpErrMsg ); CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
+      CALL AllocAry( InputFileData%FocalDistanceZ, InputFileData%NumBeam, 'FocalDistanceZ', TmpErrStat, TmpErrMsg ); CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
       if (Failed()) return
    ENDIF
     
     ! Focal Distance X
    CALL ParseAry( InFileInfo, CurLine, 'FocalDistanceX', InputFileData%FocalDistanceX, InputFileData%NumBeam, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    if (Failed()) return
  
     ! Focal Distance Y
    CALL ParseAry( InFileInfo, CurLine, 'FocalDistanceY', InputFileData%FocalDistanceY, InputFileData%NumBeam, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    if (Failed()) return
 
     ! Focal Distance Z
    CALL ParseAry( InFileInfo, CurLine, 'FocalDistanceZ', InputFileData%FocalDistanceZ, InputFileData%NumBeam, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    if (Failed()) return
 
     ! Rotor Apex Offset Position
    CALL ParseAry( InFileInfo, CurLine, "RotorApexOffsetPos", InputFileData%RotorApexOffsetPos, 1, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
    
     ! URefIni
    CALL ParseVar( InFileInfo, CurLine, "URefLid", InputFileData%URefLid, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN 
  
     ! Measurement Interval
    CALL ParseVar( InFileInfo, CurLine, "MeasurementInterval", InputFileData%MeasurementInterval, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
    
     ! Lidar Radial Vel
    CALL ParseLoVar( InFileInfo, CurLine, "LidRadialVel", InputFileData%LidRadialVel, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
      
     ! Consider Hub Motion
    CALL ParseVar( InFileInfo, CurLine, "ConsiderHubMotion", InputFileData%ConsiderHubMotion, TmpErrStat, TmpErrMsg, UnEc )
-   CALL SetErrStat( TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName )
    IF (Failed()) RETURN
    
 

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -542,7 +542,7 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
    IF (Failed()) RETURN
    
     ! Lidar Radial Vel
-   CALL ParseLoVar( InFileInfo, CurLine, "LidRadialVel", InputFileData%LidRadialVel, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "LidRadialVel", InputFileData%LidRadialVel, TmpErrStat, TmpErrMsg, UnEc )
    IF (Failed()) RETURN
      
     ! Consider Hub Motion

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -530,7 +530,7 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
    if (Failed()) return
 
     ! Rotor Apex Offset Position
-   CALL ParseAry( InFileInfo, CurLine, "RotorApexOffsetPos", InputFileData%RotorApexOffsetPos, 1, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseAry( InFileInfo, CurLine, "RotorApexOffsetPos", InputFileData%RotorApexOffsetPos, size(InputFileData%RotorApexOffsetPos), TmpErrStat, TmpErrMsg, UnEc )
    IF (Failed()) RETURN
    
     ! URefIni

--- a/modules/inflowwind/src/Lidar.f90
+++ b/modules/inflowwind/src/Lidar.f90
@@ -336,10 +336,9 @@ SUBROUTINE Lidar_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMs
                                                        
    REAL(ReKi)                                            :: Distance(3)          ! distance vector between input measurement and lidar positions
    
-   REAL(ReKi)                                            ::  LidPosition(3)      ! Lidar Position 
-   REAL(ReKi)                                            ::  LidPosition_N(3)    !Transformed Lidar Position
-   REAL(ReKi)                                            ::  LidarMsrPosition(3)    !Transformed Lidar Position
-   REAL(ReKi)                                            ::  MeasurementCurrentStep
+   REAL(ReKi)                                            :: LidPosition(3)      ! Lidar Position 
+   REAL(ReKi)                                            :: LidarMsrPosition(3)    !Transformed Lidar Position
+   REAL(ReKi)                                            :: MeasurementCurrentStep
   
    
    REAL(ReKi)                                            :: PositionXYZ(3,2)
@@ -366,13 +365,9 @@ SUBROUTINE Lidar_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMs
       RETURN
    ENDIF
    
+   LidPosition = p%lidar%LidPosition + p%lidar%RotorApexOffsetPos ! lidar offset-from-rotor-apex position
    IF (p%lidar%ConsiderHubMotion == 1) THEN
-      LidPosition_N =  (/ u%lidar%HubDisplacementX, u%lidar%HubDisplacementY, u%lidar%HubDisplacementZ /) & ! rotor apex position (absolute)
-                                                + p%lidar%RotorApexOffsetPos            ! lidar offset-from-rotor-apex position
-      LidPosition   =  p%lidar%LidPosition + LidPosition_N
-   ELSE 
-      LidPosition_N =  p%lidar%RotorApexOffsetPos
-      LidPosition   =  p%lidar%LidPosition + LidPosition_N
+      LidPosition = LidPosition + (/ u%lidar%HubDisplacementX, u%lidar%HubDisplacementY, u%lidar%HubDisplacementZ /)  ! rotor apex position (absolute)
    END IF
 
    IF (p%lidar%SensorType == SensorType_None) RETURN

--- a/modules/map/src/bstring/bstraux.c
+++ b/modules/map/src/bstring/bstraux.c
@@ -35,7 +35,7 @@
 #include "config.h"
 #endif
 
-#ifdef _MSC_VER
+#if defined _MSC_VER && !defined _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif
 

--- a/modules/map/src/bstring/bstrlib.c
+++ b/modules/map/src/bstring/bstrlib.c
@@ -39,7 +39,7 @@
 #include "config.h"
 #endif
 
-#if defined (_MSC_VER)
+#if defined _MSC_VER && !defined _CRT_SECURE_NO_WARNINGS
 /* These warnings from MSVC++ are totally pointless. */
 # define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/modules/map/src/mapapi.h
+++ b/modules/map/src/mapapi.h
@@ -35,6 +35,10 @@ extern "C"
 {
 #endif
 
+#if defined _MSC_VER && !defined _CRT_SECURE_NO_WARNINGS
+#define _CRT_SECURE_NO_WARNINGS
+#endif
+
 // Some redefinitions from MAP_Types.h, so the API does not need to exposes the
 // internal data structures.
 typedef struct MAP_InputType* MAP_Input_t;

--- a/modules/nwtc-library/src/ModMesh.f90
+++ b/modules/nwtc-library/src/ModMesh.f90
@@ -3396,7 +3396,7 @@ SUBROUTINE MeshWrVTK_PointSurface ( RefPoint, M, FileRootName, VTKcount, OutputF
       endif
       if (hasMotion) then
          mesh%Orientation      = mesh%RefOrientation
-         mesh%TranslationDisp  = 0.0_ReKi
+         mesh%TranslationDisp  = 0.0_R8Ki
          mesh%TranslationVel   = 0.0_ReKi
          mesh%RotationVel      = 0.0_ReKi
       endif

--- a/modules/nwtc-library/src/NWTC_Num.f90
+++ b/modules/nwtc-library/src/NWTC_Num.f90
@@ -6482,22 +6482,21 @@ end function Rad2M180to180Deg
 
       
    END FUNCTION TaitBryanYXZExtractR8
-
-
-      FUNCTION TaitBryanYXZConstructR4(theta) result(M)
-            ! this function creates a rotation matrix, M, from a 1-2-3 rotation
-      ! sequence of the 3 TaitBryan angles, theta_x, theta_y, and theta_z, in radians.
-      ! M represents a change of basis (from global to local coordinates; 
-      ! not a physical rotation of the body). it is the inverse of TaitBryanYXZExtract().
-      ! 
-      ! M = R(theta_z) * R(theta_x) * R(theta_y)
-      !   = [ cz sz 0 |  [ 1   0   0 |    [ cy  0 -sy | 
-      !     |-sz cz 0 |* | 0  cx  sx |  * |  0  1   0 | 
-      !     |  0  0 1 ]  | 0 -sx  cx ]    | sy  0  cy ] 
-      !   = [ cy*cz+sy*sx*sz   cx*sz    cy*sx*sz-cz*sy |
-      !     |cz*sy*sx-cy*sz   cx*cz    cy*cz*sx+sy*sz |
-      !     |cx*sy           -sx             cx*cy    ]
-      ! where cz = cos(theta_z), sz = sin(theta_z), cy = cos(theta_y), etc.
+!=======================================================================
+!> this function creates a rotation matrix, M, from a 1-2-3 rotation
+!! sequence of the 3 TaitBryan angles, theta_x, theta_y, and theta_z, in radians.
+!! M represents a change of basis (from global to local coordinates; 
+!! not a physical rotation of the body). it is the inverse of TaitBryanYXZExtract().
+!! 
+!! M = R(theta_z) * R(theta_x) * R(theta_y)
+!!   = [ cz sz 0 |  [ 1   0   0 |    [ cy  0 -sy | 
+!!     |-sz cz 0 |* | 0  cx  sx |  * |  0  1   0 | 
+!!     |  0  0 1 ]  | 0 -sx  cx ]    | sy  0  cy ] 
+!!   = [ cy*cz+sy*sx*sz   cx*sz    cy*sx*sz-cz*sy |
+!!     |cz*sy*sx-cy*sz   cx*cz    cy*cz*sx+sy*sz |
+!!     |cx*sy           -sx             cx*cy    ]
+!! where cz = cos(theta_z), sz = sin(theta_z), cy = cos(theta_y), etc.
+   PURE FUNCTION TaitBryanYXZConstructR4(theta) result(M)
    
       REAL(SiKi)             :: M(3,3)    !< rotation matrix, M 
       REAL(SiKi), INTENT(IN) :: theta(3)  !< the 3 rotation angles: \f$\theta_x, \theta_y, \theta_z\f$
@@ -6531,8 +6530,8 @@ end function Rad2M180to180Deg
       M(3,3) =   cy*cx   
 
    END FUNCTION TaitBryanYXZConstructR4
-   
-   FUNCTION TaitBryanYXZConstructR8(theta) result(M)
+!=======================================================================
+   PURE FUNCTION TaitBryanYXZConstructR8(theta) result(M)
    
       ! this function creates a rotation matrix, M, from a 1-2-3 rotation
       ! sequence of the 3 TaitBryan angles, theta_x, theta_y, and theta_z, in radians.
@@ -6580,7 +6579,6 @@ end function Rad2M180to180Deg
       M(3,3) =   cy*cx               
    
    END FUNCTION TaitBryanYXZConstructR8
-   
 
 !=======================================================================
 !> This routine takes an array of time values such as that returned from

--- a/modules/nwtc-library/src/Registry_NWTC_Library.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library.txt
@@ -18,8 +18,6 @@ typedef     ^             ^                 DbKi                           TimeS
 typedef     ^             ^                 CHARACTER(ChanLen)             ChanNames       {:}    -  - "Strings describing the names of the channels from the binary file (including the time channel)"
 typedef     ^             ^                 CHARACTER(ChanLen)             ChanUnits       {:}    -  - "Strings describing the units of the channels from the binary file (including the time channel)"
 typedef     ^             ^                 ReKi                           Data            {:}{:} -  - "numeric data (rows and columns) from the binary file, including the time channel"
-typedef     ^             ^                 DbKi                           Time            {:}
-typedef     ^             ^                 IntKi                          OutputFileFmtID
 
 typedef   NWTC_Library  OutParmType         IntKi                          Indx             -     -  - "An index into AllOuts array where this channel is computed/stored"
 typedef     ^             ^                 CHARACTER(ChanLen)             Name             -     -  - "Name of the output channel"

--- a/modules/nwtc-library/src/Registry_NWTC_Library.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library.txt
@@ -6,38 +6,40 @@
 #.............................................................
 
 
-typedef   NWTC_Library  ProgDesc            CHARACTER(99)            Name - - - "Name of the program or module"
-typedef     ^             ^                 CHARACTER(99)            Ver  - - - "Version number of the program or module"
-typedef     ^             ^                 CHARACTER(24)            Date - - - "String containing date module was last updated"
+typedef   NWTC_Library  ProgDesc            CHARACTER(99)                  Name              -    -  - "Name of the program or module"
+typedef     ^             ^                 CHARACTER(99)                  Ver               -    -  - "Version number of the program or module"
+typedef     ^             ^                 CHARACTER(24)                  Date              -    -  - "String containing date module was last updated"
 
-typedef   NWTC_Library  FASTdataType        CHARACTER(1024)          File     - - - "Name of the FAST-style binary file"
-typedef     ^             ^                 CHARACTER(1024)          Descr    - - - "String describing file"
-typedef     ^             ^                 IntKi                    NumChans - - - "Number of output channels in this binary file (not including the time channel)"
-typedef     ^             ^                 IntKi                    NumRecs  - - - "Number of records (rows) of data in the file"
-typedef     ^             ^                 DbKi                     TimeStep - - - "Time step for evenly-spaced data in the output file (when NumRecs is not allo"
-typedef     ^             ^                 CHARACTER(ChanLen)       ChanNames {:} - - "Strings describing the names of the channels from the binary file (including the time channel)"
-typedef     ^             ^                 CHARACTER(ChanLen)       ChanUnits {:} - - "Strings describing the units of the channels from the binary file (including the time channel)"
-typedef     ^             ^                 ReKi                     Data      {:}{:} - - "numeric data (rows and columns) from the binary file, including the time channel"
+typedef   NWTC_Library  FASTdataType        CHARACTER(1024)                File              -    -  - "Name of the FAST-style binary file"
+typedef     ^             ^                 CHARACTER(1024)                Descr             -    -  - "String describing file"
+typedef     ^             ^                 IntKi                          NumChans          -    -  - "Number of output channels in this binary file (not including the time channel)"
+typedef     ^             ^                 IntKi                          NumRecs           -    -  - "Number of records (rows) of data in the file"
+typedef     ^             ^                 DbKi                           TimeStep          -    -  - "Time step for evenly-spaced data in the output file (when NumRecs is not allo"
+typedef     ^             ^                 CHARACTER(ChanLen)             ChanNames       {:}    -  - "Strings describing the names of the channels from the binary file (including the time channel)"
+typedef     ^             ^                 CHARACTER(ChanLen)             ChanUnits       {:}    -  - "Strings describing the units of the channels from the binary file (including the time channel)"
+typedef     ^             ^                 ReKi                           Data            {:}{:} -  - "numeric data (rows and columns) from the binary file, including the time channel"
+typedef     ^             ^                 DbKi                           Time            {:}
+typedef     ^             ^                 IntKi                          OutputFileFmtID
 
-typedef   NWTC_Library  OutParmType         IntKi                    Indx   - - - "An index into AllOuts array where this channel is computed/stored"
-typedef     ^             ^                 CHARACTER(ChanLen)       Name   - - - "Name of the output channel"
-typedef     ^             ^                 CHARACTER(ChanLen)       Units  - - - "Units this channel is specified in"
-typedef     ^             ^                 IntKi                    SignM  - - - "Multiplier for output channel; usually -1 (minus) or 0 (invalid channel)"
+typedef   NWTC_Library  OutParmType         IntKi                          Indx             -     -  - "An index into AllOuts array where this channel is computed/stored"
+typedef     ^             ^                 CHARACTER(ChanLen)             Name             -     -  - "Name of the output channel"
+typedef     ^             ^                 CHARACTER(ChanLen)             Units            -     -  - "Units this channel is specified in"
+typedef     ^             ^                 IntKi                          SignM            -     -  - "Multiplier for output channel; usually -1 (minus) or 0 (invalid channel)"
 
-typedef   NWTC_Library  FileInfoType        IntKi                    NumLines
-typedef     ^             ^                 IntKi                    NumFiles
-typedef     ^             ^                 IntKi                    FileLine  {:}
-typedef     ^             ^                 IntKi                    FileIndx  {:}
+typedef   NWTC_Library  FileInfoType        IntKi                          NumLines
+typedef     ^             ^                 IntKi                          NumFiles
+typedef     ^             ^                 IntKi                          FileLine  {:}
+typedef     ^             ^                 IntKi                          FileIndx  {:}
 typedef     ^             ^                 CHARACTER(MaxFileInfoLineLen)  FileList  {:}
 typedef     ^             ^                 CHARACTER(MaxFileInfoLineLen)  Lines     {:}
 
-typedef   NWTC_Library  Quaternion          ReKi                     q0
-typedef     ^             ^                 ReKi                     v  {3}
+typedef   NWTC_Library  Quaternion          ReKi                           q0
+typedef     ^             ^                 ReKi                           v         {3}
 
-typedef   NWTC_Library  NWTC_RandomNumber_ParameterType   IntKi                pRNG
-typedef     ^             ^                     IntKi                RandSeed          {3}
-typedef     ^             ^                     IntKi                RandSeedAry       {:}
-typedef     ^             ^              CHARACTER(6)                RNG_type
+typedef   NWTC_Library  NWTC_RandomNumber_ParameterType   IntKi            pRNG
+typedef     ^             ^                               IntKi            RandSeed          {3}
+typedef     ^             ^                               IntKi            RandSeedAry       {:}
+typedef     ^             ^                        CHARACTER(6)            RNG_type
 
 #-------------------------------------------------------------------------------
 # Module Variables
@@ -138,17 +140,17 @@ typedef     ^             ^                 R8Ki                     distance   
 typedef     ^             ^                 R8Ki                     couple_arm        {3}       - - "Vector between a point and node 1 of an element (p_ODR - p_OSR)" m
 typedef     ^             ^                 R8Ki                     shape_fn          {2}       - - "shape functions: 1-D element-level location [0,1] based on closest-line projection of point" -
 
-typedef   NWTC_Library  MeshMapLinearizationType R8Ki                mi        {:}{:}  - -  "block matrix of motions that reflects identity (i.e., solely the mapping of one quantity to itself on another mesh)"
-typedef     ^             ^                 R8Ki                     fx_p      {:}{:}  - -  "block matrix of motions that reflects skew-symmetric (cross-product) matrix"
-typedef     ^             ^                 R8Ki                     tv_uD     {:}{:}  - -  "block matrix of translational velocity that is multiplied by destination translational displacement"
-typedef     ^             ^                 R8Ki                     tv_uS     {:}{:}  - -  "block matrix of translational velocity that is multiplied by source translational displacement"
-typedef     ^             ^                 R8Ki                     ta_uD     {:}{:}  - -  "block matrix of translational acceleration that is multiplied by destination translational displacement"
-typedef     ^             ^                 R8Ki                     ta_uS     {:}{:}  - -  "block matrix of translational acceleration that is multiplied by source translational displacement"
-typedef     ^             ^                 R8Ki                     ta_rv     {:}{:}  - -  "block matrix of translational acceleration that is multiplied by omega (RotationVel)"
-typedef     ^             ^                 R8Ki                     li        {:}{:}  - -  "block matrix of loads that reflects identity (i.e., solely the mapping on one quantity to itself on another mesh)"
-typedef     ^             ^                 R8Ki                     M_uS      {:}{:}  - -  "block matrix of moment that is multiplied by Source u (translationDisp)"
-typedef     ^             ^                 R8Ki                     M_uD      {:}{:}  - -  "block matrix of moment that is multiplied by Destination u (translationDisp)"
-typedef     ^             ^                 R8Ki                     M_f       {:}{:}  - -  "block matrix of moment that is multiplied by force"
+typedef   NWTC_Library  MeshMapLinearizationType R8Ki                mi                {:}{:}    - - "block matrix of motions that reflects identity (i.e., solely the mapping of one quantity to itself on another mesh)"
+typedef     ^             ^                 R8Ki                     fx_p              {:}{:}    - - "block matrix of motions that reflects skew-symmetric (cross-product) matrix"
+typedef     ^             ^                 R8Ki                     tv_uD             {:}{:}    - - "block matrix of translational velocity that is multiplied by destination translational displacement"
+typedef     ^             ^                 R8Ki                     tv_uS             {:}{:}    - - "block matrix of translational velocity that is multiplied by source translational displacement"
+typedef     ^             ^                 R8Ki                     ta_uD             {:}{:}    - - "block matrix of translational acceleration that is multiplied by destination translational displacement"
+typedef     ^             ^                 R8Ki                     ta_uS             {:}{:}    - - "block matrix of translational acceleration that is multiplied by source translational displacement"
+typedef     ^             ^                 R8Ki                     ta_rv             {:}{:}    - - "block matrix of translational acceleration that is multiplied by omega (RotationVel)"
+typedef     ^             ^                 R8Ki                     li                {:}{:}    - - "block matrix of loads that reflects identity (i.e., solely the mapping on one quantity to itself on another mesh)"
+typedef     ^             ^                 R8Ki                     M_uS              {:}{:}    - - "block matrix of moment that is multiplied by Source u (translationDisp)"
+typedef     ^             ^                 R8Ki                     M_uD              {:}{:}    - - "block matrix of moment that is multiplied by Destination u (translationDisp)"
+typedef     ^             ^                 R8Ki                     M_f               {:}{:}    - - "block matrix of moment that is multiplied by force"
 
 typedef   NWTC_Library  MeshMapType         MapType                  MapLoads          {:}       - - "mapping data structure for load fields on the mesh"
 typedef     ^               ^               MapType                  MapMotions        {:}       - - "mapping data structure for motion and/or scalar fields on the mesh"
@@ -160,6 +162,6 @@ typedef     ^               ^               R8Ki                     DisplacedPo
 typedef     ^               ^               R8Ki                     LoadLn2_A_Mat     {:}{:}    - - "The 3-components of the forces for each node of an element in the point-to-line load mapping (for each element)"
 typedef     ^               ^               R8Ki                     LoadLn2_F         {:}{:}    - - "The 6-by-6 matrix that makes up the diagonal of the [A 0; B A] matrix in the point-to-line load mapping"
 typedef     ^               ^               R8Ki                     LoadLn2_M         {:}{:}    - - "The 3-components of the moments for each node of an element in the point-to-line load mapping (for each element)"
-typedef     ^             ^                 MeshMapLinearizationType dM
-#typedef     ^               ^               MeshType                 Lumped_Points_Dest -        - - "temporary mesh for debugging the lumped values in the line2-to-line2"
+typedef     ^               ^               MeshMapLinearizationType dM
+#typedef    ^               ^               MeshType                 Lumped_Points_Dest -        - - "temporary mesh for debugging the lumped values in the line2-to-line2"
 

--- a/modules/nwtc-library/src/Registry_NWTC_Library_base.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library_base.txt
@@ -18,6 +18,8 @@ typedef     ^             ^                 DbKi                     TimeStep - 
 typedef     ^             ^                 CHARACTER(ChanLen)       ChanNames {:} - - "Strings describing the names of the channels from the binary file (including the time channel)"
 typedef     ^             ^                 CHARACTER(ChanLen)       ChanUnits {:} - - "Strings describing the units of the channels from the binary file (including the time channel)"
 typedef     ^             ^                 ReKi                     Data      {:}{:} - - "numeric data (rows and columns) from the binary file, including the time channel"
+typedef     ^             ^                 DbKi                     Time      {:}    - - "The time being output to the file (if using FileFmtID_WithoutTime [or FileFmtID_ChanLen]: element 1 is the first output time, element 2 is the delta t)"
+typedef     ^             ^                 IntKi                    OutputFileFmtID - - - "Identifier for file format (changes definition of Time field)"
 
 typedef   NWTC_Library  OutParmType         IntKi                    Indx   - - - "An index into AllOuts array where this channel is computed/stored"
 typedef     ^             ^                 CHARACTER(ChanLen)       Name   - - - "Name of the output channel"
@@ -34,7 +36,7 @@ typedef     ^             ^                 CHARACTER(MaxFileInfoLineLen)  Lines
 typedef   NWTC_Library  Quaternion          ReKi                     q0
 typedef     ^             ^                 ReKi                     v  {3}
 
-typedef   NWTC_Library  NWTC_RandomNumber_ParameterType   IntKi                pRNG
+typedef   NWTC_Library  NWTC_RandomNumber_ParameterType   IntKi      pRNG
 typedef     ^             ^                     IntKi                RandSeed          {3}
 typedef     ^             ^                     IntKi                RandSeedAry       {:}
 typedef     ^             ^              CHARACTER(6)                RNG_type

--- a/modules/nwtc-library/src/Registry_NWTC_Library_base.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library_base.txt
@@ -18,8 +18,6 @@ typedef     ^             ^                 DbKi                     TimeStep - 
 typedef     ^             ^                 CHARACTER(ChanLen)       ChanNames {:} - - "Strings describing the names of the channels from the binary file (including the time channel)"
 typedef     ^             ^                 CHARACTER(ChanLen)       ChanUnits {:} - - "Strings describing the units of the channels from the binary file (including the time channel)"
 typedef     ^             ^                 ReKi                     Data      {:}{:} - - "numeric data (rows and columns) from the binary file, including the time channel"
-typedef     ^             ^                 DbKi                     Time      {:}    - - "The time being output to the file (if using FileFmtID_WithoutTime [or FileFmtID_ChanLen]: element 1 is the first output time, element 2 is the delta t)"
-typedef     ^             ^                 IntKi                    OutputFileFmtID - - - "Identifier for file format (changes definition of Time field)"
 
 typedef   NWTC_Library  OutParmType         IntKi                    Indx   - - - "An index into AllOuts array where this channel is computed/stored"
 typedef     ^             ^                 CHARACTER(ChanLen)       Name   - - - "Name of the output channel"

--- a/modules/nwtc-library/src/Registry_NWTC_Library_mesh.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library_mesh.txt
@@ -8,7 +8,7 @@
 
 
 #BJJ: the following three types will actually be placed in the ModMesh_Mapping.f90 file instead of NWTC_Library_Types.f90
-typedef   NWTC_Library  MapType             IntKi                    OtherMesh_Element  -        - - "Node (for point meshes) or Element (for line2 meshes) number on other mesh; for loads, other mesh is Dest, for motions/scalars, other mesh is Src"
+typedef   NWTC_Library  MapType             IntKi                    OtherMesh_Element  -        - - "Node (for point meshes) or Element (for line2 meshes) number on other mesh; for loads, other mesh is Dest, for motions/scalars, other mesh is Src" -
 typedef     ^             ^                 R8Ki                     distance           -        - - "Magnitude of couple_arm" m
 typedef     ^             ^                 R8Ki                     couple_arm        {3}       - - "Vector between a point and node 1 of an element (p_ODR - p_OSR)" m
 typedef     ^             ^                 R8Ki                     shape_fn          {2}       - - "shape functions: 1-D element-level location [0,1] based on closest-line projection of point" -

--- a/modules/nwtc-library/src/SingPrec.f90
+++ b/modules/nwtc-library/src/SingPrec.f90
@@ -56,6 +56,9 @@ INTEGER, PARAMETER              :: R8Ki     = SELECTED_REAL_KIND( 14, 300 )     
 
 #endif
 
+INTEGER, PARAMETER              :: BYTES_IN_B4Ki =  4                           !< Number of bytes per B4Ki number
+INTEGER, PARAMETER              :: BYTES_IN_B8Ki =  8                           !< Number of bytes per B8Ki number 
+
 INTEGER, PARAMETER              :: BYTES_IN_R4Ki =  4                           !< Number of bytes per R4Ki number
 INTEGER, PARAMETER              :: BYTES_IN_R8Ki =  8                           !< Number of bytes per R8Ki number 
 
@@ -64,7 +67,7 @@ INTEGER, PARAMETER              :: BYTES_IN_R8Ki =  8                           
       ! The default kinds for reals and integers, and the number of bytes they contain:
 
 INTEGER, PARAMETER              :: IntKi          = B4Ki                        !< Default kind for integers
-INTEGER, PARAMETER              :: BYTES_IN_INT   = 4                           !< Number of bytes per IntKi number    - use SIZEOF()
+INTEGER, PARAMETER              :: BYTES_IN_INT   = BYTES_IN_B4Ki               !< Number of bytes per IntKi number    - use SIZEOF()
 
 INTEGER, PARAMETER              :: SiKi           = R4Ki                        !< Default kind for single floating-point numbers
 INTEGER, PARAMETER              :: BYTES_IN_SiKi  = BYTES_IN_R4Ki               !< Number of bytes per R4Ki number     - use SIZEOF()

--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -134,17 +134,10 @@ subroutine FAST_Sizes(iTurb_c, InputFileName_c, AbortErrLev_c, NumOuts_c, dt_c, 
       ExternInitData%TurbinePos = 0.0_ReKi  ! turbine position is at the origin
       ExternInitData%NumCtrl2SC = 0
       ExternInitData%NumSC2Ctrl = 0
-      ExternInitData%SensorType = NINT(InitInpAry(1))
       ! -- MATLAB Integration --
       ! Make sure fast farm integration is false
       ExternInitData%FarmIntegration = .false.
       ExternInitData%WaveFieldMod = 0
-
-      IF ( NINT(InitInpAry(2)) == 1 ) THEN
-         ExternInitData%LidRadialVel = .true.
-      ELSE
-         ExternInitData%LidRadialVel = .false.
-      END IF
 
       CALL FAST_InitializeAll_T( t_initial, iTurb, Turbine(iTurb), ErrStat, ErrMsg, InputFileName, ExternInitData)
 
@@ -591,7 +584,6 @@ subroutine FAST_ExtLoads_Init(iTurb_c, TMax, InputFileName_c, TurbIDforName, Out
    ExternInitData%TMax = TMax
    ExternInitData%TurbIDforName = TurbIDforName
    ExternInitData%TurbinePos = TurbPosn
-   ExternInitData%SensorType = SensorType_None
    ExternInitData%NumSC2CtrlGlob = 0
    ExternInitData%NumCtrl2SC = 0
    ExternInitData%NumSC2Ctrl = 0
@@ -707,7 +699,6 @@ subroutine FAST_ExtInfw_Init(iTurb_c, TMax, InputFileName_c, TurbIDforName, OutF
    ExternInitData%TMax = TMax
    ExternInitData%TurbIDforName = TurbIDforName
    ExternInitData%TurbinePos = TurbPosn
-   ExternInitData%SensorType = SensorType_None
    ExternInitData%NumCtrl2SC = NumCtrl2SC
    ExternInitData%NumSC2CtrlGlob = NumSC2CtrlGlob
 

--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -62,8 +62,6 @@ EXTERNAL_ROUTINE void FAST_CreateCheckpoint(int * iTurb, const char *CheckpointR
 #define ErrID_Fatal 4 
 
 
-#define SensorType_None -1
-
 // make sure these parameters match with FAST_Library.f90 and NWTC_Base.f90
 #define MAXIMUM_BLADES 3
 #define MAXIMUM_AFCTRL 3

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -869,8 +869,6 @@ typedef   ^   FAST_InitData    IceD_InitOutputType         OutData_IceD     -  -
 
 # ..... FAST External Initialization Input data .......................................................................................................
 typedef	^	FAST_ExternInitType	DbKi	Tmax	-	-1	-	"External code specified Tmax"	s
-typedef	^	FAST_ExternInitType	IntKi	SensorType	-	SensorType_None	-	"lidar sensor type, which should not be pulsed at the moment; this input should be replaced with a section in the InflowWind input file"	-
-typedef	^	FAST_ExternInitType	LOGICAL	LidRadialVel	-	-	-	"TRUE => return radial component, FALSE => return 'x' direction estimate"	-
 typedef	^	FAST_ExternInitType	IntKi	TurbIDforName	-	-1	-	"ID number for turbine (used to create output file naming convention)"	-
 typedef	^	FAST_ExternInitType	ReKi	TurbinePos	{3}	-	-	"Initial position of turbine base (origin used for graphics or in FAST.Farm)"	m
 typedef ^   FAST_ExternInitType IntKi   WaveFieldMod -  -   -   "Wave field handling (-) (switch) 0: use individual HydroDyn inputs without adjustment, 1: adjust wave phases based on turbine offsets from farm origin"   -

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -135,7 +135,7 @@ typedef	^	FAST_ParameterType	IntKi	CompAero	-	-	-	"Compute aerodynamic loads (sw
 typedef	^	FAST_ParameterType	IntKi	CompServo	-	-	-	"Compute control and electrical-drive dynamics (switch) {Module_None; Module_SrvD}"	-
 typedef	^	FAST_ParameterType	IntKi	CompSeaSt   -	-	-	"Compute sea states; wave kinematics (switch) {Module_None; Module_SeaSt}"	-
 typedef	^	FAST_ParameterType	IntKi	CompHydro	-	-	-	"Compute hydrodynamic loads (switch) {Module_None; Module_HD}"	-
-typedef	^	FAST_ParameterType	IntKi	CompSub	-	-	-	"Compute sub-structural dynamics (switch) {Module_None; Module_HD}"	-
+typedef	^	FAST_ParameterType	IntKi	CompSub	-	-	-	"Compute sub-structural dynamics (switch) {Module_None; Module_SD, Module_ExtPtfm}"	-
 typedef	^	FAST_ParameterType	IntKi	CompMooring	-	-	-	"Compute mooring system (switch) {Module_None; Module_MAP; Module_FEAM; Module_MD; Module_Orca}"	-
 typedef	^	FAST_ParameterType	IntKi	CompIce	-	-	-	"Compute ice loading (switch) {Module_None; Module_IceF, Module_IceD}"	-
 typedef	^	FAST_ParameterType	IntKi	MHK	        -	-	-	"MHK turbine type (switch) {0=Not an MHK turbine; 1=Fixed MHK turbine; 2=Floating MHK turbine}"	-

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -547,34 +547,6 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
          RETURN
       END IF
 
-      IF ( p_FAST%CompServo == Module_SrvD ) THEN !assign the number of gates to ServD
-         if (allocated(IfW%y%lidar%LidSpeed)) then    ! make sure we have the array allocated before setting it
-            CALL AllocAry(Init%InData_SrvD%LidSpeed, size(IfW%y%lidar%LidSpeed), 'Init%InData_SrvD%LidSpeed',     errStat2, ErrMsg2)
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-            Init%InData_SrvD%LidSpeed = IfW%y%lidar%LidSpeed
-         endif
-         if (allocated(IfW%y%lidar%MsrPositionsX)) then    ! make sure we have the array allocated before setting it
-            CALL AllocAry(Init%InData_SrvD%MsrPositionsX, size(IfW%y%lidar%MsrPositionsX), 'Init%InData_SrvD%MsrPositionsX',     errStat2, ErrMsg2)
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-            Init%InData_SrvD%MsrPositionsX = IfW%y%lidar%MsrPositionsX
-         endif
-         if (allocated(IfW%y%lidar%MsrPositionsY)) then    ! make sure we have the array allocated before setting it
-            CALL AllocAry(Init%InData_SrvD%MsrPositionsY, size(IfW%y%lidar%MsrPositionsY), 'Init%InData_SrvD%MsrPositionsY',     errStat2, ErrMsg2)
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-            Init%InData_SrvD%MsrPositionsY = IfW%y%lidar%MsrPositionsY
-         endif
-         if (allocated(IfW%y%lidar%MsrPositionsZ)) then    ! make sure we have the array allocated before setting it
-            CALL AllocAry(Init%InData_SrvD%MsrPositionsZ, size(IfW%y%lidar%MsrPositionsZ), 'Init%InData_SrvD%MsrPositionsZ',     errStat2, ErrMsg2)
-            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
-            Init%InData_SrvD%MsrPositionsZ = IfW%y%lidar%MsrPositionsZ
-         endif
-         Init%InData_SrvD%SensorType    = IfW%p%lidar%SensorType
-         Init%InData_SrvD%NumBeam       = IfW%p%lidar%NumBeam
-         Init%InData_SrvD%NumPulseGate  = IfW%p%lidar%NumPulseGate
-         Init%InData_SrvD%PulseSpacing  = IfW%p%lidar%PulseSpacing
-      END IF
-
-
    ELSEIF ( p_FAST%CompInflow == Module_ExtInfw ) THEN
 
       IF ( PRESENT(ExternInitData) ) THEN
@@ -1572,6 +1544,34 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
          Init%InData_SrvD%NumCtrl2SC = 0
       END IF
 
+      IF ( p_FAST%CompInflow == Module_IfW ) THEN !assign the number of gates to ServD
+         if (allocated(IfW%y%lidar%LidSpeed)) then    ! make sure we have the array allocated before setting it
+            CALL AllocAry(Init%InData_SrvD%LidSpeed, size(IfW%y%lidar%LidSpeed), 'Init%InData_SrvD%LidSpeed',     errStat2, ErrMsg2)
+            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+            Init%InData_SrvD%LidSpeed = IfW%y%lidar%LidSpeed
+         endif
+         if (allocated(IfW%y%lidar%MsrPositionsX)) then    ! make sure we have the array allocated before setting it
+            CALL AllocAry(Init%InData_SrvD%MsrPositionsX, size(IfW%y%lidar%MsrPositionsX), 'Init%InData_SrvD%MsrPositionsX',     errStat2, ErrMsg2)
+            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+            Init%InData_SrvD%MsrPositionsX = IfW%y%lidar%MsrPositionsX
+         endif
+         if (allocated(IfW%y%lidar%MsrPositionsY)) then    ! make sure we have the array allocated before setting it
+            CALL AllocAry(Init%InData_SrvD%MsrPositionsY, size(IfW%y%lidar%MsrPositionsY), 'Init%InData_SrvD%MsrPositionsY',     errStat2, ErrMsg2)
+            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+            Init%InData_SrvD%MsrPositionsY = IfW%y%lidar%MsrPositionsY
+         endif
+         if (allocated(IfW%y%lidar%MsrPositionsZ)) then    ! make sure we have the array allocated before setting it
+            CALL AllocAry(Init%InData_SrvD%MsrPositionsZ, size(IfW%y%lidar%MsrPositionsZ), 'Init%InData_SrvD%MsrPositionsZ',     errStat2, ErrMsg2)
+            CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
+            Init%InData_SrvD%MsrPositionsZ = IfW%y%lidar%MsrPositionsZ
+         endif
+         Init%InData_SrvD%SensorType    = IfW%p%lidar%SensorType
+         Init%InData_SrvD%NumBeam       = IfW%p%lidar%NumBeam
+         Init%InData_SrvD%NumPulseGate  = IfW%p%lidar%NumPulseGate
+         Init%InData_SrvD%PulseSpacing  = IfW%p%lidar%PulseSpacing
+      END IF
+
+      
       ! Set cable controls inputs (if requested by other modules)  -- There is probably a nicer way to do this, but this will work for now.
       call SetSrvDCableControls()
 

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -880,8 +880,6 @@ IMPLICIT NONE
 ! =========  FAST_ExternInitType  =======
   TYPE, PUBLIC :: FAST_ExternInitType
     REAL(DbKi)  :: Tmax = -1      !< External code specified Tmax [s]
-    INTEGER(IntKi)  :: SensorType = SensorType_None      !< lidar sensor type, which should not be pulsed at the moment; this input should be replaced with a section in the InflowWind input file [-]
-    LOGICAL  :: LidRadialVel = .false.      !< TRUE => return radial component, FALSE => return 'x' direction estimate [-]
     INTEGER(IntKi)  :: TurbIDforName = -1      !< ID number for turbine (used to create output file naming convention) [-]
     REAL(ReKi) , DIMENSION(1:3)  :: TurbinePos = 0.0_ReKi      !< Initial position of turbine base (origin used for graphics or in FAST.Farm) [m]
     INTEGER(IntKi)  :: WaveFieldMod = 0_IntKi      !< Wave field handling (-) (switch) 0: use individual HydroDyn inputs without adjustment, 1: adjust wave phases based on turbine offsets from farm origin [-]
@@ -15212,8 +15210,6 @@ subroutine FAST_CopyExternInitType(SrcExternInitTypeData, DstExternInitTypeData,
    ErrStat = ErrID_None
    ErrMsg  = ''
    DstExternInitTypeData%Tmax = SrcExternInitTypeData%Tmax
-   DstExternInitTypeData%SensorType = SrcExternInitTypeData%SensorType
-   DstExternInitTypeData%LidRadialVel = SrcExternInitTypeData%LidRadialVel
    DstExternInitTypeData%TurbIDforName = SrcExternInitTypeData%TurbIDforName
    DstExternInitTypeData%TurbinePos = SrcExternInitTypeData%TurbinePos
    DstExternInitTypeData%WaveFieldMod = SrcExternInitTypeData%WaveFieldMod
@@ -15286,8 +15282,6 @@ subroutine FAST_PackExternInitType(RF, Indata)
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
    call RegPack(RF, InData%Tmax)
-   call RegPack(RF, InData%SensorType)
-   call RegPack(RF, InData%LidRadialVel)
    call RegPack(RF, InData%TurbIDforName)
    call RegPack(RF, InData%TurbinePos)
    call RegPack(RF, InData%WaveFieldMod)
@@ -15327,8 +15321,6 @@ subroutine FAST_UnPackExternInitType(RF, OutData)
    type(c_ptr)     :: Ptr
    if (RF%ErrStat /= ErrID_None) return
    call RegUnpack(RF, OutData%Tmax); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%SensorType); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%LidRadialVel); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%TurbIDforName); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%TurbinePos); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%WaveFieldMod); if (RegCheckErr(RF, RoutineName)) return

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -153,7 +153,7 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: CompServo = 0_IntKi      !< Compute control and electrical-drive dynamics (switch) {Module_None; Module_SrvD} [-]
     INTEGER(IntKi)  :: CompSeaSt = 0_IntKi      !< Compute sea states; wave kinematics (switch) {Module_None; Module_SeaSt} [-]
     INTEGER(IntKi)  :: CompHydro = 0_IntKi      !< Compute hydrodynamic loads (switch) {Module_None; Module_HD} [-]
-    INTEGER(IntKi)  :: CompSub = 0_IntKi      !< Compute sub-structural dynamics (switch) {Module_None; Module_HD} [-]
+    INTEGER(IntKi)  :: CompSub = 0_IntKi      !< Compute sub-structural dynamics (switch) {Module_None; Module_SD, Module_ExtPtfm} [-]
     INTEGER(IntKi)  :: CompMooring = 0_IntKi      !< Compute mooring system (switch) {Module_None; Module_MAP; Module_FEAM; Module_MD; Module_Orca} [-]
     INTEGER(IntKi)  :: CompIce = 0_IntKi      !< Compute ice loading (switch) {Module_None; Module_IceF, Module_IceD} [-]
     INTEGER(IntKi)  :: MHK = 0_IntKi      !< MHK turbine type (switch) {0=Not an MHK turbine; 1=Fixed MHK turbine; 2=Floating MHK turbine} [-]

--- a/modules/servodyn/src/ServoDyn_Registry.txt
+++ b/modules/servodyn/src/ServoDyn_Registry.txt
@@ -540,7 +540,7 @@ typedef	^	InputType	ReKi	LSShftFys	-	-	-	"Nonrotating low-speed shaft force y"	N
 typedef	^	InputType	ReKi	LSShftFzs	-	-	-	"Nonrotating low-speed shaft force z"	N
 typedef	^	InputType	SiKi	fromSC	{:}	-	-	"A swap array: used to pass turbine specific input data to the DLL controller from the supercontroller"	-
 typedef	^	InputType	SiKi	fromSCglob	{:}	-	-	"A swap array: used to pass global input data to the DLL controller from the supercontroller"	-
-typedef	^	InputType	SiKi	Lidar	{:}	-	-	"A swap array: used to pass input data to the DLL controller from the Lidar"	-
+#typedef	^	InputType	SiKi	Lidar	{:}	-	-	"A swap array: used to pass input data to the DLL controller from the Lidar"	-
 typedef	^	InputType	MeshType	PtfmMotionMesh	-	-	-	"Platform motion mesh at platform reference point" -
 typedef	^	InputType	MeshType	BStCMotionMesh	{:}{:}	-	-	"StC module blade        input motion mesh" -
 typedef	^	InputType	MeshType	NStCMotionMesh	{:}	-	-	"StC module nacelle      input motion mesh" -
@@ -566,7 +566,7 @@ typedef	^	OutputType	ReKi	GenTrq	-	-	-	"Electrical generator torque"	N-m
 typedef	^	OutputType	ReKi	HSSBrTrqC	-	-	-	"Commanded HSS brake torque"	N-m
 typedef	^	OutputType	ReKi	ElecPwr	-	-	-	"Electrical power"	W
 typedef	^	OutputType	ReKi	TBDrCon	{:}	-	-	"Instantaneous tip-brake drag constant, Cd*Area"
-typedef	^	OutputType	SiKi	Lidar	{:}	-	-	"A swap array: used to pass output data from the DLL controller to the Lidar"	-
+#typedef	^	OutputType	SiKi	Lidar	{:}	-	-	"A swap array: used to pass output data from the DLL controller to the Lidar"	-
 typedef	^	OutputType	ReKi	CableDeltaL	{:}	-	-	"Cable control -- Length change request (passed to MD or SD)"	m
 typedef	^	OutputType	ReKi	CableDeltaLdot	{:}	-	-	"Cable control -- Length change rate request (passed to MD or SD)"	m/s
 typedef	^	OutputType	MeshType	BStCLoadMesh	{:}{:}	-	-	"StC module blade        output load mesh (NumBl,NumBStC)" -

--- a/modules/servodyn/src/ServoDyn_Types.f90
+++ b/modules/servodyn/src/ServoDyn_Types.f90
@@ -545,7 +545,6 @@ IMPLICIT NONE
     REAL(ReKi)  :: LSShftFzs = 0.0_ReKi      !< Nonrotating low-speed shaft force z [N]
     REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: fromSC      !< A swap array: used to pass turbine specific input data to the DLL controller from the supercontroller [-]
     REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: fromSCglob      !< A swap array: used to pass global input data to the DLL controller from the supercontroller [-]
-    REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: Lidar      !< A swap array: used to pass input data to the DLL controller from the Lidar [-]
     TYPE(MeshType)  :: PtfmMotionMesh      !< Platform motion mesh at platform reference point [-]
     TYPE(MeshType) , DIMENSION(:,:), ALLOCATABLE  :: BStCMotionMesh      !< StC module blade        input motion mesh [-]
     TYPE(MeshType) , DIMENSION(:), ALLOCATABLE  :: NStCMotionMesh      !< StC module nacelle      input motion mesh [-]
@@ -569,7 +568,6 @@ IMPLICIT NONE
     REAL(ReKi)  :: HSSBrTrqC = 0.0_ReKi      !< Commanded HSS brake torque [N-m]
     REAL(ReKi)  :: ElecPwr = 0.0_ReKi      !< Electrical power [W]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TBDrCon      !< Instantaneous tip-brake drag constant, Cd*Area [-]
-    REAL(SiKi) , DIMENSION(:), ALLOCATABLE  :: Lidar      !< A swap array: used to pass output data from the DLL controller to the Lidar [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: CableDeltaL      !< Cable control -- Length change request (passed to MD or SD) [m]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: CableDeltaLdot      !< Cable control -- Length change rate request (passed to MD or SD) [m/s]
     TYPE(MeshType) , DIMENSION(:,:), ALLOCATABLE  :: BStCLoadMesh      !< StC module blade        output load mesh (NumBl,NumBStC) [-]
@@ -5564,18 +5562,6 @@ subroutine SrvD_CopyInput(SrcInputData, DstInputData, CtrlCode, ErrStat, ErrMsg)
       end if
       DstInputData%fromSCglob = SrcInputData%fromSCglob
    end if
-   if (allocated(SrcInputData%Lidar)) then
-      LB(1:1) = lbound(SrcInputData%Lidar, kind=B8Ki)
-      UB(1:1) = ubound(SrcInputData%Lidar, kind=B8Ki)
-      if (.not. allocated(DstInputData%Lidar)) then
-         allocate(DstInputData%Lidar(LB(1):UB(1)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstInputData%Lidar.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstInputData%Lidar = SrcInputData%Lidar
-   end if
    call MeshCopy(SrcInputData%PtfmMotionMesh, DstInputData%PtfmMotionMesh, CtrlCode, ErrStat2, ErrMsg2 )
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
@@ -5727,9 +5713,6 @@ subroutine SrvD_DestroyInput(InputData, ErrStat, ErrMsg)
    if (allocated(InputData%fromSCglob)) then
       deallocate(InputData%fromSCglob)
    end if
-   if (allocated(InputData%Lidar)) then
-      deallocate(InputData%Lidar)
-   end if
    call MeshDestroy( InputData%PtfmMotionMesh, ErrStat2, ErrMsg2)
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
    if (allocated(InputData%BStCMotionMesh)) then
@@ -5832,7 +5815,6 @@ subroutine SrvD_PackInput(RF, Indata)
    call RegPack(RF, InData%LSShftFzs)
    call RegPackAlloc(RF, InData%fromSC)
    call RegPackAlloc(RF, InData%fromSCglob)
-   call RegPackAlloc(RF, InData%Lidar)
    call MeshPack(RF, InData%PtfmMotionMesh) 
    call RegPack(RF, allocated(InData%BStCMotionMesh))
    if (allocated(InData%BStCMotionMesh)) then
@@ -5929,7 +5911,6 @@ subroutine SrvD_UnPackInput(RF, OutData)
    call RegUnpack(RF, OutData%LSShftFzs); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%fromSC); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%fromSCglob); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%Lidar); if (RegCheckErr(RF, RoutineName)) return
    call MeshUnpack(RF, OutData%PtfmMotionMesh) ! PtfmMotionMesh 
    if (allocated(OutData%BStCMotionMesh)) deallocate(OutData%BStCMotionMesh)
    call RegUnpack(RF, IsAllocAssoc); if (RegCheckErr(RF, RoutineName)) return
@@ -6058,18 +6039,6 @@ subroutine SrvD_CopyOutput(SrcOutputData, DstOutputData, CtrlCode, ErrStat, ErrM
       end if
       DstOutputData%TBDrCon = SrcOutputData%TBDrCon
    end if
-   if (allocated(SrcOutputData%Lidar)) then
-      LB(1:1) = lbound(SrcOutputData%Lidar, kind=B8Ki)
-      UB(1:1) = ubound(SrcOutputData%Lidar, kind=B8Ki)
-      if (.not. allocated(DstOutputData%Lidar)) then
-         allocate(DstOutputData%Lidar(LB(1):UB(1)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstOutputData%Lidar.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstOutputData%Lidar = SrcOutputData%Lidar
-   end if
    if (allocated(SrcOutputData%CableDeltaL)) then
       LB(1:1) = lbound(SrcOutputData%CableDeltaL, kind=B8Ki)
       UB(1:1) = ubound(SrcOutputData%CableDeltaL, kind=B8Ki)
@@ -6197,9 +6166,6 @@ subroutine SrvD_DestroyOutput(OutputData, ErrStat, ErrMsg)
    if (allocated(OutputData%TBDrCon)) then
       deallocate(OutputData%TBDrCon)
    end if
-   if (allocated(OutputData%Lidar)) then
-      deallocate(OutputData%Lidar)
-   end if
    if (allocated(OutputData%CableDeltaL)) then
       deallocate(OutputData%CableDeltaL)
    end if
@@ -6266,7 +6232,6 @@ subroutine SrvD_PackOutput(RF, Indata)
    call RegPack(RF, InData%HSSBrTrqC)
    call RegPack(RF, InData%ElecPwr)
    call RegPackAlloc(RF, InData%TBDrCon)
-   call RegPackAlloc(RF, InData%Lidar)
    call RegPackAlloc(RF, InData%CableDeltaL)
    call RegPackAlloc(RF, InData%CableDeltaLdot)
    call RegPack(RF, allocated(InData%BStCLoadMesh))
@@ -6330,7 +6295,6 @@ subroutine SrvD_UnPackOutput(RF, OutData)
    call RegUnpack(RF, OutData%HSSBrTrqC); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%ElecPwr); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%TBDrCon); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%Lidar); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%CableDeltaL); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%CableDeltaLdot); if (RegCheckErr(RF, RoutineName)) return
    if (allocated(OutData%BStCLoadMesh)) deallocate(OutData%BStCLoadMesh)
@@ -6548,9 +6512,6 @@ SUBROUTINE SrvD_Input_ExtrapInterp1(u1, u2, tin, u_out, tin_out, ErrStat, ErrMsg
    IF (ALLOCATED(u_out%fromSCglob) .AND. ALLOCATED(u1%fromSCglob)) THEN
       u_out%fromSCglob = a1*u1%fromSCglob + a2*u2%fromSCglob
    END IF ! check if allocated
-   IF (ALLOCATED(u_out%Lidar) .AND. ALLOCATED(u1%Lidar)) THEN
-      u_out%Lidar = a1*u1%Lidar + a2*u2%Lidar
-   END IF ! check if allocated
    CALL MeshExtrapInterp1(u1%PtfmMotionMesh, u2%PtfmMotionMesh, tin, u_out%PtfmMotionMesh, tin_out, ErrStat2, ErrMsg2)
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg,RoutineName)
    IF (ALLOCATED(u_out%BStCMotionMesh) .AND. ALLOCATED(u1%BStCMotionMesh)) THEN
@@ -6708,9 +6669,6 @@ SUBROUTINE SrvD_Input_ExtrapInterp2(u1, u2, u3, tin, u_out, tin_out, ErrStat, Er
    END IF ! check if allocated
    IF (ALLOCATED(u_out%fromSCglob) .AND. ALLOCATED(u1%fromSCglob)) THEN
       u_out%fromSCglob = a1*u1%fromSCglob + a2*u2%fromSCglob + a3*u3%fromSCglob
-   END IF ! check if allocated
-   IF (ALLOCATED(u_out%Lidar) .AND. ALLOCATED(u1%Lidar)) THEN
-      u_out%Lidar = a1*u1%Lidar + a2*u2%Lidar + a3*u3%Lidar
    END IF ! check if allocated
    CALL MeshExtrapInterp2(u1%PtfmMotionMesh, u2%PtfmMotionMesh, u3%PtfmMotionMesh, tin, u_out%PtfmMotionMesh, tin_out, ErrStat2, ErrMsg2)
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg,RoutineName)
@@ -6873,9 +6831,6 @@ SUBROUTINE SrvD_Output_ExtrapInterp1(y1, y2, tin, y_out, tin_out, ErrStat, ErrMs
    IF (ALLOCATED(y_out%TBDrCon) .AND. ALLOCATED(y1%TBDrCon)) THEN
       y_out%TBDrCon = a1*y1%TBDrCon + a2*y2%TBDrCon
    END IF ! check if allocated
-   IF (ALLOCATED(y_out%Lidar) .AND. ALLOCATED(y1%Lidar)) THEN
-      y_out%Lidar = a1*y1%Lidar + a2*y2%Lidar
-   END IF ! check if allocated
    IF (ALLOCATED(y_out%CableDeltaL) .AND. ALLOCATED(y1%CableDeltaL)) THEN
       y_out%CableDeltaL = a1*y1%CableDeltaL + a2*y2%CableDeltaL
    END IF ! check if allocated
@@ -6989,9 +6944,6 @@ SUBROUTINE SrvD_Output_ExtrapInterp2(y1, y2, y3, tin, y_out, tin_out, ErrStat, E
    y_out%ElecPwr = a1*y1%ElecPwr + a2*y2%ElecPwr + a3*y3%ElecPwr
    IF (ALLOCATED(y_out%TBDrCon) .AND. ALLOCATED(y1%TBDrCon)) THEN
       y_out%TBDrCon = a1*y1%TBDrCon + a2*y2%TBDrCon + a3*y3%TBDrCon
-   END IF ! check if allocated
-   IF (ALLOCATED(y_out%Lidar) .AND. ALLOCATED(y1%Lidar)) THEN
-      y_out%Lidar = a1*y1%Lidar + a2*y2%Lidar + a3*y3%Lidar
    END IF ! check if allocated
    IF (ALLOCATED(y_out%CableDeltaL) .AND. ALLOCATED(y1%CableDeltaL)) THEN
       y_out%CableDeltaL = a1*y1%CableDeltaL + a2*y2%CableDeltaL + a3*y3%CableDeltaL

--- a/vs-build/FASTlib/FASTlib.vfproj
+++ b/vs-build/FASTlib/FASTlib.vfproj
@@ -505,7 +505,46 @@
 				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat AeroDisk" Description="Running Registry for AeroDisk" Outputs="..\..\modules\aerodisk\src\AeroDisk_Types.f90"/></FileConfiguration></File></Filter>
 		<File RelativePath="..\..\modules\aerodisk\src\AeroDisk.f90"/>
 		<File RelativePath="..\..\modules\aerodisk\src\AeroDisk_IO.f90"/>
-		<File RelativePath="..\..\modules\aerodisk\src\AeroDisk_Output_Params.f90"/></Filter></Filter>
+		<File RelativePath="..\..\modules\aerodisk\src\AeroDisk_Output_Params.f90"/></Filter>
+		<Filter Name="ExtLoads">
+		<Filter Name="RegistryFiles">
+		<File RelativePath="..\..\modules\extloads\src\ExtLoads_Registry.txt">
+			<FileConfiguration Name="Debug_Double|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_OpenMP|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Double|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_OpenMP|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Matlab|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Double|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Matlab|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Matlab|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Double|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Matlab|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration></File>
+		<File RelativePath="..\..\modules\extloads\src\ExtLoads_Types.f90"/>
+		<File RelativePath="..\..\modules\extloads\src\ExtLoadsDX_Registry.txt">
+			<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoadsDX" Description="Running Registry for ExtLoadsDX" Outputs="..\..\modules\extloads\src\ExtLoadsDX_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoadsDX" Description="Running Registry for ExtLoadsDX" Outputs="..\..\modules\extloads\src\ExtLoadsDX_Types.f90"/></FileConfiguration></File>
+		<File RelativePath="..\..\modules\extloads\src\ExtLoadsDX_Types.f90"/></Filter>
+		<File RelativePath="..\..\modules\extloads\src\ExtLoads.f90"/></Filter></Filter>
 		<Filter Name="BeamDyn">
 		<Filter Name="RegistryFiles">
 		<File RelativePath="..\..\modules\beamdyn\src\BeamDyn_Types.f90">
@@ -594,128 +633,6 @@
 		<File RelativePath="..\..\modules\elastodyn\src\ElastoDyn.f90"/>
 		<File RelativePath="..\..\modules\elastodyn\src\ElastoDyn_AllBldNdOuts_IO.f90"/>
 		<File RelativePath="..\..\modules\elastodyn\src\ElastoDyn_IO.f90"/></Filter>
-		<Filter Name="External Platform">
-		<Filter Name="RegistryFiles">
-		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF_Registry.txt">
-			<FileConfiguration Name="Debug_Double|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_OpenMP|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Double|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_OpenMP|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Double|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Matlab|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Double|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Matlab|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Matlab|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Matlab|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration></File>
-		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90">
-			<FileConfiguration Name="Debug_Double|Win32">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Double|x64">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
-		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF.f90"/>
-		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF_IO.f90"/></Filter>
-		<Filter Name="ExternalInflow Integration">
-		<Filter Name="RegistryFiles">
-		<File RelativePath="..\..\modules\externalinflow\src\ExternalInflow_Registry.txt">
-			<FileConfiguration Name="Debug_Double|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_OpenMP|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Double|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_OpenMP|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Double|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Matlab|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Double|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Matlab|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Matlab|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Matlab|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration></File>
-		<File RelativePath="..\..\modules\externalinflow\src\ExternalInflow_Types.f90">
-			<FileConfiguration Name="Debug_Double|Win32">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Double|x64">
-				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
-		<File RelativePath="..\..\modules\externalinflow\src\ExternalInflow.f90"/></Filter>
-		<Filter Name="ExtLoads">
-		<Filter Name="RegistryFiles">
-		<File RelativePath="..\..\modules\extloads\src\ExtLoads_Registry.txt">
-			<FileConfiguration Name="Debug_Double|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_OpenMP|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Double|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_OpenMP|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Matlab|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Double|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug_Matlab|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Matlab|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Double|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Release_Matlab|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoads" Description="Running Registry for ExtLoads" Outputs="..\..\modules\extloads\src\ExtLoads_Types.f90"/></FileConfiguration></File>
-		<File RelativePath="..\..\modules\extloads\src\ExtLoads_Types.f90"/>
-		<File RelativePath="..\..\modules\extloads\src\ExtLoadsDX_Registry.txt">
-			<FileConfiguration Name="Debug|Win32">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoadsDX" Description="Running Registry for ExtLoadsDX" Outputs="..\..\modules\extloads\src\ExtLoadsDX_Types.f90"/></FileConfiguration>
-			<FileConfiguration Name="Debug|x64">
-				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtLoadsDX" Description="Running Registry for ExtLoadsDX" Outputs="..\..\modules\extloads\src\ExtLoadsDX_Types.f90"/></FileConfiguration></File>
-		<File RelativePath="..\..\modules\extloads\src\ExtLoadsDX_Types.f90"/></Filter>
-		<File RelativePath="..\..\modules\extloads\src\ExtLoads.f90"/></Filter>
 		<Filter Name="FAST">
 		<Filter Name="RegistryFiles">
 		<File RelativePath="..\..\modules\openfast-library\src\FAST_Registry.txt">
@@ -1137,6 +1054,48 @@
 		<File RelativePath="..\..\modules\icefloe\src\icefloe\intermittentCrushing.F90"/>
 		<File RelativePath="..\..\modules\icefloe\src\icefloe\lockInISO.F90"/>
 		<File RelativePath="..\..\modules\icefloe\src\icefloe\randomCrushing.F90"/></Filter></Filter>
+		<Filter Name="Inflow">
+		<Filter Name="ExternalInflow Integration">
+		<Filter Name="RegistryFiles">
+		<File RelativePath="..\..\modules\externalinflow\src\ExternalInflow_Registry.txt">
+			<FileConfiguration Name="Debug_Double|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_OpenMP|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Double|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_OpenMP|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Double|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Matlab|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Double|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Matlab|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Matlab|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Matlab|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExternalInflow" Description="Running Registry for ExternalInflow" Outputs="..\..\modules\externalinflow\src\ExternalInflow_Types.f90"/></FileConfiguration></File>
+		<File RelativePath="..\..\modules\externalinflow\src\ExternalInflow_Types.f90">
+			<FileConfiguration Name="Debug_Double|Win32">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
+			<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Double|x64">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
+		<File RelativePath="..\..\modules\externalinflow\src\ExternalInflow.f90"/></Filter>
 		<Filter Name="InflowWind">
 		<Filter Name="RegistryFiles">
 		<File RelativePath="..\..\modules\inflowwind\src\IfW_FlowField.txt">
@@ -1295,7 +1254,7 @@
 		<File RelativePath="..\..\modules\inflowwind\src\InflowWind.f90"/>
 		<File RelativePath="..\..\modules\inflowwind\src\InflowWind_IO.f90"/>
 		<File RelativePath="..\..\modules\inflowwind\src\InflowWind_Subs.f90"/>
-		<File RelativePath="..\..\modules\inflowwind\src\Lidar.f90"/></Filter>
+		<File RelativePath="..\..\modules\inflowwind\src\Lidar.f90"/></Filter></Filter>
 		<Filter Name="Mooring Lines">
 		<Filter Name="FEAMooring">
 		<Filter Name="RegistryFiles">
@@ -2359,6 +2318,49 @@
 		<File RelativePath="..\..\modules\simple-elastodyn\src\SED.f90"/>
 		<File RelativePath="..\..\modules\simple-elastodyn\src\SED_IO.f90"/>
 		<File RelativePath="..\..\modules\simple-elastodyn\src\SED_Output_Params.f90"/></Filter>
+		<Filter Name="Substructure">
+		<Filter Name="External Platform">
+		<Filter Name="RegistryFiles">
+		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF_Registry.txt">
+			<FileConfiguration Name="Debug_Double|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_OpenMP|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Double|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_OpenMP|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Double|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Matlab|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Double|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Matlab|x64">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Matlab|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration>
+			<FileConfiguration Name="Release_Matlab|Win32">
+				<Tool Name="VFCustomBuildTool" CommandLine="CALL ..\RunRegistry.bat ExtPtfm_MCKF" Description="Running Registry for ExtPtfm_MCKF" Outputs="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90"/></FileConfiguration></File>
+		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF_Types.f90">
+			<FileConfiguration Name="Debug_Double|Win32">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
+			<FileConfiguration Name="Debug|Win32">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
+			<FileConfiguration Name="Debug|x64">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration>
+			<FileConfiguration Name="Debug_Double|x64">
+				<Tool Name="VFFortranCompilerTool" WarnUnusedVariables="false"/></FileConfiguration></File></Filter>
+		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF.f90"/>
+		<File RelativePath="..\..\modules\extptfm\src\ExtPtfm_MCKF_IO.f90"/></Filter>
 		<Filter Name="SubDyn">
 		<Filter Name="RegistryFiles">
 		<File RelativePath="..\..\modules\subdyn\src\SubDyn_Registry.txt">
@@ -2405,7 +2407,7 @@
 		<File RelativePath="..\..\modules\subdyn\src\SubDyn.f90"/>
 		<File RelativePath="..\..\modules\subdyn\src\SubDyn_Output.f90"/>
 		<File RelativePath="..\..\modules\subdyn\src\SubDyn_Output_Params.f90"/>
-		<File RelativePath="..\..\modules\subdyn\src\SubDyn_Tests.f90"/></Filter>
+		<File RelativePath="..\..\modules\subdyn\src\SubDyn_Tests.f90"/></Filter></Filter>
 		<Filter Name="SuperController_DX">
 		<Filter Name="RegistryFiles">
 		<File RelativePath="..\..\modules\supercontroller\src\SC_DataEx_Registry.txt">

--- a/vs-build/RunRegistry.bat
+++ b/vs-build/RunRegistry.bat
@@ -125,7 +125,7 @@ GOTO checkError
 :ServoDyn
 SET CURR_LOC=%SrvD_Loc%
 SET Output_Loc=%CURR_LOC%
-%REGISTRY% "%CURR_LOC%\SED_Registry.txt" -I "%NWTC_Lib_Loc%" -I "%CURR_LOC%" -O "%Output_Loc%"
+%REGISTRY% "%CURR_LOC%\%ModuleName%_Registry.txt" -I "%NWTC_Lib_Loc%" -I "%CURR_LOC%" -O "%Output_Loc%"
 GOTO checkError
 
 :Lidar


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
- Bug fixes:
   - The `RotorApexOffsetPos` input in the InflowWind input file was reading only the first (x) component of the 3-dimensional array, so the other two were likely uninitialized when used in the Lidar module. This change also required an update to one of the r-test InflowWind input files that didn't have all 3 values.
   - The Visual Studio build was not able to create ServoDyn_Types.f90. This has been fixed.

- Other updates:
   - I updated some spacing and comments in the code.
   - I reorganized small bits of code for better compatibility with Envision code base.
   - I removed unused variables.
   - I fixed some issues with single-/double-precision types in some of the new HydroDyn code.
   - I removed some redundant error handling (e.g., errors in reading the Lidar input parameters from IfW would result in 2 messages instead of 1).
   - I reorganized a bit of the FAST Visual Studio project, creating folders for CompAero modules, CompInflow, and CompSub modules.


**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/2413

**Impacted areas of the software**
InflowWind, Lidar, HydroDyn, MAP++, glue code, NWTC_Library, ServoDyn

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
This doesn't affect any results.
