### PR TITLE
Fix openfastcpp restart parsing of file name

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -94,8 +94,15 @@ void fast::OpenFAST::findRestartFile(int iTurbLoc) {
     check_nc_error(ierr, "nc_get_vara_double - getting latest time");
     tStart = latest_time;
 
-    char tmpOutFileRoot[INTERFACE_STRING_LENGTH];
+    char *tmpOutFileRoot;
+    size_t len;
+    ierr = nc_inq_attlen(ncid, NC_GLOBAL, "out_file_root", &len);
+    check_nc_error(ierr, "nc_inq_attlen - getting out_file_root length");
+
+    tmpOutFileRoot = (char*) malloc(len + 1);
     ierr = nc_get_att_text(ncid, NC_GLOBAL, "out_file_root", tmpOutFileRoot);
+    check_nc_error(ierr, "nc_get_att_text - getting out_file_root");
+    tmpOutFileRoot[len] = '\0';
     turbineData[iTurbLoc].outFileRoot.assign(tmpOutFileRoot);
 
     ierr = nc_get_att_double(ncid, NC_GLOBAL, "dt_fast", &dtFAST);


### PR DESCRIPTION
## Short story
This is a safer way to get the restart file name from the netcdf file. First, get the actual length of the string with `nc_inq_attlen`, then create a char pointer that is that length + 1. Then make sure that char pointer ends with a null char. And only then is it safe to use the `assign` operator from that char pointer to a string. 


## Really long story

I found this because I was having restart issues on Frontier. Basically one of my runs died and the restart procedure of openfast was picking up a restart time (and therefore a chkp file) (total aside: I did not realize that openfast ignored `restart_filename: "5MW_Land_BD_DLL_WTurb_T1/5MW_Land_BD_DLL_WTurb.5760"` and really just used the `_rst.nc` file `time` variable to compute a chkp tstep and used that. Is this expected? Can it be overriden? If this is the case, should we not allow the user to use this option?) that was after the time I wanted to restart from (I wanted to back up the sim a bit). Easy enough, right? Just open the nc file in python, remove the last time step from all the variables, write it out again (making sure to use the classic format) and good to go. 

However, openfast kept mangling the restart file name that it read from `out_file_root` global attribute. This is the output from several separate runs
```
Restarting from time 53.9256 at time step 62640 from file name 5MW_Land_BD_DLL_WTurb_T1/5MW_Land_BD_DLL_WTurb.T1EО.62640
Restarting from time 53.9256 at time step 62640 from file name
 5MW_Land_BD_DLL_WTurb_T1/5MW_Land_BD_DLL_WTurb.T1V.62640
Restarting from time 53.9256 at time step 62640 from file name 5MW_Land_BD_DLL_WTurb_T1/5MW_Land_BD_DLL_WTurb.T1uf.62640
```
You notice the garbled, random chars between the `T1` and the `.`? With these edits, those go away. 

I am not sure how reproduceable this is and how much it depends on compilers, etc. 

I attached the `_rst.nc` and `openfastcpp` yaml file that I used to reproduce this and test my fix. I am leaving out the chkp files and turbine defs (standard NREL5MW)
[Archive.zip](https://github.com/user-attachments/files/20001704/Archive.zip)


