### PR TITLE
Avoid ending program when called as a shared library

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -9615,12 +9615,16 @@ SUBROUTINE ExitThisProgram( p_FAST, y_FAST, m_FAST, ED, SED, BD, SrvD, AD, ADsk,
 
 
       SimMsg = TRIM(FAST_Ver%Name)//' encountered an error '//TRIM(SimMsg)//'.'//NewLine//' Simulation error level: '//TRIM(GetErrStr(ErrorLevel))
+#if (defined COMPILE_SIMULINK || defined COMPILE_LABVIEW)
+   ! When built as a shared library/dll, don't end the program.
+     CALL WrScr(trim(SimMsg))
+#else
       if (StopTheProgram) then
          CALL ProgAbort( trim(SimMsg), TrapErrors=.FALSE., TimeWait=3._ReKi )  ! wait 3 seconds (in case they double-clicked and got an error)
       else
          CALL WrScr(trim(SimMsg))
       end if
-
+#endif
    END IF
 
    !............................................................................................................................


### PR DESCRIPTION
**Feature or improvement description**
When running the OpenFAST S-Function from Simulink, Matlab could shut down if an error was encountered at the end of the simulation. This PR fixes the problem.

**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/2652

**Impacted areas of the software**
Simulink interface

**Test results, if applicable**
This shouldn't change any results