### PR TITLE
Add release notes from v2.4 - v3.4.1

### DIFF
--- a/docs/changelogs/v2.4.0.md
+++ b/docs/changelogs/v2.4.0.md
@@ -1,0 +1,38 @@
+### General
+- #428 Improve CLI for OpenFAST (`openfast -v` and `openfast -h`)
+- #350 Add offshore linearization capability
+- #488 Improve Line2-to-Line2 or Line2-to-Point mapping
+- #508 Support RANLUX as an optional pRNG
+- #373 Support for channel names up to 20 characters
+- #373 Allow mode shape visualization - [docs](https://github.com/OpenFAST/matlab-toolbox#mode-shapes-visualization)
+- #373 Find a periodic steady-state trim solution where linearization will be performed
+- Update documentation
+- Bug fixes
+
+### AeroDyn
+- #477 Add free vortex wake module - [docs](https://openfast.readthedocs.io/en/master/source/user/aerodyn-olaf/index.html)
+- #515 Add aeroacoustics module - [docs](https://openfast.readthedocs.io/en/master/source/user/aerodyn-aeroacoustics/index.html)
+- #373 Allow channel outputs at every blade node - [docs](https://openfast.readthedocs.io/en/master/source/user/aerodyn/input.html#ad-nodal-outputs)
+
+### BeamDyn
+- #373 Allow channel outputs at every blade node - [docs](https://openfast.readthedocs.io/en/master/source/user/beamdyn/input_files.html#bd-nodal-outputs)
+ 
+### ElastoDyn
+- #453 Bug fix: the rotational speed was doubled in the rotational velocity field of the blade output mesh
+- #461 Add output channel for translational displacements of tower top at yaw bearing relative to the reference position
+- #373 Allow channel outputs at every blade node - [docs](https://openfast.readthedocs.io/en/master/source/user/elastodyn/input.html#ed-nodal-outputs)
+
+### ExtPtfm
+- #344 Use Craig-Bampton reduction of support structures for sequential load calculations
+
+### InflowWind
+- #437 Add new HAWC wind profile input type for reading wind conditions without mean wind speed
+- #437 Allow to shift the HAWC wind upstream or downstream
+
+### ServoDyn
+- #456 Properly support yaw rate command integration from controller
+- #460 Fix an issue in updating the states when a yaw maneuver is beginning
+
+### r-test
+- #456 Update 5MW BeamDyn blade damping models
+

--- a/docs/changelogs/v2.5.0.md
+++ b/docs/changelogs/v2.5.0.md
@@ -1,0 +1,57 @@
+### General
+In v2.5.0, the `master` branch will become `main` and this will serve as the "trunk" or primary branch for OpenFAST. This is in line with current best practices in naming conventions (see [here](https://github.com/github/renaming)).
+
+### AeroDyn
+- #538 Update AeroDyn to allow for linearized dynamic stall and dynamic inflow models
+- #538 Disable BEM if TSR <= 1, blend BEM and non-BEM when 1 < TSR < 2, output the proportion of BEM in GeomPhi output channel
+- #590 [BugFix] VTK folder location, Vx sign for OLAF
+- #594 [BugFix] Close a file that was opened but not closed
+- #623 [BugFix] Allocate array to size 0 before getting its size
+- #627 [BugFix] Fix logic for setting size of arrays for airfoil tables
+
+### BeamDyn
+- #560 Expand and improve BeamDyn unit tests
+- #564 Documentation updates: Add BD OpenFAST solve section 
+- #576 Replace cubic spline with least squares fit
+- #619 [BugFix] Regenerate Types files after registry file changes
+
+### FAST Library
+- #550 Make channel length consistent between C and Fortran sides of interface
+- #616 Fix potential memory leak and expand error handling
+
+### HydroDyn
+- #582 Use RANLUX pRNG in offshore floating regression test cases
+- #586 Hd Driver - Add Morrison mesh and standalone driver test cases
+- #602 Vectorize a section of VariousWaves_Init (also #606)
+
+### InflowWind
+- #578 InflowWind Updates (vertical flow angle, Bladed support, negetive height)
+- #596 Add support for initializing InflowWind with string inputs
+
+### MoorDyn
+- #565 Add active tensioning capabilities in MoorDyn
+- #604 [BugFix] Fix position and tension node outputs
+- #619 [BugFix] Regenerate Types files after registry file changes
+
+### NWTC Library
+- #588 Add NWTC Library infrastructure for parsing inputs as strings
+- #603 [BugFix] Fix order of variables declaration
+
+### Simulink
+- #545 Support for GNU compiler on Linux systems
+- #577 Updated examples for OpenFAST-Simulink Interface
+- #616 Fix potential memory leak and add more error handling
+
+### Documentation
+- #558 Refer to conda for installation ([docs](https://openfast.readthedocs.io/en/dev/source/install/index.html#download-binaries))
+- #559 Update unit test guidance ([docs](https://openfast.readthedocs.io/en/dev/source/testing/unit_test.html))
+- #614 [BugFix] Fix api_change.rst ([docs](https://openfast.readthedocs.io/en/dev/source/user/api_change.html))
+
+### Build system
+- #547 [BugFix] cmake configuration for  Linux + Intel + Debug
+- #583 CMake: set CMP0074 policy explicitly to avoid warnings
+- #595 Disable gfortran stack-reuse compiler option
+- #610 Prevent variable tracking in large Fortran modules
+
+### Testing
+- #579 #599 #610 Improve GH Actions

--- a/docs/changelogs/v2.6.0.md
+++ b/docs/changelogs/v2.6.0.md
@@ -1,0 +1,30 @@
+This release includes the following major enhancements:
+- Support for flexible floating platforms and expansion of linearization capability (#537)
+
+### AeroDyn
+#645 Add Eames tower shadow model to AD15
+#643 Support primary input file parsing through strings
+
+### BeamDyn
+#615 [BugFix] Initialized error variables
+#636 Add unit tests for BD_ComputeIniNodalCrv
+
+### HydroDyn
+#537 Flexible floating platforms
+#615 Morison performance improvement
+#634 Fix HydroDyn linearization matrix multiplication using unallocated arrays
+
+### InflowWind
+#642 [BugFix] Reenable InflowWind echo file lost in #596
+
+### NWTC Library
+#615 NWTC Lib bug fixes
+
+### Simulink Interface
+#641 [BugFix] Simulink error message overwrite
+
+### Testing
+#637 Use default runner and GFortran 10
+#635 Use Intel 2021 Toolset for regression test
+
+

--- a/docs/changelogs/v3.0.0.md
+++ b/docs/changelogs/v3.0.0.md
@@ -1,0 +1,67 @@
+This release includes the following major enhancements:
+- FAST.Farm (#584)
+- ServoDyn structural control submodule (#607)
+
+### AeroDyn
+#597 AD/AA: Add new TE definition, improve airfoil thickness calculation, simplify input
+#647 Add ability to turn unsteady aero back on during a simulation
+#648 OLAF improvements for WEIS
+#672 Preliminary support for multiple rotors in AeroDyn
+#728 AllBldOuts more forgiving and support for 0
+
+### BeamDyn
+#677 BD Driver bug fix and expand BeamDyn unit testing
+
+### ElastoDyn
+#589 Allow one-blade turbine model
+#653 Add YawBrTV[xyz]p output channels
+#736 AllBldOuts more forgiving and support for 0
+
+### FAST.Farm
+#584 Incorporate FAST.Farm to OpenFAST
+#726 Build FAST.Farm when configured via BUILD_FASTFARM
+#749 Add Missing Attribute for sc_end in the FAST.Farm Super Controller
+
+### HydroDyn
+#687 [BugFix] incorrect pitch/roll moments on tapered elements crossing water line
+#713 [BugFix] Uninitialized variables in HydroDyn::Morisson calculations
+
+### NWTC Library
+#668 [BugFix] Sys files for MATLAB
+#683 Big fix in NWTC Library unit tests
+
+### OpenFAST Library
+#744 Avoid gfortran 11 error in FAST_Solver.f90
+
+### ServoDyn
+#607 ServoDyn Structural control submodule (formerly TMD)
+#690 [BugFix] Rename Structural Control driver program
+#739 [BugFix] Logic error in glue code for StC loads on SD with no HD
+
+### Documentation
+#678 Add documentation on input file parsing
+#682 Update installation instructions
+#696 Update the api_change for MoorDyn after PR #565
+
+### C++ Inteface
+#703 [BugFix] unallocated AD%y%Rotors when AD14 is used with cpp interface
+#709 Remove unused import to C++ driver code
+
+### Simulink interface
+#702 [BugFix] Correct the expected format of the output channel names array
+
+### Build systems
+#698 Configure runtime path linking when using shared libraries
+#706 Automate incrementing the dev-label conda build
+#725 Updated linking dependencies for newer version of Visual Studio
+#727 Update rules for Intel OneAPI compiler detection
+
+### Testing
+#670 Enable regression tests for the C++ API
+#686 Bug fix for regression tests without C++ API enabled
+#689 Enable types generation in CI
+#691 Add SubDyn and AeroDyn drivers regression tests to github action
+#717 GH Actions: run module tests with debug build
+#718 [BugFix] Raise an error if reg test results contain NaN or infinity
+#741 CTest: Add FF reg tests when FF build is enabled
+

--- a/docs/changelogs/v3.1.0.md
+++ b/docs/changelogs/v3.1.0.md
@@ -1,0 +1,66 @@
+# Release Notes
+
+### General
+#707 Add environmental variables to driver input files
+#734 OpenFAST Registry algorithm change: simplify USE statements
+Others (#826, #835, #836, #911, #918, #971, #1019)
+
+### AeroDyn
+#688 AeroDyn driver update for multiple wind turbines, with arbitrary motions and geometries
+#729 New features for unsteady aerodynamics modeling
+#834 Fix AD Driver unallocated variable error with GCC 11
+#863 AeroDyn cleanup
+#917 AD15: add nodal outputs for VUnd{xyz}i in global coords
+#919 Segment treecode
+#920 Update in Computing Default Unsteady Airfoil Coefficients
+#922 [BugFix] Minor bugfix in AirfoilInfo
+#982 [BugFix] AD15 nacelle reference position was set to hub position
+#1001 Remove conditional statement for initialization of BEMT variable
+#1009 [BugFix] Nacelle position set inconsistently by glue code and AeroDyn driver
+
+### BeamDyn
+#996 [BugFix] BeamDyn nodal outputs occasionally segfaulted
+
+### FAST Farm
+#839 Fix Bug in FAST.Farm Causing Wake Bounce-Back
+#860 Fix some memory leaks in FAST.Farm
+#895 [BugFix] incorrect init of aggregated output index arrays in FAST.Farm
+#923 [BugFix] error handling in AWAE module
+
+### HydroDyn
+#756 HydroDyn primary input file passing and parsing
+#831 HydroDyn Input/Output meshes: change from SWL to MSL for consistency with OF glue code
+#838 [BugFix] segmentation fault in HD linearization 
+#915 [BugFix] Incorrect reference frame used in HD for WAMIT/WAMIT2 
+#998 Fix HydroDyn summary file nodal data is incorrect when Member is flipped
+
+### InflowWind
+#720 inflowWind C-bound interface and python wrapper
+#769 Fix issue with interpolation that could cause a segmentation fault
+#929 Fix issue with uninitialized variables in InflowWind's Direct Scaling method
+
+### NWTC Library
+#1002 Increase line length in FileInfo parsing methods
+
+### OpenFAST Library
+#716 [BugFix] Fix C++ API for restart, Error handling in FAST Library, and AeroDyn echo file lock
+#958 Lin: CalcSteady, forcing linearization at end of simulation
+
+### ServoDyn
+#664 Extended Bladed DLL interface, improved summary file including DLL channel usage, and cable controls for MD and SD
+#902 Fixes for Intel in debug mode
+#930 Stop OpenFAST for Simulink simulation when trim solution has been found
+
+### SubDyn
+#859 Various improvements to SubDyn
+
+### Documentation
+#740 Guidelines for performance considerations with Fortran
+#753 Migrate the HydroDyn Manual to readthedocs
+#805 Include legacy documentation in pdf and MS Word format - General & ElastoDyn
+#828 Add instructions for adding new regression test cases
+#858 Documentation for ExtPtfm
+#951 Corrected the description of SkewModFactor in Documentation
+#1020 Document AD outputs
+
+

--- a/docs/changelogs/v3.2.0.md
+++ b/docs/changelogs/v3.2.0.md
@@ -1,0 +1,60 @@
+# Release Notes
+
+### General
+#866 Include legacy documentation in pdf and MS Word format - Modules
+#1021 Reg_tests python scripts: fix issue where directory returned is empty
+#1062 Add documentation for community contribution
+#1169 Update git-module urls
+#1158 Update orientation differences in linear trim solution
+#1177 Add documentation on 3D rotations in linearization
+#1178 Corrections for 3.2.0 release
+
+### AeroDyn
+#932 BugFix: UA update states that were not updated
+#1032 AD: added more nodal outputs for debugging UA
+#1039 [BugFix] Nacelle motion not passed between AeroDyn driver and AeroDyn
+#1043 AeroDyn: combine some FVW and BEMT output calculations
+#1045 OLAF: check for division by zero to avoid invalid calculations
+#1141 Move AD module reg tests to a standalone job
+
+### BeamDyn
+#1050 Fix aeroelastic stability analysis with BeamDyn
+
+### FAST.Farm
+#1107 Fix Time-Step Delay in Super Controller within FAST.Farm
+
+### HydroDyn
+#806 C-bindings interface for HydroDyn
+#1047 Fix HydroDyn Jacobian outputs when LinOutJac is True
+#1108 BugFix: Checks to populate matrix input to Newman's app were reversed
+#1173 Bug Fix: rotation matrix perturbation with small angles was wrong
+
+### InflowWind
+#1144 BugFix: Fix typo in DLLEXPORT attributes for IfW C interface
+
+### MAP++
+#1048 MAP: small fix based on MAP 1.3
+#1168 Fix MAP linearization operating point
+
+### NWTC Library
+#1050 Fix aeroelastic stability analysis with BeamDyn -- changes to the library routines for angle perturbations during linearization
+#1124 Updates to VersionInfo module and its dependencies
+#1157 Fix for binary file compression
+
+### OpenFAST Library
+#962 Add a Python glue-code interface
+#1057 FAST Library: add access to hub position and velocity
+
+### ServoDyn
+#803 Linearization of ServoDyn Structural control elements
+#1074 [BugFix] ServoDyn StC control signal channels were not zeroed properly
+#1089 BugFix: Fix API change line numbers
+#1101 BugFix: ServoDyn API change docs
+#1140 Add non-rotating hub forces to Bladed Interface
+#1160 Correction to documentation on Extended Bladed DLL interface
+
+### TurbSim
+#887 TurbSim modifications
+
+
+

--- a/docs/changelogs/v3.2.1.md
+++ b/docs/changelogs/v3.2.1.md
@@ -1,0 +1,9 @@
+# Release Notes
+
+This release contains the following bug fixes:
+
+#1201 Include stdexcept in FastLibAPI driver
+#1180 Add conditional compile for C++ / C definitions in OpenFAST Library
+Revert #1169 Update git-module urls
+
+

--- a/docs/changelogs/v3.3.0.md
+++ b/docs/changelogs/v3.3.0.md
@@ -1,0 +1,48 @@
+# Release Notes
+
+### General
+#1183 Fix bugs and issues in the online documentation
+#1248 OpenFAST Registry: allow pointers
+
+### AeroDyn
+#1000 Updates of Unsteady Aero (UAMod=4) and DBEMT (DBEMT_Mod=3) for linearization
+#1037 Bug fix: BEMT was disabled for negative inflow
+#1042 AD: merge more of `TwrInfl` and `TwrInflArray` routines
+#1061 Fix AeroDyn WriteOutput linearization (and cleanup some code)
+#1078 Enable cavitation calculation and outputs using FVW
+#1188 AD15 driver: add visualization option for line meshes in addition to surfaces
+#1239 AeroAcoustics: fix BL-thickness for heavily-tripped airfoil
+
+### HydroDyn
+#999 Fix HD added mass on member end (Close #992)
+#1230 HD: increase max length of line read from kinematics files
+
+### MoorDyn
+#1086 MoorDyn v2 + shared moorings + wave propagation in FAST.Farm
+
+### MAP++
+#1186 MAP: allow keyword `fixed` and `fix`
+
+### NWTC Library
+#1254 NWTC Library and WriteOutput updates
+
+### Build System
+#1198 Option to disable variable tracking with GNU compiler
+#1228 r-test: Remove -m64 in CMAKE_Fortran_FLAG from r-test
+
+### Testing System
+#1203 Add parallel branches to GitHub Actions
+#1217 Consolidate regression test baseline set
+#1222 Improvements to regression test python scripts
+#1244 Reg-test scripts modification to help avoid race condition and cleanup of caselist
+#1264 GitHub Workflow: adding build-all-debug-single to check type errors
+
+### C++ API
+#1176 Simulink: add documentation of inputs to FAST_Library.h
+#1211 Use dt_out when storing OpenFAST outputs in Python interface
+#1227 Seg Fault due to hub model and external inflow
+
+### Linearization
+#1199 Small improvements for -VTKLin visualization outputs
+
+

--- a/docs/changelogs/v3.4.0.md
+++ b/docs/changelogs/v3.4.0.md
@@ -1,0 +1,70 @@
+# Release Notes
+
+OpenFAST v3.4.0 includes several major new features and bug fixes.  New features include a new curled-wake model in FAST.Farm (#931), buoyancy calculations in AeroDyn 15 for MHK turbines (#957), rotor and tail furling (#1277), and new library interfaces for AeroDyn 15 and MoorDyn to couple with other codes (#1110 & #848). One major bug fix is changing the CFD coupling to use only the AeroDyn 15 mesh information -- this had led to some discrepancies in CFD results (#1324).
+
+The full set of changes included in this version are further documented in the following listed pull requests.
+
+
+### General
+#889 Add a super-controller library target to CMake
+#1303 Small reorganization and clean up FAST.Farm r-test input files, upload of artifact
+#1311 NWTC_IO: nullifying DLL (on restart)  if not present when packing
+#1318 Allow Registry to generate extrap/interp routines for types without module nickname
+#1327 add version info to c-binding libraries
+#1332 Documentation fixes
+#1357 CI: exclude bokeh 3.0.[0-3] -- broken plots
+#1376 Add `regression_tests` to the ALL target.
+
+### Documentation
+#1267 OLAF: documentation: updated guidelines and using nFWPanels instead of WakeLength
+#1406 Update example InflowWind and FAST.Farm input files
+
+### Visualization
+#1319 Cleanup OpenFAST VTK output for HydroDyn
+#1321 Add safety checks to VTK output
+#1330 VTKLin: being more forgiving with number of modes
+#1333 NWTC_Lib: Adding Yaml and VTK to library (moved from SD and AD)
+
+### FAST.Farm
+#931 Implementation of the curled-wake model in FAST.Farm
+#1263 FAST.Farm WriteOutput: fix for Windows Intel OMP build
+#1304 API changes for future curl wake implementation, WD restructuring (Cq, OMP, skew filt)
+#1305 FF: Cartesian grid for AWAE and WD outputs
+#1310 FF: additional OpenMP parallelizations in FAST.Farm
+#1328  FF: update of guidelines for Curled wake dr and DT_low
+
+### OpenFAST
+#1275 Linear Trim Solution Improvements (Linearization)
+
+### AeroDyn
+#957 Calculate buoyancy for an MHK turbine
+#1110 New AeroDynInflow module with c-bindings interface
+#1276 Bug Fix: OLAF: particles are NaN when vortex segments have zero length
+#1277 Reactivating rotor furling and tailfin aerodynamics (ElastoDyn also)
+#1283 Add new projection method and BEM methods
+#1293 Minor error handling and code cleanup (OLAF)
+#1317 Fix for Visual Studio builds with ADI
+#1347 AeroDyn/UnsteadyAero_Driver: Fix for bug #1346
+#1355 OLAF: Adding free near wake panels
+#1356 AeroDyn/UnsteadyAero_Driver: Fix for bug #1346
+#1369 UA: adding UA_Driver outputs, fix separation function for UAMod=6, and adding r-tests
+
+### BeamDyn
+#1335 BeamDyn: output summary file in yaml format
+
+### InflowWind
+#1240 Improvements to the InflowWind disk averaged velocity calculations
+#1266 Temporarily removing InflowWind parallelization
+
+### MoorDyn
+#848 MoorDyn v2 C-bindings interface
+#1371 MoorDyn bending bugfix and message updates for v2
+
+### OpenFOAM
+#1324 CFD coupling to use AD15 mesh only
+#1365 OpFM: [bugfix] test for warning condition was broken
+#1372 [BugFix] the DEBUG_OPENFOAM preprocessor directive was never updated for multiple AD15 rotors
+
+### TurbSim
+#1361 TurbSim: User-defined time series updates
+

--- a/docs/changelogs/v3.4.1.md
+++ b/docs/changelogs/v3.4.1.md
@@ -1,0 +1,11 @@
+# Release Notes
+
+OpenFAST 3.4.1 is a minor release to revert a channel name change in AeroDyn 15.  This also contains minor fixes for documentation builds.
+
+### Documentation
+#1442 `[BugFix] Doxygen builds failing on rtd, and locally.   Documentation builds on readthedocs and local were failing due to a change in the backend of sphinx.  This fixes local builds, but does not fix readthedocs builds.  As a temporary workaround, doxygen is disabled on readthedocs.
+
+### AeroDyn15
+#1428 AD15: revert to Aero names for output channels (Fld is now an alias).  This fixes an issue introduced in v3.4.0 (#957)
+
+


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
These were copied from the GitHub releases page.  This will make it simpler to sort through what commits in the history for dev were in older releases and not part of the 4.0.0 release

**Related issue, if one exists**
None

**Impacted areas of the software**
Documentation only

**Additional supporting information**
Development of the v4.0.0 release has been going on in parallel with releases from v3.1.0 onwards.  To make it easier to figure out what pull requests in the history of `dev` were counted in other releases, it is convenient to have all the pull requests associated with each release in a command line searchable place. This will help with picking out what pull requests to `dev` in the last 3 years are not included in releases up to the most recent 3.5.5 release.

**Test results, if applicable**
Documentation only, no test results are affected.