### PR TITLE
bugfix: with OLAF, BoxExceed was allowed for all points

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Inflow.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow.f90
@@ -347,7 +347,7 @@ subroutine ADI_InitInflowWind(Root, i_IW, u_AD, o_AD, IW, dt, InitOutData, errSt
       ! Box exceed allow for OLAF poitns
       if (allocated(o_AD%WakeLocationPoints)) then
          InitInData%BoxExceedAllowF = .true.
-         InitInData%BoxExceedAllowIdx = min(InitInData%BoxExceedAllowIdx, AD_BoxExceedPointsIdx(u_AD, o_AD))
+         InitInData%BoxExceedAllowIdx = AD_BoxExceedPointsIdx(u_AD, o_AD)
       endif
       if (.not. i_IW%UseInputFile) then
          call NWTC_Library_Copyfileinfotype( i_IW%PassedFileData, InitInData%PassedFileData, MESH_NEWCOPY, errStat2, errMsg2 ); if (Failed()) return

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -578,7 +578,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
          ! Wake -- we allow the wake positions to exceed the wind box
          if (allocated(AD%OtherSt(STATE_CURR)%WakeLocationPoints)) then
             Init%InData_IfW%BoxExceedAllowF = .true.
-            Init%InData_IfW%BoxExceedAllowIdx = min(Init%InData_IfW%BoxExceedAllowIdx, AD_BoxExceedPointsIdx(AD%Input(1), AD%OtherSt(STATE_CURR)))
+            Init%InData_IfW%BoxExceedAllowIdx = AD_BoxExceedPointsIdx(AD%Input(1), AD%OtherSt(STATE_CURR))
          endif
       END IF
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
PR #2518 had a logic issue with how the `BoxExceedAllowIdx` was set. The _InflowWind_ registry sets this value to `-1` by default, so a check of `min(BoxExceedAllowIdx, AD_BoxExceedPointsIdx(u_AD, o_AD))` would always return a `-1`, which would cause _InflowWind_ to allow all calculation at all points requested that were outside the wind box, not just the _OLAF_ points as intended (blades, tower, etc must be inside the box, but _OLAF_ points may exit the box).

This logic issue was also present in the glue code. 

**Related issue, if one exists**
#2518 

**Impacted areas of the software**
Extrapolation of wind values outside the wind box when _OLAF_ is used.

**Additional supporting information**
It is possible that some users will find simulations that they had previously been able to run will now fail if a blade is outside the box when _OLAF_ is used.

**Test results, if applicable**
None