### PR TITLE
Remove $OMP directives from AeroDyn_Inflow due to Intel compiler bug

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Inflow.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow.f90
@@ -488,16 +488,12 @@ subroutine ADI_CalcOutput_IW(t, u_IfW, IW, errStat, errMsg)
       call InflowWind_CalcOutput(t, u_IfW, IW%p, IW%x, IW%xd, IW%z, IW%OtherSt, IW%y, IW%m, errStat2, errMsg2)
       call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'ADI_CalcOutput_IW') 
    else
-      !$OMP PARALLEL DEFAULT(SHARED)
-      !$OMP DO PRIVATE(j,z) schedule(runtime)
       do j=1,size(u_IfW%PositionXYZ,2)
          z = u_IfW%PositionXYZ(3,j)
          IW%y%VelocityUVW(1,j) = IW%HWindSpeed*(z/IW%RefHt)**IW%PLExp
          IW%y%VelocityUVW(2,j) = 0.0_ReKi !V
          IW%y%VelocityUVW(3,j) = 0.0_ReKi !W      
       end do 
-      !$OMP END DO 
-      !$OMP END PARALLEL
    endif
 end subroutine ADI_CalcOutput_IW
 !----------------------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR removes the $OMP parallel directives from `AeroDyn_Inflow.f90` which were causing compilation to fail when using the Intel oneAPI Fortran 2024.1.0 compiler with OpenMP enabled. This is a bug in the compiler itself, not specific to OpenFAST. There may be a slight decrease in performance for specific use cases since these were removed, but the related code has already been removed from the `dev` branch. 

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`AeroDyn_Inflow.f90`

