### PR TITLE
[BugFix] TurbSim calculating grid bottom location

### DIFF
--- a/modules/turbsim/src/TSsubs.f90
+++ b/modules/turbsim/src/TSsubs.f90
@@ -1347,8 +1347,7 @@ SUBROUTINE CreateGrid( p_grid, p_usr, UHub, AddTower, ErrStat, ErrMsg )
    p_grid%GridRes_Y = p_grid%GridWidth  / REAL( p_grid%NumGrid_Y - 1, ReKi )
    p_grid%GridRes_Z = p_grid%GridHeight / REAL( p_grid%NumGrid_Z - 1, ReKi )      
 
-   p_grid%Ztop = p_grid%HubHt + 0.5*p_grid%GridHeight ! height of the highest grid points
-   p_grid%Zbottom = p_grid%Ztop - p_grid%GridRes_Z * REAL(p_grid%NumGrid_Z - 1, ReKi)   ! height of the lowest grid points
+   p_grid%Zbottom = p_grid%HubHt - 0.5*p_grid%GridHeight ! height of the lowest grid points
 
    IF ( p_grid%Zbottom <= 0.0_ReKi ) THEN
       CALL SetErrStat(ErrID_Fatal,'The lowest grid point ('//TRIM(Num2LStr(p_grid%Zbottom))// ' m) must be above the ground. '//&

--- a/modules/turbsim/src/TSsubs.f90
+++ b/modules/turbsim/src/TSsubs.f90
@@ -1347,8 +1347,8 @@ SUBROUTINE CreateGrid( p_grid, p_usr, UHub, AddTower, ErrStat, ErrMsg )
    p_grid%GridRes_Y = p_grid%GridWidth  / REAL( p_grid%NumGrid_Y - 1, ReKi )
    p_grid%GridRes_Z = p_grid%GridHeight / REAL( p_grid%NumGrid_Z - 1, ReKi )      
 
-   p_grid%Zbottom = p_grid%HubHt + 0.5*p_grid%RotorDiameter                                ! height of the highest grid points
-   p_grid%Zbottom = p_grid%Zbottom - p_grid%GridRes_Z * REAL(p_grid%NumGrid_Z - 1, ReKi)   ! height of the lowest grid points
+   p_grid%Ztop = p_grid%HubHt + 0.5*p_grid%GridHeight ! height of the highest grid points
+   p_grid%Zbottom = p_grid%Ztop - p_grid%GridRes_Z * REAL(p_grid%NumGrid_Z - 1, ReKi)   ! height of the lowest grid points
 
    IF ( p_grid%Zbottom <= 0.0_ReKi ) THEN
       CALL SetErrStat(ErrID_Fatal,'The lowest grid point ('//TRIM(Num2LStr(p_grid%Zbottom))// ' m) must be above the ground. '//&

--- a/modules/turbsim/src/TurbSim_Types.f90
+++ b/modules/turbsim/src/TurbSim_Types.f90
@@ -111,6 +111,7 @@ use NWTC_Library
       INTEGER(IntKi)               :: NPoints                                  ! Number of points being simulated.                        
       INTEGER(IntKi)               :: NPacked                                  ! Number of entries stored in the packed version of the symmetric matrix of size NPoints by NPoints
       
+      REAL(ReKi)                   :: Ztop                                     ! The height of the highest point on the grid (before tower points are added)
       REAL(ReKi)                   :: Zbottom                                  ! The height of the lowest point on the grid (before tower points are added), equal to Z(1)
       REAL(ReKi)                   :: RotorDiameter                            ! The assumed diameter of the rotor
       

--- a/modules/turbsim/src/TurbSim_Types.f90
+++ b/modules/turbsim/src/TurbSim_Types.f90
@@ -111,7 +111,6 @@ use NWTC_Library
       INTEGER(IntKi)               :: NPoints                                  ! Number of points being simulated.                        
       INTEGER(IntKi)               :: NPacked                                  ! Number of entries stored in the packed version of the symmetric matrix of size NPoints by NPoints
       
-      REAL(ReKi)                   :: Ztop                                     ! The height of the highest point on the grid (before tower points are added)
       REAL(ReKi)                   :: Zbottom                                  ! The height of the lowest point on the grid (before tower points are added), equal to Z(1)
       REAL(ReKi)                   :: RotorDiameter                            ! The assumed diameter of the rotor
       


### PR DESCRIPTION
**Issue**
This PR tries to fix a long-standing issue with TurbSim, which at times errors out saying that the lowest grid point is underground, although that's not the case. 

To generate the error, try setting:

```
NumGrid_Z: 24
NumGrid_Y: 24
HubHt: 110
GridHeight: 218
GridWidth: 156
```

The lowest grid point should be at `110 - 218/2 = 1m` above ground

However the current TurbSim estimates the rotor diameter as the minimum between height and width, so `156 m`. Then, TurbSim estimates the top of the grid as `110 + 156/2 = 188`, and then errors out complaining that the bottom of the grid is underground at `188 - 218 =-30 m`

The PR fixes this issue by simply setting Zbottom as:
`p_grid%Zbottom = p_grid%Ztop - 0.5*p_grid%GridHeight`

**Impacted areas of the software**
TurbSim

**Additional supporting information**

[ws6.00_s0_TI0.06_shear0.20.txt](https://github.com/user-attachments/files/20196219/ws6.00_s0_TI0.06_shear0.20.txt)