### PR TITLE
Docker: typo was preventing docker build upload to GH

### DIFF
--- a/.github/workflows/build-docker-image-manual.yml
+++ b/.github/workflows/build-docker-image-manual.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 300
     env:
       DOCKERFILE_PATH: share/docker/Dockerfile
-      DOCKERFILE_PERMALINK: https://raw.githubusercontent.com/OpenFAST/openfast/main/share/docker/Dockerfile
+      DOCKERFILE_PERMALINK: https://raw.githubusercontent.com/openfast/openfast/main/share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
-      GH_REGISTRY: ghcr.io/OpenFAST/openfast
+      GH_REGISTRY: ghcr.io/openfast/openfast
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -41,7 +41,7 @@ jobs:
     env:
       DOCKERFILE_PATH: share/docker/Dockerfile
       DOCKERHUB_REPOSITORY: nrel/openfast
-      GH_REGISTRY: ghcr.io/OpenFAST/openfast
+      GH_REGISTRY: ghcr.io/openfast/openfast
     permissions:
       contents: read
       packages: write
@@ -68,7 +68,11 @@ jobs:
 
       - name: Extract tag from release candidate branch name
         id: extract-tag
-        run: echo "openfast-tag=$(expr substr "${{ github.head_ref }}" 4 100)" >> $GITHUB_OUTPUT
+        run: |
+          TAG="${{ github.event.release.tag_name }}"
+          CLEAN_TAG="${TAG#v}"
+          echo "openfast-tag=$CLEAN_TAG" >> $GITHUB_OUTPUT
+          echo "Extracted tag  $CLEAN_TAG"
 
       - name: Build and push to registry
         uses: docker/build-push-action@v5

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,7 @@ jobs:
           file: ${{ env.DOCKERFILE_PATH }}
           platforms: linux/amd64,linux/aarch64
           tags: |
-            ${{ env.GH_REGISTRY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
+            ${{ env.GH_REGISTRY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.GH_REGISTRY }}:latest
 # ${{ env.DOCKERHUB_REPOSITORY }}:${{ steps.extract-tag.outputs.openfast-tag }},${{ env.DOCKERHUB_REPOSITORY }}:latest
           push: true
           cache-from: type=gha


### PR DESCRIPTION
Ready to merge, pending review by @mayankchetan 

**Feature or improvement description**
A typo in the github action for deploying docker containers was preventing the upload of a finalized docker container. 

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/actions/runs/11583019546/job/32247290012

**Impacted areas of the software**
Automated Docker container deployment on GitHub only.

**Additional supporting information**
N/A

**Test results, if applicable**
N/A