### PR TITLE
Avoid ending program when called as a shared library

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -9615,12 +9615,16 @@ SUBROUTINE ExitThisProgram( p_FAST, y_FAST, m_FAST, ED, SED, BD, SrvD, AD, ADsk,
 
 
       SimMsg = TRIM(FAST_Ver%Name)//' encountered an error '//TRIM(SimMsg)//'.'//NewLine//' Simulation error level: '//TRIM(GetErrStr(ErrorLevel))
+#if (defined COMPILE_SIMULINK || defined COMPILE_LABVIEW)
+   ! When built as a shared library/dll, don't end the program.
+     CALL WrScr(trim(SimMsg))
+#else
       if (StopTheProgram) then
          CALL ProgAbort( trim(SimMsg), TrapErrors=.FALSE., TimeWait=3._ReKi )  ! wait 3 seconds (in case they double-clicked and got an error)
       else
          CALL WrScr(trim(SimMsg))
       end if
-
+#endif
    END IF
 
    !............................................................................................................................


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
When running from Simulink, Matlab would end (instead of the DLL). This PR fixes the problem.

**Related issue, if one exists**
backport of #2671 
