### PR TITLE
Fix Typo in "interpolation" in Ice Crushing Modules

### DIFF
--- a/modules/icefloe/src/icefloe/intermittentCrushing.F90
+++ b/modules/icefloe/src/icefloe/intermittentCrushing.F90
@@ -80,7 +80,7 @@ contains
    end subroutine initInterCrushing
 
 !****************************************************************************
-!  Continuous crushing uses the standard inerpolation routine
+!  Continuous crushing uses the standard interpolation routine
 !  of the precalculated time series
    function outputInterCrushLoad (myIceParams, iceLog, time)  result(iceLoads)
       type(iceFloe_ParameterType), intent(in)      :: myIceParams

--- a/modules/icefloe/src/icefloe/randomCrushing.F90
+++ b/modules/icefloe/src/icefloe/randomCrushing.F90
@@ -163,7 +163,7 @@ contains
    end subroutine initRandomCrushing   ! containing subroutine
 
 !****************************************************************************
-!  Continuous crushing uses the standard inerpolation routine
+!  Continuous crushing uses the standard interpolation routine
 !  of the precalculated time series
    function outputRandomCrushLoad (myIceParams, iceLog, time)  result(iceLoads)
       type(iceFloe_ParameterType), intent(in)      :: myIceParams


### PR DESCRIPTION

**Description:**

Corrected inerpolation → interpolation x2
