### PR TITLE
CMAKE_INSTALL_PREFIX was incorrectly being prepended to the install d…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -232,8 +232,8 @@ endforeach(IDIR IN ITEMS ${OPENFAST_MODULES})
 add_subdirectory(glue-codes)
 
 # Install fortran .mod files also to installation directory
-install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/
-  DESTINATION ${CMAKE_INSTALL_PREFIX}/include/openfast/
+install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}
+  DESTINATION include/openfast/
   FILES_MATCHING PATTERN "*.mod"
 )
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

When performing a `make install` after specifying a `CMAKE_INSTALL_PREFIX` during the configuration, the directory containing the Fortran modules would be installed to the wrong location inside the `install` directory. This was due to an extra `CMAKE_INSTALL_PREFIX` being prepended to FTNMOD_DIR variable in CMake. This was not an issue if `CMAKE_INSTALL_PREFIX` was not set or was empty. This PR removes the duplicate prefix so the installation works properly.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

This affects the main `CMakeLists.txt` file and only affects `make install` builds for which a `CMAKE_INSTALL_PREFIX` was specified.

