### PR TITLE
Fixes in ExtInflw

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -452,7 +452,7 @@ void fast::OpenFAST::prepareOutputFile(int iTurbLoc) {
         ncOutVarIDs_["bld_ld"] = tmpVarID;
         ierr = nc_def_var(ncid, "bld_ld_loc", NC_DOUBLE, 4, bldDataDims.data(), &tmpVarID);
         ncOutVarIDs_["bld_ld_loc"] = tmpVarID;
-        ierr = nc_def_var(ncid, "hub_ref_pos", NC_DOUBLE, 2, ptRefDataDims.data(), &tmpVarID);
+        ierr = nc_def_var(ncid, "hub_ref_pos", NC_DOUBLE, 1, ptRefDataDims.data(), &tmpVarID);
         ncOutVarIDs_["hub_ref_pos"] = tmpVarID;
         ierr = nc_def_var(ncid, "hub_disp", NC_DOUBLE, 2, ptDataDims.data(), &tmpVarID);
         ncOutVarIDs_["hub_disp"] = tmpVarID;
@@ -461,7 +461,7 @@ void fast::OpenFAST::prepareOutputFile(int iTurbLoc) {
         ierr = nc_def_var(ncid, "hub_rotvel", NC_DOUBLE, 2, ptDataDims.data(), &tmpVarID);
         ncOutVarIDs_["hub_rotvel"] = tmpVarID;
 
-        ierr = nc_def_var(ncid, "nac_ref_pos", NC_DOUBLE, 2, ptRefDataDims.data(), &tmpVarID);
+        ierr = nc_def_var(ncid, "nac_ref_pos", NC_DOUBLE, 1, ptRefDataDims.data(), &tmpVarID);
         ncOutVarIDs_["nac_ref_pos"] = tmpVarID;
         ierr = nc_def_var(ncid, "nac_disp", NC_DOUBLE, 2, ptDataDims.data(), &tmpVarID);
         ncOutVarIDs_["nac_disp"] = tmpVarID;

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -2367,8 +2367,8 @@ void fast::OpenFAST::get_data_from_openfast(timeStep t) {
             if (turbineData[iTurb].inflowType == 2) {
                 int nvelpts = get_numVelPtsLoc(iTurb);
                 int nfpts = get_numForcePtsLoc(iTurb);
-                std::cerr << "nvelpts = " << nvelpts << std::endl;
-                std::cerr << "nfpts = " << nfpts << "  " << get_numForcePtsBladeLoc(iTurb) << " " << get_numForcePtsTwrLoc(iTurb) << std::endl;
+                // std::cerr << "nvelpts = " << nvelpts << std::endl;
+                // std::cerr << "nfpts = " << nfpts << "  " << get_numForcePtsBladeLoc(iTurb) << " " << get_numForcePtsTwrLoc(iTurb) << std::endl;
                 for (int i=0; i<nvelpts; i++) {
                     velForceNodeData[iTurb][t].x_vel_resid += (velForceNodeData[iTurb][t].x_vel[i*3+0] - extinfw_i_f_FAST[iTurb].pxVel[i])*(velForceNodeData[iTurb][t].x_vel[i*3+0] - extinfw_i_f_FAST[iTurb].pxVel[i]);
                     velForceNodeData[iTurb][t].x_vel[i*3+0] = extinfw_i_f_FAST[iTurb].pxVel[i];

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -611,17 +611,6 @@ void fast::OpenFAST::prepareOutputFile(int iTurbLoc) {
                                           param_count_dim.data(), tmpArray.data());
             }
         }
-
-        ierr = nc_put_var_double(ncid, ncOutVarIDs_["nac_ref_pos"],
-                                 &brFSIData[iTurbLoc][3].nac_ref_pos[0]);
-        ierr = nc_put_var_double(ncid, ncOutVarIDs_["nac_ref_orient"],
-                                 &brFSIData[iTurbLoc][3].nac_ref_pos[3]);
-
-        ierr = nc_put_var_double(ncid, ncOutVarIDs_["hub_ref_pos"],
-                                 &brFSIData[iTurbLoc][3].hub_ref_pos[0]);
-        ierr = nc_put_var_double(ncid, ncOutVarIDs_["hub_ref_orient"],
-                                 &brFSIData[iTurbLoc][3].hub_ref_pos[3]);
-
     }
 
     ierr = nc_close(ncid);

--- a/modules/externalinflow/src/ExternalInflow.f90
+++ b/modules/externalinflow/src/ExternalInflow.f90
@@ -302,9 +302,9 @@ SUBROUTINE ExtInfw_UpdateFlowField(p_FAST, ExtInfw, ErrStat, ErrMsg)
    ErrStat = ErrID_None
    ErrMsg  = ""
 
-   ExtInfw%m%FlowField%Points%Vel(1:size(ExtInfw%y%u),1) = ExtInfw%y%u
-   ExtInfw%m%FlowField%Points%Vel(1:size(ExtInfw%y%v),2) = ExtInfw%y%v
-   ExtInfw%m%FlowField%Points%Vel(1:size(ExtInfw%y%w),3) = ExtInfw%y%w
+   ExtInfw%m%FlowField%Points%Vel(1,1:size(ExtInfw%y%u)) = ExtInfw%y%u
+   ExtInfw%m%FlowField%Points%Vel(2,1:size(ExtInfw%y%v)) = ExtInfw%y%v
+   ExtInfw%m%FlowField%Points%Vel(3,1:size(ExtInfw%y%w)) = ExtInfw%y%w
 END SUBROUTINE ExtInfw_UpdateFlowField
 
 !----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**

This PR does a couple of fixes for the ExtInflw path:

1. Fixes a heap-buffer-overflow error. `nc_def_var` size should take the value of the size of the dim array. The size of `ptRefDataDims` is 1 so the `nc_def_var` should take a 1. Feels like all of these `nc_def_var`  should really be using `*Dims.size()` But that would lead to a larger diff. 
2. Fixes mis-indexing (flipped) into the `extinfw` array
3. Removes the usage of an empty struct (`brFSIData`) in the ExtInflw path

Diagnosis
```
(lldb) bt
* thread #1, name = 'naluX', stop reason = Heap buffer overflow
  * frame #0: 0x00005555563e2dc0 naluX`::AsanDie() at asan_rtl.cpp:44
    frame #1: 0x00005555563fc79c naluX`__sanitizer::Die() at sanitizer_termination.cpp:55:7
    frame #2: 0x00005555563dda6f naluX`::~ScopedInErrorReport() at asan_report.cpp:192:7
    frame #3: 0x00005555563e0abd naluX`::ReportGenericError() at asan_report.cpp:497:1
    frame #4: 0x00005555563d7df2 naluX`::___interceptor_memcpy() at sanitizer_common_interceptors_memintrinsics.inc:115:5
    frame #5: 0x00007ffff7c61903 libnetcdf.so.19`new_NC_var + 259
    frame #6: 0x00007ffff7c61746 libnetcdf.so.19`NC3_def_var + 214
    frame #7: 0x00007ffff7c12657 libnetcdf.so.19`nc_def_var + 71
    frame #8: 0x00007ffff4bdf089 libopenfastcpplib.so`fast::OpenFAST::prepareOutputFile(this=0x000052000000d650, iTurbLoc=0) at OpenFAST.cpp:455:16
    frame #9: 0x00007ffff4beca22 libopenfastcpplib.so`fast::OpenFAST::solution0(this=0x000052000000d650, writeFiles=true) at OpenFAST.cpp:954:17
    frame #10: 0x0000555557cde9e6 naluX`sierra::nalu::ActuatorBulkFAST::interpolate_velocities_to_fast()::$_0::operator()(this=0x00007fffe796dea0) const at ActuatorBulkFAST.C:271:44
    frame #11: 0x0000555557cde995 naluX`void std::__invoke_impl<void, sierra::nalu::ActuatorBulkFAST::interpolate_velocities_to_fast()::$_0&>((null)=__invoke_other @ 0x00007fffffff237f, __f=0x00007fffe796dea0) at invoke.h:61:14
    frame #12: 0x0000555557cde945 naluX`std::enable_if<is_invocable_r_v<void, sierra::nalu::ActuatorBulkFAST::interpolate_velocities_to_fast()::$_0&>, void>::type std::__invoke_r<void, sierra::nalu::ActuatorBulkFAST::interpolate_velocities_to_fast()::$_0&>(__fn=0x00007fffe796dea0) at invoke.h:111:2
    frame #13: 0x0000555557cde80d naluX`std::_Function_handler<void (), sierra::nalu::ActuatorBulkFAST::interpolate_velocities_to_fast()::$_0>::_M_invoke(__functor=0x00007fffe796dea0) at std_function.h:290:9
    frame #14: 0x0000555557ce95a3 naluX`std::function<void ()>::operator()(this=0x00007fffe796dea0) const at std_function.h:591:9
    frame #15: 0x0000555557ce0c9b naluX`sierra::nalu::squash_fast_output(func=function<void ()> @ 0x00007fffe796dea0) at ActuatorBulkFAST.h:82:3
    frame #16: 0x0000555557cdbe20 naluX`sierra::nalu::ActuatorBulkFAST::interpolate_velocities_to_fast(this=0x000052000000d080) at ActuatorBulkFAST.C:271:7
    frame #17: 0x0000555557d1788e naluX`sierra::nalu::ActuatorLineFastNGP::operator()(this=0x00005070000833b0) at ActuatorExecutorsFASTNgp.C:45:12
    frame #18: 0x0000555557bf9f6a naluX`sierra::nalu::ActuatorModel::execute(this=0x00005070000608f0, timer=0x000051c000003c90) at ActuatorModel.C:169:13
    frame #19: 0x0000555557bf6347 naluX`sierra::nalu::AeroContainer::execute(this=0x00005070000608f0, actTimer=0x000051c000003c90) at AeroContainer.C:118:20
    frame #20: 0x0000555556c02794 naluX`sierra::nalu::Realm::advance_time_step(this=0x000051c000003880) at Realm.C:1955:18
    frame #21: 0x000055555644d280 naluX`sierra::nalu::TimeIntegrator::integrate_realm(this=0x000050f000017bf0) at TimeIntegrator.C:389:16
    frame #22: 0x000055555644596f naluX`sierra::nalu::Simulation::run(this=0x00007fffe7f00fa0) at Simulation.C:216:20
    frame #23: 0x000055555641ae23 naluX`main(argc=5, argv=0x00007fffffff3688) at nalu.C:198:9
    frame #24: 0x00007fffeca2e7e5 libc.so.6`__libc_start_main + 229
    frame #25: 0x000055555633c92e naluX`_start + 46
(lldb) frame s 8
frame #8: 0x00007ffff4bdf089 libopenfastcpplib.so`fast::OpenFAST::prepareOutputFile(this=0x000052000000d650, iTurbLoc=0) at OpenFAST.cpp:455:16
   452          ncOutVarIDs_["bld_ld"] = tmpVarID;
   453          ierr = nc_def_var(ncid, "bld_ld_loc", NC_DOUBLE, 4, bldDataDims.data(), &tmpVarID);
   454          ncOutVarIDs_["bld_ld_loc"] = tmpVarID;
-> 455          ierr = nc_def_var(ncid, "hub_ref_pos", NC_DOUBLE, 2, ptRefDataDims.data(), &tmpVarID);
   456          ncOutVarIDs_["hub_ref_pos"] = tmpVarID;
   457          ierr = nc_def_var(ncid, "hub_disp", NC_DOUBLE, 2, ptDataDims.data(), &tmpVarID);
   458          ncOutVarIDs_["hub_disp"] = tmpVarID;
```

The second was:
```
At line 305 of file /mnt/vdb/home/mhenryde/exawind/exawind-manager/environments/nalu-wind-cpu-test/openfast/modules/externalinflow/src/ExternalInflow.f90
Fortran runtime error: Index '35' of dimension 1 of array 'extinfw' outside of expected range (3:1)
```

The third was:
```
(lldb) frame s 7
frame #7: 0x00007ffff4be2c5c libopenfastcpplib.so`fast::OpenFAST::prepareOutputFile(this=0x000052000000d650, iTurbLoc=0) at OpenFAST.cpp:615:16
   612              }
   613          }
   614
-> 615          ierr = nc_put_var_double(ncid, ncOutVarIDs_["nac_ref_pos"],
   616                                   &brFSIData[iTurbLoc][3].nac_ref_pos[0]);
(lldb) print brFSIData[iTurbLoc][3]
(__gnu_cxx::__alloc_traits<std::allocator<fast::turbBRfsiDataType> >::value_type) {
  twr_ref_pos = size=0 {}
  twr_def = size=0 {}
  twr_vel = size=0 {}
  bld_rloc = size=0 {}
  bld_chord = size=0 {}
  bld_ref_pos = size=0 {}
  bld_def = size=0 {}
  bld_vel = size=0 {}
  hub_ref_pos = size=0 {}
  hub_def = size=0 {}
  hub_vel = size=0 {}
  nac_ref_pos = size=0 {}
  nac_def = size=0 {}
  nac_vel = size=0 {}
  bld_root_ref_pos = size=0 {}
  bld_root_def = size=0 {}
  bld_pitch = size=0 {}
  twr_ld = size=0 {}
  bld_ld = size=0 {}
  twr_def_resid = 0
  twr_vel_resid = 0
  bld_def_resid = 0
  bld_vel_resid = 0
  twr_ld_resid = 0
  bld_ld_resid = 0
```

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

openfast-cpp