### PR TITLE
Bug fix for Failed0 error checking functions

### DIFF
--- a/glue-codes/fast-farm/src/FASTWrapper.f90
+++ b/glue-codes/fast-farm/src/FASTWrapper.f90
@@ -229,12 +229,12 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate memory for "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call SetErrStat(ErrStat2, ErrMsg2, errStat, errMsg, RoutineName)
       endif
-      Failed0 = errStat >= AbortErrLev
+      Failed0 = ErrStat >= AbortErrLev
       if(Failed0) call cleanUp()
    end function Failed0
 END SUBROUTINE FWrap_Init

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -604,12 +604,12 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate memory for "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
-      Failed0 = errStat >= AbortErrLev
+      Failed0 = ErrStat >= AbortErrLev
       if(Failed0) call cleanUp()
    end function Failed0
 END SUBROUTINE Farm_InitWD
@@ -716,12 +716,12 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate memory for "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
-      Failed0 = errStat >= AbortErrLev
+      Failed0 = ErrStat >= AbortErrLev
       if(Failed0) call cleanUp()
    end function Failed0
 END SUBROUTINE Farm_InitFAST
@@ -873,12 +873,12 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate memory for "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
-      Failed0 = errStat >= AbortErrLev
+      Failed0 = ErrStat >= AbortErrLev
       if(Failed0) call cleanUp()
    end function Failed0
 END SUBROUTINE Farm_InitMD

--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -557,12 +557,12 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, 'Init_ADI_ForDriver')
+         call SetErrStat(ErrStat2, ErrMsg2, errStat, errMsg, 'Init_ADI_ForDriver')
       endif
-      Failed0 = errStat >= AbortErrLev
+      Failed0 = ErrStat >= AbortErrLev
       if(Failed0) call cleanUp()
    end function Failed0
 

--- a/modules/aerodyn/src/AeroDyn_Inflow_C_Binding.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow_C_Binding.f90
@@ -375,7 +375,10 @@ contains
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
       Failed0 = ErrStat >= AbortErrLev
-      if(Failed0) call ClearTmpStorage()
+      if(Failed0) then
+         call ClearTmpStorage()
+         call SetErr(ErrStat,ErrMsg,ErrStat_C,ErrMsg_C)
+      endif
    end function Failed0
 
    !> This subroutine prints out all the variables that are passed in.  Use this only
@@ -1538,7 +1541,10 @@ contains
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
       Failed0 = ErrStat >= AbortErrLev
-      if(Failed0) call ClearTmpStorage()
+      if(Failed0) then
+         call ClearTmpStorage()
+         call SetErr(ErrStat,ErrMsg,ErrStat_C,ErrMsg_C)
+      endif
    end function Failed0
 
    !> This subroutine prints out all the variables that are passed in.  Use this only

--- a/modules/aerodyn/src/AeroDyn_Inflow_C_Binding.f90
+++ b/modules/aerodyn/src/AeroDyn_Inflow_C_Binding.f90
@@ -369,7 +369,7 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
@@ -787,7 +787,7 @@ CONTAINS
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat2 /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
@@ -1532,7 +1532,7 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)

--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1207,12 +1207,12 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate memory for "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
-      Failed0 = errStat >= AbortErrLev
+      Failed0 = ErrStat >= AbortErrLev
    end function Failed0
 end subroutine AWAE_Init
 

--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -2999,7 +2999,7 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg2, RoutineName)

--- a/modules/moordyn/src/MoorDyn_Line.f90
+++ b/modules/moordyn/src/MoorDyn_Line.f90
@@ -2016,7 +2016,7 @@ CONTAINS
       ! check for failed where /= 0 is fatal
       logical function Failed0(txt)
          character(*), intent(in) :: txt
-         if (errStat /= 0) then
+         if (ErrStat2 /= 0) then
             ErrStat2 = ErrID_Fatal
             ErrMsg2  = "Could not allocate "//trim(txt)
             call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -1298,7 +1298,7 @@ CONTAINS
       ! check for failed where /= 0 is fatal
       logical function Failed0(txt)
          character(*), intent(in) :: txt
-         if (errStat /= 0) then
+         if (ErrStat2 /= 0) then
             ErrStat2 = ErrID_Fatal
             ErrMsg2  = "Could not allocate "//trim(txt)
             call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)

--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -5258,7 +5258,7 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate "//trim(txt)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -633,10 +633,10 @@ contains
    ! check for failed where /= 0 is fatal
    logical function Failed0(txt)
       character(*), intent(in) :: txt
-      if (errStat /= 0) then
+      if (ErrStat2 /= 0) then
          ErrStat2 = ErrID_Fatal
          ErrMsg2  = "Could not allocate memory for "//trim(txt)
-         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
+         call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       endif
       Failed0 = errStat >= AbortErrLev
    end function Failed0


### PR DESCRIPTION
# Bug fix in repeated Failed0 error checking functions

This pull request corrects a bug in the `Failed0` error checking functions. Since the bug is repeated exactly, I'm assuming it was present when the function was introduced and then spread by copy / paste throughout. Therefore, while this is likely not causing any issues at the moment, I'm submitting the change to fix it so that it does not continue to spread.

Currently, most of the `Failed0` functions check for whether the global error, usually `ErrStat`, is not 0. However, these functions are primarily used after array allocations with the error status going into the local error, usually `ErrStat2`. See the example below. In the current `Failed0`, the if-statement to set the error status and message is only entered if the global error is already non-zero, but it is intending to check for whether the local error is set by the allocation.

```f90
! In FAST_Farm_Subs.f90

! Farm_InitWD
ALLOCATE(farm%WD(farm%p%NumTurbines),STAT=ErrStat2);  if (Failed0('Wake Dynamics data')) return;

contains

   ! check for failed where /= 0 is fatal
   logical function Failed0(txt)
      character(*), intent(in) :: txt
      if (errStat /= 0) then
         ErrStat2 = ErrID_Fatal
         ErrMsg2  = "Could not allocate memory for "//trim(txt)
         call SetErrStat(errStat2, errMsg2, errStat, errMsg, RoutineName)
      endif
      Failed0 = errStat >= AbortErrLev
      if(Failed0) call cleanUp()
   end function Failed0
```

There are two more changes included:
- When I changed the `Failed0` functions, I also used a consistent case for the error status and error message variables to make it easier to scan for these words. Note that a few instances of `Failed0` already had the correct error checking but inconsistent case. I did not modify those.
- The AeroDyn Inflow C Binding library was not copying the Fortran error to the C error in `Failed0`. Even if the error was caught by the Fortran module, it wouldn't have been sent to the calling code. This is fixed here.
