### PR TITLE
Gh actions debug

### DIFF
--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -96,7 +96,7 @@ jobs:
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
             -DBUILD_SHARED_LIBS:BOOL=OFF \
             -DBLA_VENDOR:STRING=OpenBLAS \
-            -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
+            -DCMAKE_BUILD_TYPE:STRING=Debug \
             -DVARIABLE_TRACKING:BOOL=OFF \
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \
@@ -253,6 +253,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -312,6 +313,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -363,6 +366,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -413,6 +418,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -465,6 +472,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -513,6 +522,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -562,6 +573,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -610,6 +623,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -25,7 +25,9 @@ env:
 
 jobs:
 
-  ### BUILD JOBS
+  #-----------------------------------------------------------------------------
+  #  BUILD JOBS
+  #-----------------------------------------------------------------------------
 
   build-all-debug-single:
     # Tests compiling in debug mode with single precision.
@@ -111,14 +113,18 @@ jobs:
         working-directory: ${{github.workspace}}/build
         run: |
           cmake --build . --target all
+      - name: Archive files
+        run: tar -cvf workspace.tar ${{github.workspace}}
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:
           name: build-all-release
-          path: ${{github.workspace}}
+          path: workspace.tar
           compression-level: 0
 
-  ### BUILD AND TEST JOBS
+  #-----------------------------------------------------------------------------
+  #  BUILD AND TEST JOBS
+  #-----------------------------------------------------------------------------
 
   build-all-test-modules-debug:
     # Tests compiling in debug mode.
@@ -244,7 +250,9 @@ jobs:
           test-results-junit: test-results/results.xml
           code-coverage-cobertura: code-coverage/coverage.xml
 
-  ### TEST JOBS
+  #-----------------------------------------------------------------------------
+  #  TEST JOBS
+  #-----------------------------------------------------------------------------
 
   rtest-module-drivers:
     runs-on: ubuntu-22.04
@@ -254,6 +262,10 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
@@ -314,6 +326,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -368,6 +382,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -421,6 +437,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -476,6 +494,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -527,6 +547,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -579,6 +601,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -630,6 +654,8 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
+      - name: Untar workspace
+        run: tar -xvf workspace.tar ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -114,7 +114,10 @@ jobs:
         run: |
           cmake --build . --target all
       - name: Archive files
-        run: tar -cf workspace.tar -C ${{github.workspace}} .
+        run: |
+          tar -cvf workspace.tar -C ${{github.workspace}} \
+          ./build ./reg_tests ./requirements.txt ./glue-codes/python ./.github \
+          --exclude='CMakeFiles' --exclude='*.a' --exclude='build/ftnmods'
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:
@@ -263,7 +266,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C ${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C ${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -327,7 +332,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -383,7 +390,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -438,7 +447,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -495,7 +506,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -548,7 +561,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -602,7 +617,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -655,7 +672,9 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar -C${{github.workspace}}
+        run: |
+          tar -xf workspace.tar -C${{github.workspace}}
+          rm workspace.tar
       - name: List files in workspace
         run: ls
       - name: Setup Python

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -98,16 +98,16 @@ jobs:
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
             -DBUILD_SHARED_LIBS:BOOL=OFF \
             -DBLA_VENDOR:STRING=OpenBLAS \
-            -DCMAKE_BUILD_TYPE:STRING=Debug \
+            -DCMAKE_BUILD_TYPE:STRING=RelWithDebInfo \
             -DVARIABLE_TRACKING:BOOL=OFF \
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \
-            -DOPENMP:BOOL=OFF \
+            -DOPENMP:BOOL=ON \
             -DDOUBLE_PRECISION=ON \
-            -DBUILD_OPENFAST_CPP_API:BOOL=OFF \
-            -DBUILD_OPENFAST_LIB_DRIVER:BOOL=OFF \
-            -DBUILD_OPENFAST_CPP_DRIVER:BOOL=OFF \
-            -DBUILD_FASTFARM:BOOL=OFF \
+            -DBUILD_OPENFAST_CPP_API:BOOL=ON \
+            -DBUILD_OPENFAST_LIB_DRIVER:BOOL=ON \
+            -DBUILD_OPENFAST_CPP_DRIVER:BOOL=ON \
+            -DBUILD_FASTFARM:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Build all
         working-directory: ${{github.workspace}}/build
@@ -117,6 +117,7 @@ jobs:
         run: |
           tar -cvf workspace.tar -C ${{github.workspace}} \
           --exclude='*.a' --exclude='*.o' --exclude='build/ftnmods' \
+          --exclude='.git' --exclude='docs' --exclude='vs-build'\
           .
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -80,6 +80,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -138,6 +139,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast/build
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -255,13 +257,13 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           name: build-all-release
-      
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -323,6 +325,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -376,6 +379,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -428,6 +432,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -482,6 +487,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -532,6 +538,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -583,6 +590,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -633,6 +641,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
+        working-directory: ${{runner.workspace}}/openfast
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -116,14 +116,13 @@ jobs:
       - name: Archive files
         run: |
           tar -cvf workspace.tar -C ${{github.workspace}} \
-          --exclude='CMakeFiles' --exclude='*.a' --exclude='build/ftnmods' \
+          --exclude='*.a' --exclude='*.o' --exclude='build/ftnmods' \
           ./build ./reg_tests ./requirements.txt ./glue-codes/python ./.github 
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:
           name: build-all-release
           path: workspace.tar
-          compression-level: 0
 
   #-----------------------------------------------------------------------------
   #  BUILD AND TEST JOBS

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -40,12 +40,12 @@ jobs:
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Setup workspace
-        run: cmake -E make_directory ${{runner.workspace}}/openfast/build
+        run: cmake -E make_directory ${{github.workspace}}/build
       - name: Configure build
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/openfast/install \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{github.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
@@ -60,7 +60,7 @@ jobs:
             -DBUILD_FASTFARM:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Build all
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake --build . --target all
 
@@ -72,27 +72,24 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-      - name: List files in workspace
-        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
           cache: 'pip'
+      - name: List files in workspace
+        run: ls ${{github.workspace}}
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
         run: |
-          pip install -r requirements.txt
-          pip install glue-codes/python/.   # Installs the interface library
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Setup workspace
-        run: cmake -E make_directory ${{runner.workspace}}/openfast/build
+        run: cmake -E make_directory ${{github.workspace}}/build
       - name: Configure build
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/openfast/install \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{github.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
@@ -111,14 +108,14 @@ jobs:
             -DBUILD_FASTFARM:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Build all
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake --build . --target all
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:
           name: build-all-release
-          path: ${{runner.workspace}}
+          path: ${{github.workspace}}
           compression-level: 0
 
   ### BUILD AND TEST JOBS
@@ -139,19 +136,19 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
           sudo apt-get update -y
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
       - name: Setup workspace
-        run: cmake -E make_directory ${{runner.workspace}}/openfast/build
+        run: cmake -E make_directory ${{github.workspace}}/build
       - name: Configure build
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/openfast/install \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{github.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
@@ -165,11 +162,11 @@ jobs:
             ${GITHUB_WORKSPACE}
             # -DDOUBLE_PRECISION=OFF \
       - name: Build all
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake --build . --target all
       - name: Run UnsteadyAero tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         shell: bash
         run: |
           ctest -VV -R "^ua_" 
@@ -200,8 +197,8 @@ jobs:
         with:
           name: rtest-modules-debug
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/modules
-            ${{runner.workspace}}/openfast/build/unit_tests
+            ${{github.workspace}}/build/reg_tests/modules
+            ${{github.workspace}}/build/unit_tests
 
 
   build-test-OF-simulink:
@@ -220,12 +217,12 @@ jobs:
         with:
           products: Simulink
       - name: Setup workspace
-        run: cmake -E make_directory ${{runner.workspace}}/openfast/build
+        run: cmake -E make_directory ${{github.workspace}}/build
       - name: Configure build
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
-            -DCMAKE_INSTALL_PREFIX:PATH=${{runner.workspace}}/openfast/install \
+            -DCMAKE_INSTALL_PREFIX:PATH=${{github.workspace}}/install \
             -DCMAKE_Fortran_COMPILER:STRING=${{env.FORTRAN_COMPILER}} \
             -DCMAKE_CXX_COMPILER:STRING=${{env.CXX_COMPILER}} \
             -DCMAKE_C_COMPILER:STRING=${{env.C_COMPILER}} \
@@ -237,13 +234,13 @@ jobs:
             -DVARIABLE_TRACKING:BOOL=OFF \
             ${GITHUB_WORKSPACE}
       - name: Build FAST_SFunc
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake --build . --target FAST_SFunc
       - name: Run MATLAB tests and generate artifacts
         uses: matlab-actions/run-tests@v2
         with:
-          source-folder: ${{runner.workspace}}/openfast/build/glue-codes/simulink; ${{runner.workspace}}/openfast/glue-codes/simulink/examples
+          source-folder: ${{github.workspace}}/build/glue-codes/simulink; ${{github.workspace}}/glue-codes/simulink/examples
           test-results-junit: test-results/results.xml
           code-coverage-cobertura: code-coverage/coverage.xml
 
@@ -263,7 +260,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -271,7 +268,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -304,7 +301,7 @@ jobs:
         with:
           name: rtest-module-drivers
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/modules
+            ${{github.workspace}}/build/reg_tests/modules
 
 
   rtest-interfaces:
@@ -325,7 +322,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -333,7 +330,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -341,7 +338,7 @@ jobs:
             -DCTEST_PLOT_ERRORS:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Run Interface / API tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           ctest -VV \
               -L "cpp|python|fastlib" \
@@ -352,13 +349,13 @@ jobs:
         with:
           name: rtest-interfaces
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast-cpp
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/python
-            ${{runner.workspace}}/openfast/build/reg_tests/modules/aerodyn
-            ${{runner.workspace}}/openfast/build/reg_tests/modules/moordyn
-            ${{runner.workspace}}/openfast/build/reg_tests/modules/inflowwind
-            ${{runner.workspace}}/openfast/build/reg_tests/modules/hydrodyn
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast-cpp/5MW_Baseline
+            ${{github.workspace}}/build/reg_tests/glue-codes/openfast-cpp
+            ${{github.workspace}}/build/reg_tests/glue-codes/python
+            ${{github.workspace}}/build/reg_tests/modules/aerodyn
+            ${{github.workspace}}/build/reg_tests/modules/moordyn
+            ${{github.workspace}}/build/reg_tests/modules/inflowwind
+            ${{github.workspace}}/build/reg_tests/modules/hydrodyn
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast-cpp/5MW_Baseline
 
 
   rtest-OF:
@@ -379,7 +376,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -387,7 +384,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -396,7 +393,7 @@ jobs:
             ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           ctest -VV \
           -L openfast \
@@ -407,13 +404,13 @@ jobs:
         with:
           name: rtest-OF
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/5MW_Baseline
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AOC
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AWT27
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/SWRT
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/UAE_VI
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/WP_Baseline
+            ${{github.workspace}}/build/reg_tests/glue-codes/openfast
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/5MW_Baseline
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AOC
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AWT27
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/SWRT
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/UAE_VI
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/WP_Baseline
 
 
   rtest-OF-offshore:
@@ -432,7 +429,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -440,7 +437,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -449,7 +446,7 @@ jobs:
             ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run 5MW tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           ctest -VV \
           -L openfast -L offshore \
@@ -460,13 +457,13 @@ jobs:
         with:
           name: rtest-OF-offshore
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/5MW_Baseline
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AOC
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AWT27
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/SWRT
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/UAE_VI
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/WP_Baseline
+            ${{github.workspace}}/build/reg_tests/glue-codes/openfast
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/5MW_Baseline
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AOC
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AWT27
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/SWRT
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/UAE_VI
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/WP_Baseline
 
  
   rtest-OF-linearization:
@@ -487,7 +484,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -495,7 +492,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -503,7 +500,7 @@ jobs:
             -DCTEST_PLOT_ERRORS:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Run OpenFAST linearization tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           ctest -VV -L linear
       - name: Failing test artifacts
@@ -512,13 +509,13 @@ jobs:
         with:
           name: rtest-OF-linearization
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/5MW_Baseline
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AOC
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AWT27
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/SWRT
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/UAE_VI
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/WP_Baseline
+            ${{github.workspace}}/build/reg_tests/glue-codes/openfast
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/5MW_Baseline
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AOC
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AWT27
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/SWRT
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/UAE_VI
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/WP_Baseline
 
   rtest-OF-aeromap:
     runs-on: ubuntu-22.04
@@ -538,7 +535,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -546,7 +543,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -554,7 +551,7 @@ jobs:
             -DCTEST_PLOT_ERRORS:BOOL=ON \
             ${GITHUB_WORKSPACE}
       - name: Run aero map tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           ctest -VV -L aeromap -LE "cpp|linear|python"
       - name: Failing test artifacts
@@ -563,13 +560,13 @@ jobs:
         with:
           name: rtest-OF-aeromap
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/5MW_Baseline
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AOC
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/AWT27
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/SWRT
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/UAE_VI
-            !${{runner.workspace}}/openfast/build/reg_tests/glue-codes/openfast/WP_Baseline
+            ${{github.workspace}}/build/reg_tests/glue-codes/openfast
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/5MW_Baseline
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AOC
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/AWT27
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/SWRT
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/UAE_VI
+            !${{github.workspace}}/build/reg_tests/glue-codes/openfast/WP_Baseline
 
 
   rtest-openfast_io:
@@ -590,7 +587,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -598,11 +595,11 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Install openfast_io
-        working-directory: ${{runner.workspace}}/openfast/openfast_io
+        working-directory: ${{github.workspace}}/openfast_io
         run: |
           pip install -e .
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -611,7 +608,7 @@ jobs:
             ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run openfast_io tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           ctest -VV -L openfast_io 
       - name: Failing test artifacts
@@ -620,7 +617,7 @@ jobs:
         with:
           name: rtest-openfast_io
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/openfast_io
+            ${{github.workspace}}/build/reg_tests/openfast_io
 
 
   rtest-FF:
@@ -641,7 +638,7 @@ jobs:
           python-version: '3.11'
           cache: 'pip'
       - name: Install dependencies
-        working-directory: ${{runner.workspace}}/openfast
+        working-directory: ${{github.workspace}}
         run: |
           pip install -r requirements.txt
           pip install glue-codes/python/.   # Installs the interface library
@@ -649,7 +646,7 @@ jobs:
           sudo apt-get install -y libopenblas-dev libopenblas-openmp-dev
           sudo apt-get install -y libhdf5-dev libnetcdf-dev libopenmpi-dev libyaml-cpp-dev
       - name: Configure Tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         run: |
           cmake \
             -DPython_ROOT_DIR:PATH=${{env.pythonLocation}} \
@@ -658,7 +655,7 @@ jobs:
             ${GITHUB_WORKSPACE}
           cmake --build . --target regression_test_controllers
       - name: Run FAST.Farm tests
-        working-directory: ${{runner.workspace}}/openfast/build
+        working-directory: ${{github.workspace}}/build
         shell: bash
         run: |
           ctest -VV -j1 -L fastfarm --verbose
@@ -668,4 +665,4 @@ jobs:
         with:
           name: rtest-FF
           path: |
-            ${{runner.workspace}}/openfast/build/reg_tests/glue-codes/fast-farm
+            ${{github.workspace}}/build/reg_tests/glue-codes/fast-farm

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -114,7 +114,7 @@ jobs:
         run: |
           cmake --build . --target all
       - name: Archive files
-        run: tar -cvf workspace.tar ${{github.workspace}}
+        run: tar -cf workspace.tar -C ${{github.workspace}} .
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:
@@ -263,7 +263,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C ${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -327,7 +327,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -383,7 +383,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -438,7 +438,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -495,7 +495,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -548,7 +548,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -602,7 +602,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python
@@ -655,7 +655,7 @@ jobs:
         with:
           name: build-all-release
       - name: Untar workspace
-        run: tar -xvf workspace.tar ${{github.workspace}}
+        run: tar -xvf workspace.tar -C${{github.workspace}}
       - name: List files in workspace
         run: ls
       - name: Setup Python

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -330,7 +330,7 @@ jobs:
           name: build-all-release
       - name: Untar workspace
         run: |
-          tar -xf workspace.tar -C${{github.workspace}}
+          tar -xf workspace.tar -C ${{github.workspace}}
           rm workspace.tar
       - name: List files in workspace
         run: ls

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -72,6 +72,8 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
+      - name: List files in workspace
+        run: ls
       - name: Setup Python
         uses: actions/setup-python@v5
         with:

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -76,6 +76,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -110,13 +111,12 @@ jobs:
         working-directory: ${{runner.workspace}}/openfast/build
         run: |
           cmake --build . --target all
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Save workspace for other jobs
+        uses: actions/upload-artifact@v4
         with:
+          name: build-all-release
           path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
-
-
+          compression-level: 0
 
   ### BUILD AND TEST JOBS
 
@@ -134,6 +134,7 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -248,15 +249,15 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-all-release
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -307,15 +308,15 @@ jobs:
     env:
       OMP_NUM_THREADS: 1
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -358,15 +359,15 @@ jobs:
     env:
       OMP_NUM_THREADS: 1
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -408,15 +409,15 @@ jobs:
     runs-on: ubuntu-22.04
     needs: build-all-release
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -460,15 +461,15 @@ jobs:
     env:
       OMP_NUM_THREADS: 1
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -508,15 +509,15 @@ jobs:
     env:
       OMP_NUM_THREADS: 1
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -557,15 +558,15 @@ jobs:
     env:
       OMP_NUM_THREADS: 1
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt
@@ -605,15 +606,15 @@ jobs:
     env:
       OMP_NUM_THREADS: 2
     steps:
-      - name: Cache the workspace
-        uses: actions/cache@v4
+      - name: Restore workspace from artifact
+        uses: actions/download-artifact@v4
         with:
-          path: ${{runner.workspace}}
-          key: build-all-release-${{ github.sha }}
+          name: build-all-release
       - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
+          cache: 'pip'
       - name: Install dependencies
         run: |
           pip install -r requirements.txt

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           tar -cvf workspace.tar -C ${{github.workspace}} \
           --exclude='*.a' --exclude='*.o' --exclude='build/ftnmods' \
-          --exclude='.git' --exclude='docs' --exclude='vs-build'\
+          --exclude='.git' --exclude='docs' --exclude='vs-build' \
           .
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -117,7 +117,7 @@ jobs:
         run: |
           tar -cvf workspace.tar -C ${{github.workspace}} \
           --exclude='*.a' --exclude='*.o' --exclude='build/ftnmods' \
-          ./build ./reg_tests ./requirements.txt ./glue-codes/python ./.github 
+          .
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -102,12 +102,12 @@ jobs:
             -DVARIABLE_TRACKING:BOOL=OFF \
             -DBUILD_TESTING:BOOL=ON \
             -DCTEST_PLOT_ERRORS:BOOL=ON \
-            -DOPENMP:BOOL=ON \
+            -DOPENMP:BOOL=OFF \
             -DDOUBLE_PRECISION=ON \
-            -DBUILD_OPENFAST_CPP_API:BOOL=ON \
-            -DBUILD_OPENFAST_LIB_DRIVER:BOOL=ON \
-            -DBUILD_OPENFAST_CPP_DRIVER:BOOL=ON \
-            -DBUILD_FASTFARM:BOOL=ON \
+            -DBUILD_OPENFAST_CPP_API:BOOL=OFF \
+            -DBUILD_OPENFAST_LIB_DRIVER:BOOL=OFF \
+            -DBUILD_OPENFAST_CPP_DRIVER:BOOL=OFF \
+            -DBUILD_FASTFARM:BOOL=OFF \
             ${GITHUB_WORKSPACE}
       - name: Build all
         working-directory: ${{github.workspace}}/build
@@ -116,8 +116,8 @@ jobs:
       - name: Archive files
         run: |
           tar -cvf workspace.tar -C ${{github.workspace}} \
-          ./build ./reg_tests ./requirements.txt ./glue-codes/python ./.github \
-          --exclude='CMakeFiles' --exclude='*.a' --exclude='build/ftnmods'
+          --exclude='CMakeFiles' --exclude='*.a' --exclude='build/ftnmods' \
+          ./build ./reg_tests ./requirements.txt ./glue-codes/python ./.github 
       - name: Save workspace for other jobs
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/automated-dev-tests.yml
+++ b/.github/workflows/automated-dev-tests.yml
@@ -78,7 +78,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: List files in workspace
         run: ls ${{github.workspace}}
       - name: Install dependencies
@@ -143,7 +142,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -275,7 +273,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -341,7 +338,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -399,7 +395,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -456,7 +451,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -515,7 +509,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -570,7 +563,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -626,7 +618,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |
@@ -681,7 +672,6 @@ jobs:
         uses: actions/setup-python@v5
         with:
           python-version: '3.11'
-          cache: 'pip'
       - name: Install dependencies
         working-directory: ${{github.workspace}}
         run: |


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR fixes the issue with Python not being able to find the `requirements.txt` file in the regression test GitHub action. The issue was caused by not specifying or using the wrong variable for the working directory when running `pip install -r requirements.txt`. Different runners would interpret the working directory differently causing tests to sometimes pass and sometimes fail. This PR uses `${{github.workspace}}` instead of `${{runner.workspace}}` to specify the working directory.

In addition, the existing regression test GitHub action uses caches to transfer data and binaries between the jobs in a run. Based on https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/storing-and-sharing-data-from-a-workflow#comparing-artifacts-and-dependency-caching, artifacts should be used for sharing data within a run (across jobs) and caches should be used for sharing dependencies across workflow runs. This PR changes the action to use artifacts, which reduces storage size and makes it possible for the user to download the compilation output after the run, which may be useful.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`automated-dev-tests.yml`
