### PR TITLE
bug fix #2762

### DIFF
--- a/openfast_io/openfast_io/FAST_reader.py
+++ b/openfast_io/openfast_io/FAST_reader.py
@@ -3254,7 +3254,7 @@ class InputReader_OpenFAST(object):
         bd_file1 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(1)']))
         bd_file2 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(2)']))
         bd_file3 = os.path.normpath(os.path.join(self.FAST_directory, self.fst_vt['Fst']['BDBldFile(3)']))
-        if os.path.exists(bd_file1):
+        if os.path.isfile(bd_file1):
             # if the files are the same then we only need to read it once, need to handle the cases where we have a 2 or 1 bladed rotor
             # Check unique BeamDyn blade files and read only once if identical
             if bd_file1 == bd_file2 and bd_file1 == bd_file3:


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->
 `openfast_io` will only read the BD file if it exists. This will solve the case when `CompElast=1` and `BDBldFile(:) = ""`

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->
Solves, https://github.com/OpenFAST/openfast/issues/2762

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->
`openfast_io`

**Additional supporting information**
<!-- Add any other context about the problem here. -->


**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

Tests run OK locally.


cc: @abhineet-gupta, @ptrbortolotti 

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
