### PR TITLE
MD: Automatically detect the number of header lines in the WaveKin (wave elevation) file

### DIFF
--- a/modules/moordyn/src/MoorDyn_Misc.f90
+++ b/modules/moordyn/src/MoorDyn_Misc.f90
@@ -1480,7 +1480,7 @@ CONTAINS
             READ(Line,*,IOSTAT=ErrStatTmp) tmpReal
             IF (ErrStatTmp/=0) THEN  ! Not a number
                IF (dataBegin) THEN
-                  CALL SetErrStat( ErrID_Fatal,'Non-data line detected in WaveKinFile past the header lines.',ErrStat, ErrMsg, RoutineName); return
+                  CALL SetErrStat( ErrID_Fatal,' Non-data line detected in WaveKinFile past the header lines.',ErrStat, ErrMsg, RoutineName); return
                END IF
                numHdrLn = numHdrLn + 1
             ELSE
@@ -1515,7 +1515,7 @@ CONTAINS
          CLOSE ( UnElev ) 
 
          IF (WaveTimeIn(1) .NE. 0.0) THEN
-            CALL SetErrStat( ErrID_Warn, ' MoorDyn WaveElev time series should start at t = 0 seconds. First two lines are read as headers.',ErrStat, ErrMsg, RoutineName); return
+            CALL SetErrStat( ErrID_Fatal, ' MoorDyn WaveElev time series should start at t = 0 seconds.',ErrStat, ErrMsg, RoutineName); return
          ENDIF
          
          call WrScr( "Read "//trim(num2lstr(ntIn))//" time steps from input file." )


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**
Previously, MoorDyn always assumes the wave-elevation input file to contain 2 lines of header. It can result in a segmentation fault if the file contains an incorrect number of header lines. This also prevents MoorDyn from directly using the SeaState wave-elevation output file as input, a common use case. This PR allows MoorDyn to automatically detect and skip header lines in the wave-elevation input file for added flexibility.

**Impacted areas of the software**
MoorDyn

**Test results, if applicable**
No change to test results. All tests passed.