### PR TITLE
Update GH conda-deploy action to use Ubuntu 24.04

### DIFF
--- a/.github/workflows/conda-deploy.yml
+++ b/.github/workflows/conda-deploy.yml
@@ -15,7 +15,7 @@ on:
 jobs:
   update-dev:
     if: github.repository_owner == 'OpenFAST'
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       # - name: Echo path
       #   run: |


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
Ubuntu 20.04 was deprecated last week on GH actions.

**Related issue, if one exists**
none

**Impacted areas of the software**
Packaging for distribution with conda only.

