### PR TITLE
generate BD files if fst_vt dictionary BD keys are not empty

### DIFF
--- a/openfast_io/openfast_io/FAST_reader.py
+++ b/openfast_io/openfast_io/FAST_reader.py
@@ -3250,11 +3250,11 @@ class InputReader_OpenFAST(object):
             moordyn_file = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['MooringFile']))
             if os.path.isfile(moordyn_file):
                 self.read_MoorDyn(moordyn_file)
-        if self.fst_vt['Fst']['CompElast'] == 2:
-            bd_file1 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(1)']))
-            bd_file2 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(2)']))
-            bd_file3 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(3)']))
 
+        bd_file1 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(1)']))
+        bd_file2 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(2)']))
+        bd_file3 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(3)']))
+        if os.path.exists(bd_file1):
             # if the files are the same then we only need to read it once, need to handle the cases where we have a 2 or 1 bladed rotor
             # Check unique BeamDyn blade files and read only once if identical
             if bd_file1 == bd_file2 and bd_file1 == bd_file3:

--- a/openfast_io/openfast_io/FAST_writer.py
+++ b/openfast_io/openfast_io/FAST_writer.py
@@ -239,18 +239,17 @@ class InputWriter_OpenFAST(object):
             if 'options' in self.fst_vt['MoorDyn'] and 'WaterKin' in self.fst_vt['MoorDyn']['options']:
                 self.write_WaterKin(os.path.join(self.FAST_runDirectory,self.fst_vt['MoorDyn']['WaterKin_file']))
 
-        if self.fst_vt['Fst']['CompElast'] == 2:
+        #     # look at if the the self.fst_vt['BeamDyn'] is an array, if so, loop through the array
+        #     # if its a dictionary, just write the same BeamDyn file 
 
-            # look at if the the self.fst_vt['BeamDyn'] is an array, if so, loop through the array
-            # if its a dictionary, just write the same BeamDyn file 
-
-            if isinstance(self.fst_vt['BeamDyn'], list):
-                for i_BD, BD in enumerate(self.fst_vt['BeamDyn']):
-
+        if isinstance(self.fst_vt['BeamDyn'], list):
+            for i_BD, BD in enumerate(self.fst_vt['BeamDyn']):
+                if not BD == {}:
                     self.fst_vt['Fst']['BDBldFile(%d)'%(i_BD+1)] = self.FAST_namingOut + '_BeamDyn_%d.dat'%(i_BD+1)
                     self.write_BeamDyn(bldInd = i_BD)
 
-            elif isinstance(self.fst_vt['BeamDyn'], dict):
+        elif isinstance(self.fst_vt['BeamDyn'], dict):
+            if not self.fst_vt['BeamDyn'] == {}:
                 self.fst_vt['Fst']['BDBldFile(1)'] = self.FAST_namingOut + '_BeamDyn.dat'
                 self.fst_vt['Fst']['BDBldFile(2)'] = self.fst_vt['Fst']['BDBldFile(1)']
                 self.fst_vt['Fst']['BDBldFile(3)'] = self.fst_vt['Fst']['BDBldFile(1)']


### PR DESCRIPTION
@ptrbortolotti: In openfast_io, write BeamDyn files if data structure is available in the fast_vt dictionary (and not only if CompElast=2)

Replaces PR: https://github.com/OpenFAST/openfast/pull/2726

We might need extend the ability to write the input files even if the modules are not enabled in the .fst file across to all modules. But, this looks good for v4.0.3.

Tests pass locally:
```
1/1 Test #156: openfast_io_library ..............   Passed  510.57 sec

100% tests passed, 0 tests failed out of 1

Label Time Summary:
openfast_io    = 510.57 sec*proc (1 test)
python         = 510.57 sec*proc (1 test)

Total Test time (real) = 510.60 sec
```