### PR TITLE
Bug Fix: AD: projection method should now depend on BEM_Mod

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -3154,7 +3154,7 @@ subroutine SetInputsForBEMT(p, p_AD, u, RotInflow, m, indx, errStat, errMsg)
    !..........................
    ! Set main geometry parameters (orientatioAnnulus, Twist, Toe, Cant, rLocal)
    !..........................
-   ! TODO (EB): For harmonization between BEM and OLAF we should always compute R_li, r_Local, Twist, Toe, Cant
+   ! TODO (EB): For harmonization between BEM and OLAF we should always compute R_li, r_Local, Twist, Toe, Cant, drdz
    !            BEM would then switch below between an "orientationMomentum", either Annulus (R_li) or NoPitchSweepPitch (R_wi)
    if (p%AeroProjMod==APM_BEM_NoSweepPitchTwist .or. p%AeroProjMod==APM_LiftingLine) then
 

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -732,7 +732,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
       endif
 
       ! Note: not passing tailfin position and orientation at init
-      Init%InData_AD%rotors(1)%AeroProjMod        = APM_BEM_NoSweepPitchTwist
+      Init%InData_AD%rotors(1)%AeroProjMod  = -1  ! -1 means AeroDyn will decide based on BEM_Mod
 
       ! Set pointers to flowfield
       IF (p_FAST%CompInflow == Module_IfW) Init%InData_AD%FlowField => Init%OutData_IfW%FlowField


### PR DESCRIPTION
This pull request is ready to be merged.

**Feature or improvement description**
For BEM_Mod to be working properly, AeroDyn needs to change the AeroDyn Projection Method based on BEM_Mod. To achieve this, teh OpenFAST driver needs to set the AeroDyn Projection Method to -1  "automatic". 

The projection method is an input to AeroDyn to allow the AeroDyn driver to change it (e.g. for vertical axis turbines). 

We will likely be able to simplify the code logic in the future by:
- Removing legacy nodal outputs
- Removing outputs that do not have a well defined coordinate system ("x" and "y")
- Always computing key geometrical quantities (toe, cant, drdz, R_li)
- Renaming orientation annulus to orientation_momentum, and not using this coordinate for outputs. 

**Related issue, if one exists**
Somehow related to the discussion found  #2349 

**Impacted areas of the software**
AeroDyn with `BEM_Mod=2`

