### PR TITLE
[BugFix] BD: variable passing in Calc_RR0mEta_rho

### DIFF
--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -2662,7 +2662,8 @@ SUBROUTINE BD_QPData_mEta_rho( p, m )
    do nelem = 1, p%elem_total
       qp_start = (nelem-1)*p%nqp
       do idx_qp = 1, p%nqp
-         call Calc_RR0mEta_rho(m%qp%RR0(:,:,idx_qp,nelem), &
+         call Calc_RR0mEta_rho(p%qp%mEta(:,idx_qp,nelem), &
+                               m%qp%RR0(:,:,idx_qp,nelem), &
                                p%Mass0_QP(:,:,qp_start+idx_qp), &
                                m%qp%RR0mEta(:,idx_qp,nelem), &
                                m%qp%rho(:,:,idx_qp,nelem))
@@ -2670,13 +2671,13 @@ SUBROUTINE BD_QPData_mEta_rho( p, m )
    end do
 
 contains
-   subroutine Calc_RR0mEta_rho(RR0, Mass0, RR0mEta, rho)
-      real(BDKi), intent(in)  :: RR0(:,:), Mass0(:,:)
+   subroutine Calc_RR0mEta_rho(mEta, RR0, Mass0, RR0mEta, rho)
+      real(BDKi), intent(in)  :: mEta(:), RR0(:,:), Mass0(:,:)
       real(BDKi), intent(out)  :: RR0mEta(:), rho(:,:)
 
          !> Calculate the new center of mass times mass at the deflected location
          !! as \f$ \left(\underline{\underline{R}}\underline{\underline{R}}_0\right) m \underline{\eta} \f$
-         RR0mEta(:) = MATMUL(RR0, p%qp%mEta(:,idx_qp,nelem))
+         RR0mEta(:) = MATMUL(RR0, mEta)
 
          !> Calculate \f$ \rho = \left(\underline{\underline{R}}\underline{\underline{R}}_0\right)
          !!                      \underline{\underline{M}}_{2,2}

--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -2676,7 +2676,7 @@ contains
 
          !> Calculate the new center of mass times mass at the deflected location
          !! as \f$ \left(\underline{\underline{R}}\underline{\underline{R}}_0\right) m \underline{\eta} \f$
-         RR0mEta(:,idx_qp,nelem) = MATMUL(RR0, p%qp%mEta(:,idx_qp,nelem))
+         RR0mEta(:) = MATMUL(RR0, p%qp%mEta(:,idx_qp,nelem))
 
          !> Calculate \f$ \rho = \left(\underline{\underline{R}}\underline{\underline{R}}_0\right)
          !!                      \underline{\underline{M}}_{2,2}

--- a/modules/beamdyn/src/BeamDyn.f90
+++ b/modules/beamdyn/src/BeamDyn.f90
@@ -2676,7 +2676,7 @@ contains
 
          !> Calculate the new center of mass times mass at the deflected location
          !! as \f$ \left(\underline{\underline{R}}\underline{\underline{R}}_0\right) m \underline{\eta} \f$
-         m%qp%RR0mEta(:,idx_qp,nelem) = MATMUL(RR0, p%qp%mEta(:,idx_qp,nelem))
+         RR0mEta(:,idx_qp,nelem) = MATMUL(RR0, p%qp%mEta(:,idx_qp,nelem))
 
          !> Calculate \f$ \rho = \left(\underline{\underline{R}}\underline{\underline{R}}_0\right)
          !!                      \underline{\underline{M}}_{2,2}


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
In the  `BD_Calc_RR0mEta_rho` routine, the `RR0mEta` output was not getting set, but instead the `m%qp%RR0mEta` was set directly.  However the `RR0mEta` value was passed out of the routine directly to `m%qp%RR0mEta`, so it becomes ambiguous if the compiler would set that value through the routine, or set it to the uninitialized value of `RR0mEta`.


**Related issue, if one exists**
Issue #2641 outlines the issue in more detail.

**Impacted areas of the software**
_BeamDyn_, but likely only with specific compilers (most seem to handle this odd code).

closes #2641 