### PR TITLE
Fix FAST_CreateCheckpoint in c++ interface

### DIFF
--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -1291,7 +1291,10 @@ void fast::OpenFAST::advance_to_next_driver_time_step(bool writeFiles) {
           int tStepRatio = time_step_ratio(dtFAST, dtDriver);
           if ( (restartFreq_*tStepRatio > 0) && (((nt_global - ntStart) % (restartFreq_*tStepRatio)) == 0 )  && (nt_global != ntStart) ) {
               turbineData[iTurb].FASTRestartFileName = " "; // if blank, it will use FAST convention <RootName>.nt_global
-              FAST_CreateCheckpoint(&iTurb, turbineData[iTurb].FASTRestartFileName.data(), &ErrStat, ErrMsg);
+              char tmpRstFileRoot[INTERFACE_STRING_LENGTH];
+              strncpy(tmpRstFileRoot, turbineData[iTurb].FASTRestartFileName.c_str(), turbineData[iTurb].FASTRestartFileName.size());
+              tmpRstFileRoot[turbineData[iTurb].FASTRestartFileName.size()] = '\0';
+              FAST_CreateCheckpoint(&iTurb, tmpRstFileRoot, &ErrStat, ErrMsg);
               checkError(ErrStat, ErrMsg);
               writeRestartFile(iTurb, nt_global);
           }
@@ -1432,7 +1435,10 @@ void fast::OpenFAST::step(bool writeFiles) {
         for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
             if ( (((nt_global - ntStart) % (restartFreq_ * tStepRatio)) == 0 )  && (nt_global != ntStart) ) {
                 turbineData[iTurb].FASTRestartFileName = " "; // if blank, it will use FAST convention <RootName>.nt_global
-                FAST_CreateCheckpoint(&iTurb, turbineData[iTurb].FASTRestartFileName.data(), &ErrStat, ErrMsg);
+                char tmpRstFileRoot[INTERFACE_STRING_LENGTH];
+                strncpy(tmpRstFileRoot, turbineData[iTurb].FASTRestartFileName.c_str(), turbineData[iTurb].FASTRestartFileName.size());
+                tmpRstFileRoot[turbineData[iTurb].FASTRestartFileName.size()] = '\0';
+                FAST_CreateCheckpoint(&iTurb, tmpRstFileRoot, &ErrStat, ErrMsg);
                 checkError(ErrStat, ErrMsg);
                 writeRestartFile(iTurb, nt_global);
             }

--- a/glue-codes/openfast-cpp/src/OpenFAST.cpp
+++ b/glue-codes/openfast-cpp/src/OpenFAST.cpp
@@ -635,14 +635,13 @@ void fast::OpenFAST::init() {
 
                 findRestartFile(iTurb);
                 findOutputFile(iTurb);
-                char tmpRstFileRoot[INTERFACE_STRING_LENGTH];
-                strncpy(tmpRstFileRoot, turbineData[iTurb].FASTRestartFileName.c_str(), turbineData[iTurb].FASTRestartFileName.size());
-                tmpRstFileRoot[turbineData[iTurb].FASTRestartFileName.size()] = '\0';
+                std::string tmpRstFileRoot{turbineData[iTurb].FASTRestartFileName};
+                tmpRstFileRoot.resize(INTERFACE_STRING_LENGTH, ' ');
                 if (turbineData[iTurb].sType == EXTINFLOW) {
                     /* note that this will set nt_global inside the FAST library */
                     FAST_ExtInfw_Restart(
                         &iTurb,
-                        tmpRstFileRoot,
+                        tmpRstFileRoot.c_str(),
                         &AbortErrLev,
                         &turbineData[iTurb].dt,
                         &turbineData[iTurb].numBlades,
@@ -657,7 +656,7 @@ void fast::OpenFAST::init() {
                 } else if(turbineData[iTurb].sType == EXTLOADS) {
                     FAST_ExtLoads_Restart(
                         &iTurb,
-                        tmpRstFileRoot,
+                        tmpRstFileRoot.c_str(),
                         &AbortErrLev,
                         &turbineData[iTurb].dt,
                         &turbineData[iTurb].numBlades,
@@ -1291,10 +1290,9 @@ void fast::OpenFAST::advance_to_next_driver_time_step(bool writeFiles) {
           int tStepRatio = time_step_ratio(dtFAST, dtDriver);
           if ( (restartFreq_*tStepRatio > 0) && (((nt_global - ntStart) % (restartFreq_*tStepRatio)) == 0 )  && (nt_global != ntStart) ) {
               turbineData[iTurb].FASTRestartFileName = " "; // if blank, it will use FAST convention <RootName>.nt_global
-              char tmpRstFileRoot[INTERFACE_STRING_LENGTH];
-              strncpy(tmpRstFileRoot, turbineData[iTurb].FASTRestartFileName.c_str(), turbineData[iTurb].FASTRestartFileName.size());
-              tmpRstFileRoot[turbineData[iTurb].FASTRestartFileName.size()] = '\0';
-              FAST_CreateCheckpoint(&iTurb, tmpRstFileRoot, &ErrStat, ErrMsg);
+              std::string tmpRstFileRoot{turbineData[iTurb].FASTRestartFileName};
+              tmpRstFileRoot.resize(INTERFACE_STRING_LENGTH, ' ');
+              FAST_CreateCheckpoint(&iTurb, tmpRstFileRoot.c_str(), &ErrStat, ErrMsg);
               checkError(ErrStat, ErrMsg);
               writeRestartFile(iTurb, nt_global);
           }
@@ -1435,10 +1433,9 @@ void fast::OpenFAST::step(bool writeFiles) {
         for (int iTurb=0; iTurb < nTurbinesProc; iTurb++) {
             if ( (((nt_global - ntStart) % (restartFreq_ * tStepRatio)) == 0 )  && (nt_global != ntStart) ) {
                 turbineData[iTurb].FASTRestartFileName = " "; // if blank, it will use FAST convention <RootName>.nt_global
-                char tmpRstFileRoot[INTERFACE_STRING_LENGTH];
-                strncpy(tmpRstFileRoot, turbineData[iTurb].FASTRestartFileName.c_str(), turbineData[iTurb].FASTRestartFileName.size());
-                tmpRstFileRoot[turbineData[iTurb].FASTRestartFileName.size()] = '\0';
-                FAST_CreateCheckpoint(&iTurb, tmpRstFileRoot, &ErrStat, ErrMsg);
+                std::string tmpRstFileRoot{turbineData[iTurb].FASTRestartFileName};
+                tmpRstFileRoot.resize(INTERFACE_STRING_LENGTH, ' ');
+                FAST_CreateCheckpoint(&iTurb, tmpRstFileRoot.c_str(), &ErrStat, ErrMsg);
                 checkError(ErrStat, ErrMsg);
                 writeRestartFile(iTurb, nt_global);
             }


### PR DESCRIPTION
FAST_CreateCheckpoint expects a fixed sized char buffer of size 1025: `CHARACTER(KIND=C_CHAR), INTENT(IN ) ::
CheckpointRootName_c(IntfStrLen)`. However the c++ is taking a 1 char string and sending a pointer to that data to the Fortran. The Fortran `TRANSFER` function then throws a good old:

```
==2684227==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5120002144e8 at pc 0x557e98358a61 bp 0x7ffc0f87ea90 sp 0x7ffc0f87e248
READ of size 1025 at 0x5120002144e8 thread T0
    #0 0x557e98358a60 in memcpy /mnt/vdb/home/jrood/goose/spack/var/spack/stage/spack-stage-llvm-17.0.6-fzo52dlnsdgyyb3wgxrrlxmnvepk6esa/spack-src/compiler-rt/lib/asan/../sanitizer_common/sanitizer_common_interceptors_memintrinsics.inc:115:5
    #1 0x7f0d5b25c311 in FAST_CreateCheckpoint /mnt/vdb/home/mhenryde/exawind/exawind-manager/environments/nalu-wind-dev/openfast/modules/openfast-library/src/FAST_Library.f90:445:76
    #2 0x7f0d5f5ea22e in fast::OpenFAST::step(bool)
    /mnt/vdb/home/mhenryde/exawind/exawind-manager/environments/nalu-wind-dev/openfast/glue-codes/openfast-cpp/src/OpenFAST.cpp:1436:17
```

This PR fixes this error.