### PR TITLE
Fix restart parsing of file name (backport of #2792 and #2793)

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -126,7 +126,7 @@ void fast::OpenFAST::findRestartFile(int iTurbLoc) {
     std::cout << "Restarting from time " << latest_time << " at time step " << tstep << " from file name " << turbineData[iTurbLoc].FASTRestartFileName << std::endl ;
 
     nc_close(ncid);
-
+    free(tmpOutFileRoot);
 }
 
 void fast::OpenFAST::prepareRestartFile(int iTurbLoc) {

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -94,8 +94,15 @@ void fast::OpenFAST::findRestartFile(int iTurbLoc) {
     check_nc_error(ierr, "nc_get_vara_double - getting latest time");
     tStart = latest_time;
 
-    char tmpOutFileRoot[INTERFACE_STRING_LENGTH];
+    char *tmpOutFileRoot;
+    size_t len;
+    ierr = nc_inq_attlen(ncid, NC_GLOBAL, "out_file_root", &len);
+    check_nc_error(ierr, "nc_inq_attlen - getting out_file_root length");
+
+    tmpOutFileRoot = (char*) malloc(len + 1);
     ierr = nc_get_att_text(ncid, NC_GLOBAL, "out_file_root", tmpOutFileRoot);
+    check_nc_error(ierr, "nc_get_att_text - getting out_file_root");
+    tmpOutFileRoot[len] = '\0';
     turbineData[iTurbLoc].outFileRoot.assign(tmpOutFileRoot);
 
     ierr = nc_get_att_double(ncid, NC_GLOBAL, "dt_fast", &dtFAST);


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
PR #2792 fixed a parsing issue with restarts in the cpp interface.  That PR will be included in 4.1, but since we are doing a 4.0.5 release, we might as well backport it.

**Related issue, if one exists**
See #2792 for details.
Also includes #2793 (fix possible memory leak)

**Impacted areas of the software**
CPP interface restarts only

**Test results, if applicable**
None.