### PR TITLE
SeaState: Allow WaveStMod=1 with WaveMod=0

### DIFF
--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -601,7 +601,10 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
 
    ! WaveStMod - Model switch for stretching incident wave kinematics to instantaneous free surface.
    IF ( InputFileData%WaveMod == WaveMod_None ) THEN
-      InputFileData%WaveStMod = 0_IntKi
+      IF ( (InputFileData%WaveStMod /= 0) .AND. (InputFileData%WaveStMod /= 1) ) THEN
+         CALL SetErrStat( ErrID_Fatal,'WaveStMod must be 0 or 1 when WaveMod = 0.',ErrStat,ErrMsg,RoutineName)
+         RETURN
+      END IF
    ELSEIF ( InputFileData%WaveMod == WaveMod_ExtFull ) THEN
       IF ( (InputFileData%WaveStMod /= 0) .AND. (InputFileData%WaveStMod /= 1) .AND. &
                                                 (InputFileData%WaveStMod /= 3) ) THEN


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
This PR enables `WaveStMod=1` (vertical wave stretching) when `WaveMod=0` (calm water). 

Previously, SeaState automatically sets `WaveStMod=0` (no wave stretching) if `WaveMod=0`. HydroDyn only considers the vertical displacements of strip-theory member nodes when `WaveStMod/=0`. This prevents accurate linearization if the structure has a large heave offset because linearization requires `WaveMod=0`, which, in turn, forces `WaveStMod=0`.

This PR allows the user to set `WaveStMod=1` when performing linearization, so that the vertical offset of the strip-theory members and the resulting change in wetted lengths are taken into account. 

**Impacted areas of the software**
SeaState

**Test results, if applicable**
No change to existing test results.