### PR TITLE
Increase length of error messages

### DIFF
--- a/modules/nwtc-library/src/NWTC_Base.f90
+++ b/modules/nwtc-library/src/NWTC_Base.f90
@@ -33,7 +33,7 @@ MODULE NWTC_Base
       ! General constants:
 
    INTEGER, PARAMETER            :: BITS_IN_ADDR  = C_INTPTR_T*8                  !< The number of bits in an address (32-bit or 64-bit).
-   INTEGER, PARAMETER            :: ErrMsgLen = 1024                              !< The maximum number of characters in an error message in the FAST framework
+   INTEGER, PARAMETER            :: ErrMsgLen = 65536                             !< The maximum number of characters in an error message in the FAST framework
    
    INTEGER(IntKi), PARAMETER     :: ChanLen   = 20                                !< The maximum allowable length of channel names (i.e., width of output columns) in the FAST framework
    INTEGER(IntKi), PARAMETER     :: OutStrLenM1 = ChanLen - 1                     !< The maximum allowable length of channel names without optional "-" or "M" at the beginning to indicate the negative of the channel

--- a/modules/nwtc-library/src/NWTC_Base.f90
+++ b/modules/nwtc-library/src/NWTC_Base.f90
@@ -33,7 +33,7 @@ MODULE NWTC_Base
       ! General constants:
 
    INTEGER, PARAMETER            :: BITS_IN_ADDR  = C_INTPTR_T*8                  !< The number of bits in an address (32-bit or 64-bit).
-   INTEGER, PARAMETER            :: ErrMsgLen = 65536                             !< The maximum number of characters in an error message in the FAST framework
+   INTEGER, PARAMETER            :: ErrMsgLen = 8196                              !< The maximum number of characters in an error message in the FAST framework
    
    INTEGER(IntKi), PARAMETER     :: ChanLen   = 20                                !< The maximum allowable length of channel names (i.e., width of output columns) in the FAST framework
    INTEGER(IntKi), PARAMETER     :: OutStrLenM1 = ChanLen - 1                     !< The maximum allowable length of channel names without optional "-" or "M" at the beginning to indicate the negative of the channel


### PR DESCRIPTION
Ready to merge (probably)

**Feature or improvement description**
The error messages have been far too short for complex messages or messages from FAST.Farm.  Increasing it to ~2^16 characters (maybe a bit of an overkill)~ 2^13 characters (8192).

This will result in more memory required for error messages.  

In theory this should be enough (cue the "no-one will ever need more than 640k of memory..." quotes from the grey beards)...

**Related issue, if one exists**
#2701 

**Impacted areas of the software**
The few users that read error messages will see more of the error messages

**Additional supporting information**
Another option is to increase the `ErrMsgLen` by a more sane amount and change how we write errors to screen.

Long term we will want to go with @bjonkman's solution - for 5.0.

**Test results, if applicable**
Output log text from test results may change slightly, but we don't check this data (timestamp always changes during testing).