### PR TITLE
docs: add guide for WSL+VScode

### DIFF
--- a/docs/source/install/index.rst
+++ b/docs/source/install/index.rst
@@ -259,6 +259,9 @@ development, CMake is adequate. Background on CMake is given in
 :ref:`understanding_cmake`, and procedures for configuring and
 compiling are given in :ref:`cmake_unix` and :ref:`cmake_windows`.
 
+For a guide to compiling on Windows with the linux subsystem, cmake, and VS code, see
+:ref:`OFcompile_WSL_VScode`.
+
 Generally, the steps required to compile are:
 
 1. Install Dependencies (Section :numref:`dependencies`)
@@ -373,6 +376,22 @@ with the build process are documented in the following section:
    :maxdepth: 1
 
    install_vs_windows.rst
+
+.. _OFcompile_WSL_VScode:
+
+Windows with the linux subsystem and VS code
+--------------------------------------------
+
+This guide provides step-by-step instructions for compiling OpenFAST from source
+on Windows using WSL (Windows Subsystem for Linux), setting up a Python
+environment with pyOpenFAST, and configuring VS Code for development and testing
+with Jupyter notebooks.
+
+.. toctree::
+   :maxdepth: 1
+
+   OFcompile_WSL_VScode.rst
+
 
 .. _understanding_cmake:
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
This adds a new guide with step-by-step instructions for compiling OpenFAST from source on Windows using WSL (Windows Subsystem for Linux), setting up a Python environment with pyOpenFAST, and configuring VS Code for development and testing with Jupyter notebooks.

Taken from  here: https://github.com/OpenFAST/openfast/issues/2904#issuecomment-3056252458, authored by @skvibimigger



**Related issue, if one exists**
https://github.com/OpenFAST/openfast/issues/2904#issuecomment-3056252458

**Impacted areas of the software**
Documentation only

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
No tests affected