### PR TITLE
MAP: replace strncpy with strncpy_s

### DIFF
--- a/modules/map/src/mapapi.c
+++ b/modules/map/src/mapapi.c
@@ -1164,7 +1164,16 @@ MAP_EXTERNCALL void map_set_gravity(MAP_ParameterType_t* p_type, const double gr
 
 MAP_EXTERNCALL void map_set_input_text(MAP_InitInputType_t* init_type, const char* input_txt_line)
 {
-  strncpy_s(init_type->library_input_str, sizeof init_type->library_input_str, input_txt_line, (sizeof init_type->library_input_str)-1);
+  int i = 0;
+  for (i = 0; i < (sizeof init_type->library_input_str); ++i)
+  {
+    init_type->library_input_str[i] = input_txt_line[i];
+    if (input_txt_line[i] == 0) break;
+  }
+  if (init_type->library_input_str[i] != 0)
+  {
+    init_type->library_input_str[i] = 0;
+  }
   init_type->library_input_str[254] = '\0';
 }
 

--- a/modules/map/src/mapapi.c
+++ b/modules/map/src/mapapi.c
@@ -1164,7 +1164,7 @@ MAP_EXTERNCALL void map_set_gravity(MAP_ParameterType_t* p_type, const double gr
 
 MAP_EXTERNCALL void map_set_input_text(MAP_InitInputType_t* init_type, const char* input_txt_line)
 {
-  strncpy(init_type->library_input_str, input_txt_line, 254);
+  strncpy_s(init_type->library_input_str, sizeof init_type->library_input_str, input_txt_line, (sizeof init_type->library_input_str)-1);
   init_type->library_input_str[254] = '\0';
 }
 


### PR DESCRIPTION
Ready to merge (need someone with actual C knowledge to review it though).

**Feature or improvement description**
The intel c++ w_oneAPI_2021.1.1.99 compiler does not like the `strncpy` function and won't compile.  Changing to `strncpy_s`.

**Related issue, if one exists**
See comment here: https://github.com/OpenFAST/openfast/commit/93e2d2776a17146c505f6e6158dcad4995db5f99#r14664285  from PR #2394
**Impacted areas of the software**
Compilation of MAP with some compilers.


@sanguinariojoe, can you check this?