### PR TITLE
Use temporary mesh for HD low-pass filter initialization

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1671,6 +1671,9 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
             call Cleanup()
             return
          endif
+         !FIXME: if SD is used, need to create a temporary mapping here as it doesn't exist
+         !else, make copy of meshmapdata
+
          ! Set the initial displacement of PtfmPtMesh_tmp here to use MeshMapping
          PtfmPtMesh_tmp%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
          CALL SmllRotTrans( 'initial platform rotation ', &
@@ -1682,7 +1685,10 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
          PtfmPtMesh_tmp%TranslationDisp(1,1) = PtfmPtMesh_tmp%TranslationDisp(1,1) + PtfmPtMesh_tmp%Orientation(3,1,1) * ED%p%PtfmRefzt
          PtfmPtMesh_tmp%TranslationDisp(2,1) = PtfmPtMesh_tmp%TranslationDisp(2,1) + PtfmPtMesh_tmp%Orientation(3,2,1) * ED%p%PtfmRefzt
          PtfmPtMesh_tmp%TranslationDisp(3,1) = PtfmPtMesh_tmp%TranslationDisp(3,1) + PtfmPtMesh_tmp%Orientation(3,3,1) * ED%p%PtfmRefzt - ED%p%PtfmRefzt
-         CALL Transfer_PlatformMotion_to_HD( PtfmPtMesh_tmp, HD%Input(1), MeshMapData, ErrStat2, ErrMsg2 )
+
+         !FIXME: manually use a temporary mapping here instead of the call
+!         CALL Transfer_PlatformMotion_to_HD( PtfmPtMesh_tmp, HD%Input(1), MeshMapData, ErrStat2, ErrMsg2 )
+
          CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
          IF (ErrStat >= AbortErrLev) THEN
             CALL Cleanup()


### PR DESCRIPTION
*NOT* Ready to merge.  This needs reworking.

**Feature or improvement description**
The ED%y%PlatformPtMesh was being directly altered during HD init to set the low pass filter history stored in discrete states.  Changing an output of a module outside of the CalcOutput call within a module is generally not a great idea.  It can lead to unintended consequences downstream -- such as in VTK writing, or if another module needs that info before it is recalculated.

So instead a temporary mesh is used.

**Related issue, if one exists**
This issue occurred #2341 (https://github.com/OpenFAST/openfast/pull/2341/files#diff-4a8a64358b038dd979f41ea2dd88c0e588a85d068560c0c1b42f98ae5d453452R1563)

**Impacted areas of the software**
Glue code, and maybe VTK outputs

**Test results, if applicable**
No results change with this