### PR TITLE
Add a checkError in openfast cpp

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -668,6 +668,7 @@ void fast::OpenFAST::init() {
                         &sc->op_to_FAST[iTurb],
                         &ErrStat,
                         ErrMsg);
+                    checkError(ErrStat, ErrMsg);
                     turbineData[iTurb].inflowType = 0;
                 }
 


### PR DESCRIPTION
I was having problem with an openfast restart on a machine and could not figure out why it was segfaulting. Turns out I was missing a file and if this check had been there I would have known much earlier instead of it silently failing. 

status before: segfault (because it fails to read a file, makes the number of blades 0 and then everything else breaks)
status with this PR (proper failure mode):
```
terminate called after throwing an instance of 'std::runtime_error'
  what():  FAST_RestoreFromCheckpoint_T:OpenBInpFile:The input file, "5MW_Land_BD_DLL_WTurb_T3/5MW_Land_BD_DLL_WTurb.T3.109440.chkp", was not found.
```