### PR TITLE
Add SeaState path when running MoorDyn registry in RunRegistry.bat

### DIFF
--- a/vs-build/RunRegistry.bat
+++ b/vs-build/RunRegistry.bat
@@ -255,7 +255,7 @@ GOTO checkError
 :MoorDyn
 SET CURR_LOC=%MD_Loc%
 SET Output_Loc=%CURR_LOC%
-%REGISTRY% "%CURR_LOC%\%ModuleName%_Registry.txt" -I "%NWTC_Lib_Loc%"  -O "%Output_Loc%"
+%REGISTRY% "%CURR_LOC%\%ModuleName%_Registry.txt" -I "%NWTC_Lib_Loc%"  -I "%SEAST_Loc%" -O "%Output_Loc%"
 GOTO checkError
 
 :IceFloe


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to be merged.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR fixes an issue when running the registry for Visual Studio projects where the path to the SeaState registry files wasn't specified when running the MoorDyn registry. Since v4.0.0, MoorDyn has depended on SeaState and needs access to the registry files.

This appears to mainly affect users building with the IFX compiler as IFORT doesn't automatically regenerate the registry files when building, which is why the issue wasn't previously discovered.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

Closes #2904

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`RunRegistry.bat` which is used Visual Studio to run the registry and generate the module Types files.

This PR only affects users who build on Windows and use the Visual Studio projects.
