### PR TITLE
Fix FAST_ExtInfw_Restart API

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -642,7 +642,6 @@ void fast::OpenFAST::init() {
                         tmpRstFileRoot,
                         &AbortErrLev,
                         &turbineData[iTurb].dt,
-                        &turbineData[iTurb].inflowType,
                         &turbineData[iTurb].numBlades,
                         &turbineData[iTurb].numVelPtsBlade,
                         &turbineData[iTurb].numVelPtsTwr,

--- a/modules/openfast-library/src/FAST_Library.h
+++ b/modules/openfast-library/src/FAST_Library.h
@@ -16,7 +16,7 @@
 EXTERNAL_ROUTINE void FAST_AllocateTurbines(int * iTurb, int *ErrStat, char *ErrMsg);
 EXTERNAL_ROUTINE void FAST_DeallocateTurbines(int *ErrStat, char *ErrMsg);
 
-EXTERNAL_ROUTINE void FAST_ExtInfw_Restart(int * iTurb, const char *CheckpointRootName, int *AbortErrLev, double * dt, int * InflowType,
+EXTERNAL_ROUTINE void FAST_ExtInfw_Restart(int * iTurb, const char *CheckpointRootName, int *AbortErrLev, double * dt,
                                            int * NumBl, int * NumBlElem, int * NumTwrElem, int * n_t_global,
                                            ExtInfw_InputType_t* ExtInfw_Input, ExtInfw_OutputType_t* ExtInfw_Output, SC_DX_InputType_t* SC_DX_Input, SC_DX_OutputType_t* SC_DX_Output,
                                            int *ErrStat, char *ErrMsg);


### PR DESCRIPTION
The C++ function declaration had an extra argument InflowType, that is not present in the Fortran function definition.
