### PR TITLE
Docs: correct Bladed Interface channel 63 description

### DIFF
--- a/docs/source/user/servodyn/SrvD--Ex.sum
+++ b/docs/source/user/servodyn/SrvD--Ex.sum
@@ -56,7 +56,7 @@
           60      -->  Rotor azimuth angle (rad) [SrvD input]
           61      -->  Number of blades (-) [SrvD NumBl parameter]
           62      -->  Maximum number of values which can be returned for logging (-) [set to 300]
-          63      <--  Number logging channels
+          63      -->  Record number for start of logging output (-) [set to ###]
           64      -->  Maximum number of characters which can be returned in "OUTNAME" (-) [set to 12601 (including the C NULL CHARACTER)]
           65      <--  Number of variables returned for logging [anything greater than MaxLoggingChannels is an error]
           69      -->  Blade 1 root in-plane bending moment (Nm) [SrvD input]

--- a/modules/servodyn/src/BladedInterface.f90
+++ b/modules/servodyn/src/BladedInterface.f90
@@ -579,7 +579,6 @@ subroutine WrLegacyChannelInfoToSummaryFile(u,p,dll_data,UnSum,ErrStat,ErrMsg)
    call WrSumInfoRcvd(120, 'Airfoil command, blade 1')
    call WrSumInfoRcvd(121, 'Airfoil command, blade 2')
    call WrSumInfoRcvd(122, 'Airfoil command, blade 3')
-   call WrSumInfoRcvd(63,'Number logging channels')
 
 
       ! Write to summary file


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The description for the `avrSWAP` array record 63 was incorrect. This was reflected both in the documentation on readthedocs.org and in the summary file generated by _ServoDyn_.  The internal code was correct.

Original:
* `63      <--  Number logging channels`
Corrected:
* `63      -->  Record number for start of logging output (-) [set to ###]`



**Related issue, if one exists**
Reported internally

**Impacted areas of the software**
Documentation only.



Consider for backporting to 4.0.5
