### PR TITLE
Fix bug in ExternalInflow Orientation indexing

### DIFF
--- a/modules/externalinflow/src/ExternalInflow.f90
+++ b/modules/externalinflow/src/ExternalInflow.f90
@@ -423,7 +423,7 @@ SUBROUTINE SetExtInfwPositions(p_FAST, u_AD, ExtInfw, ErrStat, ErrMsg)
          ExtInfw%u%xdotForce(Node) = real(ExtInfw%m%ActForceMotionsPoints(k)%TranslationVel(1,J),c_float)
          ExtInfw%u%ydotForce(Node) = real(ExtInfw%m%ActForceMotionsPoints(k)%TranslationVel(2,J),c_float)
          ExtInfw%u%zdotForce(Node) = real(ExtInfw%m%ActForceMotionsPoints(k)%TranslationVel(3,J),c_float)
-         ExtInfw%u%pOrientation((Node-1)*9_1:Node*9) = real(pack(ExtInfw%m%ActForceMotionsPoints(k)%Orientation(:,:,J),.true.),c_float)
+         ExtInfw%u%pOrientation((Node-1)*9+1:Node*9) = real(pack(ExtInfw%m%ActForceMotionsPoints(k)%Orientation(:,:,J),.true.),c_float)
       END DO
 
    END DO

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -359,6 +359,7 @@ of_aeromap_regression("5MW_Land_AeroMap"               "aeromap;elastodyn;aerody
 if(BUILD_OPENFAST_CPP_DRIVER)
   of_cpp_interface_regression("5MW_Land_DLL_WTurb_cpp" "openfast;fastlib;cpp")
   of_cpp_interface_regression("5MW_Restart_cpp"        "openfast;fastlib;cpp;restart")
+  of_cpp_interface_regression("5MW_Land_DLL_WTurb_ExtInfw_cpp" "openfast;fastlib;extinfw;cpp")
 endif()
 
 # OpenFAST Driver test for OpenFAST C++ Library


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged. 

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

An issue was discovered with the indexing in ExternalInflow which populates the Orientation data that is sent to AMR-Wind. Effectively a `+1` was replaced with a `_1` and instead of throwing a compilation error, this was interpreted as a type specification. This lead to an off-by-one indexing error in the orientation matrices. This PR fixes this issue and adds a new regression test which exercises the ExternalInflow module.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

ExternalInflow and regression tests.

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

New test was added and is passing.
