### PR TITLE
Allow ParseVar to parse file paths containing spaces.

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -958,7 +958,7 @@ subroutine Dvr_ReadInputFile(fileName, dvr, errStat, errMsg )
    call ParseVar(FileInfo_In, CurLine, "analysisType", dvr%analysisType, errStat2, errMsg2, unEc); if (Failed()) return
    call ParseVar(FileInfo_In, CurLine, "tMax"        , dvr%tMax        , errStat2, errMsg2, unEc); if (Failed()) return
    call ParseVar(FileInfo_In, CurLine, "dt"          , dvr%dt          , errStat2, errMsg2, unEc); if (Failed()) return
-   call ParseVar(FileInfo_In, CurLine, "AeroFile"    , dvr%AD_InputFile, errStat2, errMsg2, unEc); if (Failed()) return
+   call ParseVar(FileInfo_In, CurLine, "AeroFile"    , dvr%AD_InputFile, errStat2, errMsg2, unEc, IsPath=.true.); if (Failed()) return
 
    ! --- Environmental conditions
    call ParseCom(FileInfo_In, CurLine, Line, errStat2, errMsg2, unEc); if (Failed()) return
@@ -973,7 +973,7 @@ subroutine Dvr_ReadInputFile(fileName, dvr, errStat, errMsg )
    ! --- Inflow data
    call ParseCom(FileInfo_In, CurLine, Line, errStat2, errMsg2, unEc); if (Failed()) return
    call ParseVar(FileInfo_In, CurLine, "compInflow", dvr%IW_InitInp%compInflow  , errStat2, errMsg2, unEc); if (Failed()) return
-   call ParseVar(FileInfo_In, CurLine, "InflowFile", dvr%IW_InitInp%InputFile, errStat2, errMsg2, unEc); if (Failed()) return
+   call ParseVar(FileInfo_In, CurLine, "InflowFile", dvr%IW_InitInp%InputFile, errStat2, errMsg2, unEc, IsPath=.true.); if (Failed()) return
    if (dvr%IW_InitInp%compInflow==0) then
       call ParseVar(FileInfo_In, CurLine, "HWindSpeed", dvr%IW_InitInp%HWindSpeed  , errStat2, errMsg2, unEc); if (Failed()) return
       call ParseVar(FileInfo_In, CurLine, "RefHt"     , dvr%IW_InitInp%RefHt       , errStat2, errMsg2, unEc); if (Failed()) return

--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -730,7 +730,7 @@ SUBROUTINE ParsePrimaryFileInfo( PriPath, InitInp, InputFile, RootName, NumBlade
    call ParseVar( FileInfo_In, CurLine, "CompAA", InputFileData%CompAA, ErrStat2, ErrMsg2, UnEc )
       if (Failed()) return
       ! AA_InputFile - Aeroacoustics input file
-   call ParseVar( FileInfo_In, CurLine, "AA_InputFile", InputFileData%AA_InputFile, ErrStat2, ErrMsg2, UnEc )
+   call ParseVar( FileInfo_In, CurLine, "AA_InputFile", InputFileData%AA_InputFile, ErrStat2, ErrMsg2, UnEc, IsPath=.true. )
       if (Failed()) return
       IF ( PathIsRelative( InputFileData%AA_InputFile ) ) InputFileData%AA_InputFile = TRIM(PriPath)//TRIM(InputFileData%AA_InputFile)
 
@@ -802,7 +802,7 @@ SUBROUTINE ParsePrimaryFileInfo( PriPath, InitInp, InputFile, RootName, NumBlade
    if ( InputFileData%Echo )   WRITE(UnEc, '(A)') FileInfo_In%Lines(CurLine)    ! Write section break to echo
    CurLine = CurLine + 1
       ! OLAFInputFileName - Input file for OLAF [used only when WakeMod=3]
-   call ParseVar( FileInfo_In, CurLine, "OLAFInputFileName", InputFileData%FVWFileName, ErrStat2, ErrMsg2, UnEc )
+   call ParseVar( FileInfo_In, CurLine, "OLAFInputFileName", InputFileData%FVWFileName, ErrStat2, ErrMsg2, UnEc, IsPath=.true. )
       if (Failed()) return
       IF ( PathIsRelative( InputFileData%FVWFileName ) ) InputFileData%FVWFileName = TRIM(PriPath)//TRIM(InputFileData%FVWFileName)
 
@@ -906,7 +906,7 @@ SUBROUTINE ParsePrimaryFileInfo( PriPath, InitInp, InputFile, RootName, NumBlade
       ! NOTE: being nice with legacy input file. Uncomment in next release
       call ParseVar(FileInfo_In, CurLine, "TFinAero", InputFileData%rotors(iR)%TFinAero, ErrStat2, ErrMsg2, UnEc); 
       if (ErrStat2==ErrID_None) then
-         call ParseVar(FileInfo_In, CurLine, "TFinFile", InputFileData%rotors(iR)%TFinFile, ErrStat2, ErrMsg2, UnEc); if (Failed()) return
+         call ParseVar(FileInfo_In, CurLine, "TFinFile", InputFileData%rotors(iR)%TFinFile, ErrStat2, ErrMsg2, UnEc, IsPath=.true.); if (Failed()) return
          InputFileData%rotors(iR)%TFinFile = trim(PriPath) // trim(InputFileData%rotors(iR)%TFinFile)
       else
          call LegacyWarning('Tail Fin section (TFinAero, TFinFile) is missing from input file.')

--- a/modules/aerodyn/src/AirfoilInfo.f90
+++ b/modules/aerodyn/src/AirfoilInfo.f90
@@ -479,7 +479,7 @@ CONTAINS
       ENDIF
 
       ! Reading Boundary layer file  for aeroacoustics
-      CALL ParseVar ( FileInfo, CurLine, 'BL_file' , p%BL_file , ErrStat2, ErrMsg2, UnEc )
+      CALL ParseVar ( FileInfo, CurLine, 'BL_file' , p%BL_file , ErrStat2, ErrMsg2, UnEc, IsPath=.true. )
          IF (ErrStat2 >= AbortErrLev) p%BL_file = "NOT_SET_IN_AIRFOIL_FILE"
          !CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( PathIsRelative( p%BL_file ) )  p%BL_file=trim(PriPath)//trim(p%BL_file)

--- a/modules/hydrodyn/src/HydroDyn_Input.f90
+++ b/modules/hydrodyn/src/HydroDyn_Input.f90
@@ -359,7 +359,7 @@ SUBROUTINE HydroDyn_ParseInput( InputFileName, OutRootName, defWtrDens, defWtrDp
       if (Failed())  return;
 
       ! WvKinFile
-   call ParseVar( FileInfo_In, CurLine, 'WvKinFile', InputFileData%Waves%WvKinFile, ErrStat2, ErrMsg2, UnEc )
+   call ParseVar( FileInfo_In, CurLine, 'WvKinFile', InputFileData%Waves%WvKinFile, ErrStat2, ErrMsg2, UnEc, IsPath=.true. )
       if (Failed())  return;
 
       ! NWaveElev

--- a/modules/inflowwind/src/InflowWind_Subs.f90
+++ b/modules/inflowwind/src/InflowWind_Subs.f90
@@ -317,7 +317,7 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
    !-------------------------------------------------------------------------------------------------
 
    CurLine = CurLine + 1  ! Skip section break
-   CALL ParseVar( InFileInfo, CurLine, "FileName_Uni", InputFileData%Uniform_FileName, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "FileName_Uni", InputFileData%Uniform_FileName, TmpErrStat, TmpErrMsg, UnEc, IsPath=.true. )
    if (Failed()) return
    IF ( PathIsRelative( InputFileData%Uniform_FileName ) ) InputFileData%Uniform_FileName = TRIM(PriPath)//TRIM(InputFileData%Uniform_FileName)
    IF ( FixedWindFileRootName ) THEN ! .TRUE. when FAST.Farm uses multiple instances of InflowWind for ambient wind data
@@ -339,7 +339,7 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
    !-------------------------------------------------------------------------------------------------
 
    CurLine = CurLine + 1  ! Skip section break
-   CALL ParseVar( InFileInfo, CurLine, "FileName_BTS", InputFileData%TSFF_FileName, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "FileName_BTS", InputFileData%TSFF_FileName, TmpErrStat, TmpErrMsg, UnEc, IsPath=.true. )
    if (Failed()) return
    IF ( PathIsRelative( InputFileData%TSFF_FileName ) ) InputFileData%TSFF_FileName = TRIM(PriPath)//TRIM(InputFileData%TSFF_FileName)
    IF ( FixedWindFileRootName ) THEN ! .TRUE. when FAST.Farm uses multiple instances of InflowWind for ambient wind data
@@ -355,7 +355,7 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
    !-------------------------------------------------------------------------------------------------
 
    CurLine = CurLine + 1  ! Skip section break
-   CALL ParseVar( InFileInfo, CurLine, "FilenameRoot", InputFileData%BladedFF_FileName, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "FilenameRoot", InputFileData%BladedFF_FileName, TmpErrStat, TmpErrMsg, UnEc, IsPath=.true. )
    if (Failed()) return
    IF ( PathIsRelative( InputFileData%BladedFF_FileName ) ) InputFileData%BladedFF_FileName = TRIM(PriPath)//TRIM(InputFileData%BladedFF_FileName)
 
@@ -383,15 +383,15 @@ SUBROUTINE InflowWind_ParseInputFileInfo( InputFileData, InFileInfo, PriPath, In
    !-------------------------------------------------------------------------------------------------
 
    CurLine = CurLine + 1  ! Skip section break
-   CALL ParseVar( InFileInfo, CurLine, "FileName_u", InputFileData%HAWC_FileName_u, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "FileName_u", InputFileData%HAWC_FileName_u, TmpErrStat, TmpErrMsg, UnEc, IsPath=.true. )
    if (Failed()) return
    IF ( PathIsRelative( InputFileData%HAWC_FileName_u ) ) InputFileData%HAWC_FileName_u = TRIM(PriPath)//TRIM(InputFileData%HAWC_FileName_u)
 
-   CALL ParseVar( InFileInfo, CurLine, "FileName_v", InputFileData%HAWC_FileName_v, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "FileName_v", InputFileData%HAWC_FileName_v, TmpErrStat, TmpErrMsg, UnEc, IsPath=.true. )
    if (Failed()) return
    IF ( PathIsRelative( InputFileData%HAWC_FileName_v ) ) InputFileData%HAWC_FileName_v = TRIM(PriPath)//TRIM(InputFileData%HAWC_FileName_v)
 
-   CALL ParseVar( InFileInfo, CurLine, "FileName_w", InputFileData%HAWC_FileName_w, TmpErrStat, TmpErrMsg, UnEc )
+   CALL ParseVar( InFileInfo, CurLine, "FileName_w", InputFileData%HAWC_FileName_w, TmpErrStat, TmpErrMsg, UnEc, IsPath=.true. )
    if (Failed()) return
    IF ( PathIsRelative( InputFileData%HAWC_FileName_w ) ) InputFileData%HAWC_FileName_w = TRIM(PriPath)//TRIM(InputFileData%HAWC_FileName_w)
    

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2068,7 +2068,7 @@ END SUBROUTINE CheckR8Var
    INTEGER, INTENT(IN)            :: NumWords                                     !< The maximum number of words to look for (and size of Words)
 
    CHARACTER(*), INTENT(IN)       :: Line                                         !< The string to search.
-   CHARACTER(*), INTENT(OUT)      :: Words(:)                                     !< The array of found words.
+   CHARACTER(*), INTENT(OUT)      :: Words(NumWords)                              !< The array of found words.
    INTEGER, OPTIONAL, INTENT(OUT) :: NumFound                                     !< The number of words found
 
    INTEGER                        :: iWord                                        ! Word index.

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2120,7 +2120,8 @@ END SUBROUTINE CheckR8Var
          end if
          cycle
 
-      case (' ', ',', ';', Tab)     ! Whitespace, comma, semicolon
+      case (' ', Tab)               ! Whitespace
+         ! If between quotes, keep whitespace; otherwise separate words
          if (.not. InQuotes) then
             if (iChar > 0) then
                iWord = iWord + 1
@@ -2128,6 +2129,14 @@ END SUBROUTINE CheckR8Var
             end if
             cycle
          end if
+
+      case (',', ';')               ! Comma, semicolon
+         ! Always separate words on these characters
+         if (iChar > 0) then
+            iWord = iWord + 1
+            iChar = 0
+         end if
+         cycle
       end select
 
       ! If sufficient words have been collected, exit loop
@@ -2138,7 +2147,7 @@ END SUBROUTINE CheckR8Var
 
       ! If index is larger than length of word, continue
       if (iChar > len(words(iWord))) then 
-         call ProgWarn('Error reading field from file. There are too many characters in the input file to store in the field. Value may be truncated.')
+         call ProgWarn('Error reading field from file. There are too many characters in the input file to store in the field. Value may be truncated. '//Line)
          cycle
       end if
 

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2079,6 +2079,9 @@ END SUBROUTINE CheckR8Var
    LOGICAL                        :: InQuotes                                     ! Flag indicating text is within quotes
    LOGICAL                        :: IgnoreQuotesLoc                              ! Local flag to ignore quotes
 
+   ! Initialize number of words found to zero if present
+   if (present(NumFound)) NumFound = 0
+
    ! If no text on line, return
    if (len_trim(Line) == 0) return
 
@@ -2089,16 +2092,10 @@ END SUBROUTINE CheckR8Var
       IgnoreQuotesLoc = .true. 
    end if
 
-   ! Let's prefill the array with blanks.
+   ! Let's prefill the array with blanks
    do iWord = 1, NumWords
       Words(iWord) = ' '
    end do
-
-   ! Initialize number of words found to zero if present
-   if (present(NumFound)) NumFound = 0
-
-   ! If no text on line, return
-   if (len_trim(Line) == 0) return
 
    ! Initialize word index to first word
    iWord = 1
@@ -2121,7 +2118,7 @@ END SUBROUTINE CheckR8Var
          if (IgnoreQuotesLoc .or. InQuotes) then
             InQuotes = .false.
             if (iChar > 0) then
-               ! If requested number of words found, exit
+               ! If requested number of words found, exit; otherwise, new word
                if (iWord == NumWords) exit
                iWord = iWord + 1
                iChar = 0
@@ -2131,11 +2128,12 @@ END SUBROUTINE CheckR8Var
          end if
          cycle
 
-      case (' ', Tab)               ! Whitespace
-         ! If between quotes, keep whitespace; otherwise separate words
+      ! Word separator
+      case (',', ';', ' ', Tab)   ! Comma, semicolon, space, tab
+         ! If in quotes, keep these in word
          if (.not. InQuotes) then
             if (iChar > 0) then
-               ! If requested number of words found, exit
+               ! If requested number of words found, exit; otherwise, new word
                if (iWord == NumWords) exit
                iWord = iWord + 1
                iChar = 0
@@ -2143,15 +2141,6 @@ END SUBROUTINE CheckR8Var
             cycle
          end if
 
-      case (',', ';')               ! Comma, semicolon
-         ! Always separate words on these characters
-         if (iChar > 0) then
-            ! If requested number of words found, exit
-            if (iWord == NumWords) exit
-            iWord = iWord + 1
-            iChar = 0
-         end if
-         cycle
       end select
 
       ! Increment character index

--- a/modules/servodyn/src/ServoDyn_IO.f90
+++ b/modules/servodyn/src/ServoDyn_IO.f90
@@ -1332,15 +1332,15 @@ subroutine ParseInputFileInfo( PriPath, InputFile, OutFileRoot, FileInfo_In, Inp
    if ( InputFileData%Echo )   WRITE(UnEcho, '(A)') FileInfo_In%Lines(CurLine)    ! Write section break to echo
    CurLine = CurLine + 1
       !  DLL_FileName  - Name/location of the dynamic library {.dll [Windows] or .so [Linux]} in the Bladed-DLL format (-) [used only with Bladed Interface]
-   call ParseVar( FileInfo_In, CurLine, 'DLL_FileName', InputFileData%DLL_FileName, ErrStat2, ErrMsg2, UnEcho )
+   call ParseVar( FileInfo_In, CurLine, 'DLL_FileName', InputFileData%DLL_FileName, ErrStat2, ErrMsg2, UnEcho, IsPath=.true. )
       if (Failed())  return;
    IF ( PathIsRelative( InputFileData%DLL_FileName ) ) InputFileData%DLL_FileName = TRIM(PriPath)//TRIM(InputFileData%DLL_FileName)
       !  DLL_InFile  - Name of input file sent to the DLL (-) [used only with Bladed Interface]
-   call ParseVar( FileInfo_In, CurLine, 'DLL_InFile', InputFileData%DLL_InFile, ErrStat2, ErrMsg2, UnEcho )
+   call ParseVar( FileInfo_In, CurLine, 'DLL_InFile', InputFileData%DLL_InFile, ErrStat2, ErrMsg2, UnEcho, IsPath=.true. )
       if (Failed())  return;
    IF ( PathIsRelative( InputFileData%DLL_InFile ) ) InputFileData%DLL_InFile = TRIM(PriPath)//TRIM(InputFileData%DLL_InFile)   
       !  DLL_ProcName  - Name of procedure in DLL to be called (-) [case sensitive; used only with DLL Interface]
-   call ParseVar( FileInfo_In, CurLine, 'DLL_ProcName', InputFileData%DLL_ProcName, ErrStat2, ErrMsg2, UnEcho )
+   call ParseVar( FileInfo_In, CurLine, 'DLL_ProcName', InputFileData%DLL_ProcName, ErrStat2, ErrMsg2, UnEcho, IsPath=.true. )
       if (Failed())  return;
       !  DLL_DT  - Communication interval for dynamic library (s) (or "default") [used only with Bladed Interface]
    call ParseVarWDefault( FileInfo_In, CurLine, 'DLL_DT', InputFileData%DLL_DT, InputFileData%DT, ErrStat2, ErrMsg2, UnEcho )

--- a/modules/servodyn/src/StrucCtrl.f90
+++ b/modules/servodyn/src/StrucCtrl.f90
@@ -2115,7 +2115,7 @@ SUBROUTINE StC_ParseInputFileInfo( PriPath, InputFile, RootName, NumMeshPts, Fil
    call ParseVar( FileInfo_In, Curline, 'PrescribedForcesCoordSys', InputFileData%PrescribedForcesCoordSys, ErrStat2, ErrMsg2 )
       If (Failed()) return;
       ! Prescribed input time series
-   call ParseVar( FileInfo_In, Curline, 'PrescribedForcesFile', InputFileData%PrescribedForcesFile, ErrStat2, ErrMsg2 )
+   call ParseVar( FileInfo_In, Curline, 'PrescribedForcesFile', InputFileData%PrescribedForcesFile, ErrStat2, ErrMsg2, IsPath=.true. )
       if (Failed()) return;
       if ( PathIsRelative( InputFileData%PrescribedForcesFile ) ) InputFileData%PrescribedForcesFile = TRIM(PriPath)//TRIM(InputFileData%PrescribedForcesFile)
 


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR attempts to add support for file paths containing spaces when the paths are parsed with `ParseVar`. The `IsPath` optional argument was added to `ParseChVar` so this flag can be added instances where `ParseVar` is use to parse a path. This required modifications to `GetWords` to respect or ignore single or double quotes.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

#2552

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`NWTC_IO.f90` and AeroDyn, HydroDyn, InflowWind input reading functions.
