### PR TITLE
MAP: change strncpy to use macro MAP_STRNCPY

### DIFF
--- a/modules/map/src/mapapi.c
+++ b/modules/map/src/mapapi.c
@@ -1164,7 +1164,7 @@ MAP_EXTERNCALL void map_set_gravity(MAP_ParameterType_t* p_type, const double gr
 
 MAP_EXTERNCALL void map_set_input_text(MAP_InitInputType_t* init_type, const char* input_txt_line)
 {
-  strncpy(init_type->library_input_str, input_txt_line, 254);
+  MAP_STRNCPY(init_type->library_input_str, input_txt_line, 254);
   init_type->library_input_str[254] = '\0';
 }
 

--- a/modules/map/src/mapsys.h
+++ b/modules/map/src/mapsys.h
@@ -69,11 +69,13 @@
 #  define map_snprintf _snprintf
 #  define map_strcat(a,b,c) strcat_s(a,b,c)
 #  define MAP_STRCPY(a,b,c) strcpy_s(a,b,c)
+#  define MAP_STRNCPY(a,b,c) strncpy_s(a,c,b,c)
 #else
 #  include <stdbool.h>
 #  define map_snprintf snprintf
 #  define map_strcat(a,b,c) strncat(a,c,b)
 #  define MAP_STRCPY(a,b,c) strcpy(a,c)
+#  define MAP_STRNCPY(a,b,c) strncpy(a,b,c)
 #endif
 
 


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
Some compilers do not support the `strncpy_s` routine.  Replacing this call with a call to a macro who's definition is based on which compiler is in use.  This new macro `MAP_STRNCPY` is based on the `MAP_STRCPY` macro and  points to either `strncpy` or `strncpy_s`.


**Related issue, if one exists**
Supersedes PR #2417
Original issue mentioned in comment here: https://github.com/OpenFAST/openfast/commit/93e2d2776a17146c505f6e6158dcad4995db5f99#r14664285 from PR https://github.com/OpenFAST/openfast/pull/2394

**Impacted areas of the software**
_MAP_ module compilation only

**Additional supporting information**
Evidently incompatibilities between MSVC and gcc were run into before.  I suspect this is why @mmasciol added the macro definitions for `MAP_STRCPY` during initial _MAP_ development in ~2011.

**Test results, if applicable**
No tests exist for this, so nothing changes.