### PR TITLE
HydroDyn C-binding: Added mass matrix

### DIFF
--- a/modules/hydrodyn/python-lib/hydrodyn_library.py
+++ b/modules/hydrodyn/python-lib/hydrodyn_library.py
@@ -315,7 +315,7 @@ class HydroDynLib(CDLL):
     def hydrodyn_calcOutput(self, time, nodePos, nodeVel, nodeAcc, nodeFrcMom, outputChannelValues):
 
         # Check input motion info
-        self.check_input_motions(nodePos,nodeVel,nodeAcc)
+        self.check_input_motions(time,nodePos,nodeVel,nodeAcc)
 
         # set flat arrays for inputs of motion
         #   Position -- [x1,y1,z1,Rx1,Ry1,Rz1, x2,y2,z2,Rx2,Ry2,Rz2 ...]

--- a/modules/hydrodyn/python-lib/hydrodyn_library.py
+++ b/modules/hydrodyn/python-lib/hydrodyn_library.py
@@ -376,7 +376,7 @@ class HydroDynLib(CDLL):
     def hydrodyn_calcOutput_and_addedMass(self, time, nodePos, nodeVel, nodeFrcMom, nodeAdm, outputChannelValues):
 
         # Check input motion info
-        self.check_input_motions_noAcc(nodePos,nodeVel)
+        self.check_input_motions_noAcc(time,nodePos,nodeVel)
 
         # set flat arrays for inputs of motion
         #   Position -- [x1,y1,z1,Rx1,Ry1,Rz1, x2,y2,z2,Rx2,Ry2,Rz2 ...]
@@ -441,7 +441,7 @@ class HydroDynLib(CDLL):
     def hydrodyn_updateStates(self, time, timeNext, nodePos, nodeVel, nodeAcc, nodeFrcMom):
 
         # Check input motion info
-        self.check_input_motions(nodePos,nodeVel,nodeAcc)
+        self.check_input_motions(time,nodePos,nodeVel,nodeAcc)
 
         # set flat arrays for inputs of motion
         #   Position -- [x2,y1,z1,Rx1,Ry1,Rz1, x2,y2,z2,Rx2,Ry2,Rz2 ...]
@@ -503,10 +503,9 @@ class HydroDynLib(CDLL):
             raise Exception("\nHydroDyn terminated prematurely.")
 
 
-    def check_input_motions(self,nodePos,nodeVel,nodeAcc):
+    def check_input_motions(self,time,nodePos,nodeVel,nodeAcc):
         # make sure number of nodes didn't change for some reason
         if self._initNumNodePts != self.numNodePts:
-            # @ANDY TODO: `time` is not available here so this would be a runtime error
             print(f"At time {time}, the number of node points changed from initial value of {self._initNumNodePts}.  This is not permitted during the simulation.")
             self.hydrodyn_end()
             raise Exception("\nError in calling HydroDyn library.")
@@ -544,10 +543,9 @@ class HydroDynLib(CDLL):
             raise Exception("\nHydroDyn terminated prematurely.")
 
 
-    def check_input_motions_noAcc(self,nodePos,nodeVel):
+    def check_input_motions_noAcc(self,time,nodePos,nodeVel):
         # make sure number of nodes didn't change for some reason
         if self._initNumNodePts != self.numNodePts:
-            # @ANDY TODO: `time` is not available here so this would be a runtime error
             print(f"At time {time}, the number of node points changed from initial value of {self._initNumNodePts}.  This is not permitted during the simulation.")
             self.hydrodyn_end()
             raise Exception("\nError in calling HydroDyn library.")

--- a/modules/hydrodyn/python-lib/hydrodyn_library.py
+++ b/modules/hydrodyn/python-lib/hydrodyn_library.py
@@ -199,6 +199,19 @@ class HydroDynLib(CDLL):
         ]
         self.HydroDyn_C_CalcOutput.restype = c_int
 
+        self.HydroDyn_C_CalcOutput_and_AddedMass.argtypes = [
+            POINTER(c_double),                  # Time_C
+            POINTER(c_int),                     # numNodePts -- number of points expecting motions/loads
+            POINTER(c_float),                   # nodePos -- node positions      in flat array of 6*numNodePts
+            POINTER(c_float),                   # nodeVel -- node velocities     in flat array of 6*numNodePts
+            POINTER(c_float),                   # nodeFrc -- node forces/moments in flat array of 6*numNodePts
+            POINTER(c_float),                   # nodeAdm -- node added mass matrix in flat array of 6*numNodePts*6*numNodePts
+            POINTER(c_float),                   # Output Channel Values
+            POINTER(c_int),                     # ErrStat_C
+            POINTER(c_char)                     # ErrMsg_C
+        ]
+        self.HydroDyn_C_CalcOutput_and_AddedMass.restype = c_int
+
         self.HydroDyn_C_UpdateStates.argtypes = [
             POINTER(c_double),                  # Time_C
             POINTER(c_double),                  # TimeNext_C


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
This PR adds a new subroutine in HydroDyn C-binding called `HydroDyn_C_CalcOutput_and_AddedMass` that returns a 6N-by-6N added mass matrix, where N is the number nodes in the coupling mesh (input to the subroutine). It also returns the remainder of the hydrodynamic, hydrostatic, and other loads computed by HydroDyn with the added-mass component removed. 

This subroutine is added to facilitate the coupling of HydroDyn with other structural solvers. It allows the added-mass loads to be treated as an unknown and solved for together with structure acceleration in the structural solver for stability. Note that added mass refers to not only hydrodynamic added mass, but also other inertial load components from internal ballast and marine growth.

**Impacted areas of the software**
HydroDyn C-binding only. No change to HydroDyn itself.

**Test results, if applicable**
No change to existing r-test results.
