### PR TITLE
Multi-Rotor input file and glue-code changes

### DIFF
--- a/docs/source/user/api_change.rst
+++ b/docs/source/user/api_change.rst
@@ -22,11 +22,26 @@ rather than via a separate flag for each.
 Superposition of wave and current velocities between InflowWind and SeaState was enabled,
 which requires a "SeaState Data" section in the AeroDyn driver input file.
 
+Changes to the OpenFAST input file support multiple rotors in one turbine. Line 16, NRotors,
+is required to specify the number of rotors in the turbine. Lines 50-56 specify the 
+ElastoDyn, BeamDyn, and ServoDyn input files for the second rotor. The `MirrorRotor` line
+sets a flag to reverse the direction the rotor is spinning. The first rotor always spins
+in the typical direction. These lines are specified only if NRotors is greater than 1 and
+are repeated for subsequent rotors.
+
 ============================================= ======== ==================== ========================================================================================================================================================================================================
 Added in OpenFAST `dev`                             
 ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 Module                                        Line     Flag Name            Example Value
 ============================================= ======== ==================== ========================================================================================================================================================================================================
+OpenFAST                                      16       NRotors              2   NRotors         - Number of rotors in turbine (-)
+OpenFAST                                      50                            ---------------------- INPUT FILES Rotor 2 -------------------------------------
+OpenFAST                                      51       EDFile               "ElastoDyn.dat"   EDFile          - Name of file containing ElastoDyn input parameters (quoted string)
+OpenFAST                                      52       BDBldFile(1)         "BeamDyn.dat"     BDBldFile(1)    - Name of file containing BeamDyn input parameters for blade 1 (quoted string)
+OpenFAST                                      53       BDBldFile(2)         "BeamDyn.dat"     BDBldFile(2)    - Name of file containing BeamDyn input parameters for blade 2 (quoted string)
+OpenFAST                                      54       BDBldFile(3)         "BeamDyn.dat"     BDBldFile(3)    - Name of file containing BeamDyn input parameters for blade 3 (quoted string)
+OpenFAST                                      55       ServoFile            "ServoDyn_R2.dat" ServoFile       - Name of file containing control and electrical-drive input parameters (quoted string)
+OpenFAST                                      56       MirrorRotor          False             MirrorRotor     - Use CW rotor definition definition files for a CCW rotor (-)
 AeroDyn blade file                                     t_c                  0.8651      [additional column in *Blade Properties* table]
 AeroDyn blade file                                     BlCpn                1.0         [additional column in *Blade Properties* table]
 AeroDyn blade file                                     BlCpt                1.0         [additional column in *Blade Properties* table]

--- a/modules/nwtc-library/src/ModVar.f90
+++ b/modules/nwtc-library/src/ModVar.f90
@@ -349,17 +349,18 @@ contains
    end function
 end subroutine
 
-subroutine MV_AddModule(ModDataAry, ModID, ModAbbr, Instance, ModDT, SolverDT, Vars, Linearize, ErrStat, ErrMsg)
-   type(ModDataType), allocatable, intent(inout)   :: ModDataAry(:)
-   integer(IntKi), intent(in)                      :: ModID
-   character(*), intent(in)                        :: ModAbbr
-   integer(IntKi), intent(in)                      :: Instance
-   real(R8Ki), intent(in)                          :: ModDT
-   real(R8Ki), intent(in)                          :: SolverDT
-   type(ModVarsType), intent(in)                   :: Vars
-   logical, intent(in)                             :: Linearize
-   integer(IntKi), intent(out)                     :: ErrStat
-   character(ErrMsgLen), intent(out)               :: ErrMsg
+subroutine MV_AddModule(ModDataAry, ModID, ModAbbr, Instance, ModDT, SolverDT, Vars, Linearize, ErrStat, ErrMsg, iRotor)
+   type(ModDataType), allocatable, intent(inout)   :: ModDataAry(:)  !< Array of module data to append new module
+   integer(IntKi), intent(in)                      :: ModID          !< Module identifier
+   character(*), intent(in)                        :: ModAbbr        !< Module name abbreviation
+   integer(IntKi), intent(in)                      :: Instance       !< Instance number
+   real(R8Ki), intent(in)                          :: ModDT          !< Module time step
+   real(R8Ki), intent(in)                          :: SolverDT       !< Solver time step
+   type(ModVarsType), intent(in)                   :: Vars           !< Module variables
+   logical, intent(in)                             :: Linearize      !< Flag indicating linearization
+   integer(IntKi), intent(out)                     :: ErrStat        !< Error status
+   character(ErrMsgLen), intent(out)               :: ErrMsg         !< Error message
+   integer(IntKi), optional, intent(in)            :: iRotor         !< Rotor number (0 indicates all rotors)
 
    character(*), parameter                         :: RoutineName = 'MV_AddModule'
    integer(IntKi)                                  :: ErrStat2
@@ -382,6 +383,11 @@ subroutine MV_AddModule(ModDataAry, ModID, ModAbbr, Instance, ModDT, SolverDT, V
    ModData%Ins = Instance
    ModData%DT = ModDT
    call NWTC_Library_CopyModVarsType(Vars, ModData%Vars, MESH_NEWCOPY, ErrStat2, ErrMsg2); if (Failed()) return
+   if (present(iRotor)) then
+      ModData%iRotor = iRotor
+   else
+      ModData%iRotor = 0
+   end if
 
    !----------------------------------------------------------------------------
    ! Calculate Module Sub-stepping

--- a/modules/nwtc-library/src/NWTC_Library_Types.f90
+++ b/modules/nwtc-library/src/NWTC_Library_Types.f90
@@ -197,6 +197,7 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: iMod = 0      !< Module index in array of modules [-]
     INTEGER(IntKi)  :: ID = 0      !< Module identification number [-]
     INTEGER(IntKi)  :: Ins = 0      !< Module instance number [-]
+    INTEGER(IntKi)  :: iRotor = 0      !< Module rotor number [-]
     INTEGER(IntKi)  :: SubSteps = 0      !< Module number of substeps per solver time step [-]
     REAL(R8Ki)  :: DT = 0      !< Module time step [-]
     TYPE(ModVarsType)  :: Vars      !< Module variables type [-]
@@ -1452,6 +1453,7 @@ subroutine NWTC_Library_CopyModDataType(SrcModDataTypeData, DstModDataTypeData, 
    DstModDataTypeData%iMod = SrcModDataTypeData%iMod
    DstModDataTypeData%ID = SrcModDataTypeData%ID
    DstModDataTypeData%Ins = SrcModDataTypeData%Ins
+   DstModDataTypeData%iRotor = SrcModDataTypeData%iRotor
    DstModDataTypeData%SubSteps = SrcModDataTypeData%SubSteps
    DstModDataTypeData%DT = SrcModDataTypeData%DT
    call NWTC_Library_CopyModVarsType(SrcModDataTypeData%Vars, DstModDataTypeData%Vars, CtrlCode, ErrStat2, ErrMsg2)
@@ -1486,6 +1488,7 @@ subroutine NWTC_Library_PackModDataType(RF, Indata)
    call RegPack(RF, InData%iMod)
    call RegPack(RF, InData%ID)
    call RegPack(RF, InData%Ins)
+   call RegPack(RF, InData%iRotor)
    call RegPack(RF, InData%SubSteps)
    call RegPack(RF, InData%DT)
    call NWTC_Library_PackModVarsType(RF, InData%Vars) 
@@ -1502,6 +1505,7 @@ subroutine NWTC_Library_UnPackModDataType(RF, OutData)
    call RegUnpack(RF, OutData%iMod); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%ID); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%Ins); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%iRotor); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%SubSteps); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%DT); if (RegCheckErr(RF, RoutineName)) return
    call NWTC_Library_UnpackModVarsType(RF, OutData%Vars) ! Vars 

--- a/modules/nwtc-library/src/Registry_NWTC_Library.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library.txt
@@ -141,6 +141,7 @@ typedef     ^       ModDataType character(ChanLen) Abbr             -   -   -   
 typedef     ^       ^           IntKi           iMod                -   0   -   "Module index in array of modules"  -
 typedef     ^       ^           IntKi           ID                  -   0   -   "Module identification number"  -
 typedef     ^       ^           IntKi           Ins                 -   0   -   "Module instance number"  -
+typedef     ^       ^           IntKi           iRotor              -   0   -   "Module rotor number"  -
 typedef     ^       ^           IntKi           SubSteps            -   0   -   "Module number of substeps per solver time step"  -
 typedef     ^       ^           R8Ki            DT                  -   0   -   "Module time step"  -
 typedef     ^       ^           ModVarsType     Vars                -   -   -   "Module variables type"  -

--- a/modules/nwtc-library/src/Registry_NWTC_Library_base.txt
+++ b/modules/nwtc-library/src/Registry_NWTC_Library_base.txt
@@ -141,6 +141,7 @@ typedef     ^       ModDataType character(ChanLen) Abbr             -   -   -   
 typedef     ^       ^           IntKi           iMod                -   0   -   "Module index in array of modules"  -
 typedef     ^       ^           IntKi           ID                  -   0   -   "Module identification number"  -
 typedef     ^       ^           IntKi           Ins                 -   0   -   "Module instance number"  -
+typedef     ^       ^           IntKi           iRotor              -   0   -   "Module rotor number"  -
 typedef     ^       ^           IntKi           SubSteps            -   0   -   "Module number of substeps per solver time step"  -
 typedef     ^       ^           R8Ki            DT                  -   0   -   "Module time step"  -
 typedef     ^       ^           ModVarsType     Vars                -   -   -   "Module variables type"  -

--- a/modules/openfast-library/src/FAST_Funcs.f90
+++ b/modules/openfast-library/src/FAST_Funcs.f90
@@ -684,6 +684,9 @@ subroutine FAST_CalcOutput(ModData, Mappings, ThisTime, iInput, iState, T, ErrSt
          call AD_CalcOutput(ThisTime, T%AD%Input(iInput), T%AD%p, &
                             T%AD%x(iState), T%AD%xd(iState), T%AD%z(iState), T%AD%OtherSt(iState), &
                             T%AD%y, T%AD%m, ErrStat2, ErrMsg2, CalcWriteOutput)
+      else
+         ErrStat2 = ErrID_None
+         ErrMsg2 = ''
       end if
 
    case (Module_ADsK)

--- a/modules/openfast-library/src/FAST_Funcs.f90
+++ b/modules/openfast-library/src/FAST_Funcs.f90
@@ -292,12 +292,11 @@ subroutine FAST_ExtrapInterp(ModData, t_global_next, T, ErrStat, ErrMsg)
       ! T%SeaSt%InputTimes(1) = t_global_next
 
    case (Module_SrvD)
-
-      call SrvD_Input_ExtrapInterp(T%SrvD%Input(1:), T%SrvD%InputTimes, T%SrvD%Input(INPUT_TEMP), t_global_next, ErrStat2, ErrMsg2); if (Failed()) return
+      call SrvD_Input_ExtrapInterp(T%SrvD%Input(1:, ModData%Ins), T%SrvD%InputTimes(:, ModData%Ins), T%SrvD%Input(INPUT_TEMP, ModData%Ins), t_global_next, ErrStat2, ErrMsg2); if (Failed()) return
       do j = T%p_FAST%InterpOrder, 0, -1
-         call SrvD_CopyInput(T%SrvD%Input(j), T%SrvD%Input(j + 1), MESH_UPDATECOPY, ErrStat2, ErrMsg2); if (Failed()) return
+         call SrvD_CopyInput(T%SrvD%Input(j, ModData%Ins), T%SrvD%Input(j + 1, ModData%Ins), MESH_UPDATECOPY, ErrStat2, ErrMsg2); if (Failed()) return
       end do
-      call ShiftInputTimes(T%SrvD%InputTimes)
+      call ShiftInputTimes(T%SrvD%InputTimes(:, ModData%Ins))
 
    case default
       call SetErrStat(ErrID_Fatal, "Unknown module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
@@ -398,7 +397,7 @@ subroutine FAST_InitInputStateArrays(ModAry, ThisTime, DT, T, ErrStat, ErrMsg)
          case (Module_SeaSt)
             T%SeaSt%InputTimes = InputTimes
          case (Module_SrvD)
-            T%SrvD%InputTimes = InputTimes
+            T%SrvD%InputTimes(:, ModData%Ins) = InputTimes
          case default
             call SetErrStat(ErrID_Fatal, "Unknown module "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
             return
@@ -631,10 +630,10 @@ subroutine FAST_UpdateStates(ModData, t_initial, n_t_global, T, ErrStat, ErrMsg)
       do j_ss = 1, ModData%SubSteps
          n_t_module = n_t_global*ModData%SubSteps + j_ss - 1
          t_module = n_t_module*ModData%DT + t_initial
-         call SrvD_UpdateStates(t_module, n_t_module, T%SrvD%Input(1:), T%SrvD%InputTimes, T%SrvD%p, &
-                                T%SrvD%x(STATE_PRED), T%SrvD%xd(STATE_PRED), &
-                                T%SrvD%z(STATE_PRED), T%SrvD%OtherSt(STATE_PRED), &
-                                T%SrvD%m, ErrStat2, ErrMsg2)
+         call SrvD_UpdateStates(t_module, n_t_module, T%SrvD%Input(1:,ModData%Ins), T%SrvD%InputTimes(:,ModData%Ins), T%SrvD%p(ModData%Ins), &
+                                T%SrvD%x(ModData%Ins, STATE_PRED), T%SrvD%xd(ModData%Ins, STATE_PRED), &
+                                T%SrvD%z(ModData%Ins, STATE_PRED), T%SrvD%OtherSt(ModData%Ins, STATE_PRED), &
+                                T%SrvD%m(ModData%Ins), ErrStat2, ErrMsg2)
          if (Failed()) return
       end do
 
@@ -771,9 +770,9 @@ subroutine FAST_CalcOutput(ModData, Mappings, ThisTime, iInput, iState, T, ErrSt
                             T%SeaSt%y, T%SeaSt%m, ErrStat2, ErrMsg2)
 
    case (Module_SrvD)
-      call SrvD_CalcOutput(ThisTime, T%SrvD%Input(iInput), T%SrvD%p, &
-                           T%SrvD%x(iState), T%SrvD%xd(iState), T%SrvD%z(iState), T%SrvD%OtherSt(iState), &
-                           T%SrvD%y, T%SrvD%m, ErrStat2, ErrMsg2)
+      call SrvD_CalcOutput(ThisTime, T%SrvD%Input(iInput,ModData%Ins), T%SrvD%p(ModData%Ins), &
+                           T%SrvD%x(ModData%Ins,iState), T%SrvD%xd(ModData%Ins,iState), T%SrvD%z(ModData%Ins,iState), T%SrvD%OtherSt(ModData%Ins,iState), &
+                           T%SrvD%y(ModData%Ins), T%SrvD%m(ModData%Ins), ErrStat2, ErrMsg2)
 
    case default
       call SetErrStat(ErrID_Fatal, "Unknown module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
@@ -870,7 +869,7 @@ subroutine FAST_GetOP(ModData, ThisTime, iInput, iState, T, ErrStat, ErrMsg, &
          call SeaSt_VarsPackInput(ModData%Vars, T%SeaSt%Input(iInput), u_op)
          call SeaSt_PackExtInputAry(ModData%Vars, T%SeaSt%Input(iInput), u_op)
       case (Module_SrvD)
-         call SrvD_VarsPackInput(ModData%Vars, T%SrvD%Input(iInput), u_op)
+         call SrvD_VarsPackInput(ModData%Vars, T%SrvD%Input(iInput,ModData%Ins), u_op)
       case default
          call SetErrStat(ErrID_Fatal, "Input unsupported module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
          return
@@ -927,7 +926,7 @@ subroutine FAST_GetOP(ModData, ThisTime, iInput, iState, T, ErrStat, ErrMsg, &
          call SeaSt_PackExtOutputAry(ModData%Vars, T%SeaSt%y, y_op)
          call SeaSt_VarsPackOutput(ModData%Vars, T%SeaSt%y, y_op)
       case (Module_SrvD)
-         call SrvD_VarsPackOutput(ModData%Vars, T%SrvD%y, y_op)
+         call SrvD_VarsPackOutput(ModData%Vars, T%SrvD%y(ModData%Ins), y_op)
       case default
          call SetErrStat(ErrID_Fatal, "Output unsupported module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
          return
@@ -982,7 +981,7 @@ subroutine FAST_GetOP(ModData, ThisTime, iInput, iState, T, ErrStat, ErrMsg, &
       case (Module_SeaSt)
          call SeaSt_VarsPackContState(ModData%Vars, T%SeaSt%x(iState), x_op)
       case (Module_SrvD)
-         call SrvD_VarsPackContState(ModData%Vars, T%SrvD%x(iState), x_op)
+         call SrvD_VarsPackContState(ModData%Vars, T%SrvD%x(ModData%Ins, iState), x_op)
       case default
          call SetErrStat(ErrID_Fatal, "Continuous State unsupported module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
          return
@@ -1121,10 +1120,11 @@ subroutine FAST_GetOP(ModData, ThisTime, iInput, iState, T, ErrStat, ErrMsg, &
 !        call SeaSt_VarsPackContStateDeriv(ModData%Vars, T%SeaSt%x(StateIndex), dx_op)
 
       case (Module_SrvD)
-         call SrvD_CalcContStateDeriv(ThisTime, T%SrvD%Input(iInput), T%SrvD%p, T%SrvD%x(iState), &
-                                      T%SrvD%xd(iState), T%SrvD%z(iState), T%SrvD%OtherSt(iState), &
-                                      T%SrvD%m, T%SrvD%m%dxdt_lin, ErrStat2, ErrMsg2)
-         call SrvD_VarsPackContStateDeriv(ModData%Vars, T%SrvD%m%dxdt_lin, dx_op)
+         call SrvD_CalcContStateDeriv(ThisTime, T%SrvD%Input(iInput, ModData%Ins), T%SrvD%p(ModData%Ins), &
+                                      T%SrvD%x(ModData%Ins, iState), T%SrvD%xd(ModData%Ins, iState), &
+                                      T%SrvD%z(ModData%Ins, iState), T%SrvD%OtherSt(ModData%Ins, iState), &
+                                      T%SrvD%m(ModData%Ins), T%SrvD%m(ModData%Ins)%dxdt_lin, ErrStat2, ErrMsg2)
+         call SrvD_VarsPackContStateDeriv(ModData%Vars, T%SrvD%m(ModData%Ins)%dxdt_lin, dx_op)
 
       case default
          call SetErrStat(ErrID_Fatal, "Continuous State Derivatives unsupported module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
@@ -1205,7 +1205,7 @@ subroutine FAST_SetOP(ModData, iInput, iState, T, ErrStat, ErrMsg, &
       case (Module_SeaSt)
          call SeaSt_VarsUnpackInput(ModData%Vars, u_op, T%SeaSt%Input(iInput))
       case (Module_SrvD)
-         call SrvD_VarsUnpackInput(ModData%Vars, u_op, T%SrvD%Input(iInput))
+         call SrvD_VarsUnpackInput(ModData%Vars, u_op, T%SrvD%Input(iInput, ModData%Ins))
       case default
          call SetErrStat(ErrID_Fatal, "Input unsupported module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
          return
@@ -1256,7 +1256,7 @@ subroutine FAST_SetOP(ModData, iInput, iState, T, ErrStat, ErrMsg, &
       case (Module_SeaSt)
          call SeaSt_VarsUnpackContState(ModData%Vars, x_op, T%SeaSt%x(iState))
       case (Module_SrvD)
-         call SrvD_VarsUnpackContState(ModData%Vars, x_op, T%SrvD%x(iState))
+         call SrvD_VarsUnpackContState(ModData%Vars, x_op, T%SrvD%x(ModData%Ins, iState))
       case default
          call SetErrStat(ErrID_Fatal, "Continuous State unsupported module: "//ModData%Abbr, ErrStat, ErrMsg, RoutineName)
          return
@@ -1359,8 +1359,10 @@ subroutine FAST_JacobianPInput(ModData, ThisTime, iInput, iState, T, ErrStat, Er
                                 dYdu=dYdu, dXdu=dXdu)
 
    case (Module_SrvD)
-      call SrvD_JacobianPInput(ThisTime, T%SrvD%Input(iInput), T%SrvD%p, T%SrvD%x(iState), T%SrvD%xd(iState), &
-                               T%SrvD%z(iState), T%SrvD%OtherSt(iState), T%SrvD%y, T%SrvD%m, &
+      call SrvD_JacobianPInput(ThisTime, T%SrvD%Input(iInput, ModData%Ins), T%SrvD%p(ModData%Ins), &
+                               T%SrvD%x(ModData%Ins, iState), T%SrvD%xd(ModData%Ins, iState), &
+                               T%SrvD%z(ModData%Ins, iState), T%SrvD%OtherSt(ModData%Ins, iState), &
+                               T%SrvD%y(ModData%Ins), T%SrvD%m(ModData%Ins), &
                                ErrStat2, ErrMsg2, dYdu=dYdu, dXdu=dXdu)
 
    case default
@@ -1480,10 +1482,10 @@ subroutine FAST_JacobianPContState(ModData, ThisTime, iInput, iState, T, ErrStat
                                     dYdx=dYdx, dXdx=dXdx)
 
    case (Module_SrvD)
-      call SrvD_JacobianPContState(ThisTime, T%SrvD%Input(iInput), T%SrvD%p, &
-                                   T%SrvD%x(iState), T%SrvD%xd(iState), &
-                                   T%SrvD%z(iState), T%SrvD%OtherSt(iState), &
-                                   T%SrvD%y, T%SrvD%m, ErrStat2, ErrMsg2, &
+      call SrvD_JacobianPContState(ThisTime, T%SrvD%Input(iInput, ModData%Ins), T%SrvD%p(ModData%Ins), &
+                                   T%SrvD%x(ModData%Ins, iState), T%SrvD%xd(ModData%Ins, iState), &
+                                   T%SrvD%z(ModData%Ins, iState), T%SrvD%OtherSt(ModData%Ins, iState), &
+                                   T%SrvD%y(ModData%Ins), T%SrvD%m(ModData%Ins), ErrStat2, ErrMsg2, &
                                    dYdx=dYdx, dXdx=dXdx)
 
    case default
@@ -1653,10 +1655,10 @@ subroutine FAST_CopyStates(ModData, T, iSrc, iDst, CtrlCode, ErrStat, ErrMsg)
 
    case (Module_SrvD)
 
-      call SrvD_CopyContState(T%SrvD%x(iSrc), T%SrvD%x(iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
-      call SrvD_CopyDiscState(T%SrvD%xd(iSrc), T%SrvD%xd(iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
-      call SrvD_CopyConstrState(T%SrvD%z(iSrc), T%SrvD%z(iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
-      call SrvD_CopyOtherState(T%SrvD%OtherSt(iSrc), T%SrvD%OtherSt(iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
+      call SrvD_CopyContState(T%SrvD%x(ModData%Ins, iSrc), T%SrvD%x(ModData%Ins, iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
+      call SrvD_CopyDiscState(T%SrvD%xd(ModData%Ins, iSrc), T%SrvD%xd(ModData%Ins, iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
+      call SrvD_CopyConstrState(T%SrvD%z(ModData%Ins, iSrc), T%SrvD%z(ModData%Ins, iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
+      call SrvD_CopyOtherState(T%SrvD%OtherSt(ModData%Ins, iSrc), T%SrvD%OtherSt(ModData%Ins, iDst), CtrlCode, ErrStat2, ErrMsg2); if (Failed()) return
 
    case default
       call SetErrStat(ErrID_Fatal, "Unknown module "//trim(ModData%Abbr), ErrStat, ErrMsg, RoutineName)
@@ -1757,7 +1759,7 @@ subroutine FAST_CopyInput(ModData, T, iSrc, iDst, CtrlCode, ErrStat, ErrMsg)
       call SeaSt_CopyInput(T%SeaSt%Input(iSrc), T%SeaSt%Input(iDst), CtrlCode, ErrStat2, ErrMsg2)
 
    case (Module_SrvD)
-      call SrvD_CopyInput(T%SrvD%Input(iSrc), T%SrvD%Input(iDst), CtrlCode, ErrStat2, ErrMsg2)
+      call SrvD_CopyInput(T%SrvD%Input(iSrc, ModData%Ins), T%SrvD%Input(iDst, ModData%Ins), CtrlCode, ErrStat2, ErrMsg2)
 
    case default
       ErrStat2 = ErrID_Fatal
@@ -1916,9 +1918,9 @@ subroutine FAST_ModEnd(Mods, T, ErrStat, ErrMsg)
                            T%SeaSt%y, T%SeaSt%m, ErrStat2, ErrMsg2)
 
          case (Module_SrvD)
-            call SrvD_End(T%SrvD%Input(1), T%SrvD%p, T%SrvD%x(STATE_CURR), T%SrvD%xd(STATE_CURR), &
-                          T%SrvD%z(STATE_CURR), T%SrvD%OtherSt(STATE_CURR), &
-                          T%SrvD%y, T%SrvD%m, ErrStat2, ErrMsg2)
+            call SrvD_End(T%SrvD%Input(1, ModData%Ins), T%SrvD%p(ModData%Ins), T%SrvD%x(ModData%Ins, STATE_CURR), T%SrvD%xd(ModData%Ins, STATE_CURR), &
+                          T%SrvD%z(ModData%Ins, STATE_CURR), T%SrvD%OtherSt(ModData%Ins, STATE_CURR), &
+                          T%SrvD%y(ModData%Ins), T%SrvD%m(ModData%Ins), ErrStat2, ErrMsg2)
 
          case default
             call SetErrStat(ErrID_Fatal, "Unknown module "//trim(ModData%Abbr), ErrStat, ErrMsg, RoutineName)

--- a/modules/openfast-library/src/FAST_Mapping.f90
+++ b/modules/openfast-library/src/FAST_Mapping.f90
@@ -3319,12 +3319,12 @@ subroutine Custom_InputSolve(Mapping, ModSrc, ModDst, iInput, T, ErrStat, ErrMsg
       iBld = T%p_FAST%BDBldMap(ModSrc%Ins)
 
       T%SrvD%Input(iInput,ModDst%Ins)%RootMxc(iBld) = &
-         T%BD%y(Mapping%SrcIns)%RootMxr*cos(T%ED%y(ModDst%Ins)%BlPitch(iBld)) + &
-         T%BD%y(Mapping%SrcIns)%RootMyr*sin(T%ED%y(ModDst%Ins)%BlPitch(iBld))
+         T%BD%y(Mapping%SrcIns)%RootMxr*cos(T%ED%y(ModDst%iRotor)%BlPitch(iBld)) + &
+         T%BD%y(Mapping%SrcIns)%RootMyr*sin(T%ED%y(ModDst%iRotor)%BlPitch(iBld))
 
       T%SrvD%Input(iInput,ModDst%Ins)%RootMyc(iBld) = &
-         -T%BD%y(Mapping%SrcIns)%RootMxr*sin(T%ED%y(ModDst%Ins)%BlPitch(iBld)) + &
-         T%BD%y(Mapping%SrcIns)%RootMyr*cos(T%ED%y(ModDst%Ins)%BlPitch(iBld))
+         -T%BD%y(Mapping%SrcIns)%RootMxr*sin(T%ED%y(ModDst%iRotor)%BlPitch(iBld)) + &
+         T%BD%y(Mapping%SrcIns)%RootMyr*cos(T%ED%y(ModDst%iRotor)%BlPitch(iBld))
 
    case (Custom_ED_to_SrvD)
 

--- a/modules/openfast-library/src/FAST_ModGlue.f90
+++ b/modules/openfast-library/src/FAST_ModGlue.f90
@@ -112,6 +112,7 @@ subroutine ModGlue_CombineModules(ModGlue, ModDataAry, Mappings, iModAry, FlagFi
          GlueModData%Ins = ModData%Ins
          GlueModData%DT = ModData%DT
          GlueModData%SubSteps = ModData%SubSteps
+         GlueModData%iRotor = ModData%iRotor
 
          ! Continuous state
          call CopyVariables(ModData%Vars%x, GlueModData%Vars%x, xNumVals); if (Failed()) return

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -61,7 +61,7 @@ param	^	-	INTEGER	Module_ADsk	-	20	-	"AeroDisk"	-
 param	^	-	INTEGER	Module_SED 	-	21	-	"Simplified-ElastoDyn" -
 param	^	-	INTEGER	NumModules	-	21	-	"The number of modules available in FAST"	-
 # Other Constants
-param	^	-	INTEGER	MaxNBlades	-	3	-	"Maximum number of blades allowed on a turbine"	-
+param	^	-	INTEGER	MaxBladesBD	-	3	-	"Maximum number of blades allowed on a turbine"	-
 param	^	-	INTEGER	IceD_MaxLegs	-	4	-	"because I don't know how many legs there are before calling IceD_Init and I don't want to copy the data because of sibling mesh issues, I'm going to allocate IceD based on this number"	-
 # Constants for steady-state solve (indices for output channels)
 param	^	-	INTEGER	SS_Indx_Pitch	-	1	-	"pitch"	-
@@ -106,15 +106,14 @@ typedef   ^   FAST_VTK_ModeShapeType   R8Ki     x_eig_phase     {:}{:}{:}  -  - 
 # ..... FAST_ParameterType data .......................................................................................................
 # Misc data for coupling:
 typedef	FAST	FAST_ParameterType	DbKi	DT	-	-	-	"Integration time step [global time]"	s
-typedef	^	FAST_ParameterType	DbKi	DT_module	{NumModules}	-	-	"Integration time step [global time]"	s
-typedef	^	FAST_ParameterType	IntKi	n_substeps	{NumModules}	-	-	"The number of module substeps for advancing states from t_global to t_global_next"	-
 typedef	^	FAST_ParameterType	INTEGER	n_TMax_m1	-	-	-	"The time step of TMax - dt (the end time of the simulation)"	(-)
 typedef	^	FAST_ParameterType	DbKi	TMax	-	-	-	"Total run time"	s
 typedef	^	FAST_ParameterType	IntKi	InterpOrder	-	-	-	"Interpolation order {0,1,2}"	-
 typedef	^	FAST_ParameterType	IntKi	NumCrctn	-	-	-	"Number of correction iterations"	-
 typedef	^	FAST_ParameterType	IntKi	KMax	-	-	-	"Maximum number of input-output-solve or nonlinear solve residual equation iterations (KMax >= 1) [>0]"	-
 typedef	^	FAST_ParameterType	IntKi	numIceLegs	-	-	-	"number of suport-structure legs in contact with ice (IceDyn coupling)"	-
-typedef	^	FAST_ParameterType	IntKi	nBeams	-	-	-	"number of BeamDyn instances"	-
+typedef	^	FAST_ParameterType	IntKi	NumBD	-	-	-	"number of BeamDyn instances"	-
+typedef	^	FAST_ParameterType	IntKi	BDRotMap	:	-	-	"array mapping BeamDyn instance to rotor number"	-
 typedef	^	FAST_ParameterType	LOGICAL	BD_OutputSibling	-	-	-	"flag to determine if BD input is sibling of output mesh"	-
 # Data for TC Solver:
 typedef	^	FAST_ParameterType	DbKi	RhoInf	-	-	-	"Numerical damping parameter for tight coupling generalized-alpha integrator (-) [0.0 to 1.0]"	-
@@ -126,6 +125,7 @@ typedef	^	FAST_ParameterType	Reki	UJacSclFact	-	-	-	"Scaling factor used to get 
 typedef	^	FAST_ParameterType	IntKi	SizeJac_Opt1	{9}	-	-	"(1)=size of matrix; (2)=size of ED portion; (3)=size of SD portion [2 meshes]; (4)=size of HD portion; (5)=size of BD portion blade 1; (6)=size of BD portion blade 2; (7)=size of BD portion blade 3; (8)=size of Orca portion; (9)=size of ExtPtfm portion;"	-
 typedef	^	FAST_ParameterType	IntKi	SolveOption	-	-	-	"Switch to determine which solve option we are going to use (see Solve_FullOpt1, etc)"	-
 # Feature switches and flags:
+typedef	^	FAST_ParameterType	IntKi	NRotors	-	-	-	"Number of rotors in turbine"	-
 typedef	^	FAST_ParameterType	IntKi	CompElast	-	-	-	"Compute blade loads (switch) {Module_ED; Module_BD; Module_SED}"	-
 typedef	^	FAST_ParameterType	IntKi	CompInflow	-	-	-	"Compute inflow wind conditions (switch) {Module_None; Module_IfW; Module_ExtInfw}"	-
 typedef	^	FAST_ParameterType	IntKi	CompAero	-	-	-	"Compute aerodynamic loads (switch) {Module_None; Module_ADsk; Module_AD}"	-
@@ -152,16 +152,16 @@ typedef ^   FAST_ParameterType  ReKi    Pvap        -   -   -   "Vapour pressure
 typedef ^   FAST_ParameterType  ReKi    WtrDpth     -   -   -   "Water depth" m
 typedef ^   FAST_ParameterType  ReKi    MSL2SWL     -   -   -   "Offset between still-water level and mean sea level" m
 # Input file names:
-typedef	^	FAST_ParameterType	CHARACTER(1024)	EDFile	-	-	-	"The name of the ElastoDyn/Simplified-ElastoDyn input file"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	BDBldFile	{MaxNBlades}	-	-	"Name of files containing BeamDyn inputs for each blade"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	InflowFile	-	-	-	"Name of file containing inflow wind input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	AeroFile	-	-	-	"Name of file containing aerodynamic input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	ServoFile	-	-	-	"Name of file containing control and electrical-drive input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	SeaStFile   -	-	-	"Name of file containing sea state input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	HydroFile	-	-	-	"Name of file containing hydrodynamic input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	SubFile	-	-	-	"Name of file containing sub-structural input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	MooringFile	-	-	-	"Name of file containing mooring system input parameters"	-
-typedef	^	FAST_ParameterType	CHARACTER(1024)	IceFile	-	-	-	"Name of file containing ice loading input parameters"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	EDFile	:	-	-	"ElastoDyn/Simplified-ElastoDyn input file paths (NRotors)"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	BDBldFile	::	-	-	"BeamDyn input file paths for each blade (MaxBladesBD,NRotors)"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	ServoFile	:	-	-	"Turbine control and electrical-drive input file paths (NRotors)"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	InflowFile	-	-	-	"Inflow wind input file path"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	AeroFile	-	-	-	"Aerodynamic input file path"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	SeaStFile   -	-	-	"Sea state input file path"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	HydroFile	-	-	-	"Hydrodynamic input file path"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	SubFile	-	-	-	"sub-structural input file path"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	MooringFile	-	-	-	"mooring system input file path"	-
+typedef	^	FAST_ParameterType	CHARACTER(1024)	IceFile	-	-	-	"ice loading input file path"	-
 #  Parameters for file/screen output
 #typedef	^	FAST_ParameterType	DbKi	SttsTime	-	-	-	"Amount of time between screen status messages"	s
 typedef	^	FAST_ParameterType	DbKi	TStart	-	-	-	"Time to begin tabular output"	s
@@ -322,15 +322,15 @@ typedef	^	^	DbKi	InputTimes	{:}	-	-	"Array of times associated with Input Array"
 
 
 # ..... ServoDyn data .......................................................................................................
-typedef	FAST	ServoDyn_Data	SrvD_ContinuousStateType	x	{:}	-	-	"Continuous states"
-typedef	^	^	SrvD_DiscreteStateType	xd	{:}	-	-	"Discrete states"
-typedef	^	^	SrvD_ConstraintStateType	z	{:}	-	-	"Constraint states"
-typedef	^	^	SrvD_OtherStateType	OtherSt	{:}	-	-	"Other states"
-typedef	^	^	SrvD_ParameterType	p	-	-	-	"Parameters"
-typedef	^	^	SrvD_OutputType	y	-	-	-	"System outputs"
-typedef	^	^	SrvD_MiscVarType	m	-	-	-	"Misc (optimization) variables not associated with time"
-typedef	^	^	SrvD_InputType	Input	{:}	-	-	"Array of inputs associated with InputTimes"
-typedef	^	^	DbKi	InputTimes	{:}	-	-	"Array of times associated with Input Array"
+typedef	FAST	ServoDyn_Data	SrvD_ContinuousStateType	x	{:}{:}	-	-	"Continuous states"
+typedef	^	^	SrvD_DiscreteStateType	xd	{:}{:}	-	-	"Discrete states"
+typedef	^	^	SrvD_ConstraintStateType	z	{:}{:}	-	-	"Constraint states"
+typedef	^	^	SrvD_OtherStateType	OtherSt	{:}{:}	-	-	"Other states"
+typedef	^	^	SrvD_ParameterType	p	{:}	-	-	"Parameters"
+typedef	^	^	SrvD_OutputType	y	{:}	-	-	"System outputs"
+typedef	^	^	SrvD_MiscVarType	m	{:}	-	-	"Misc (optimization) variables not associated with time"
+typedef	^	^	SrvD_InputType	Input	{:}{:}	-	-	"Array of inputs associated with InputTimes"
+typedef	^	^	DbKi	InputTimes	{:}{:}	-	-	"Array of times associated with Input Array"
 
 # ..... AeroDyn data .......................................................................................................
 typedef	FAST	AeroDyn_Data	AD_ContinuousStateType	x	{:}	-	-	"Continuous states"
@@ -499,14 +499,12 @@ typedef	^	FAST_ExternInputType	ReKi	CableDeltaLdot	{20}	-	-	"Cable control Delta
 # ..... FAST_MiscVarType data .......................................................................................................
 typedef	FAST	FAST_MiscVarType	DbKi	TiLstPrn	-	-	-	"The simulation time of the last print (to file)"	(s)
 typedef	^	FAST_MiscVarType	DbKi	t_global	-	-	-	"Current simulation time (for global/FAST simulation)"	(s)
-typedef	^	FAST_MiscVarType	DbKi	NextJacCalcTime	-	-	-	"Time between calculating Jacobians in the HD-ED and SD-ED simulations"	(s)
 typedef	^	FAST_MiscVarType	ReKi	PrevClockTime	-	-	-	"Clock time at start of simulation in seconds"	(s)
 typedef	^	FAST_MiscVarType	ReKi	UsrTime1	-	-	-	"User CPU time for simulation initialization"	(s)
 typedef	^	FAST_MiscVarType	ReKi	UsrTime2	-	-	-	"User CPU time for simulation (without intialization)"	(s)
 typedef	^	FAST_MiscVarType	INTEGER	StrtTime	{8}	-	-	"Start time of simulation (including intialization)"
 typedef	^	FAST_MiscVarType	INTEGER	SimStrtTime	{8}	-	-	"Start time of simulation (after initialization)"
 #typedef	^	FAST_MiscVarType	IntKi	n_t_global	-	-	-	"simulation time step, loop counter for global (FAST) simulation"	(s)
-typedef	^	FAST_MiscVarType	Logical	calcJacobian	-	-	-	"Should we calculate Jacobians in Option 1?"	(flag)
 typedef	^	FAST_MiscVarType	FAST_ExternInputType	ExternInput	-	-	-	"external input values"	-
 typedef	^	FAST_MiscVarType	FAST_MiscLinType	Lin	-	-	-	"misc data for linearization analysis"	-
 
@@ -519,7 +517,7 @@ typedef   ^   FAST_InitData    SED_InitOutputType          OutData_SED      -  -
 typedef   ^   FAST_InitData    BD_InitInputType             InData_BD       -  -  -  "BD Initialization input data"
 typedef   ^   FAST_InitData    BD_InitOutputType           OutData_BD       :  -  -  "BD Initialization output data"
 typedef   ^   FAST_InitData    SrvD_InitInputType           InData_SrvD     -  -  -  "SrvD Initialization input data"
-typedef   ^   FAST_InitData    SrvD_InitOutputType         OutData_SrvD     -  -  -  "SrvD Initialization output data"
+typedef   ^   FAST_InitData    SrvD_InitOutputType         OutData_SrvD     :  -  -  "SrvD Initialization output data"
 typedef   ^   FAST_InitData    AD_InitInputType             InData_AD       -  -  -  "AD Initialization input data"
 typedef   ^   FAST_InitData    AD_InitOutputType           OutData_AD       -  -  -  "AD Initialization output data"
 typedef   ^   FAST_InitData    ADsk_InitInputType           InData_ADsk     -  -  -  "ADsk Initialization input data"

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -116,6 +116,7 @@ typedef	^	FAST_ParameterType	IntKi	RotNumBld	:	-	-	"number of blades in each rot
 typedef	^	FAST_ParameterType	logical	RotMirror	:	-	-	"Array of flags indicating if rotor rotation should be mirrored (true=mirror)"	-
 typedef	^	FAST_ParameterType	IntKi	NumBD	-	-	-	"number of BeamDyn instances"	-
 typedef	^	FAST_ParameterType	IntKi	BDRotMap	:	-	-	"array mapping BeamDyn instance to rotor number"	-
+typedef	^	FAST_ParameterType	IntKi	BDBldMap	:	-	-	"array mapping BeamDyn instance to blade number"	-
 typedef	^	FAST_ParameterType	LOGICAL	BD_OutputSibling	-	-	-	"flag to determine if BD input is sibling of output mesh"	-
 # Data for TC Solver:
 typedef	^	FAST_ParameterType	DbKi	RhoInf	-	-	-	"Numerical damping parameter for tight coupling generalized-alpha integrator (-) [0.0 to 1.0]"	-

--- a/modules/openfast-library/src/FAST_Registry.txt
+++ b/modules/openfast-library/src/FAST_Registry.txt
@@ -18,7 +18,7 @@ usefrom	Registry_BeamDyn.txt
 usefrom	ServoDyn_Registry.txt
 usefrom	AeroDyn_Registry.txt
 usefrom	AeroDisk_Registry.txt
-usefrom  ExtLoads_Registry.txt
+usefrom ExtLoads_Registry.txt
 usefrom	SubDyn_Registry.txt
 usefrom	SeaState.txt
 usefrom	HydroDyn.txt
@@ -112,6 +112,8 @@ typedef	^	FAST_ParameterType	IntKi	InterpOrder	-	-	-	"Interpolation order {0,1,2
 typedef	^	FAST_ParameterType	IntKi	NumCrctn	-	-	-	"Number of correction iterations"	-
 typedef	^	FAST_ParameterType	IntKi	KMax	-	-	-	"Maximum number of input-output-solve or nonlinear solve residual equation iterations (KMax >= 1) [>0]"	-
 typedef	^	FAST_ParameterType	IntKi	numIceLegs	-	-	-	"number of suport-structure legs in contact with ice (IceDyn coupling)"	-
+typedef	^	FAST_ParameterType	IntKi	RotNumBld	:	-	-	"number of blades in each rotor"	-
+typedef	^	FAST_ParameterType	logical	RotMirror	:	-	-	"Array of flags indicating if rotor rotation should be mirrored (true=mirror)"	-
 typedef	^	FAST_ParameterType	IntKi	NumBD	-	-	-	"number of BeamDyn instances"	-
 typedef	^	FAST_ParameterType	IntKi	BDRotMap	:	-	-	"array mapping BeamDyn instance to rotor number"	-
 typedef	^	FAST_ParameterType	LOGICAL	BD_OutputSibling	-	-	-	"flag to determine if BD input is sibling of output mesh"	-

--- a/modules/openfast-library/src/FAST_Solver.f90
+++ b/modules/openfast-library/src/FAST_Solver.f90
@@ -886,6 +886,7 @@ subroutine FAST_SolverStep0(p, m, GlueModData, GlueModMaps, Turbine, ErrStat, Er
 
    call FAST_CalcOutputsAndSolveForInputs(p, m, GlueModData, GlueModMaps, t_initial, INPUT_CURR, STATE_CURR, Turbine, &
                                    ConvIter, ConvError, IsConverged, ErrStat2, ErrMsg2, UpdateJacobian=.true.)
+   if (Failed()) return
 
    ! Print warning if not converged
    if (.not. IsConverged) then
@@ -1491,6 +1492,9 @@ subroutine FAST_CalcOutputsAndSolveForInputs(p, m, GlueModData, GlueModMaps, Thi
    integer(IntKi)                         :: ErrStat2
    character(ErrMsgLen)                   :: ErrMsg2
    integer(IntKi)                         :: i
+
+   ErrStat = ErrID_None
+   ErrMsg = ''
 
    !----------------------------------------------------------------------------
    ! Initialization

--- a/modules/openfast-library/src/FAST_Types.f90
+++ b/modules/openfast-library/src/FAST_Types.f90
@@ -134,6 +134,7 @@ IMPLICIT NONE
     LOGICAL , DIMENSION(:), ALLOCATABLE  :: RotMirror      !< Array of flags indicating if rotor rotation should be mirrored (true=mirror) [-]
     INTEGER(IntKi)  :: NumBD = 0_IntKi      !< number of BeamDyn instances [-]
     INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: BDRotMap      !< array mapping BeamDyn instance to rotor number [-]
+    INTEGER(IntKi) , DIMENSION(:), ALLOCATABLE  :: BDBldMap      !< array mapping BeamDyn instance to blade number [-]
     LOGICAL  :: BD_OutputSibling = .false.      !< flag to determine if BD input is sibling of output mesh [-]
     REAL(DbKi)  :: RhoInf = 0.0_R8Ki      !< Numerical damping parameter for tight coupling generalized-alpha integrator (-) [0.0 to 1.0] [-]
     REAL(DbKi)  :: ConvTol = 0.0_R8Ki      !< Convergence iteration error tolerance for tight coupling generalized alpha integrator (-) [-]
@@ -1119,6 +1120,18 @@ subroutine FAST_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
       end if
       DstParamData%BDRotMap = SrcParamData%BDRotMap
    end if
+   if (allocated(SrcParamData%BDBldMap)) then
+      LB(1:1) = lbound(SrcParamData%BDBldMap)
+      UB(1:1) = ubound(SrcParamData%BDBldMap)
+      if (.not. allocated(DstParamData%BDBldMap)) then
+         allocate(DstParamData%BDBldMap(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%BDBldMap.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstParamData%BDBldMap = SrcParamData%BDBldMap
+   end if
    DstParamData%BD_OutputSibling = SrcParamData%BD_OutputSibling
    DstParamData%RhoInf = SrcParamData%RhoInf
    DstParamData%ConvTol = SrcParamData%ConvTol
@@ -1303,6 +1316,9 @@ subroutine FAST_DestroyParam(ParamData, ErrStat, ErrMsg)
    if (allocated(ParamData%BDRotMap)) then
       deallocate(ParamData%BDRotMap)
    end if
+   if (allocated(ParamData%BDBldMap)) then
+      deallocate(ParamData%BDBldMap)
+   end if
    if (allocated(ParamData%EDFile)) then
       deallocate(ParamData%EDFile)
    end if
@@ -1341,6 +1357,7 @@ subroutine FAST_PackParam(RF, Indata)
    call RegPackAlloc(RF, InData%RotMirror)
    call RegPack(RF, InData%NumBD)
    call RegPackAlloc(RF, InData%BDRotMap)
+   call RegPackAlloc(RF, InData%BDBldMap)
    call RegPack(RF, InData%BD_OutputSibling)
    call RegPack(RF, InData%RhoInf)
    call RegPack(RF, InData%ConvTol)
@@ -1459,6 +1476,7 @@ subroutine FAST_UnPackParam(RF, OutData)
    call RegUnpackAlloc(RF, OutData%RotMirror); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%NumBD); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%BDRotMap); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%BDBldMap); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%BD_OutputSibling); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%RhoInf); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%ConvTol); if (RegCheckErr(RF, RoutineName)) return

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -294,6 +294,10 @@ SUBROUTINE SD_Init( InitInput, u, p, x, xd, z, OtherState, y, m, Interval, InitO
    endif
    if(Failed()) return
 
+   ! Copy initial platform displacement and floating flag to initialization output
+   InitOut%qR0 = Init%qR0
+   InitOut%IsFloating = p%Floating
+
    ! --------------------------------------------------------------------------------
    ! --- Manipulation of Init and parameters
    ! --------------------------------------------------------------------------------

--- a/modules/subdyn/src/SubDyn_Registry.txt
+++ b/modules/subdyn/src/SubDyn_Registry.txt
@@ -85,6 +85,8 @@ typedef  ^  InitOutputType  CHARACTER(ChanLen)     WriteOutputHdr {:}  - -   "Na
 typedef  ^  InitOutputType  CHARACTER(ChanLen)     WriteOutputUnt {:}  - -   "Units of the output-to-file channels" -
 typedef  ^  InitOutputType  ProgDesc               Ver             -   - -   "This module's name, version, and date" -
 typedef	 ^  InitOutputType  ModVarsType            Vars            -   - -   "Module Variables"
+typedef  ^  InitOutputType  R8Ki                   qR0            {6}  - -   "Initial rigid-body displacement (floating only)"
+typedef  ^  InitOutputType  logical                IsFloating      -   - -   "Flag indicating if the substructure is floating"
 typedef  ^  ^               LOGICAL                CableCChanRqst  {:}  .FALSE.  -   "flag indicating control channel for active cable tensioning is requested"   -
 
 # ============================== Define initialization data (not from glue code) here: ============================================================================================================================================

--- a/modules/subdyn/src/SubDyn_Types.f90
+++ b/modules/subdyn/src/SubDyn_Types.f90
@@ -124,6 +124,8 @@ IMPLICIT NONE
     CHARACTER(ChanLen) , DIMENSION(:), ALLOCATABLE  :: WriteOutputUnt      !< Units of the output-to-file channels [-]
     TYPE(ProgDesc)  :: Ver      !< This module's name, version, and date [-]
     TYPE(ModVarsType)  :: Vars      !< Module Variables [-]
+    REAL(R8Ki) , DIMENSION(1:6)  :: qR0 = 0.0_R8Ki      !< Initial rigid-body displacement (floating only) [-]
+    LOGICAL  :: IsFloating = .false.      !< Flag indicating if the substructure is floating [-]
     LOGICAL , DIMENSION(:), ALLOCATABLE  :: CableCChanRqst      !< flag indicating control channel for active cable tensioning is requested [-]
   END TYPE SD_InitOutputType
 ! =======================
@@ -1090,6 +1092,8 @@ subroutine SD_CopyInitOutput(SrcInitOutputData, DstInitOutputData, CtrlCode, Err
    call NWTC_Library_CopyModVarsType(SrcInitOutputData%Vars, DstInitOutputData%Vars, CtrlCode, ErrStat2, ErrMsg2)
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
+   DstInitOutputData%qR0 = SrcInitOutputData%qR0
+   DstInitOutputData%IsFloating = SrcInitOutputData%IsFloating
    if (allocated(SrcInitOutputData%CableCChanRqst)) then
       LB(1:1) = lbound(SrcInitOutputData%CableCChanRqst)
       UB(1:1) = ubound(SrcInitOutputData%CableCChanRqst)
@@ -1137,6 +1141,8 @@ subroutine SD_PackInitOutput(RF, Indata)
    call RegPackAlloc(RF, InData%WriteOutputUnt)
    call NWTC_Library_PackProgDesc(RF, InData%Ver) 
    call NWTC_Library_PackModVarsType(RF, InData%Vars) 
+   call RegPack(RF, InData%qR0)
+   call RegPack(RF, InData%IsFloating)
    call RegPackAlloc(RF, InData%CableCChanRqst)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
@@ -1153,6 +1159,8 @@ subroutine SD_UnPackInitOutput(RF, OutData)
    call RegUnpackAlloc(RF, OutData%WriteOutputUnt); if (RegCheckErr(RF, RoutineName)) return
    call NWTC_Library_UnpackProgDesc(RF, OutData%Ver) ! Ver 
    call NWTC_Library_UnpackModVarsType(RF, OutData%Vars) ! Vars 
+   call RegUnpack(RF, OutData%qR0); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%IsFloating); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%CableCChanRqst); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 

--- a/openfast_io/openfast_io/FAST_reader.py
+++ b/openfast_io/openfast_io/FAST_reader.py
@@ -302,6 +302,7 @@ class InputReader_OpenFAST(object):
 
         # Feature Switches and Flags (ftr_swtchs_flgs)
         f.readline()
+        self.fst_vt['Fst']['NRotors'] = int(f.readline().split()[0])
         self.fst_vt['Fst']['CompElast'] = int(f.readline().split()[0])
         self.fst_vt['Fst']['CompInflow'] = int(f.readline().split()[0])
         self.fst_vt['Fst']['CompAero'] = int(f.readline().split()[0])

--- a/openfast_io/openfast_io/FAST_writer.py
+++ b/openfast_io/openfast_io/FAST_writer.py
@@ -296,6 +296,7 @@ class InputWriter_OpenFAST(object):
         f.write('{:<22} {:<11} {:}'.format(self.fst_vt['Fst']['DT_UJac'], 'DT_UJac', '- Time between calls to get Jacobians (s)\n'))
         f.write('{:<22} {:<11} {:}'.format(self.fst_vt['Fst']['UJacSclFact'], 'UJacSclFact', '- Scaling factor used in Jacobians (-)\n'))
         f.write('---------------------- FEATURE SWITCHES AND FLAGS ------------------------------\n')
+        f.write('{:<22} {:<11} {:}'.format(self.fst_vt['Fst']['NRotors'], 'NRotors', '- Number of rotors in turbine\n'))
         f.write('{:<22} {:<11} {:}'.format(self.fst_vt['Fst']['CompElast'], 'CompElast', '- Compute structural dynamics (switch) {1=ElastoDyn; 2=ElastoDyn + BeamDyn for blades; 3=Simplified ElastoDyn}\n'))
         f.write('{:<22} {:<11} {:}'.format(self.fst_vt['Fst']['CompInflow'], 'CompInflow', '- Compute inflow wind velocities (switch) {0=still air; 1=InflowWind; 2=external from ExtInflow}\n'))
         f.write('{:<22} {:<11} {:}'.format(self.fst_vt['Fst']['CompAero'], 'CompAero', '- Compute aerodynamic loads (switch) {0=None; 1=AeroDisk; 2=AeroDyn; 3=ExtLoads}\n'))

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -338,6 +338,7 @@ of_regression("5MW_ITIBarge_DLL_WTurb_WavesIrr"        "openfast;elastodyn;aerod
 of_regression("5MW_TLP_DLL_WTurb_WavesIrr_WavesMulti"  "openfast;elastodyn;aerodyn;servodyn;hydrodyn;map;offshore")
 of_regression("5MW_OC3Spar_DLL_WTurb_WavesIrr"         "openfast;elastodyn;aerodyn;servodyn;hydrodyn;map;offshore")
 of_regression("5MW_OC4Semi_WSt_WavesWN"                "openfast;elastodyn;aerodyn;servodyn;hydrodyn;moordyn;offshore")
+# of_regression("5MW_OC4Semi_WSt_WavesWN_MR"             "openfast;elastodyn;aerodyn;servodyn;hydrodyn;moordyn;multirotor;offshore")
 of_regression("5MW_Land_BD_DLL_WTurb"                  "openfast;beamdyn;aerodyn;servodyn")
 of_regression("5MW_Land_BD_DLL_WTurb_StC"              "openfast;beamdyn;aerodyn;servodyn;stc")
 of_regression("5MW_Land_BD_Init"                       "openfast;beamdyn;aerodyn;servodyn")


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR adds support for multiple rotors to the input files and the glue code for OpenFAST. A demo regression test was added for the multi-rotor capability in `5MW_OC4Semi_WSt_WavesWN_MR`; however, this test is not run as part of the test suit as it is not fully working.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

This PR has changes throughout the OpenFAST glue code to handle indexing, allow multiple ServoDyn instances, and allow mapping of module instances within the same rotor or across rotors. The `5MW_OC4Semi_WSt_WavesWN_MR` multi-rotor regression test was added to the `r-test` repository, but is not enabled in `CTestLists.txt` (the line is commented out).

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

Existing test results are unchanged.
