### PR TITLE
SD: Fix a bug where interface DoF loads are incomplete if the interface joint is part of a rigid assembly

### DIFF
--- a/modules/subdyn/src/SD_FEM.f90
+++ b/modules/subdyn/src/SD_FEM.f90
@@ -386,11 +386,6 @@ SUBROUTINE SD_ReIndex_CreateNodesAndElems(Init,p, ErrStat, ErrMsg)
                CALL Fatal('All joints of a rigid link should be cantilever (not ball/pin/universal). The problematic member is MemberID='//TRIM(Num2LStr(mID))//' (which is a rigid link) involving joint JointID='// TRIM(Num2LStr(JointID))// ' (which is not a cantilever joint).')
                return
             endif
-            ! Check that rigid links are not connected to the interface
-            iInterf = FINDLOCI(p%Nodes_I(:,1), iJoint )
-            if (iInterf>=1) then
-               CALL WrScr('[WARNING] There might be a bug when one beam and one rigid link are connected to the interface nodes. The problematic member might be MemberID='//TRIM(Num2LStr(mID))//' (which is a rigid link) involving joint JointID='// TRIM(Num2LStr(JointID))// ' (which is in an interface joint).')
-            endif
          endif
       enddo
       ! Column 4-5: PropIndex 1-2 (instead of PropSetID1&2)


### PR DESCRIPTION
This PR is ready to be merged. 

**Feature or improvement description**
This PR fixes a bug where the external loads on SubDyn interface degrees of freedom are incomplete if the interface joint is part of a rigid assembly. Previously, only the loads on the interface joint itself are computed. This is incomplete. We instead need to include the external loads on all nodes belonging to the same rigid assembly due to DoF reduction.

**Related issue, if one exists**
Addresses both Issue #854 and Issue #1081 (verified by @RBergua below). Both issues can now be closed. The corresponding warning message in SubDyn is also deleted.

**Additional information**
This appears to be a very old bug present since rigid links were first added to SubDyn. We can consider backporting to v4.x.

**Impacted areas of the software**
SubDyn

**Test results, if applicable**
No change to existing test results. 