### PR TITLE
Incorrect mesh mapping between BeamDyn and ServoDyn for Blade Structural Controller

### DIFF
--- a/modules/openfast-library/src/FAST_Mapping.f90
+++ b/modules/openfast-library/src/FAST_Mapping.f90
@@ -629,7 +629,7 @@ subroutine InitMappings_AD(Mappings, SrcMod, DstMod, Turbine, ErrStat, ErrMsg)
    case (Module_BD)
 
       call MapMotionMesh(Turbine, Mappings, &
-                         SrcMod=SrcMod, SrcDL=DatLoc(BD_y_BldMotion), &                                    ! BD%y(SrcMod%Ins)%BldMotion
+                         SrcMod=SrcMod, SrcDL=DatLoc(BD_y_BldMotion), &                 ! BD%y(SrcMod%Ins)%BldMotion
                          DstMod=DstMod, DstDL=DatLoc(AD_u_BladeMotion, SrcMod%Ins), &   ! AD%u%rotors(DstMod%Ins)%BladeMotion(SrcMod%Ins)
                          ErrStat=ErrStat2, ErrMsg=ErrMsg2, &
                          Active=NotCompAeroMaps .or. (SrcMod%Ins == 1))
@@ -641,7 +641,7 @@ subroutine InitMappings_AD(Mappings, SrcMod, DstMod, Turbine, ErrStat, ErrMsg)
       if (Turbine%p_FAST%CompElast == Module_ED) then
          do i = 1, size(Turbine%ED%y(SrcMod%Ins)%BladeLn2Mesh)
             call MapMotionMesh(Turbine, Mappings, &
-                               SrcMod=SrcMod, SrcDL=DatLoc(ED_y_BladeLn2Mesh, i), &                     ! ED%y%BladeLn2Mesh(i)
+                               SrcMod=SrcMod, SrcDL=DatLoc(ED_y_BladeLn2Mesh, i), &  ! ED%y%BladeLn2Mesh(i)
                                DstMod=DstMod, DstDL=DatLoc(AD_u_BladeMotion, i), &   ! AD%u%rotors(DstMod%Ins)%BladeMotion(i)
                                ErrStat=ErrStat2, ErrMsg=ErrMsg2, &
                                Active=CompElastED .and. (NotCompAeroMaps .or. (i == 1)))
@@ -1931,7 +1931,7 @@ subroutine InitMappings_SrvD(Mappings, SrcMod, DstMod, Turbine, ErrStat, ErrMsg)
    integer(IntKi), intent(out)            :: ErrStat
    character(*), intent(out)              :: ErrMsg
 
-   character(*), parameter    :: RoutineName = 'InitMappings_BD'
+   character(*), parameter    :: RoutineName = 'InitMappings_SrvD'
    integer(IntKi)             :: ErrStat2
    character(ErrMsgLen)       :: ErrMsg2
    integer(IntKi)             :: i, j
@@ -1948,8 +1948,8 @@ subroutine InitMappings_SrvD(Mappings, SrcMod, DstMod, Turbine, ErrStat, ErrMsg)
       ! Blade Structural Controller
       do i = 1, Turbine%SrvD%p%NumBStC
          call MapMotionMesh(Turbine, Mappings, SrcMod=SrcMod, DstMod=DstMod, &
-                            SrcDL=DatLoc(BD_y_BldMotion), &                         ! BD%y%BldMotion
-                            DstDL=DatLoc(SrvD_u_BStCMotionMesh, DstMod%Ins, i), &   ! SrvD%u%BStCMotionMesh(i, j)
+                            SrcDL=DatLoc(BD_y_BldMotion, SrcMod%Ins), &             ! BD%y(SrcMod%Ins)%BldMotion
+                            DstDL=DatLoc(SrvD_u_BStCMotionMesh, SrcMod%Ins, i), &   ! SrvD%u%BStCMotionMesh(i, j)
                             ErrStat=ErrStat2, ErrMsg=ErrMsg2); if(Failed()) return
       end do
 

--- a/modules/openfast-library/src/FAST_Mapping.f90
+++ b/modules/openfast-library/src/FAST_Mapping.f90
@@ -1949,7 +1949,7 @@ subroutine InitMappings_SrvD(Mappings, SrcMod, DstMod, Turbine, ErrStat, ErrMsg)
       do i = 1, Turbine%SrvD%p%NumBStC
          call MapMotionMesh(Turbine, Mappings, SrcMod=SrcMod, DstMod=DstMod, &
                             SrcDL=DatLoc(BD_y_BldMotion, SrcMod%Ins), &             ! BD%y(SrcMod%Ins)%BldMotion
-                            DstDL=DatLoc(SrvD_u_BStCMotionMesh, SrcMod%Ins, i), &   ! SrvD%u%BStCMotionMesh(i, j)
+                            DstDL=DatLoc(SrvD_u_BStCMotionMesh, SrcMod%Ins, i), &   ! SrvD%u%BStCMotionMesh(SrcMod%Ins,i)
                             ErrStat=ErrStat2, ErrMsg=ErrMsg2); if(Failed()) return
       end do
 

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -339,6 +339,7 @@ of_regression("5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti"  "openfast;elastodyn;aerod
 of_regression("5MW_OC3Spar_DLL_WTurb_WavesIrr"         "openfast;elastodyn;aerodyn;servodyn;hydrodyn;map;offshore")
 of_regression("5MW_OC4Semi_WSt_WavesWN"                "openfast;elastodyn;aerodyn;servodyn;hydrodyn;moordyn;offshore")
 of_regression("5MW_Land_BD_DLL_WTurb"                  "openfast;beamdyn;aerodyn;servodyn")
+of_regression("5MW_Land_BD_DLL_WTurb_StC"              "openfast;beamdyn;aerodyn;servodyn;stc")
 of_regression("5MW_Land_BD_Init"                       "openfast;beamdyn;aerodyn;servodyn")
 of_regression("5MW_OC4Jckt_ExtPtfm"                    "openfast;elastodyn;extptfm;offshore")
 of_regression("HelicalWake_OLAF"                       "openfast;aerodyn;olaf")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

The mesh mapping initialization in `InitMappings_SrvD` was incorrect for the blade structural controller motion between BeamDyn and ServoDyn. Specifically, the indexing into the `BD%y%BldMotion` and `SrvD%u%BStCMotionMesh` structs based on the BeamDyn instance was wrong and has been corrected in this PR.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`InitMappings_SrvD` function in `FAST_Mapping.f90`.

