### PR TITLE
Flang doesn't compile NWTC_IO.f90

### DIFF
--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2074,7 +2074,6 @@ END SUBROUTINE CheckR8Var
    INTEGER                        :: iWord                                        ! Word index.
    INTEGER                        :: i                                            ! Character index in line.
    INTEGER                        :: iChar                                        ! Character index in word.
-   CHARACTER(len=1)               :: Char                                         ! Current character
    LOGICAL                        :: InQuotes                                     ! Flag indicating text is within quotes
    LOGICAL                        :: IgnoreQuotesLoc                              ! Local flag to ignore quotes
 
@@ -2108,11 +2107,8 @@ END SUBROUTINE CheckR8Var
    ! Loop through characters in line
    do i = 1, len_trim(line)
 
-      ! Get current character
-      Char = Line(i:i)
-
       ! Select based on character
-      select case (Char)
+      select case (Line(i:i))
       case ('"', "'")               ! Double quotes, single quotes
          if (IgnoreQuotesLoc .or. InQuotes) then
             InQuotes = .false.

--- a/modules/nwtc-library/src/NWTC_IO.f90
+++ b/modules/nwtc-library/src/NWTC_IO.f90
@@ -2148,7 +2148,7 @@ END SUBROUTINE CheckR8Var
       end if
 
       ! Add character to word
-      Words(iWord)(iChar:iChar) = Char
+      Words(iWord)(iChar:iChar) = Line(i:i)
 
    end do
    


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The ROCM Flang compiler doesn't handle character arrays of length 1 in case statements for some reason.  This modifies one routine very lightly so that Flang can compile OpenFAST

**Related issue, if one exists**
Issue reported internally

**Impacted areas of the software**
Compilation with ROCM Flang compiler only.

**Additional supporting information**
Flang has some peculiarities.

**Test results, if applicable**
None affected