### PR TITLE
MD cbind: correction to description of mesh point mapping

### DIFF
--- a/modules/moordyn/src/MoorDyn_C_Binding.f90
+++ b/modules/moordyn/src/MoorDyn_C_Binding.f90
@@ -106,10 +106,12 @@ INTEGER(IntKi),   PARAMETER             :: INPUT_PRED = 1      !< Index for pred
 !------------------------------
 !  Meshes for external nodes
 !     These point meshes are merely used to simplify the mapping of motions/loads
-!     to/from MD using the library mesh mapping routines.  These meshes may contain
-!     one or multiple points.
-!        - 1 point   -- rigid floating body assumption
-!        - N points  -- flexible structure (either floating or fixed bottom)
+!     to/from MD using the library mesh mapping routines.  The input mesh into the
+!     library can only contain one point at present and is rigidly mapped to multiple
+!     MoorDyn mesh points.
+!
+!     In the future, we may wish modify this interface to allow for N mesh points
+!     for coupling to N MoorDyn mesh points for modeling things likeflexible structures.
 TYPE(MeshType)                          :: MD_MotionMesh       !< mesh for motions of external nodes
 TYPE(MeshType)                          :: MD_LoadMesh         !< mesh for loads  for external nodes
 TYPE(MeshMapType)                       :: Map_Motion_2_MD     !< Mesh mapping between input motion mesh and MD
@@ -600,7 +602,7 @@ SUBROUTINE SetMotionLoadsInterfaceMeshes(ErrStat,ErrMsg)
    !     this to the input mesh.
    CALL MeshCreate(  MD_MotionMesh                       ,  &
                      IOS              = COMPONENT_INPUT  ,  &
-                     Nnodes           = 1                ,  &
+                     Nnodes           = 1                ,  &     ! Single node for now -- rigid body mapping to MD mesh points
                      ErrStat          = ErrStat          ,  &
                      ErrMess          = ErrMsg           ,  &
                      TranslationDisp  = .TRUE.,    Orientation = .TRUE., &

--- a/modules/moordyn/src/MoorDyn_C_Binding.f90
+++ b/modules/moordyn/src/MoorDyn_C_Binding.f90
@@ -108,7 +108,8 @@ INTEGER(IntKi),   PARAMETER             :: INPUT_PRED = 1      !< Index for pred
 !     These point meshes are merely used to simplify the mapping of motions/loads
 !     to/from MD using the library mesh mapping routines.  The input mesh into the
 !     library can only contain one point at present and is rigidly mapped to multiple
-!     MoorDyn mesh points.
+!     MoorDyn mesh points. This means all MoorDyn coupled objects as defined in the
+!     input file will be rigidly attached to the input mesh
 !
 !     In the future, we may wish modify this interface to allow for N mesh points
 !     for coupling to N MoorDyn mesh points for modeling things likeflexible structures.


### PR DESCRIPTION
Merge after #2735

**Feature or improvement description**
The documentation in `MoorDyn_c-binding.f90` about the input/output mesh was incorrect. Only a single mesh point can be passed across the interface, but it is able to rigidly map over to multiple _MoorDyn_ mesh points

**Related issue, if one exists**
Question raised in #2735 review: https://github.com/OpenFAST/openfast/pull/2735#discussion_r2049554766
