### PR TITLE
Enable linearization with MHK turbines

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -2159,7 +2159,7 @@ subroutine RotWriteOutputs( t, u, RotInflow, p, p_AD, x, xd, z, OtherState, y, m
 
    integer(intKi)                               :: ErrStat2
    character(ErrMsgLen)                         :: ErrMsg2
-   character(*), parameter                      :: RoutineName = 'RotCalcOutput'
+   character(*), parameter                      :: RoutineName = 'RotWriteOutputs'
    real(R8Ki)                                   :: x_hat_disk(3)
 !   LOGICAL                                      :: CalcWriteOutput   
    !-------------------------------------------------------   

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -2271,7 +2271,7 @@ SUBROUTINE ValidateInputData(p, m_FAST, ErrStat, ErrMsg)
 
    IF (p%MHK /= MHK_None .and. p%MHK /= MHK_FixedBottom .and. p%MHK /= MHK_Floating) CALL SetErrStat( ErrID_Fatal, 'MHK switch is invalid. Set MHK to 0, 1, or 2 in the FAST input file.', ErrStat, ErrMsg, RoutineName )
 
-   IF (p%MHK /= MHK_None .and. p%Linearize) CALL SetErrStat( ErrID_Fatal, 'Linearization has not yet been implemented for an MHK turbine. Change MHK or Linearize in the FAST input file.', ErrStat, ErrMsg, RoutineName )
+   IF (p%MHK /= MHK_None .and. p%Linearize) CALL SetErrStat( ErrID_Warn, 'Linearization is not fully implemented for an MHK turbine (buoyancy not included in perturbations, and added mass not included anywhere).', ErrStat, ErrMsg, RoutineName )
 
    IF (p%Gravity < 0.0_ReKi) CALL SetErrStat( ErrID_Fatal, 'Gravity must not be negative.', ErrStat, ErrMsg, RoutineName )
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
When linearization for MHK turbines was added (PRs #1882, #2014, and #2181), it was not enabled.  This PR turns on this feature, but adds a warning.

While the MHK linearization is now possible, there are several key things missing that will reduce the accuracy of the results:
- Added mass is not included in any _AeroDyn_ calculations (pending PR for v5.0.0: #2213)
- Buoyancy calculations are not included in perturbation.  This may not change results much as buoyancy is included in the operating point and is likely a small effect in the linearization compared to the missing added mass.

It should also be noted that linearization of the MHK RM1 floating turbine is extremely slow.  This will be improved on significantly with v5.0.0 when MHK linearization is fully supported.

**Related issue, if one exists**
#1882 
#2014
#2181

**Impacted areas of the software**
Linearization with MHK turbines.
