### PR TITLE
Free tmpOutFileRoot char pointer in openfast cpp

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -122,7 +122,7 @@ void fast::OpenFAST::findRestartFile(int iTurbLoc) {
     std::cout << "Restarting from time " << latest_time << " at time step " << tstep << " from file name " << turbineData[iTurbLoc].FASTRestartFileName << std::endl ;
 
     nc_close(ncid);
-
+    free(tmpOutFileRoot);
 }
 
 void fast::OpenFAST::prepareRestartFile(int iTurbLoc) {


### PR DESCRIPTION
Apologies for the noise but I couldn't let that pointer live on without being freed. 