### PR TITLE
HD: Reimplement the initialization of low-pass-filtered potential-flow body positions for ExctnDisp=2

### DIFF
--- a/modules/hydrodyn/src/HydroDyn.f90
+++ b/modules/hydrodyn/src/HydroDyn.f90
@@ -293,6 +293,7 @@ SUBROUTINE HydroDyn_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, I
             p%vecMultiplier          = InputFileData%vecMultiplier  ! Multiply all vectors and matrices row/column lengths by NBody
             InputFileData%WAMIT%NBodyMod = InputFileData%NBodyMod
             InputFileData%WAMIT%Gravity  = InitInp%Gravity
+            InputFileData%WAMIT%PlatformPos = InitInp%PlatformPos   ! Initial platform/HD origin position
             p%NBody                  = InputFileData%NBody
             p%NBodyMod               = InputFileData%NBodyMod
             call AllocAry( m%F_PtfmAdd, 6*InputFileData%NBody, "m%F_PtfmAdd", ErrStat2, ErrMsg2 ); call SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )

--- a/modules/hydrodyn/src/HydroDyn.txt
+++ b/modules/hydrodyn/src/HydroDyn.txt
@@ -71,13 +71,13 @@ typedef   HydroDyn/HydroDyn            InitInputType                 CHARACTER(1
 typedef   ^                            ^                             LOGICAL                  UseInputFile                    -       .TRUE.        -         "Supplied by Driver:  .TRUE. if using a input file, .FALSE. if all inputs are being passed in by the caller"    -
 typedef   ^                            ^                             FileInfoType             PassedFileData                  -          -          -         "If we don't use the input file, pass everything through this"   -
 typedef   ^                            ^                             CHARACTER(1024)          OutRootName                     -          -          -         "Supplied by Driver:  The name of the root file (without extension) including the full path"    -
-typedef	  ^	                           ^                             Logical	              Linearize                       -       .FALSE.       -         "Flag that tells this module if the glue code wants to linearize."	-
+typedef	  ^	                       ^                             Logical	              Linearize                       -       .FALSE.       -         "Flag that tells this module if the glue code wants to linearize."	-
 typedef   ^                            ^                             ReKi                     Gravity                         -          -          -         "Supplied by Driver:  Gravitational acceleration"  "(m/s^2)"
 typedef   ^                            ^                             DbKi                     TMax                            -          -          -         "Supplied by Driver:  The total simulation time"    "(sec)"
 typedef   ^                            ^                             logical                  VisMeshes                       -       .false.       -         "Output visualization meshes" -
-#
 typedef   ^                            ^                             LOGICAL                  InvalidWithSSExctn              -          -          -         "Whether SeaState configuration is invalid with HydroDyn's state-space excitation (ExctnMod=2)" (-)
 typedef   ^                            ^                             SeaSt_WaveFieldType     *WaveField                       -          -          -         "Pointer to SeaState wave field" -
+typedef   ^                            ^                             ReKi                     PlatformPos                    {6}         -          -         "Initial platform position (6 DOFs)"
 #
 #
 # Define outputs from the initialization routine here:

--- a/modules/hydrodyn/src/HydroDyn_DriverCode.f90
+++ b/modules/hydrodyn/src/HydroDyn_DriverCode.f90
@@ -240,23 +240,6 @@ PROGRAM HydroDynDriver
       CALL SetHDInputs(0.0_R8Ki, n, u(1), mappingData, drvrData, ErrStat, ErrMsg);   CALL CheckError()
    END IF
 
-   ! Set the initial low-pass-filtered displacements of potential-flow bodies if ExctnDisp = 2
-   IF ( p%PotMod == 1_IntKi ) THEN
-      IF ( p%WAMIT(1)%ExctnDisp == 2_IntKi ) THEN
-         IF (p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
-            DO i = 1,p%NBody
-               xd%WAMIT(1)%BdyPosFilt(1,i,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
-               xd%WAMIT(1)%BdyPosFilt(2,i,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
-            END DO
-         ELSE IF (p%NBodyMod > 1_IntKi) THEN ! NBody instances of WAMIT with one body each
-            DO i = 1,p%NBody
-               xd%WAMIT(i)%BdyPosFilt(1,1,:) = u(1)%WAMITMesh%TranslationDisp(1,i)
-               xd%WAMIT(i)%BdyPosFilt(2,1,:) = u(1)%WAMITMesh%TranslationDisp(2,i)
-            END DO
-         END IF
-      END IF
-   END IF
-
    !...............................................................................................................................
    ! --- Linearization
    !...............................................................................................................................
@@ -347,6 +330,12 @@ subroutine SetHD_InitInputs()
    InitInData_HD%InvalidWithSSExctn     =  InitOutData_SeaSt%InvalidWithSSExctn
 
    InitInData_HD%WaveField => InitOutData_SeaSt%WaveField
+
+   IF (( drvrData%PRPInputsMod /= 2 ) .AND. ( drvrData%PRPInputsMod >= 0 )) THEN
+      InitInData_HD%PlatformPos  = drvrData%uPRPInSteady
+   ELSE
+      InitInData_HD%PlatformPos  = drvrData%PRPin(1,1:6)
+   END IF
 
 end subroutine SetHD_InitInputs
 !----------------------------------------------------------------------------------------------------------------------------------

--- a/modules/hydrodyn/src/HydroDyn_Types.f90
+++ b/modules/hydrodyn/src/HydroDyn_Types.f90
@@ -94,6 +94,7 @@ IMPLICIT NONE
     LOGICAL  :: VisMeshes = .false.      !< Output visualization meshes [-]
     LOGICAL  :: InvalidWithSSExctn = .false.      !< Whether SeaState configuration is invalid with HydroDyn's state-space excitation (ExctnMod=2) [(-)]
     TYPE(SeaSt_WaveFieldType) , POINTER :: WaveField => NULL()      !< Pointer to SeaState wave field [-]
+    REAL(ReKi) , DIMENSION(1:6)  :: PlatformPos = 0.0_ReKi      !< Initial platform position (6 DOFs) [-]
   END TYPE HydroDyn_InitInputType
 ! =======================
 ! =========  HydroDyn_InitOutputType  =======
@@ -594,7 +595,7 @@ subroutine HydroDyn_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, 
    integer(IntKi),  intent(in   ) :: CtrlCode
    integer(IntKi),  intent(  out) :: ErrStat
    character(*),    intent(  out) :: ErrMsg
-   integer(B8Ki)                  :: LB(0), UB(0)
+   integer(B8Ki)                  :: LB(1), UB(1)
    integer(IntKi)                 :: ErrStat2
    character(ErrMsgLen)           :: ErrMsg2
    character(*), parameter        :: RoutineName = 'HydroDyn_CopyInitInput'
@@ -612,6 +613,7 @@ subroutine HydroDyn_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, 
    DstInitInputData%VisMeshes = SrcInitInputData%VisMeshes
    DstInitInputData%InvalidWithSSExctn = SrcInitInputData%InvalidWithSSExctn
    DstInitInputData%WaveField => SrcInitInputData%WaveField
+   DstInitInputData%PlatformPos = SrcInitInputData%PlatformPos
 end subroutine
 
 subroutine HydroDyn_DestroyInitInput(InitInputData, ErrStat, ErrMsg)
@@ -650,6 +652,7 @@ subroutine HydroDyn_PackInitInput(RF, Indata)
          call SeaSt_WaveField_PackSeaSt_WaveFieldType(RF, InData%WaveField) 
       end if
    end if
+   call RegPack(RF, InData%PlatformPos)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -657,7 +660,7 @@ subroutine HydroDyn_UnPackInitInput(RF, OutData)
    type(RegFile), intent(inout)    :: RF
    type(HydroDyn_InitInputType), intent(inout) :: OutData
    character(*), parameter            :: RoutineName = 'HydroDyn_UnPackInitInput'
-   integer(B8Ki)   :: LB(0), UB(0)
+   integer(B8Ki)   :: LB(1), UB(1)
    integer(IntKi)  :: stat
    logical         :: IsAllocAssoc
    integer(B8Ki)   :: PtrIdx
@@ -690,6 +693,7 @@ subroutine HydroDyn_UnPackInitInput(RF, OutData)
    else
       OutData%WaveField => null()
    end if
+   call RegUnpack(RF, OutData%PlatformPos); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine HydroDyn_CopyInitOutput(SrcInitOutputData, DstInitOutputData, CtrlCode, ErrStat, ErrMsg)

--- a/modules/hydrodyn/src/WAMIT.txt
+++ b/modules/hydrodyn/src/WAMIT.txt
@@ -41,6 +41,7 @@ typedef   ^                            ^                             Conv_Rdtn_I
 typedef   ^                            ^                             SeaSt_WaveFieldType     *WaveField                       -          -        -         "Pointer to wave field"
 typedef   ^                            ^                             INTEGER                  PtfmYMod                        -          -        -         "Large yaw model" -
 typedef   ^                            ^                             ReKi                     PtfmRefY                        -          -        -         "Initial reference yaw offset" (rad)
+typedef   ^                            ^                             ReKi                     PlatformPos                     {6}        -        -         "Initial platform position (6 DOFs)"
 #
 #
 # Define outputs from the initialization routine here:

--- a/modules/hydrodyn/src/WAMIT_Types.f90
+++ b/modules/hydrodyn/src/WAMIT_Types.f90
@@ -61,6 +61,7 @@ IMPLICIT NONE
     TYPE(SeaSt_WaveFieldType) , POINTER :: WaveField => NULL()      !< Pointer to wave field [-]
     INTEGER(IntKi)  :: PtfmYMod = 0_IntKi      !< Large yaw model [-]
     REAL(ReKi)  :: PtfmRefY = 0.0_ReKi      !< Initial reference yaw offset [(rad)]
+    REAL(ReKi) , DIMENSION(1:6)  :: PlatformPos = 0.0_ReKi      !< Initial platform position (6 DOFs) [-]
   END TYPE WAMIT_InitInputType
 ! =======================
 ! =========  WAMIT_ContinuousStateType  =======
@@ -262,6 +263,7 @@ subroutine WAMIT_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, Err
    DstInitInputData%WaveField => SrcInitInputData%WaveField
    DstInitInputData%PtfmYMod = SrcInitInputData%PtfmYMod
    DstInitInputData%PtfmRefY = SrcInitInputData%PtfmRefY
+   DstInitInputData%PlatformPos = SrcInitInputData%PlatformPos
 end subroutine
 
 subroutine WAMIT_DestroyInitInput(InitInputData, ErrStat, ErrMsg)
@@ -334,6 +336,7 @@ subroutine WAMIT_PackInitInput(RF, Indata)
    end if
    call RegPack(RF, InData%PtfmYMod)
    call RegPack(RF, InData%PtfmRefY)
+   call RegPack(RF, InData%PlatformPos)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -387,6 +390,7 @@ subroutine WAMIT_UnPackInitInput(RF, OutData)
    end if
    call RegUnpack(RF, OutData%PtfmYMod); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%PtfmRefY); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%PlatformPos); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine WAMIT_CopyContState(SrcContStateData, DstContStateData, CtrlCode, ErrStat, ErrMsg)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -924,6 +924,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
       Init%InData_HD%OutRootName   = TRIM(p_FAST%OutFileRoot)//'.'//TRIM(y_FAST%Module_Abrev(Module_HD))
       Init%InData_HD%TMax          = p_FAST%TMax
       Init%InData_HD%Linearize     = p_FAST%Linearize
+      Init%InData_HD%PlatformPos   = Init%OutData_ED%PlatformPos ! Initial platform position; PlatformPos(1:3) is effectively the initial position of the HD origin
       if (p_FAST%WrVTK /= VTK_None) Init%InData_HD%VisMeshes=.true.
       
       ! if ( p_FAST%CompSeaSt == Module_SeaSt ) then  ! this is always true
@@ -1656,42 +1657,6 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
          ErrStat = ErrID_None
          ErrMsg = ""
       END IF
-
-   ! ----------------------------------------------------------------------------
-   ! Initialize low-pass-filtered displacements of HydroDyn potential-flow bodies
-   ! ----------------------------------------------------------------------------
-   IF ( (p_FAST%CompHydro == Module_HD) .AND. (HD%p%PotMod == 1_IntKi) ) THEN
-      IF ( HD%p%WAMIT(1)%ExctnDisp == 2_IntKi ) THEN
-         ! Set the initial displacement of ED%PlatformPtMesh here to use MeshMapping
-         ED%y%PlatformPtMesh%TranslationDisp(:,1) = Init%OutData_ED%PlatformPos(1:3)
-         CALL SmllRotTrans( 'initial platform rotation ', &
-                             REAL(Init%OutData_ED%PlatformPos(4),R8Ki), &
-                             REAL(Init%OutData_ED%PlatformPos(5),R8Ki), &
-                             REAL(Init%OutData_ED%PlatformPos(6),R8Ki), &
-                             ED%y%PlatformPtMesh%Orientation(:,:,1), '', ErrStat2, ErrMsg2 )
-         CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
-         ED%y%PlatformPtMesh%TranslationDisp(1,1) = ED%y%PlatformPtMesh%TranslationDisp(1,1) + ED%y%PlatformPtMesh%Orientation(3,1,1) * ED%p%PtfmRefzt
-         ED%y%PlatformPtMesh%TranslationDisp(2,1) = ED%y%PlatformPtMesh%TranslationDisp(2,1) + ED%y%PlatformPtMesh%Orientation(3,2,1) * ED%p%PtfmRefzt
-         ED%y%PlatformPtMesh%TranslationDisp(3,1) = ED%y%PlatformPtMesh%TranslationDisp(3,1) + ED%y%PlatformPtMesh%Orientation(3,3,1) * ED%p%PtfmRefzt - ED%p%PtfmRefzt
-         CALL Transfer_PlatformMotion_to_HD( ED%y%PlatformPtMesh, HD%Input(1), MeshMapData, ErrStat2, ErrMsg2 )
-         CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
-         IF (ErrStat >= AbortErrLev) THEN
-            CALL Cleanup()
-            RETURN
-         END IF
-         IF (HD%p%NBodyMod .EQ. 1_IntKi) THEN ! One instance of WAMIT with NBody
-            DO i = 1,HD%p%NBody
-               HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(1,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
-               HD%xd(STATE_CURR)%WAMIT(1)%BdyPosFilt(2,i,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
-            END DO
-         ELSE IF (HD%p%NBodyMod > 1_IntKi) THEN ! NBody instances of WAMIT with one body each
-            DO i = 1,HD%p%NBody
-               HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(1,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(1,i)
-               HD%xd(STATE_CURR)%WAMIT(i)%BdyPosFilt(2,1,:) = HD%Input(1)%WAMITMesh%TranslationDisp(2,i)
-            END DO
-         END IF
-      END IF
-   END IF
 
    ! -------------------------------------------------------------------------
    ! Initialize for linearization or computing aero maps:


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**
This new implementation moves the initialization of the low-pass-filtered potential-flow body positions for `ExctnDisp=2` out of the glue-code and into `HydroDyn_Init`. The initial platform offset from `Init%OutData_ED%PlatformPos` is copied to `Init%InData_HD%PlatformPos` for HD initialization. This is more consistent with the OpenFAST modular structure and should help avoid some problems with tight coupling in the future. 

This updated implementation should fix several issues:
* `ED%y` is no longer modified in `FAST_InitializeAll` to avoid problems with tight coupling.
* It does not rely on mesh mapping, so it works with ED+HD and ED+SD+HD.
* `SmllRotTrans` is replaced with `EulerConstructZYX` to support large platform rotation.
* It avoids some code duplication with initialization in the HD driver code. 

**Related issue, if one exists**
This PR is a reimplementation of PR #2341 to address the issues raised in PR #2421 based on the discussions with @bjonkman and @andrew-platt.

**Impacted areas of the software**
Glue code, HydroDyn

**Test results, if applicable**
No change to existing test results. All tests passed.
