### PR TITLE
bugfix: SD maximum number of output channels was incorrectly set

### DIFF
--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -24,7 +24,6 @@ MODULE SD_FEM
 
  
   INTEGER(IntKi),   PARAMETER  :: MaxMemJnt       = 20                    ! Maximum number of members at one joint
-  INTEGER(IntKi),   PARAMETER  :: MaxOutChs       = 2000                  ! Max number of Output Channels to be read in
   INTEGER(IntKi),   PARAMETER  :: nDOFL_TP        = 6  !TODO rename me    ! 6 degrees of freedom (length of u subarray [UTP])
    
   ! values of these parameters are ordered by their place in SubDyn input file:

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -25,6 +25,7 @@ Module SubDyn
    
    USE NWTC_Library
    USE SubDyn_Types
+   USE SubDyn_Output_Params, only: MaxOutPts
    USE SubDyn_Output
    USE SubDyn_Tests
    USE SD_FEM
@@ -1511,7 +1512,7 @@ END IF
 ! OutList - list of requested parameters to output to a file
 CALL ReadCom( UnIn, SDInputFile, 'SSOutList',ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
 
-ALLOCATE(Init%SSOutList(MaxOutChs), STAT=ErrStat2)
+ALLOCATE(Init%SSOutList(MaxOutPts + p%OutAllInt*p%OutAllDims), STAT=ErrStat2)
 If (Check( ErrStat2 /= ErrID_None ,'Error allocating SSOutList arrays')) return
 CALL ReadOutputList ( UnIn, SDInputFile, Init%SSOutList, p%NumOuts, 'SSOutList', 'List of outputs requested', ErrStat2, ErrMsg2, UnEc ); if(Failed()) return
 CALL CleanUp()

--- a/modules/subdyn/src/SubDyn_Output.f90
+++ b/modules/subdyn/src/SubDyn_Output.f90
@@ -22,12 +22,9 @@ MODULE SubDyn_Output
    USE SubDyn_Types
    USE SD_FEM
    USE SubDyn_Output_Params, only: MNfmKe, MNfmMe, MNTDss, MNRDe, MNTRAe, IntfSS, IntfTRss, IntfTRAss, ReactSS, OutStrLenM1
-   USE SubDyn_Output_Params, only: ParamIndxAry, ParamUnitsAry, ValidParamAry, SSqm01, SSqmd01, SSqmdd01
+   USE SubDyn_Output_Params, only: ParamIndxAry, ParamUnitsAry, ValidParamAry, SSqm01, SSqmd01, SSqmdd01, MaxOutPts
 
    IMPLICIT NONE
-
-   ! The maximum number of output channels which can be output by the code.
-   INTEGER(IntKi),PUBLIC, PARAMETER      :: MaxOutPts = 21705
 
    PRIVATE
       ! ..... Public Subroutines ...................................................................................................

--- a/modules/subdyn/src/SubDyn_Output_Params.f90
+++ b/modules/subdyn/src/SubDyn_Output_Params.f90
@@ -21757,7 +21757,7 @@ module SubDyn_Output_Params
 
 
      ! The maximum number of output channels which can be output by the code.
-   !INTEGER(IntKi), PARAMETER      :: MaxOutPts  = 21705
+   INTEGER(IntKi), PARAMETER      :: MaxOutPts  = 21705
 
 
    INTEGER(IntKi), PARAMETER ::MNfmKe(6,9,99) = reshape((/ &


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
A user had a case where they wanted to output ~8000 channels from _SD_.  However, there was an inconsisntency in how the `MaxOutPts` was set.  To fix this:
- uncomment `MaxOutPts` to `SubDyn_Output_Param.f90`
- remove `MaxOutPts` from `SubDyn_Output.f90` so it is in the autogenerated file instead
- remove `MaxOutChs` from `SD_FEM.f90` and use `MaxOutPts` instead



**Related issue, if one exists**
Fixes #2802

**Impacted areas of the software**
_SubDyn_ outputs only.

**Additional supporting information**


**Test results, if applicable**
None affected