### PR TITLE
Fix seg-fault for DBEMT_Mod=-1

### DIFF
--- a/modules/aerodyn/src/BEMT.f90
+++ b/modules/aerodyn/src/BEMT.f90
@@ -636,7 +636,7 @@ subroutine BEMT_Init( InitInp, u, p, x, xd, z, OtherState, AFInfo, y, misc, Inte
    if (errStat >= AbortErrLev) return
 
    InitInp_DBEMT%DBEMT_Mod = p%DBEMT_Mod
-   if ( p%DBEMT_Mod > DBEMT_none .or. p%DBEMT_Mod == DBEMT_Frozen  ) then
+   if ( p%DBEMT_Mod > DBEMT_none ) then
       InitInp_DBEMT%DBEMT_Mod  = p%DBEMT_Mod
       InitInp_DBEMT%numBlades  = p%numBlades 
       InitInp_DBEMT%numNodes   = p%numBladeNodes

--- a/modules/aerodyn/src/BEMT.f90
+++ b/modules/aerodyn/src/BEMT.f90
@@ -929,7 +929,7 @@ subroutine BEMT_UpdateStates( t, n, u, utimes, p, x, xd, z, OtherState, AFInfo, 
    !...............................................................................................................................
    !  update DBEMT states to step n+1
    !...............................................................................................................................
-   if (p%DBEMT_Mod /= DBEMT_none) then
+   if (p%DBEMT_Mod > DBEMT_none) then
 
       !........................
       ! update DBEMT states to t+dt
@@ -956,7 +956,7 @@ subroutine BEMT_UpdateStates( t, n, u, utimes, p, x, xd, z, OtherState, AFInfo, 
             !............................................
             ! apply DBEMT correction to axInduction and tanInduction:
             !............................................
-            if (p%DBEMT_Mod /= DBEMT_none) then
+            if (p%DBEMT_Mod > DBEMT_none) then
                call calculate_Inductions_from_DBEMT_AllNodes(TimeIndex_t_plus_dt, uTimes(TimeIndex_t_plus_dt), u(TimeIndex_t_plus_dt), p, x, OtherState, m, m%axInduction, m%tanInduction)
             end if
          

--- a/modules/aerodyn/src/DBEMT.f90
+++ b/modules/aerodyn/src/DBEMT.f90
@@ -64,11 +64,9 @@ subroutine DBEMT_ValidateInitInp(interval, InitInp, errStat, errMsg)
    errMsg  = ""
    
    if ( interval <= sqrt(epsilon(1.0_ReKi)) ) call SetErrStat( ErrID_Fatal, " The timestep size for DBEMT (interval) must be larger than sqrt(epsilon).", ErrStat, ErrMsg, RoutineName)
-   select case(InitInp%DBEMT_Mod)
-   case (DBEMT_frozen, DBEMT_tauConst, DBEMT_tauVaries, DBEMT_cont_tauConst)
-   case default
-      call SetErrStat( ErrID_Fatal, " DBEMT_Mod must be set to -1, 1, 2, or 3.", ErrStat, ErrMsg, RoutineName)
-   end select
+   if ( (InitInp%DBEMT_Mod .ne. DBEMT_tauConst) .and. (InitInp%DBEMT_Mod .ne. DBEMT_tauVaries) .and. (InitInp%DBEMT_Mod .ne. DBEMT_cont_tauConst)) then
+      call SetErrStat( ErrID_Fatal, " DBEMT_Mod must be set to 1, 2, or 3.", ErrStat, ErrMsg, RoutineName)
+   end if
    
    if (InitInp%numBlades < 1) call SetErrStat( ErrID_Fatal, " InitInp%numBlades must set to 1 or more.", ErrStat, ErrMsg, RoutineName)
    if (InitInp%numNodes < 2) call SetErrStat( ErrID_Fatal, " InitInp%numNodes must set to 2 or more.", ErrStat, ErrMsg, RoutineName)


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
A segmentation fault would occur if `DBEMT_Mod` was set to `-1`.  In PR #2427, I incorrectly assumed that `DBEMT` should be run if `DBEMT_Mod=-1`.  However, with the frozen wake, this should not be done.

There were a few places where `if (p%DBEMT_Mod /= DBEMT_none)` should have been updated to `if (p%DBEMT_Mod > DBEMT_none)`.  This fixes the issues we were seeing.

Also note that this PR reverts commit 7305adb67

**Related issue, if one exists**
#2427, see comment https://github.com/OpenFAST/openfast/pull/2427/files#r1765719295

**Impacted areas of the software**
_AeroDyn_ with `DBEMT_Mod=-1`

