### PR TITLE
Fix path to installed MAP include files

### DIFF
--- a/modules/map/CMakeLists.txt
+++ b/modules/map/CMakeLists.txt
@@ -42,13 +42,13 @@ add_library(mappplib STATIC
 target_sources(
   mappplib
   PUBLIC
-    $<INSTALL_INTERFACE:MAP_Types.h>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/mappp/MAP_Types.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/MAP_Types.h>
-    $<INSTALL_INTERFACE:mapsys.h>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/mappp/mapsys.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/mapsys.h>
-    $<INSTALL_INTERFACE:maperror.h>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/mappp/maperror.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/maperror.h>
-    $<INSTALL_INTERFACE:mapapi.h>
+    $<INSTALL_INTERFACE:$<INSTALL_PREFIX>/include/mappp/mapapi.h>
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src/mapapi.h>
 )
 target_link_libraries(mappplib nwtclibs)


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

PR #2392 added support for installing the MAP header files; however, the location of the installed files in `$<INSTALL_INTERFACE:*>` weren't specified correctly. This caused CMake to generate an error about the header files not being found when importing the library in Nalu-Wind (#2435). This PR corrects the path specified via `$<INSTALL_INTERFACE:*>`. This PR has been verified to fix the issue during a Nalu-Wind compilation.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

MAP++'s CMakeList.txt

