### PR TITLE
Disable LiDAR in IfW at FAST.Farm level

### DIFF
--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -224,7 +224,16 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
    p%lidar%PulseSpacing = InputFileData%PulseSpacing
    p%lidar%URefLid = InputFileData%URefLid
    p%lidar%ConsiderHubMotion = InputFileData%ConsiderHubMotion  
-         
+
+   ! Disable Lidar if not allowed (FAST.Farm doesn't allow this)
+   if (InitInp%LidarDisable) then
+      if (p%lidar%SensorType /= SensorType_None) then
+         call WrScr('  WARNING: LiDAR cannot be used with this instance of InflowWind (not usable with FAST.Farm).')
+         call WrScr('   --> Disabling LiDAR.')
+         p%lidar%SensorType = SensorType_None
+      end if
+   endif
+
          
    CALL Lidar_Init( InitInp, InputGuess, p, ContStates, DiscStates, ConstrStateGuess, OtherStates,   &
                     y, m, TimeInterval, InitOutData, TmpErrStat, TmpErrMsg )

--- a/modules/inflowwind/src/InflowWind.f90
+++ b/modules/inflowwind/src/InflowWind.f90
@@ -226,7 +226,7 @@ SUBROUTINE InflowWind_Init( InitInp, InputGuess, p, ContStates, DiscStates, Cons
    p%lidar%ConsiderHubMotion = InputFileData%ConsiderHubMotion  
 
    ! Disable Lidar if not allowed (FAST.Farm doesn't allow this)
-   if (InitInp%LidarDisable) then
+   if (.not. InitInp%LidarEnabled) then
       if (p%lidar%SensorType /= SensorType_None) then
          call WrScr('  WARNING: LiDAR cannot be used with this instance of InflowWind (not usable with FAST.Farm).')
          call WrScr('   --> Disabling LiDAR.')

--- a/modules/inflowwind/src/InflowWind.txt
+++ b/modules/inflowwind/src/InflowWind.txt
@@ -101,6 +101,7 @@ typedef  ^                       ^                 ReKi              WtrDpth    
 typedef  ^                       ^                 ReKi              MSL2SWL           -     -     -     "Mean sea level to still water level" m
 typedef  ^                       ^                 IntKi             BoxExceedAllowIdx    -  -1       -     "Extrapolate winds outside box starting at this index (for OLAF wakes and LidarSim)" -
 typedef  ^                       ^                 LOGICAL           BoxExceedAllowF      -  .FALSE.  -     "Flag to allow Extrapolation winds outside box starting at this index (for OLAF wakes and LidarSim)" -
+typedef  ^                       ^                 LOGICAL           LidarDisable      -     .true.   -     "Disable LiDAR for this instance of InflowWind? (FAST.Farm not compatible)" -
 
 
 # Init Output

--- a/modules/inflowwind/src/InflowWind.txt
+++ b/modules/inflowwind/src/InflowWind.txt
@@ -101,7 +101,7 @@ typedef  ^                       ^                 ReKi              WtrDpth    
 typedef  ^                       ^                 ReKi              MSL2SWL           -     -     -     "Mean sea level to still water level" m
 typedef  ^                       ^                 IntKi             BoxExceedAllowIdx    -  -1       -     "Extrapolate winds outside box starting at this index (for OLAF wakes and LidarSim)" -
 typedef  ^                       ^                 LOGICAL           BoxExceedAllowF      -  .FALSE.  -     "Flag to allow Extrapolation winds outside box starting at this index (for OLAF wakes and LidarSim)" -
-typedef  ^                       ^                 LOGICAL           LidarDisable      -     .true.   -     "Disable LiDAR for this instance of InflowWind? (FAST.Farm not compatible)" -
+typedef  ^                       ^                 LOGICAL           LidarEnabled      -     .false.  -     "Enable LiDAR for this instance of InflowWind? (FAST.Farm, ADI, and InflowWind driver/library are not compatible)" -
 
 
 # Init Output

--- a/modules/inflowwind/src/InflowWind_Types.f90
+++ b/modules/inflowwind/src/InflowWind_Types.f90
@@ -119,6 +119,7 @@ IMPLICIT NONE
     REAL(ReKi)  :: MSL2SWL      !< Mean sea level to still water level [m]
     INTEGER(IntKi)  :: BoxExceedAllowIdx = -1      !< Extrapolate winds outside box starting at this index (for OLAF wakes and LidarSim) [-]
     LOGICAL  :: BoxExceedAllowF = .FALSE.      !< Flag to allow Extrapolation winds outside box starting at this index (for OLAF wakes and LidarSim) [-]
+    LOGICAL  :: LidarDisable = .true.      !< Disable LiDAR for this instance of InflowWind? (FAST.Farm not compatible) [-]
   END TYPE InflowWind_InitInputType
 ! =======================
 ! =========  InflowWind_InitOutputType  =======
@@ -1110,6 +1111,7 @@ ENDIF
     DstInitInputData%MSL2SWL = SrcInitInputData%MSL2SWL
     DstInitInputData%BoxExceedAllowIdx = SrcInitInputData%BoxExceedAllowIdx
     DstInitInputData%BoxExceedAllowF = SrcInitInputData%BoxExceedAllowF
+    DstInitInputData%LidarDisable = SrcInitInputData%LidarDisable
  END SUBROUTINE InflowWind_CopyInitInput
 
  SUBROUTINE InflowWind_DestroyInitInput( InitInputData, ErrStat, ErrMsg, DEALLOCATEpointers )
@@ -1263,6 +1265,7 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! MSL2SWL
       Int_BufSz  = Int_BufSz  + 1  ! BoxExceedAllowIdx
       Int_BufSz  = Int_BufSz  + 1  ! BoxExceedAllowF
+      Int_BufSz  = Int_BufSz  + 1  ! LidarDisable
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -1437,6 +1440,8 @@ ENDIF
     IntKiBuf(Int_Xferred) = InData%BoxExceedAllowIdx
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = TRANSFER(InData%BoxExceedAllowF, IntKiBuf(1))
+    Int_Xferred = Int_Xferred + 1
+    IntKiBuf(Int_Xferred) = TRANSFER(InData%LidarDisable, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
  END SUBROUTINE InflowWind_PackInitInput
 
@@ -1661,6 +1666,8 @@ ENDIF
     OutData%BoxExceedAllowIdx = IntKiBuf(Int_Xferred)
     Int_Xferred = Int_Xferred + 1
     OutData%BoxExceedAllowF = TRANSFER(IntKiBuf(Int_Xferred), OutData%BoxExceedAllowF)
+    Int_Xferred = Int_Xferred + 1
+    OutData%LidarDisable = TRANSFER(IntKiBuf(Int_Xferred), OutData%LidarDisable)
     Int_Xferred = Int_Xferred + 1
  END SUBROUTINE InflowWind_UnPackInitInput
 

--- a/modules/inflowwind/src/InflowWind_Types.f90
+++ b/modules/inflowwind/src/InflowWind_Types.f90
@@ -119,7 +119,7 @@ IMPLICIT NONE
     REAL(ReKi)  :: MSL2SWL      !< Mean sea level to still water level [m]
     INTEGER(IntKi)  :: BoxExceedAllowIdx = -1      !< Extrapolate winds outside box starting at this index (for OLAF wakes and LidarSim) [-]
     LOGICAL  :: BoxExceedAllowF = .FALSE.      !< Flag to allow Extrapolation winds outside box starting at this index (for OLAF wakes and LidarSim) [-]
-    LOGICAL  :: LidarDisable = .true.      !< Disable LiDAR for this instance of InflowWind? (FAST.Farm not compatible) [-]
+    LOGICAL  :: LidarEnabled = .false.      !< Enable LiDAR for this instance of InflowWind? (FAST.Farm, ADI, and InflowWind driver/library are not compatible) [-]
   END TYPE InflowWind_InitInputType
 ! =======================
 ! =========  InflowWind_InitOutputType  =======
@@ -1111,7 +1111,7 @@ ENDIF
     DstInitInputData%MSL2SWL = SrcInitInputData%MSL2SWL
     DstInitInputData%BoxExceedAllowIdx = SrcInitInputData%BoxExceedAllowIdx
     DstInitInputData%BoxExceedAllowF = SrcInitInputData%BoxExceedAllowF
-    DstInitInputData%LidarDisable = SrcInitInputData%LidarDisable
+    DstInitInputData%LidarEnabled = SrcInitInputData%LidarEnabled
  END SUBROUTINE InflowWind_CopyInitInput
 
  SUBROUTINE InflowWind_DestroyInitInput( InitInputData, ErrStat, ErrMsg, DEALLOCATEpointers )
@@ -1265,7 +1265,7 @@ ENDIF
       Re_BufSz   = Re_BufSz   + 1  ! MSL2SWL
       Int_BufSz  = Int_BufSz  + 1  ! BoxExceedAllowIdx
       Int_BufSz  = Int_BufSz  + 1  ! BoxExceedAllowF
-      Int_BufSz  = Int_BufSz  + 1  ! LidarDisable
+      Int_BufSz  = Int_BufSz  + 1  ! LidarEnabled
   IF ( Re_BufSz  .GT. 0 ) THEN 
      ALLOCATE( ReKiBuf(  Re_BufSz  ), STAT=ErrStat2 )
      IF (ErrStat2 /= 0) THEN 
@@ -1441,7 +1441,7 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     IntKiBuf(Int_Xferred) = TRANSFER(InData%BoxExceedAllowF, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
-    IntKiBuf(Int_Xferred) = TRANSFER(InData%LidarDisable, IntKiBuf(1))
+    IntKiBuf(Int_Xferred) = TRANSFER(InData%LidarEnabled, IntKiBuf(1))
     Int_Xferred = Int_Xferred + 1
  END SUBROUTINE InflowWind_PackInitInput
 
@@ -1667,7 +1667,7 @@ ENDIF
     Int_Xferred = Int_Xferred + 1
     OutData%BoxExceedAllowF = TRANSFER(IntKiBuf(Int_Xferred), OutData%BoxExceedAllowF)
     Int_Xferred = Int_Xferred + 1
-    OutData%LidarDisable = TRANSFER(IntKiBuf(Int_Xferred), OutData%LidarDisable)
+    OutData%LidarEnabled = TRANSFER(IntKiBuf(Int_Xferred), OutData%LidarEnabled)
     Int_Xferred = Int_Xferred + 1
  END SUBROUTINE InflowWind_UnPackInitInput
 

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -583,6 +583,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       END IF
 
       ! lidar
+      Init%InData_IfW%LidarDisable                 = .false.   ! allowed with OF, but not FF
       Init%InData_IfW%lidar%Tmax                   = p_FAST%TMax
       Init%InData_IfW%lidar%HubPosition            = ED%y%HubPtMotion%Position(:,1)
 

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -583,7 +583,7 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, BD, SrvD, 
       END IF
 
       ! lidar
-      Init%InData_IfW%LidarDisable                 = .false.   ! allowed with OF, but not FF
+      Init%InData_IfW%LidarEnabled                 = .true.    ! allowed with OF, but not FF
       Init%InData_IfW%lidar%Tmax                   = p_FAST%TMax
       Init%InData_IfW%lidar%HubPosition            = ED%y%HubPtMotion%Position(:,1)
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The _LiDAR_ sub-module inside _InflowWind_ requires turbine specific information such as hub location.  However, this information is not available at the _FAST.Farm_ level instance of _InflowWind_.  This was resulting in segmentation faults when someone attempted to use it at this level.

This PR disables the _LiDAR_ submodule from use with the _InflowWind_ module used at the _FAST.Farm_ level.

**Related issue, if one exists**
#2316 
#2324 

**Impacted areas of the software**
_InflowWind_ module at the _FAST.Farm_ level only.

**Additional supporting information**
A few users have attempted to use the _LiDAR_ sub-module at the _FAST.Farm_ level and received segmentation faults.  Since this is not something the code can really do, we are simply disabling it for now.

**Test results, if applicable**
No results change.