### PR TITLE
Bug fix: remove spaces in OLAF's UA summary file name

### DIFF
--- a/modules/aerodyn/src/FVW.f90
+++ b/modules/aerodyn/src/FVW.f90
@@ -1601,7 +1601,7 @@ subroutine UA_Init_Wrapper(AFInfo, InitInp, interval, p, x, xd, OtherState, m, E
          do i = 1,InitInp%numBladeNodes
             InitInp%UA_Init%c(i,1)      = p%W(iW)%chord_LL(i) ! NOTE: InitInp chord move-allocd to p
          end do
-         InitInp%UA_Init%OutRootName     = trim(InitInp%RootName)//'W'//num2lstr(iW)//'.UA'
+         InitInp%UA_Init%OutRootName     = trim(InitInp%RootName)//'W'//trim(num2lstr(iW))//'.UA'
 
          InitInp%UA_Init%ShedEffect      = .False. ! Important, when coupling UA wih vortex code, shed vorticity is inherently accounted for
          InitInp%UA_Init%UAOff_innerNode(1) = InitInp%W(iW)%UAOff_innerNode


### PR DESCRIPTION
**Feature or improvement description**
UA summary file names had spaces when generated with OLAF simulations. The wing/blade number was 11 characters long, so most files had 10 spaces in the middle of the file name: `<RootName>.W<11 character number with spaces>.UA.sum`. I added a `trim()` statement around the character version of the wing number.

**Related issue, if one exists**
None

**Impacted areas of the software**
Uunsteady aero file names when used with OLAF simulations.

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
This doesn't change any test results.