### PR TITLE
SD: Bug fix for concentrated mass with CoG offset

### DIFF
--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -1249,6 +1249,9 @@ SUBROUTINE AssembleKM(Init, p, ErrStat, ErrMsg)
    ENDDO
       
    ! Add concentrated mass to mass matrix
+   CALL AllocAry( p%CMassNode,   Init%nCMass,    'p%CMassNode',   ErrStat2, ErrMsg2); if(Failed()) return;
+   CALL AllocAry( p%CMassWeight, Init%nCMass,    'p%CMassWeight', ErrStat2, ErrMsg2); if(Failed()) return;
+   CALL AllocAry( p%CMassOffset, Init%nCMass, 3, 'p%CMassOffset', ErrStat2, ErrMsg2); if(Failed()) return;
    DO I = 1, Init%nCMass
       iNode = NINT(Init%CMass(I, 1)) ! Note index where concentrated mass is to be added
       ! Safety check (otherwise we might have more than 6 DOF)
@@ -1271,14 +1274,20 @@ SUBROUTINE AssembleKM(Init, p, ErrStat, ErrMsg)
             Init%M(jGlob, kGlob) = Init%M(jGlob, kGlob) + M66(J,K)
          ENDDO
       ENDDO
-   ENDDO ! Loop on concentrated mass
 
-   ! Add concentrated mass induced gravity force
-   DO I = 1, Init%nCMass
-       iNode = NINT(Init%CMass(I, 1)) ! Note index where concentrated mass is to be added
-       iGlob = p%NodesDOF(iNode)%List(3) ! uz
-       p%FG(iGlob) = p%FG(iGlob) - Init%CMass(I, 2)*Init%g 
-   ENDDO
+      ! Add concentrated mass contribution to gravity force and moment
+      iGlob = p%NodesDOF(iNode)%List(3); p%FG(iGlob) = p%FG(iGlob) - m*Init%g     ! uz: -mg
+      iGlob = p%NodesDOF(iNode)%List(4); p%FG(iGlob) = p%FG(iGlob) - m*Init%g * y ! tx: -mgy
+      iGlob = p%NodesDOF(iNode)%List(5); p%FG(iGlob) = p%FG(iGlob) + m*Init%g * x ! ty:  mgx
+
+      ! Save concentrated mass information for GuyanLoadCorrection
+      p%CMassNode(I)     = iNode
+      p%CMassWeight(I)   = m*Init%g
+      p%CMassOffset(I,1) = x
+      p%CMassOffset(I,2) = y
+      p%CMassOffset(I,3) = z
+
+   ENDDO ! Loop on concentrated mass
 
    CALL CleanUp_AssembleKM()
    

--- a/modules/subdyn/src/SubDyn_Registry.txt
+++ b/modules/subdyn/src/SubDyn_Registry.txt
@@ -207,10 +207,13 @@ typedef  ^  ParameterType  IntKi           Nmembers      -  -  -  "Number of mem
 typedef  ^  ParameterType  IntKi           Elems  {:}{:}    -  -  "Element nodes connections"
 typedef  ^  ParameterType  ElemPropType    ElemProps   {:}   - -  "List of element properties"
 typedef  ^  ParameterType  R8Ki            FC         {:}    - -  "Initial cable force T0, not reduced"  N
-typedef  ^  ParameterType  R8Ki            FG         {:}    - -  "Gravity force vector (with initial cable force T0), not reduced"  N
+typedef  ^  ParameterType  R8Ki            FG         {:}    - -  "Gravity force vector, not reduced"  N
 typedef  ^  ParameterType  ReKi            DP0        {:}{:} - -  "Vector from TP to a Node at t=0, used for Floating Rigid Body motion"  m
 typedef  ^  ParameterType  ReKi            rPG        {:}    - -  "Vector from TP to rigid-body CoG in the Guyan (rigid-body) frame, used for Floating Rigid Body Motion"  m
 typedef  ^  ParameterType  IntKi           NodeID2JointID {:} - - "Store Joint ID for each NodeID since SubDyn re-label nodes (and add more nodes)"  "-"
+typedef  ^  ParameterType  IntKi           CMassNode   {:}    - - "Node indices for concentrated masses"
+typedef  ^  ParameterType  ReKi            CMassWeight {:}    - - "Weight of concentrated masses" N
+typedef  ^  ParameterType  ReKi            CMassOffset {:}{:} - - "Concentrated mass CoG offset from attached nodes" m
 # --- Parameters - Constraints reduction
 typedef  ^  ParameterType  Logical reduced           -      -  -  "True if system has been reduced to account for constraints"  "-"
 typedef  ^  ParameterType  R8Ki    T_red             {:}{:} -  -  "Transformation matrix performing the constraint reduction x = T. xtilde"  "-"


### PR DESCRIPTION
This PR should be ready to merge after review.

**Feature or improvement description**
This PR aims to fix a known bug with non-zero CoG offset/eccentricity of concentrated masses in SubDyn (Issue #1710) that was causing problems for some users (Issue #2451). The following fixes are implemented:
* The missing moments from the weight of offset concentrated masses are added during initialization when computing `p%FG` following the suggested fix of @ebranlard in Issue #1710.
* The node index, weight, and CoG offset of all concentrated masses are now saved in `p%CMassNode`. `p%CMassWeight`, and `p%CMassOffset` to support `GuyanLoadCorrection` for fixed-bottom structures and self-weight update for floating structures during the run.
* For fixed-bottom structures, an additional `GuyanLoadCorrection` term to the nodal moments is added. This term is in the form of `cross_product( matmul(p%CMassOffset(i,:),orientation)-p%CMassOffset(i,:), (/0.0,0.0,-p%CMassWeight(i)/) )`, where `orientation` is just the nodal orientation matrix due to the Guyan modes only. This additional correction term is zero if the offset/eccentricity is zero as expected.
* For floating structures, the additional force and moment from the weight of the concentrated masses are simply recomputed at each time step based on the Guyan (rigid-body) displacement of the structure. This follows naturally from the changes made in PR #2203.

This PR also adds a warning that SubDyn currently does not account for geometric stiffness from cable pretension if the user specifies one or more cables with non-zero pretension. See Issue #1956 and PR #2363.

**Related issue, if one exists**
Issues #1710, #2451, #1956

**Impacted areas of the software**
SubDyn

**Test results, if applicable**
* There is no change to existing test results. All r-tests passed.
* An additional test was performed with a fixed-bottom structure having a concentrated mass with a large CoG offset. The results after the bug fix are effectively identical to those generated with the workaround proposed in Issue #1710, i.e., using a rigid link to connect the node for attachment to the concentrated mass CoG to avoid having non-zero eccentricity.
* A similar test with a floating structure also shows consistent results between the two approaches.