### PR TITLE
Add "nouninit" to debug flags for IntelLLVM

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -164,7 +164,11 @@ macro(set_fast_intel_fortran_posix)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,noarg_temp_created -traceback -init=huge,infinity" )
+    if(${CMAKE_Fortran_COMPILER_ID} MATCHES "IntelLLVM")
+      set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,noarg_temp_created,nouninit -traceback -init=huge,infinity" )
+    else()
+      set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -check all,noarg_temp_created -traceback -init=huge,infinity" )
+    endif()
   endif()
 
   # If double precision, make real and double constants 64 bits
@@ -222,7 +226,11 @@ macro(set_fast_intel_fortran_windows)
 
   # debug flags
   if(CMAKE_BUILD_TYPE MATCHES Debug)
-    set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all,noarg_temp_created /traceback /Qinit=huge,infinity" )
+    if(${CMAKE_Fortran_COMPILER_ID} MATCHES "IntelLLVM")
+      set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all,noarg_temp_created,nouninit /traceback /Qinit=huge,infinity" )
+    else()
+      set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} /check:all,noarg_temp_created /traceback /Qinit=huge,infinity" )
+    endif()
   endif()
 
   check_f2008_features()


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
There is a bug in 2024 and 2025 IFX compiler that creates a conflict with `-lm` and `-ldl` if `check uninit` is enabled.

**Related issue, if one exists**

**Impacted areas of the software**
Compilation with `debug` and the Intel IFX compilers was failing on the linking step on many systems.

**Additional supporting information**
https://community.intel.com/t5/Intel-Fortran-Compiler/ifx-IFX-2023-2-0-20230721-linker-problems-with-check-uninit/m-p/1527816


**Test results, if applicable**
No tests affected.