### PR TITLE
HD bug fix: avoid division by zero with MHstLMod=2

### DIFF
--- a/modules/hydrodyn/src/Morison.f90
+++ b/modules/hydrodyn/src/Morison.f90
@@ -3660,7 +3660,8 @@ SUBROUTINE Morison_CalcOutput( Time, u, p, x, xd, z, OtherState, y, m, errStat, 
       b  = R * dot_product(z_hat,n_hat)
       c  = dot_product(FSPt-pos0,n_hat)
       d2 = a*a+b*b
-      IF ( d2 >= c*c ) THEN ! Has intersection
+      ! Note: if d2=0, the current section is perfectly parallel to the free surface
+      IF ( (d2 >= c*c) .and. (.not. EqualRealNos(d2,0.0_DbKi)) ) THEN ! Has intersection
          d = SQRT(d2)
          IF (b>=0.0) THEN
             alpha =  ACOS(a/d)


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
This is a simple HydroDyn bug fix to avoid division by zero when computing strip-theory hydrostatic loads with `MHstLMod`=2 if the member radius/diameter is zero. This happens when `Cb` coefficients are set to zero (usually by mistake).

**Impacted areas of the software**
HydroDyn

**Test results, if applicable**
No change to test results.
