### PR TITLE
OLAF out of bounds

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -1929,7 +1929,7 @@ subroutine AD_CalcWind_Rotor(t, u, FlowField, p, RotInflow, StartNode, ErrStat, 
 
 contains
    logical function Failed()
-      call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'AD_CalcWind')
+      call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'AD_CalcWindRotor')
       Failed = errStat >= AbortErrLev
    end function Failed
 end subroutine

--- a/modules/aerodyn/src/AeroDyn_Inflow.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow.f90
@@ -388,6 +388,10 @@ subroutine ADI_InitInflowWind(Root, i_IW, u_AD, o_AD, IW, dt, InitOutData, errSt
       endif
       InitInData%RootName         = trim(Root)//'.IfW'
       InitInData%MHK              = i_IW%MHK
+      ! OLAF might be used in AD, in which case we need to allow out of bounds for some calcs. To do that
+      ! the average values for the entire wind profile must be calculated and stored (we don't know if OLAF
+      ! is used until after AD_Init below).
+      InitInData%BoxExceedAllow = .true.
       CALL InflowWind_Init( InitInData, IW%u, IW%p, &
                      IW%x, IW%xd, IW%z, IW%OtherSt, &
                      IW%y, IW%m, dt,  InitOutData, errStat2, errMsg2 )

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -520,6 +520,13 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
          Init%InData_IfW%Use4Dext                  = .false.
       END IF
 
+      ! OLAF might be used in AD, in which case we need to allow out of bounds for some calcs. To do that
+      ! the average values for the entire wind profile must be calculated and stored (we don't know if OLAF
+      ! is used until after AD_Init below).
+      if (p_FAST%CompAero == Module_AD) then
+         Init%InData_IfW%BoxExceedAllow = .true.
+      endif
+
       CALL InflowWind_Init( Init%InData_IfW, IfW%Input(1), IfW%p, IfW%x(STATE_CURR), IfW%xd(STATE_CURR), IfW%z(STATE_CURR),  &
                      IfW%OtherSt(STATE_CURR), IfW%y, IfW%m, p_FAST%dt_module( MODULE_IfW ), Init%OutData_IfW, ErrStat2, ErrMsg2 )
          CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
If _OLAF_ is used, the wakes may move out of bounds of the wind box (i.e. TurbSim .bts format).  When this happens, wind for _OLAF_ points outside the box should be extrapolated beyond the box as described here: https://openfast.readthedocs.io/en/dev/source/user/inflowwind/driver.html#boxexceedallow-flag.

In both the AeroDyn_Driver and in OpenFAST, the _InflowWind_ module is initialized before _AeroDyn_ so we don't know at that time if _OLAF_ will be used.  This PR sets the `BoxExceedAllow` flag if AD is used in either context, which can be a computational waste if _OLAF_ is not used.  Ideally we would initialize the data structure for the extrapolation the first time it is accessed to avoid the unnecessary computation ahead of time if it isn't needed.

**Related issue, if one exists**
#2518 
#1748 
#1516 

This particular issue was reported in a conversation outside of GH.

**Impacted areas of the software**
_AeroDyn_ only

**Additional supporting information**


**Test results, if applicable**
No results change with this case -- we don't run an _OLAF_ cases with turbulent wind flow for long in enough to see this issue in the regression testing.