### PR TITLE
Add safety checks in AirfoilInfo for ill-defined airfoils

### DIFF
--- a/modules/aerodyn/src/AirfoilInfo.f90
+++ b/modules/aerodyn/src/AirfoilInfo.f90
@@ -990,6 +990,8 @@ ALPHA_LOOP: DO Row=1,p%Table(iTable)%NumAlf-1
                ! find bounding indices for limitAlphaRange
             iHighLimit = min( maxloc( alpha_ , DIM=1, MASK=alpha_ <  LimitAlphaRange) + 1, size(alpha_) ) ! we can limit this to some range
             iLowLimit  = max( minloc( alpha_ , DIM=1, MASK=alpha_ > -LimitAlphaRange) - 1, 1            ) ! we can limit this to some range
+            if (iHighLimit - iLowLimit < 3) iHighLimit = min(iLowLimit+2,size(alpha_)) ! this could still be an issue if we don't have very many points in the airfoil table. If that's the case, this data is not worth anything anyway
+            if (iHighLimit - iLowLimit < 3) iLowLimit  = max(iHighLimit-2,1) ! this could still be an issue if we don't have very many points in the airfoil table. If that's the case, this data is not worth anything anyway
             
                ! find alphaUpper (using smoothed Cn values):
             if (CalcDefaults%alphaUpper) then
@@ -1053,12 +1055,12 @@ ALPHA_LOOP: DO Row=1,p%Table(iTable)%NumAlf-1
                !mask = p%alpha >= p%UA_BL%alphaLower+alphaMargin & p%alpha <= p%UA_BL%alphaUpper-alphaMargin;
             
                iLow2 = iLowLimit
-               do while (iLow2 < iHighLimit .and. p%alpha(iLow2) <  p%UA_BL%alphaLower + alphaMargin) 
+               do while (iLow2 < iHighLimit-1 .and. p%alpha(iLow2) <  p%UA_BL%alphaLower + alphaMargin) 
                   iLow2 = iLow2 + 1
                end do
 
                iHigh2 = iHighLimit
-               do while (iHigh2 > iLowLimit .and. p%alpha(iHigh2) >  p%UA_BL%alphaUpper - alphaMargin) 
+               do while (iHigh2 > iLow2+1 .and. p%alpha(iHigh2) >  p%UA_BL%alphaUpper - alphaMargin) 
                   iHigh2 = iHigh2 - 1
                end do
 
@@ -1180,6 +1182,15 @@ ALPHA_LOOP: DO Row=1,p%Table(iTable)%NumAlf-1
       
       REAL(ReKi)                              :: A(      size(alpha), 2)
       REAL(ReKi)                              :: B(max(2,size(alpha)),2)
+
+      if (SIZE(Cn) < 2 .OR. SIZE(Cl) < 2) then
+         ErrMsg='Calculate_C_alpha: Not enough data points to compute Cn and Cl slopes.'
+         ErrStat=ErrID_Fatal
+         Default_Cn_alpha = EPSILON(Default_Cn_alpha)
+         Default_Cl_alpha = EPSILON(Default_Cl_alpha)
+         Default_alpha0 = 0.0_ReKi
+         return
+      end if
 
       A(:,1) = alpha
       A(:,2) = 1.0_ReKi


### PR DESCRIPTION
**Feature or improvement description**
When calculating UA parameters, we need to check that there are sufficient points to compute the least-squares solution. 

This can be a problem when the airfoil doesn't have enough points between -20 and 20 degrees angle of attack and/or when the shape of the polar is somewhat unusual. This fix should get around the issues we have been seeing in some unusual airfoils, but a more robust fix will come later.

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/2447

**Impacted areas of the software**
AeroDyn: AirfoilInfo and UnsteadyAero

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
This does not appear to change results in the current regression tests. I don't think the UA parameters that failed in debug mode were used in the simulations (based on the UA models that are used).