### PR TITLE
Build OpenFAST in Visual Studio 2022 using IFX

### DIFF
--- a/vs-build/MAPlib/MAP_dll.vcxproj
+++ b/vs-build/MAPlib/MAP_dll.vcxproj
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|Win32">
@@ -75,6 +75,7 @@
     <TargetName>MAP_$(PlatformName)</TargetName>
     <LinkIncremental>true</LinkIncremental>
     <OutDir>..\..\build\bin\</OutDir>
+<IntDir>$(PlatformName)\$(ConfigurationName)</IntDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <LinkIncremental>false</LinkIncremental>
@@ -85,6 +86,7 @@
     <TargetName>MAP_$(PlatformName)</TargetName>
     <LinkIncremental>false</LinkIncremental>
     <OutDir>..\..\build\bin\</OutDir>
+<IntDir>$(PlatformName)\$(ConfigurationName)</IntDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

The MAP_dll Visual Studio project doesn't specify an Intermediate Directory so when it is included in the `FAST` and `MAP_dll` solutions, it is assigned different intermediate directories by Visual Studio 2022. This is probably an issue in how default project properties are handled in the latest version of Visual Studio. The simplest fix was just to specify the Intermediate Directory property in the project so that both solutions build files go to the same place.

This PR does not change the compiler from IFORT to IFX, but the issue that revealed the problem was using IFX as the compiler. 

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

Closes #2539.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

MAP Visual Studio Project: `vs-build/MAPlib/MAP_dll.vcxproj`

