### PR TITLE
Add `!$OMP critical` directives around some GetNewUnit/Open*File calls

### DIFF
--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -1080,6 +1080,7 @@ SUBROUTINE ReadBladeInputs ( ADBlFile, BladeKInputFileData, AeroProjMod, UnEc, E
    ErrMsg  = ""
    UnIn = -1
    
+   !$OMP critical(filename)
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
 
@@ -1087,6 +1088,7 @@ SUBROUTINE ReadBladeInputs ( ADBlFile, BladeKInputFileData, AeroProjMod, UnEc, E
       ! Open the input file for blade K.
 
    CALL OpenFInpFile ( UnIn, ADBlFile, ErrStat2, ErrMsg2 )
+   !$OMP end critical(filename)
       CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       IF ( ErrStat >= AbortErrLev ) RETURN
 
@@ -1324,8 +1326,10 @@ SUBROUTINE AD_PrintSum( InputFileData, p, p_AD, u, y, ErrStat, ErrMsg )
 
    ! Open the summary file and give it a heading.
       
+   !$OMP critical(filename)
    CALL GetNewUnit( UnSu, ErrStat, ErrMsg )
    CALL OpenFOutFile ( UnSu, TRIM( p%RootName )//'.sum', ErrStat, ErrMsg )
+   !$OMP end critical(filename)
    IF ( ErrStat >= AbortErrLev ) RETURN
 
       ! Heading:

--- a/modules/aerodyn/src/UnsteadyAero.f90
+++ b/modules/aerodyn/src/UnsteadyAero.f90
@@ -1328,10 +1328,12 @@ subroutine UA_Init( InitInp, u, p, x, xd, OtherState, y,  m, Interval, &
    p%Delim   =''
    
    if (p%NumOuts > 0) then
+      !$OMP critical(filename)
       CALL GetNewUnit( p%unOutFile, ErrStat2, ErrMsg2 )
-         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
-         if (ErrStat >= AbortErrLev) return
-      CALL OpenFOutFile ( p%unOutFile, trim(InitInp%OutRootName)//'.UA.out', ErrStat2, ErrMsg2 )
+      if (ErrStat2 < AbortErrLev) then
+         CALL OpenFOutFile ( p%unOutFile, trim(InitInp%OutRootName)//'.UA.out', ErrStat2, ErrMsg2 )
+      endif
+      !$OMP end critical(filename)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
          if (ErrStat >= AbortErrLev) return
 
@@ -3685,10 +3687,12 @@ subroutine UA_WriteAFIParamsToFile(InitInp, AFInfo, ErrStat, ErrMsg)
    ChanName(i) = 'c_Rate';           ChanUnit(i) = '(-/rad)';    i = i+1;
    ChanName(i) = 'c_RateUpper';      ChanUnit(i) = '(-/rad)';    i = i+1;
       
+   !$OMP critical(filename)
    CALL GetNewUnit( unOutFile, ErrStat, ErrMsg )
-   IF ( ErrStat /= ErrID_None ) RETURN
-
-   CALL OpenFOutFile ( unOutFile, trim(InitInp%OutRootName)//'.UA.sum', ErrStat2, ErrMsg2 )
+   if (ErrStat < AbortErrLev) then
+      CALL OpenFOutFile ( unOutFile, trim(InitInp%OutRootName)//'.UA.sum', ErrStat2, ErrMsg2 )
+   endif
+   !$OMP end critical(filename)
       call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) return
       

--- a/modules/awae/src/AWAE_IO.f90
+++ b/modules/awae/src/AWAE_IO.f90
@@ -548,8 +548,10 @@ SUBROUTINE AWAE_PrintSum(  p, u, y, ErrStat, ErrMsg )
 
    ! Open the summary file and give it a heading.
       
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnSu, ErrStat, ErrMsg )
    CALL OpenFOutFile ( UnSu, TRIM( p%OutFileRoot )//'.sum', ErrStat, ErrMsg )
+   !$OMP end critical(fileopen)
    IF ( ErrStat >= AbortErrLev ) RETURN
 
  

--- a/modules/beamdyn/src/BeamDyn_IO.f90
+++ b/modules/beamdyn/src/BeamDyn_IO.f90
@@ -588,9 +588,11 @@ SUBROUTINE BD_ReadPrimaryFile(InputFile,InputFileData,OutFileRoot,UnEc,ErrStat,E
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
 
+   !$OMP critical(filename)
    CALL GetNewUnit(UnIn,ErrStat2,ErrMsg2)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
    CALL OpenFInpFile(UnIn,InputFile,ErrStat2,ErrMsg2)
+   !$OMP end critical(filename)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF (ErrStat >= AbortErrLev) then
          call cleanup()
@@ -1048,9 +1050,11 @@ SUBROUTINE BD_ReadBladeFile(BldFile,BladeInputFileData,UnEc,ErrStat,ErrMsg)
    ErrStat = ErrID_None
    ErrMsg  = ""
 
+   !$OMP critical(filename)
    CALL GetNewUnit(UnIn,ErrStat2,ErrMsg2)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
    CALL OpenFInpFile (UnIn,BldFile,ErrStat2,ErrMsg2)
+   !$OMP end critical(filename)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
          if (ErrStat >= AbortErrLev) then
             return
@@ -1940,8 +1944,10 @@ SUBROUTINE BD_PrintSum( p, x, OtherState, m, InitInp, ErrStat, ErrMsg )
 
    ! Open the summary file and give it a heading.
 
+   !$OMP critical(filename)
    CALL GetNewUnit( UnSu, ErrStat, ErrMsg )
    CALL OpenFOutFile ( UnSu, TRIM( InitInp%RootName )//'.sum.yaml', ErrStat, ErrMsg )
+   !$OMP end critical(filename)
    IF ( ErrStat >= AbortErrLev ) RETURN
 
       ! Heading:

--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -9634,10 +9634,12 @@ SUBROUTINE ED_PrintSum( p, OtherState, ErrStat, ErrMsg )
 
    ! Open the summary file and give it a heading.
    
+   !$OMP critical(filename)
    CALL GetNewUnit( UnSu, ErrStat, ErrMsg )
-   IF ( ErrStat /= ErrID_None ) RETURN
-
-   CALL OpenFOutFile ( UnSu, TRIM( p%RootName )//'.sum', ErrStat, ErrMsg )
+   if (ErrStat < AbortErrLev) then
+      CALL OpenFOutFile ( UnSu, TRIM( p%RootName )//'.sum', ErrStat, ErrMsg )
+   endif
+   !$OMP end critical(filename)
    IF ( ErrStat /= ErrID_None ) RETURN
 
    

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -1582,12 +1582,13 @@ SUBROUTINE ReadBladeFile ( BldFile, BladeKInputFileData, UnEc, ErrStat, ErrMsg )
    ErrMsg = ""
    
    UnIn = -1
+   !$OMP critical(filename)
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )
-
-
+   IF (ErrStat2 < AbortErrLev) THEN
       ! Open the input file for blade K.
-
-   CALL OpenFInpFile ( UnIn, BldFile, ErrStat2, ErrMsg2 )
+      CALL OpenFInpFile ( UnIn, BldFile, ErrStat2, ErrMsg2 )
+   ENDIF
+   !$OMP end critical(filename)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL Cleanup()
@@ -1888,13 +1889,13 @@ SUBROUTINE ReadBladeMeshFileAD( BladeKInputFileMesh, MeshFile, UnEc, ErrStat, Er
 
       ! Get an available unit number for the file.
 
+   !$OMP critical(filename)
    CALL GetNewUnit( UnIn, ErrStat, ErrMsg )
-   IF ( ErrStat >= AbortErrLev ) RETURN
-
-
+   IF ( ErrStat < AbortErrLev ) THEN
       ! Open the AeroDyn input file.
-
-   CALL OpenFInpFile ( UnIn, MeshFile, ErrStat2, ErrMsg2 )
+      CALL OpenFInpFile ( UnIn, MeshFile, ErrStat2, ErrMsg2 )
+   ENDIF
+   !$OMP end critical(filename)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL Cleanup()
@@ -2179,12 +2180,13 @@ SUBROUTINE ReadTowerFile( TwrFile, InputFileData, UnEc, ErrStat, ErrMsg )
    ErrMsg   =  ""
 
 
+   !$OMP critical(filename)
    CALL GetNewUnit( UnIn, ErrStat, ErrMsg )
-   IF ( ErrStat >= AbortErrLev ) RETURN
-
+   IF ( ErrStat < AbortErrLev ) THEN
       ! Open the tower input file.
-
-   CALL OpenFInpFile ( UnIn, TwrFile, ErrStat2, ErrMsg2 )
+      CALL OpenFInpFile ( UnIn, TwrFile, ErrStat2, ErrMsg2 )
+   ENDIF
+   !$OMP end critical(filename)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL Cleanup()
@@ -2521,14 +2523,13 @@ SUBROUTINE ReadPrimaryFile( InputFile, InputFileData, BldFile, FurlFile, TwrFile
 
 
       ! Get an available unit number for the file.
-
+   !$OMP critical(filename)
    CALL GetNewUnit( UnIn, ErrStat, ErrMsg )
-   IF ( ErrStat >= AbortErrLev ) RETURN
-
-
+   IF ( ErrStat < AbortErrLev ) THEN
       ! Open the Primary input file.
-
-   CALL OpenFInpFile ( UnIn, InputFile, ErrStat2, ErrMsg2 )
+      CALL OpenFInpFile ( UnIn, InputFile, ErrStat2, ErrMsg2 )
+   ENDIF
+   !$OMP end critical(filename)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL Cleanup()

--- a/modules/hydrodyn/src/HydroDyn_Output.f90
+++ b/modules/hydrodyn/src/HydroDyn_Output.f90
@@ -979,9 +979,11 @@ SUBROUTINE HDOut_OpenSum( UnSum, SummaryName, HD_Prog, ErrStat, ErrMsg )
    ErrMsg  = ""       
       
 
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnSum )
 
    CALL OpenFOutFile ( UnSum, SummaryName, ErrStat, ErrMsg ) 
+   !$OMP end critical(fileopen)
    IF (ErrStat >=AbortErrLev) RETURN
       
       
@@ -1033,10 +1035,12 @@ SUBROUTINE HDOut_WriteWvKinFiles( Rootname, HD_Prog, NStepWave, NNodes, NWaveEle
          
    DO iFile = 1,7
       
+      !$OMP critical(fileopen)
       CALL GetNewUnit( UnWv )
 
       WvName = Rootname // TRIM(extension(iFile))
       CALL OpenFOutFile ( UnWv, WvName, ErrStat, ErrMsg ) 
+      !$OMP end critical(fileopen)
          IF (ErrStat >=AbortErrLev) RETURN
       
       
@@ -1084,10 +1088,12 @@ SUBROUTINE HDOut_WriteWvKinFiles( Rootname, HD_Prog, NStepWave, NNodes, NWaveEle
    
    IF ( NWaveElev > 0 ) THEN
    
+      !$OMP critical(fileopen)
       CALL GetNewUnit( UnWv )
 
       WvName = Rootname // '.Elev'
       CALL OpenFOutFile ( UnWv, WvName, ErrStat, ErrMsg ) 
+      !$OMP end critical(fileopen)
          IF (ErrStat >=AbortErrLev) RETURN
       
       
@@ -1463,9 +1469,11 @@ SUBROUTINE HDOut_OpenOutput( HydroDyn_ProgDesc, OutRootName,  p, InitOut, ErrSta
       
          ! Open the file for output
       OutFileName = TRIM(OutRootName)//'.HD.out'
+      !$OMP critical(fileopen)
       CALL GetNewUnit( p%UnOutFile )
    
       CALL OpenFOutFile ( p%UnOutFile, OutFileName, ErrStat, ErrMsg ) 
+      !$OMP end critical(fileopen)
       IF (ErrStat >=AbortErrLev) RETURN
       
       

--- a/modules/hydrodyn/src/Morison_Output.f90
+++ b/modules/hydrodyn/src/Morison_Output.f90
@@ -6610,9 +6610,11 @@ SUBROUTINE MrsnOut_OpenOutput( ProgName, OutRootName,  p, InitOut, ErrStat, ErrM
       
          ! Open the file for output
       OutFileName = TRIM(OutRootName)//'.MRSN.out'
+      !$OMP critical(fileopen)
       CALL GetNewUnit( p%UnOutFile )
    
       CALL OpenFOutFile ( p%UnOutFile, OutFileName, ErrStat, ErrMsg ) 
+      !$OMP end critical(fileopen)
       IF (ErrStat >=AbortErrLev) RETURN
       
       

--- a/modules/hydrodyn/src/WAMIT2.f90
+++ b/modules/hydrodyn/src/WAMIT2.f90
@@ -3649,20 +3649,13 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
          !------------------------------------------------------------------------------
 
          ! Find a unit number to use
+      !$OMP critical(fileopen)
       CALL GetNewUnit(UnitDataFile,ErrStatTmp,ErrMsgTmp)
-      CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName)
-      IF ( ErrStat >= AbortErrLev ) THEN
-         IF (ALLOCATED(TmpRealArr))       DEALLOCATE(TmpRealArr,STAT=ErrStatTmp)
-         IF (ALLOCATED(RawData3D))        DEALLOCATE(RawData3D,STAT=ErrStatTmp)
-         IF (ALLOCATED(RawData3DTmp))     DEALLOCATE(RawData3DTmp,STAT=ErrStatTmp)
-         IF (ALLOCATED(TmpDataRow))       DEALLOCATE(TmpDataRow,STAT=ErrStatTmp)
-         IF (ALLOCATED(TmpWvFreq1))       DEALLOCATE(TmpWvFreq1,STAT=ErrStatTmp)
-         CALL CleanUp
-         RETURN
-      ENDIF
-
-         ! Open the file
-      CALL OpenFInpFile(  UnitDataFile, TRIM(Filename3D), ErrStat, ErrMsg )  ! Open file containing mean drift information
+      if (ErrStatTmp < AbortErrLev) then
+            ! Open the file
+         CALL OpenFInpFile(  UnitDataFile, TRIM(Filename3D), ErrStat, ErrMsg )  ! Open file containing mean drift information
+      endif
+      !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName)
       IF ( ErrStat >= AbortErrLev ) THEN
          CLOSE( UnitDataFile )
@@ -4423,21 +4416,13 @@ SUBROUTINE WAMIT2_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Ini
          !------------------------------------------------------------------------------
 
          ! Find a unit number to use
+      !$OMP critical(fileopen)
       CALL GetNewUnit(UnitDataFile,ErrStatTmp,ErrMsgTmp)
-      CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName)
-      IF ( ErrStat >= AbortErrLev ) THEN
-         IF (ALLOCATED(RawData4D))        DEALLOCATE(RawData4D,STAT=ErrStatTmp)
-         IF (ALLOCATED(RawData4DTmp))     DEALLOCATE(RawData4DTmp,STAT=ErrStatTmp)
-         IF (ALLOCATED(TmpRealArr))       DEALLOCATE(TmpRealArr,STAT=ErrStatTmp)
-         IF (ALLOCATED(TmpDataRow))       DEALLOCATE(TmpDataRow,STAT=ErrStatTmp)
-         IF (ALLOCATED(TmpWvFreq1))       DEALLOCATE(TmpWvFreq1,STAT=ErrStatTmp)
-         IF (ALLOCATED(TmpWvFreq2))       DEALLOCATE(TmpWvFreq2,STAT=ErrStatTmp)
-         CALL CleanUp
-         RETURN
-      ENDIF
-
+      if (ErrStatTmp < AbortErrLev) then
          ! Open the file
-      CALL OpenFInpFile(  UnitDataFile, TRIM(Filename4D), ErrStat, ErrMsg )  ! Open file containing mean drift information
+         CALL OpenFInpFile(  UnitDataFile, TRIM(Filename4D), ErrStat, ErrMsg )  ! Open file containing mean drift information
+      endif
+      !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStatTmp, ErrMsgTmp, ErrStat, ErrMsg, RoutineName)
       IF ( ErrStat >= AbortErrLev ) THEN
          CLOSE( UnitDataFile )

--- a/modules/inflowwind/src/InflowWind_IO.f90
+++ b/modules/inflowwind/src/InflowWind_IO.f90
@@ -518,12 +518,13 @@ subroutine IfW_TurbSim_Init(InitInp, SumFileUnit, G3D, FileDat, ErrStat, ErrMsg)
    !----------------------------------------------------------------------------
 
    ! Get a unit number to use for the wind file
+   !$OMP critical(fileopen)
    call GetNewUnit(WindFileUnit, TmpErrStat, TmpErrMsg)
-   call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
-   if (ErrStat >= AbortErrLev) return
-
-   ! Open binary file
-   call OpenBInpFile(WindFileUnit, TRIM(InitInp%WindFileName), TmpErrStat, TmpErrMsg)
+   if (TmpErrStat < AbortErrLev) then
+      ! Open binary file
+      call OpenBInpFile(WindFileUnit, TRIM(InitInp%WindFileName), TmpErrStat, TmpErrMsg)
+   endif
+   !$OMP end critical(fileopen)
    call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
 
@@ -883,16 +884,17 @@ subroutine IfW_HAWC_Init(InitInp, SumFileUnit, G3D, FileDat, ErrStat, ErrMsg)
               TRIM(Num2LStr(G3D%GridBase + G3D%ZHWid*2))// &
               ' m above ground) with a characteristic wind speed of '//TRIM(Num2LStr(G3D%MeanWS))//' m/s. ')
 
-   ! Get a unit number to use for the wind file
-   call GetNewUnit(WindFileUnit, TmpErrStat, TmpErrMsg)
-   call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
-   if (ErrStat >= AbortErrLev) return
-
    ! Loop through wind components (X, Y, Z)
    do IC = 1, G3D%NComp
 
-      ! Open wind file for this component
-      call OpenBInpFile(WindFileUnit, InitInp%WindFileName(IC), TmpErrStat, TmpErrMsg)
+      ! Get a unit number to use for the wind file
+      !$OMP critical(fileopen)
+      call GetNewUnit(WindFileUnit, TmpErrStat, TmpErrMsg)
+      if (TmpErrStat < AbortErrLev) then
+         ! Open wind file for this component
+         call OpenBInpFile(WindFileUnit, InitInp%WindFileName(IC), TmpErrStat, TmpErrMsg)
+      endif
+      !$OMP end critical(fileopen)
       call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
       if (ErrStat >= AbortErrLev) return
 
@@ -1132,16 +1134,18 @@ subroutine IfW_Bladed_Init(InitInp, SumFileUnit, InitOut, G3D, FileDat, ErrStat,
    end if
 
    ! Get a unit number to use
+   !$OMP critical(fileopen)
    call GetNewUnit(UnitWind, TmpErrStat, TmpErrMsg)
-   call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
-   if (ErrStat >= AbortErrLev) return
+   if (TmpErrStat < AbortErrLev) then
 
    !----------------------------------------------------------------------------
    ! Open the binary file, read its "header" (first 2-byte integer) to
    ! determine what format binary file it is, and close it.
    !----------------------------------------------------------------------------
 
-   call OpenBInpFile(UnitWind, TRIM(BinFileName), TmpErrStat, TmpErrMsg)
+      call OpenBInpFile(UnitWind, TRIM(BinFileName), TmpErrStat, TmpErrMsg)
+   endif
+   !$OMP end critical(fileopen)
    call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
 

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -1575,8 +1575,10 @@ SUBROUTINE InflowWind_OpenSumFile( SumFileUnit, SummaryName, IfW_Prog, WindType,
    ErrMsg  = ""
 
    SumFileUnit = -1
+   !$OMP critical(fileopen)
    CALL GetNewUnit( SumFileUnit )
    CALL OpenFOutFile ( SumFileUnit, SummaryName, ErrStat, ErrMsg )
+   !$OMP end critical(fileopen)
    IF (ErrStat >=AbortErrLev) RETURN
 
 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2409,6 +2409,7 @@ END SUBROUTINE CheckR8Var
 
       ! Get a unit number for the echo file:
 
+   !$OMP critical(fileopenNWTCio)
    IF ( Un < 0 ) THEN
       CALL GetNewUnit( Un, ErrStat2, ErrMsg2 )
          CALL SetErrStat(ErrStat2, ErrMsg2,ErrStat, ErrMsg, RoutineName )
@@ -2419,6 +2420,7 @@ END SUBROUTINE CheckR8Var
 
    CALL OpenFOutFile( Un, OutFile, ErrStat2, ErrMsg2 )
       CALL SetErrStat(ErrStat2, ErrMsg2,ErrStat, ErrMsg, RoutineName )
+   !$OMP end critical(fileopenNWTCio)
       IF ( ErrStat >= AbortErrLev ) RETURN
 
 
@@ -4615,11 +4617,13 @@ END SUBROUTINE CheckR8Var
       RETURN
    END IF
    
+   !$OMP critical(fileopenNWTCio)
    CALL GetNewUnit ( UnIn, ErrStatLcl, ErrMsg2 )
       CALL SetErrStat( ErrStatLcl, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
    CALL OpenFInpFile ( UnIn, FileInfo%FileList(FileIndx), ErrStatLcl, ErrMsg2 )
       CALL SetErrStat( ErrStatLcl, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+   !$OMP end critical(fileopenNWTCio)
       IF ( ErrStat >= AbortErrLev )  RETURN
 
 
@@ -6410,9 +6414,11 @@ END SUBROUTINE CheckR8Var
 
          ! Open the input file.
       UnIn = -1
+      !$OMP critical(fileopenNWTCio)
       CALL GetNewUnit ( UnIn, ErrStatLcl, ErrMsg2 )
 
       CALL OpenFInpFile ( UnIn, Filename, ErrStatLcl, ErrMsg2 )
+      !$OMP end critical(fileopenNWTCio)
       IF ( ErrStatLcl /= 0 )  THEN
          CALL SetErrStat( ErrStatLcl, ErrMsg2, ErrStat, ErrMsg, RoutineName )
          CALL Cleanup()
@@ -6720,6 +6726,7 @@ END SUBROUTINE CheckR8Var
 
       ! Generate the unit number for the binary file
    UnIn = 0
+   !$OMP critical(fileopenNWTCio)
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
 
@@ -6729,6 +6736,7 @@ END SUBROUTINE CheckR8Var
 
    CALL OpenBOutFile ( UnIn, TRIM(FileName), ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+   !$OMP end critical(fileopenNWTCio)
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL Cleanup()
          RETURN

--- a/modules/nwtc-library/src/VTK.f90
+++ b/modules/nwtc-library/src/VTK.f90
@@ -94,8 +94,10 @@ contains
       INTEGER(IntKi)  , INTENT(  OUT)        :: ErrStat              !< error level/status of OpenFOutFile operation
       CHARACTER(*)    , INTENT(  OUT)        :: ErrMsg               !< message when error occurs
    
+      !$OMP critical(fileopen)
       CALL GetNewUnit( Un, ErrStat, ErrMsg )      
       CALL OpenFOutFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
+      !$OMP end critical(fileopen)
          if (ErrStat >= AbortErrLev) return
       
       ! Write a VTP mesh file (Polygonal VTK file) with positions and polygons (surfaces)
@@ -158,10 +160,10 @@ contains
          closeOnReturn = .FALSE.
       END IF
       
-      !$OMP critical
+      !$OMP critical(fileopen)
       CALL GetNewUnit( Un, ErrStat, ErrMsg )      
       CALL OpenFInpFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
-      !$OMP end critical
+      !$OMP end critical(fileopen)
          if (ErrStat >= AbortErrLev) return
       
        CALL ReadCom( Un, FileName, 'File header: Module Version (line 1)', ErrStat2, ErrMsg2, 0 )
@@ -360,10 +362,10 @@ contains
       INTEGER(IntKi)  , INTENT(  OUT)        :: ErrStat              !< error level/status of OpenFOutFile operation
       CHARACTER(*)    , INTENT(  OUT)        :: ErrMsg               !< message when error occurs
    
-      !$OMP critical
+      !$OMP critical(fileopen)
       CALL GetNewUnit( Un, ErrStat, ErrMsg )      
       CALL OpenFOutFile ( Un, TRIM(FileName), ErrStat, ErrMsg )
-      !$OMP end critical
+      !$OMP end critical(fileopen)
          if (ErrStat >= AbortErrLev) return
       
       WRITE(Un,'(A)')  '# vtk DataFile Version 3.0'
@@ -451,6 +453,7 @@ contains
         logical :: b
 
         if (.not. mvtk%bFileOpen) then
+            !$OMP critical(fileopen)
             CALL GetNewUnit( mvtk%vtk_unit )   
             if (mvtk%bBinary) then
                 ! Fortran 2003 stream, otherwise intel fortran !
@@ -466,6 +469,7 @@ contains
             else
                 open(mvtk%vtk_unit,file=trim(adjustl(filename)),iostat=iostatvar,action="write",status='replace')
             endif
+            !$OMP end critical(fileopen)
             if (iostatvar == 0) then
                 if (mvtk%bBinary) then
                     write(mvtk%vtk_unit)'# vtk DataFile Version 3.0'//NewLine

--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -1839,8 +1839,10 @@ SUBROUTINE ED_HD_InputOutputSolve(  this_time, p_FAST, calcJacobian &
 
 #ifdef OUTPUT_ADDEDMASS  
    UnAM = -1
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnAM, ErrStat, ErrMsg )
    CALL OpenFOutFile( UnAM, TRIM(p_FAST%OutFileRoot)//'.AddedMassMatrix', ErrStat2, ErrMsg2)
+   !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )               
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL CleanUp()
@@ -1853,8 +1855,10 @@ SUBROUTINE ED_HD_InputOutputSolve(  this_time, p_FAST, calcJacobian &
 #endif   
 #ifdef OUTPUT_JACOBIAN
    UnJac = -1
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnJac, ErrStat2, ErrMsg2 )
    CALL OpenFOutFile( UnJac, TRIM(p_FAST%OutFileRoot)//'.'//TRIM(num2lstr(this_time))//'.Jacobian2', ErrStat2, ErrMsg2)
+   !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )               
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL CleanUp()
@@ -2608,8 +2612,10 @@ SUBROUTINE FullOpt1_InputOutputSolve( this_time, p_FAST, calcJacobian &
 #ifdef OUTPUT_ADDEDMASS  
 IF (p_FAST%CompHydro == Module_HD ) THEN
    UnAM = -1
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnAM, ErrStat2, ErrMsg2 )
    CALL OpenFOutFile( UnAM, TRIM(p_FAST%OutFileRoot)//'.AddedMassMatrix', ErrStat2, ErrMsg2)
+   !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName  )
       IF ( ErrStat >= AbortErrLev ) RETURN               
    
@@ -2621,8 +2627,10 @@ END IF
 #endif
 #ifdef OUTPUT_JACOBIAN
    UnJac = -1
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnJac, ErrStat2, ErrMsg2 )
    CALL OpenFOutFile( UnJac, TRIM(p_FAST%OutFileRoot)//'.'//TRIM(num2lstr(this_time))//'.Jacobian', ErrStat2, ErrMsg2)
+   !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName  )
       IF ( ErrStat >= AbortErrLev ) RETURN               
       
@@ -5095,8 +5103,10 @@ SUBROUTINE CalcOutputs_And_SolveForInputs( n_t_global, this_time, this_state, ca
 #ifdef OUTPUT_MASS_MATRIX
    if (n_t_global == 0) then   
       UnMM = -1
+      !$OMP critical(fileopen)
       CALL GetNewUnit( UnMM, ErrStat2, ErrMsg2 )
       CALL OpenFOutFile( UnMM, TRIM(p_FAST%OutFileRoot)//'.EDMassMatrix', ErrStat2, ErrMsg2)
+      !$OMP end critical(fileopen)
          CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName  )
          IF ( ErrStat >= AbortErrLev ) RETURN                  
       CALL WrMatrix(ED%m%AugMat,UnMM, p_FAST%OutFmt)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -2280,11 +2280,13 @@ end do
          y_FAST%OutFmt_a = trim(y_FAST%OutFmt_a)//','//trim(num2lstr(y_FAST%ActualChanLen - p_FAST%FmtWidth))//'x'
       end if
 
+      !$OMP critical(fileopen)
       CALL GetNewUnit( y_FAST%UnOu, ErrStat, ErrMsg )
-         IF ( ErrStat >= AbortErrLev ) RETURN
-
-      CALL OpenFOutFile ( y_FAST%UnOu, TRIM(p_FAST%OutFileRoot)//'.out', ErrStat, ErrMsg )
-         IF ( ErrStat >= AbortErrLev ) RETURN
+      IF ( ErrStat < AbortErrLev ) then
+         CALL OpenFOutFile ( y_FAST%UnOu, TRIM(p_FAST%OutFileRoot)//'.out', ErrStat, ErrMsg )
+      ENDIF
+      !$OMP end critical(fileopen)
+      IF ( ErrStat >= AbortErrLev ) RETURN
 
          ! Add some file information:
 
@@ -2415,18 +2417,18 @@ SUBROUTINE FAST_ReadPrimaryFile( InputFile, p, m_FAST, OverrideAbortErrLev, ErrS
 
       ! Get an available unit number for the file.
 
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnIn, ErrStat, ErrMsg )
-   IF ( ErrStat >= AbortErrLev ) RETURN
-
-
+   if ( ErrStat < AbortErrLev ) then
       ! Open the Primary input file.
-
-   CALL OpenFInpFile ( UnIn, InputFile, ErrStat2, ErrMsg2 )
+      CALL OpenFInpFile ( UnIn, InputFile, ErrStat2, ErrMsg2 )
       CALL SetErrStat( ErrStat2, ErrMsg2,ErrStat,ErrMsg,RoutineName)
-      if ( ErrStat >= AbortErrLev ) then
-         call cleanup()
-         RETURN
-      end if
+   endif
+   !$OMP end critical(fileopen)
+   if ( ErrStat >= AbortErrLev ) then
+      call cleanup()
+      RETURN
+   end if
 
 
    ! Read the lines up/including to the "Echo" simulation control variable
@@ -3929,11 +3931,13 @@ SUBROUTINE FAST_WrSum( p_FAST, y_FAST, MeshMapData, ErrStat, ErrMsg )
 
       ! Get a unit number and open the file:
 
+   !$OMP critical(fileopen)
    CALL GetNewUnit( y_FAST%UnSum, ErrStat, ErrMsg )
-      IF ( ErrStat >= AbortErrLev ) RETURN
-
-   CALL OpenFOutFile ( y_FAST%UnSum, TRIM(p_FAST%OutFileRoot)//'.sum', ErrStat, ErrMsg )
-      IF ( ErrStat >= AbortErrLev ) RETURN
+   if ( ErrStat < AbortErrLev ) then
+      CALL OpenFOutFile ( y_FAST%UnSum, TRIM(p_FAST%OutFileRoot)//'.sum', ErrStat, ErrMsg )
+   endif
+   !$OMP end critical(fileopen)
+   IF ( ErrStat >= AbortErrLev ) RETURN
 
          ! Add some file information:
 
@@ -6173,8 +6177,10 @@ SUBROUTINE WriteInputMeshesToFile(u_ED, u_AD, u_SD, u_HD, u_MAP, u_BD, FileName,
 
       ! Open the binary output file:
    unOut=-1
+   !$OMP critical(fileopen)
    CALL GetNewUnit( unOut, ErrStat, ErrMsg )
    CALL OpenBOutFile ( unOut, TRIM(FileName), ErrStat, ErrMsg )
+   !$OMP end critical(fileopen)
       IF (ErrStat /= ErrID_None) RETURN
 
    ! note that I'm not doing anything with the errors here, so it won't tell
@@ -6252,9 +6258,11 @@ SUBROUTINE WriteMotionMeshesToFile(time, y_ED, u_SD, y_SD, u_HD, u_MAP, y_BD, u_
 
       ! Open the binary output file and write a header:
    if (unOut<0) then
+      !$OMP critical(fileopen)
       CALL GetNewUnit( unOut, ErrStat, ErrMsg )
 
       CALL OpenBOutFile ( unOut, TRIM(FileName), ErrStat, ErrMsg )
+      !$OMP end critical(fileopen)
          IF (ErrStat /= ErrID_None) RETURN
 
          ! Add a file identification number (in case we ever have to change this):
@@ -7045,8 +7053,10 @@ SUBROUTINE FAST_CreateCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, 
 
    IF ( unOut < 0 ) THEN
 
+      !$OMP critical(fileopen)
       CALL GetNewUnit( unOut, ErrStat2, ErrMsg2 )
       CALL OpenBOutFile ( unOut, FileName, ErrStat2, ErrMsg2)
+      !$OMP end critical(fileopen)
          CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
          if (ErrStat >= AbortErrLev ) then
             call cleanup()
@@ -7213,9 +7223,11 @@ SUBROUTINE FAST_RestoreFromCheckpoint_T(t_initial, n_t_global, NumTurbines, Turb
 
    IF ( unIn < 0 ) THEN
 
+      !$OMP critical(fileopen)
       CALL GetNewUnit( unIn, ErrStat2, ErrMsg2 )
 
       CALL OpenBInpFile ( unIn, FileName, ErrStat2, ErrMsg2)
+      !$OMP end critical(fileopen)
          CALL SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
          IF (ErrStat >= AbortErrLev ) RETURN
 
@@ -7617,9 +7629,11 @@ SUBROUTINE ReadModeShapeMatlabFile(p_FAST, ErrStat, ErrMsg)
    ErrMsg  = ""
 
       !  Open data file.
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )
 
    CALL OpenBInpFile ( UnIn, trim(p_FAST%VTK_modes%MatlabFileName), ErrStat2, ErrMsg2 )
+   !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF (ErrStat >= AbortErrLev) RETURN
 
@@ -7743,9 +7757,11 @@ SUBROUTINE ReadModeShapeFile(p_FAST, InputFile, ErrStat, ErrMsg, checkpointOnly)
    CALL GetPath( InputFile, PriPath )    ! Input files will be relative to the path where the primary input file is located.
 
       !  Open data file.
+   !$OMP critical(fileopen)
    CALL GetNewUnit( UnIn, ErrStat2, ErrMsg2 )
 
    CALL OpenFInpFile ( UnIn, InputFile, ErrStat2, ErrMsg2 )
+   !$OMP end critical(fileopen)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF (ErrStat >= AbortErrLev) RETURN
 

--- a/modules/servodyn/src/ServoDyn_IO.f90
+++ b/modules/servodyn/src/ServoDyn_IO.f90
@@ -2400,8 +2400,10 @@ subroutine InitializeSummaryFile(InputFileData,OutfileRoot,UnSum,ErrStat,ErrMsg)
    ErrStat  =  ErrID_None
    ErrMsg   =  ''
    if ( InputFileData%SumPrint ) then
+      !$OMP critical(fileopen)
       call GetNewUnit( UnSum )
       CALL OpenEcho ( UnSum, TRIM(OutFileRoot)//'.sum', ErrStat2, ErrMsg2 )
+      !$OMP end critical(fileopen)
          CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
       IF (ErrStat >= AbortErrLev) RETURN
    else

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -866,9 +866,11 @@ ErrMsg  = ""
 UnEc = -1 
 Echo = .FALSE.
 
+!$OMP critical(fileopen)
 CALL GetNewUnit( UnIn )   
   
 CALL OpenFInpfile(UnIn, TRIM(SDInputFile), ErrStat2, ErrMsg2)
+!$OMP end critical(fileopen)
 
 IF ( ErrStat2 /= ErrID_None ) THEN
    Call Fatal('Could not open SubDyn input file')
@@ -3470,6 +3472,7 @@ END SUBROUTINE OutModes
 
 
 !> Write the common part of the JSON file (Nodes, Connectivity, Element prop)
+!FIXME: error handling is broken here!!!
 SUBROUTINE WriteJSONCommon(FileName, Init, p, m, InitInput, FileKind, UnSum, ErrStat, ErrMsg)
    use JSON, only: json_write_array
    TYPE(SD_InitType),          INTENT(INOUT)  :: Init           !< Input data for initialization routine
@@ -3491,8 +3494,10 @@ SUBROUTINE WriteJSONCommon(FileName, Init, p, m, InitInput, FileKind, UnSum, Err
 
    ! --- Create file  and get unit
    UnSum = -1 ! we haven't opened the summary file, yet.   
+   !$OMP critical(fileopen)
    call GetNewUnit( UnSum )
    call OpenFOutFile ( UnSum, FileName, ErrStat2, ErrMsg2 ) 
+   !$OMP end critical(fileopen)
    write(UnSum, '(A)')'{'
 
    ! --- Misc


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
We have had issues with unit numbers when opening files for many years when `OpenMP` is used. The root issue was that the `GetNewUnit` call was separate from the actual file opening. This could lead to race conditions when multiple threads hit a `GetNewUnit` before the retrieved unit numbers were used to open the corresponding files.

As a temporary solution, I added `!$OMP critical(filename)` directives around some of the `GetNewUnit`/`Open*File` call pairs. Some logic restructuring was required in a few places since a `return` cannot take place in one of these directives (note: the only places this occurs is where `GetNewUnit` error handling was previously handled correctly, however `GetNewUnit` only returns an `ErrID_Severe`, so the logic in there now kind of ignores all error handling from `GetNewUnit`).  This solution is not really ideal.

The ideal solution would be more along the lines of what was started with #2538, but to do that correctly would break some backwards compatibility.  It is therefore better to put that solution where `GetNewUnit` is embedded within the `Open*File` subroutines into 4.0.0 instead.

**Related issue, if one exists**
#2510 (Probably others as well)
#2538 -- first attempt at fixing this in 3.5.5

**Impacted areas of the software**
There should be no real impact to end users.

**Additional supporting information**
The `!$OMP critical` directive supports labels, so for all uses added here, the label `filename` has been added.  Without this, an `!$OMP critical` around a call to a routine that includes the new directive would simply hang - the inner (unnamed) `!$OMP critical` would not be able to start until the outer finishes, which it couldn't do. I'm mostly being lazy here as I don't want to sort through all the code to find instances of `!$OMP critical` to make sure no nested calls occured.

**Test results, if applicable**
No results should change.