### PR TITLE
Changed submergence calculation and added additional rod outputs for input file

### DIFF
--- a/modules/moordyn/src/MoorDyn.f90
+++ b/modules/moordyn/src/MoorDyn.f90
@@ -1235,14 +1235,14 @@ CONTAINS
                   ! process output flag characters (LineOutString) and set line output flag array (OutFlagList)
                   m%RodList(l)%OutFlagList = 0  ! first set array all to zero
                   ! per node, 3 component
-                  IF ( scan( LineOutString, 'p') > 0 )  m%RodList(l)%OutFlagList(2 ) = 1   ! node position
-                  IF ( scan( LineOutString, 'v') > 0 )  m%RodList(l)%OutFlagList(3 ) = 1   ! node velocity
-                  IF ( scan( LineOutString, 'U') > 0 )  m%RodList(l)%OutFlagList(4 ) = 1   ! water velocity
-                  IF ( scan( LineOutString, 'B') > 0 )  m%RodList(l)%OutFlagList(5 ) = 1   ! node buoyancy force
-                  IF ( scan( LineOutString, 'D') > 0 )  m%RodList(l)%OutFlagList(6 ) = 1   ! drag force
-                  IF ( scan( LineOutString, 'I') > 0 )  m%RodList(l)%OutFlagList(7 ) = 1   ! inertia force
-                  IF ( scan( LineOutString, 'P') > 0 )  m%RodList(l)%OutFlagList(8 ) = 1   ! dynamic pressure force
-                  IF ( scan( LineOutString, 'b') > 0 )  m%RodList(l)%OutFlagList(9 ) = 1   ! seabed contact forces
+                  IF ( scan( LineOutString, 'p') > 0 )  m%RodList(l)%OutFlagList(2 ) = 1   ! node position (p)
+                  IF ( scan( LineOutString, 'v') > 0 )  m%RodList(l)%OutFlagList(3 ) = 1   ! node velocity (v)
+                  IF ( scan( LineOutString, 'U') > 0 )  m%RodList(l)%OutFlagList(4 ) = 1   ! water velocity (U)
+                  IF ( scan( LineOutString, 'B') > 0 )  m%RodList(l)%OutFlagList(5 ) = 1   ! node buoyancy force (Bo)
+                  IF ( scan( LineOutString, 'D') > 0 )  m%RodList(l)%OutFlagList(6 ) = 1   ! drag force (D)
+                  IF ( scan( LineOutString, 'I') > 0 )  m%RodList(l)%OutFlagList(7 ) = 1   ! inertia force (I)
+                  IF ( scan( LineOutString, 'P') > 0 )  m%RodList(l)%OutFlagList(8 ) = 1   ! dynamic pressure force (Pd)
+                  IF ( scan( LineOutString, 'b') > 0 )  m%RodList(l)%OutFlagList(9 ) = 1   ! seabed contact forces (B)
                   ! per node, 1 component
                   IF ( scan( LineOutString, 'W') > 0 )  m%RodList(l)%OutFlagList(10) = 1   ! node weight/buoyancy (positive up)
                   IF ( scan( LineOutString, 'K') > 0 )  m%RodList(l)%OutFlagList(11) = 1   ! curvature at node
@@ -1251,6 +1251,14 @@ CONTAINS
                   IF ( scan( LineOutString, 'c') > 0 )  m%RodList(l)%OutFlagList(13) = 1  ! segment internal damping force
                   IF ( scan( LineOutString, 's') > 0 )  m%RodList(l)%OutFlagList(14) = 1  ! Segment strain
                   IF ( scan( LineOutString, 'd') > 0 )  m%RodList(l)%OutFlagList(15) = 1  ! Segment strain rate
+                  ! Extended flags
+                  IF ( scan( LineOutString, 'A') > 0 )  m%RodList(l)%OutFlagList(16) = 1   ! Tangential drag forces (Ap)
+                  IF ( scan( LineOutString, 'a') > 0 )  m%RodList(l)%OutFlagList(17) = 1   ! Axial fluid inertia force (Aq)
+                  IF ( scan( LineOutString, 'X') > 0 )  m%RodList(l)%OutFlagList(18) = 1   ! Transverse drag forces (Dp)
+                  IF ( scan( LineOutString, 'Y') > 0 )  m%RodList(l)%OutFlagList(19) = 1   ! Tangential drag forces (Dq)
+
+
+
 
                   IF (SUM(m%RodList(l)%OutFlagList) > 0)   m%RodList(l)%OutFlagList(1) = 1  ! this first entry signals whether to create any output file at all
                   ! the above letter-index combinations define which OutFlagList entry corresponds to which output type
@@ -1625,11 +1633,11 @@ CONTAINS
                   ! process output flag characters (LineOutString) and set line output flag array (OutFlagList)
                   m%LineList(l)%OutFlagList = 0  ! first set array all to zero
                   ! per node 3 component
-                  IF ( scan( LineOutString, 'p') > 0 )  m%LineList(l)%OutFlagList(2) = 1 
-                  IF ( scan( LineOutString, 'v') > 0 )  m%LineList(l)%OutFlagList(3) = 1
-                  IF ( scan( LineOutString, 'U') > 0 )  m%LineList(l)%OutFlagList(4) = 1
-                  IF ( scan( LineOutString, 'D') > 0 )  m%LineList(l)%OutFlagList(5) = 1
-                  IF ( scan( LineOutString, 'b') > 0 )  m%LineList(l)%OutFlagList(6) = 1   ! seabed contact forces
+                  IF ( scan( LineOutString, 'p') > 0 )  m%LineList(l)%OutFlagList(2) = 1  ! node position (p)
+                  IF ( scan( LineOutString, 'v') > 0 )  m%LineList(l)%OutFlagList(3) = 1  ! node velocity (v)
+                  IF ( scan( LineOutString, 'U') > 0 )  m%LineList(l)%OutFlagList(4) = 1  ! node displacement (U)
+                  IF ( scan( LineOutString, 'D') > 0 )  m%LineList(l)%OutFlagList(5) = 1  ! node rotation (D)
+                  IF ( scan( LineOutString, 'b') > 0 )  m%LineList(l)%OutFlagList(6) = 1  ! seabed contact forces (B)
                   IF ( scan( LineOutString, 'V') > 0 )  m%LineList(l)%OutFlagList(7) = 1   ! VIV forces
                   ! per node 1 component
                   IF ( scan( LineOutString, 'W') > 0 )  m%LineList(l)%OutFlagList(8) = 1  ! node weight/buoyancy (positive up)

--- a/modules/moordyn/src/MoorDyn_IO.f90
+++ b/modules/moordyn/src/MoorDyn_IO.f90
@@ -79,19 +79,57 @@ MODULE MoorDyn_IO
   INTEGER, PARAMETER             :: MZ        =   25
   INTEGER, PARAMETER             :: Sub       =   26
   INTEGER, PARAMETER             :: TenA      =   27 
-  INTEGER, PARAMETER             :: TenB      =   28 
+  INTEGER, PARAMETER             :: TenB      =   28
+  INTEGER, PARAMETER             :: WZ        =   29
+  INTEGER, PARAMETER             :: BoX       =   30
+  INTEGER, PARAMETER             :: BoY       =   31
+  INTEGER, PARAMETER             :: BoZ       =   32
+  INTEGER, PARAMETER             :: DpX       =   33
+  INTEGER, PARAMETER             :: DpY       =   34
+  INTEGER, PARAMETER             :: DpZ       =   35
+  INTEGER, PARAMETER             :: DqX       =   36
+  INTEGER, PARAMETER             :: DqY       =   37
+  INTEGER, PARAMETER             :: DqZ       =   38
+  INTEGER, PARAMETER             :: ApX       =   39
+  INTEGER, PARAMETER             :: ApY       =   40
+  INTEGER, PARAMETER             :: ApZ       =   41
+  INTEGER, PARAMETER             :: AqX       =   42
+  INTEGER, PARAMETER             :: AqY       =   43
+  INTEGER, PARAMETER             :: AqZ       =   44
+  INTEGER, PARAMETER             :: PdX       =   45
+  INTEGER, PARAMETER             :: PdY       =   46
+  INTEGER, PARAMETER             :: PdZ       =   47
+  INTEGER, PARAMETER             :: BX        =   48
+  INTEGER, PARAMETER             :: BY        =   49
+  INTEGER, PARAMETER             :: BZ        =   50
+  INTEGER, PARAMETER             :: Pd        =   51
+
+ 
 
 
   ! List of units corresponding to the quantities parameters for QTypes
-  CHARACTER(ChanLen), PARAMETER :: UnitList(0:26) =  (/ &
-                               "(s)       ","(m)       ","(m)       ","(m)       ", &
-                               "(deg)     ","(deg)     ","(deg)     ", &
-                               "(m/s)     ","(m/s)     ","(m/s)     ", &
-                               "(deg/s)   ","(deg/s)   ","(deg/s)   ", &
-                               "(m/s2)    ","(m/s2)    ","(m/s2)    ", &
-                               "(deg/s2)  ","(deg/s2)  ","(deg/s2)  ", &
-                               "(N)       ","(N)       ","(N)       ","(N)       ", &
-                               "(Nm)      ","(Nm)      ","(Nm)      ","(frac)    "/)
+  CHARACTER(ChanLen), PARAMETER :: UnitList(0:50) = (/ &
+  "(s)       ",                             & !  0: Time
+  "(m)       ", "(m)       ", "(m)       ", & !  1–3:  PosX, PosY, PosZ
+  "(deg)     ", "(deg)     ", "(deg)     ", & !  4–6:  RotX, RotY, RotZ
+  "(m/s)     ", "(m/s)     ", "(m/s)     ", & !  7–9:  VelX, VelY, VelZ
+  "(deg/s)   ", "(deg/s)   ", "(deg/s)   ", & ! 10–12: RVelX, RVelY, RVelZ
+  "(m/s2)    ", "(m/s2)    ", "(m/s2)    ", & ! 13–15: AccX, AccY, AccZ
+  "(deg/s2)  ", "(deg/s2)  ", "(deg/s2)  ", & ! 16–18: RAccX, RAccY, RAccZ
+  "(N)       ",                             & ! 19: Ten
+  "(N)       ", "(N)       ", "(N)       ", & ! 20–22: FX, FY, FZ
+  "(Nm)      ", "(Nm)      ", "(Nm)      ", & ! 23–25: MX, MY, MZ
+  "(frac)    ",                             & ! 26: Sub
+  "(N)       ", "(N)       ",               & ! 27–28: TenA, TenB
+  "(N)       ",                             & ! 29: WZ
+  "(N)       ", "(N)       ", "(N)       ", & ! 30–32: DpX, DpY, DpZ 
+  "(N)       ", "(N)       ", "(N)       ", & ! 33–35: DqX, DqY, DqZ 
+  "(N)       ", "(N)       ", "(N)       ", & ! 36–38: ApX, ApY, ApZ 
+  "(N)       ", "(N)       ", "(N)       ", & ! 39–41: AqX, AqY, AqZ 
+  "(N)       ", "(N)       ", "(N)       ", & ! 42–44: PdX, PdY, PdZ 
+  "(N)       ", "(N)       ", "(N)       ", & ! 45–47: BX, BY, BZ
+  "(N)       ", "(N)       ", "(N)       "  & ! 48–50: BoX, BoY, BoZ
+/)                     
 
   CHARACTER(28), PARAMETER  :: OutPFmt = "( I4, 3X,A 10,1 X, A10 )"   ! Output format parameter output list.
   CHARACTER(28), PARAMETER  :: OutSFmt = "ES10.3E2"
@@ -695,6 +733,73 @@ CONTAINS
         ELSE IF (qVal == 'SUB') THEN
           p%OutParam(I)%QType = Sub
           p%OutParam(I)%Units = UnitList(Sub)
+        ELSE IF (qVal == 'WZ') THEN
+          p%OutParam(I)%QType = WZ
+          p%OutParam(I)%Units = UnitList(WZ)
+        ELSE IF (qVal == 'BoX') THEN
+          p%OutParam(I)%QType = BoX
+          p%OutParam(I)%Units = UnitList(BoX)
+        ELSE IF (qVal == 'BoY') THEN
+          p%OutParam(I)%QType = BoY
+          p%OutParam(I)%Units = UnitList(BoY)
+        ELSE IF (qVal == 'BoZ') THEN
+          p%OutParam(I)%QType = BoZ
+          p%OutParam(I)%Units = UnitList(BoZ)
+        ELSE IF (qVal == 'DpX') THEN
+          p%OutParam(I)%QType = DpX
+          p%OutParam(I)%Units = UnitList(DpX)
+        ELSE IF (qVal == 'DpY') THEN
+          p%OutParam(I)%QType = DpY
+          p%OutParam(I)%Units = UnitList(DpY)
+        ELSE IF (qVal == 'DpZ') THEN
+          p%OutParam(I)%QType = DpZ
+          p%OutParam(I)%Units = UnitList(DpZ)
+        ELSE IF (qVal == 'DqX') THEN
+          p%OutParam(I)%QType = DqX
+          p%OutParam(I)%Units = UnitList(DqX)
+        ELSE IF (qVal == 'DqY') THEN
+          p%OutParam(I)%QType = DqY
+          p%OutParam(I)%Units = UnitList(DqY)
+        ELSE IF (qVal == 'DqZ') THEN
+          p%OutParam(I)%QType = DqZ
+          p%OutParam(I)%Units = UnitList(DqZ)
+        ELSE IF (qVal == 'ApX') THEN
+          p%OutParam(I)%QType = ApX
+          p%OutParam(I)%Units = UnitList(ApX)
+        ELSE IF (qVal == 'ApY') THEN
+          p%OutParam(I)%QType = ApY
+          p%OutParam(I)%Units = UnitList(ApY)
+        ELSE IF (qVal == 'ApZ') THEN
+          p%OutParam(I)%QType = ApZ
+          p%OutParam(I)%Units = UnitList(ApZ)
+        ELSE IF (qVal == 'AqX') THEN
+          p%OutParam(I)%QType = AqX
+          p%OutParam(I)%Units = UnitList(AqX)
+        ELSE IF (qVal == 'AqY') THEN
+          p%OutParam(I)%QType = AqY
+          p%OutParam(I)%Units = UnitList(AqY)
+        ELSE IF (qVal == 'AqZ') THEN
+          p%OutParam(I)%QType = AqZ
+          p%OutParam(I)%Units = UnitList(AqZ)
+        ELSE IF (qVal == 'PdX') THEN
+          p%OutParam(I)%QType = PdX
+          p%OutParam(I)%Units = UnitList(PdX)
+        ELSE IF (qVal == 'PdY') THEN
+          p%OutParam(I)%QType = PdY
+          p%OutParam(I)%Units = UnitList(PdY)
+        ELSE IF (qVal == 'PdZ') THEN
+          p%OutParam(I)%QType = PdZ
+          p%OutParam(I)%Units = UnitList(PdZ)
+        ELSE IF (qVal == 'BX') THEN
+          p%OutParam(I)%QType = BX
+          p%OutParam(I)%Units = UnitList(BX)
+        ELSE IF (qVal == 'BY') THEN
+          p%OutParam(I)%QType = BY
+          p%OutParam(I)%Units = UnitList(BY)
+        ELSE IF (qVal == 'BZ') THEN
+          p%OutParam(I)%QType = BZ
+          p%OutParam(I)%Units = UnitList(BZ)
+
         ELSE
           CALL DenoteInvalidOutput(p%OutParam(I)) ! flag as invalid
           CALL WrScr('Warning: invalid output specifier '//trim(OutListTmp)//'.  Quantity type not recognized.')
@@ -801,9 +906,9 @@ CONTAINS
       DO I=1,p%NRods
       
          ! calculate number of output entries (excluding time) to write for this Rod
-         RodNumOuts = 3*(m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(2:9)) &
-                       + (m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(10:11)) &
-                             + m%RodList(I)%N*SUM(m%RodList(I)%OutFlagList(12:18))
+         RodNumOuts = 3*(m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(2:24)) &
+                          + (m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(25:26)) &
+                                + m%RodList(I)%N*SUM(m%RodList(I)%OutFlagList(27:51))
       
          ALLOCATE(m%RodList(I)%RodWrOutput( 1 + RodNumOuts), STAT = ErrStat)  
          IF ( ErrStat /= ErrID_None ) THEN
@@ -1097,9 +1202,9 @@ CONTAINS
 
                         
             ! calculate number of output entries (excluding time) to write for this Rod
-            RodNumOuts = 3*(m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(2:9)) &
-                          + (m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(10:11)) &
-                                + m%RodList(I)%N*SUM(m%RodList(I)%OutFlagList(12:18))
+            RodNumOuts = 3*(m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(2:24)) &
+                          + (m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(25:26)) &
+                                + m%RodList(I)%N*SUM(m%RodList(I)%OutFlagList(27:51))
                                   
             if (wordy > 2) PRINT *, RodNumOuts, " output channels"
 
@@ -1170,6 +1275,22 @@ CONTAINS
                WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr((m%RodList(I)%N)))//'(A1,A15))', advance='no', IOSTAT=ErrStat2) &
                   ( p%Delim, 'Seg'//TRIM(Int2Lstr(J))//'SRt', J=1,(m%RodList(I)%N) )
             END IF
+            IF (m%RodList(I)%OutFlagList(16) == 1) THEN
+               WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                  ( p%Delim, 'Node'//TRIM(Int2Lstr(J))//'ApX', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'ApY', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'ApZ', J=0,m%RodList(I)%N )
+            END IF
+            IF (m%RodList(I)%OutFlagList(17) == 1) THEN
+               WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                  ( p%Delim, 'Node'//TRIM(Int2Lstr(J))//'AqX', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'AqY', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'AqZ', J=0,m%RodList(I)%N )
+            END IF
+            IF (m%RodList(I)%OutFlagList(18) == 1) THEN
+               WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                  ( p%Delim, 'Node'//TRIM(Int2Lstr(J))//'DpX', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'DpY', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'DpZ', J=0,m%RodList(I)%N )
+            END IF
+            IF (m%RodList(I)%OutFlagList(19) == 1) THEN
+               WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                  ( p%Delim, 'Node'//TRIM(Int2Lstr(J))//'DqX', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'DqY', p%Delim, 'Node'//TRIM(Int2Lstr(J))//'DqZ', J=0,m%RodList(I)%N )
+            END IF
             
             WRITE(m%RodList(I)%RodUnOut,'(A1)', IOSTAT=ErrStat2) ' '  ! make line break at the end
             
@@ -1235,6 +1356,20 @@ CONTAINS
                WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr((m%RodList(I)%N)))//'(A1,A15))', advance='no', IOSTAT=ErrStat2) &
                   ( p%Delim, '(1/s)', J=1,(m%RodList(I)%N) )
             END IF
+            IF (m%RodList(I)%OutFlagList(16) == 1) THEN
+                WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                  ( p%Delim, '(N)', p%Delim, '(N)', p%Delim, '(N)', J=0,m%RodList(I)%N )
+            END IF
+            IF (m%RodList(I)%OutFlagList(17) == 1) THEN
+                WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                 ( p%Delim, '(N)', p%Delim, '(N)', p%Delim, '(N)', J=0,m%RodList(I)%N )
+            END IF
+            IF (m%RodList(I)%OutFlagList(18) == 1) THEN
+                WRITE(m%RodList(I)%RodUnOut,'('//TRIM(Int2LStr(3+3*m%RodList(I)%N))//'(A1,A15))', advance='no') &
+                 ( p%Delim, '(N)', p%Delim, '(N)', p%Delim, '(N)', J=0,m%RodList(I)%N )
+            END IF
+
+               
             
             WRITE(m%RodList(I)%RodUnOut,'(A1)', IOSTAT=ErrStat2) ' '  ! make Rod break at the end
             
@@ -1329,6 +1464,9 @@ CONTAINS
       INTEGER                                :: LineNumOuts                 ! number of entries in LineWrOutput for each line
       INTEGER                                :: RodNumOuts                  !   same for Rods
       CHARACTER(200)                         :: Frmt                        ! a string to hold a format statement
+      REAL(DbKi) :: VOFsum
+      
+
 
 
       IF ( .NOT. ALLOCATED( p%OutParam ) .OR. p%MDUnOut < 0 )  THEN
@@ -1462,11 +1600,66 @@ CONTAINS
                      CASE (MZ)
                         y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%F6net(6)  ! total force in z
                      CASE (Sub)
-                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%h0 / m%RodList(p%OutParam(I)%ObjID)%UnstrLen ! rod submergence
+                        VOFsum = 0.0_DbKi
+                        do j = 0, m%RodList(p%OutParam(I)%ObjID)%N
+                           VOFsum = VOFsum + m%RodList(p%OutParam(I)%ObjID)%VOF(j)
+                        end do
+                        y%WriteOutput(I) = VOFsum / (m%RodList(p%OutParam(I)%ObjID)%N + 1) ! rod submergence
                      CASE (TenA)
                         y%WriteOutput(I) = sqrt(m%RodList(p%OutParam(I)%ObjID)%FextA(1)**2 + m%RodList(p%OutParam(I)%ObjID)%FextA(2)**2 + m%RodList(p%OutParam(I)%ObjID)%FextA(3)**2)! external forces on end A
                      CASE (TenB)
                         y%WriteOutput(I) = sqrt(m%RodList(p%OutParam(I)%ObjID)%FextB(1)**2 + m%RodList(p%OutParam(I)%ObjID)%FextB(2)**2 + m%RodList(p%OutParam(I)%ObjID)%FextB(3)**2) ! external forces on end B
+                     CASE (ApX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Ap(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (ApY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Ap(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (ApZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Ap(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (AqX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Aq(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (AqY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Aq(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (AqZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Aq(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (BoX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Bo(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (BoY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Bo(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (BoZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Bo(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (DpX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Dp(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (DpY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Dp(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (DpZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Dp(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (DqX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Dq(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (DqY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Dq(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (DqZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Dq(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (WZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%W(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (PdX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Pd(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (PdY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Pd(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (PdZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%Pd(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+
+                     CASE (BX)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%B(1,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (BY)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%B(2,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
+                     CASE (BZ)
+                        y%WriteOutput(I) = SUM(m%RodList(p%OutParam(I)%ObjID)%B(3,:)) / (m%RodList(p%OutParam(I)%ObjID)%N + 1)
                      CASE DEFAULT
                         y%WriteOutput(I) = 0.0_ReKi
                         ErrStat = ErrID_Warn
@@ -1493,6 +1686,57 @@ CONTAINS
                         y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Fnet(2,p%OutParam(I)%NodeID)  ! node force in y
                      CASE (FZ)
                         y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Fnet(3,p%OutParam(I)%NodeID)  ! node force in z
+                     CASE (WZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%W(3,p%OutParam(I)%NodeID)
+                     ! Bo (Buoyancy)
+                     CASE (BoX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Bo(1,p%OutParam(I)%NodeID)
+                     CASE (BoY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Bo(2,p%OutParam(I)%NodeID)
+                     CASE (BoZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Bo(3,p%OutParam(I)%NodeID)
+                     ! Dp (Drag p)
+                     CASE (DpX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Dp(1,p%OutParam(I)%NodeID)
+                     CASE (DpY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Dp(2,p%OutParam(I)%NodeID)
+                     CASE (DpZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Dp(3,p%OutParam(I)%NodeID)
+                     ! Dq (Drag q)
+                     CASE (DqX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Dq(1,p%OutParam(I)%NodeID)
+                     CASE (DqY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Dq(2,p%OutParam(I)%NodeID)
+                     CASE (DqZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Dq(3,p%OutParam(I)%NodeID)
+                     ! Ap (Added Mass p)
+                     CASE (ApX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Ap(1,p%OutParam(I)%NodeID)
+                     CASE (ApY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Ap(2,p%OutParam(I)%NodeID)
+                     CASE (ApZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Ap(3,p%OutParam(I)%NodeID)
+                     ! Aq (Added Mass q)
+                     CASE (AqX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Aq(1,p%OutParam(I)%NodeID)
+                     CASE (AqY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Aq(2,p%OutParam(I)%NodeID)
+                     CASE (AqZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Aq(3,p%OutParam(I)%NodeID)
+                     ! Pd (Dynamic Pressure)
+                     CASE (PdX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Pd(1,p%OutParam(I)%NodeID)
+                     CASE (PdY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Pd(2,p%OutParam(I)%NodeID)
+                     CASE (PdZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%Pd(3,p%OutParam(I)%NodeID)
+                     ! B (bottom friction)
+                     CASE (BX)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%B(1,p%OutParam(I)%NodeID)
+                     CASE (BY)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%B(2,p%OutParam(I)%NodeID)
+                     CASE (BZ)
+                        y%WriteOutput(I) = m%RodList(p%OutParam(I)%ObjID)%B(3,p%OutParam(I)%NodeID)
                      CASE DEFAULT
                         y%WriteOutput(I) = 0.0_ReKi
                         ErrStat = ErrID_Warn
@@ -1763,9 +2007,9 @@ CONTAINS
         IF (m%RodList(I)%OutFlagList(1) == 1) THEN    ! only proceed if the line is flagged to output a file
            
            ! calculate number of output entries to write for this Rod
-           RodNumOuts = 3*(m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(2:9)) &
-                         + (m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(10:11)) &
-                               + m%RodList(I)%N*SUM(m%RodList(I)%OutFlagList(12:18))
+           RodNumOuts = 3*(m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(2:24)) &
+                         + (m%RodList(I)%N + 1)*SUM(m%RodList(I)%OutFlagList(25:26)) &
+                               + m%RodList(I)%N*SUM(m%RodList(I)%OutFlagList(27:51))
            
            
            Frmt = '(F10.4,'//TRIM(Int2LStr(RodNumOuts))//'(A1,ES15.7))'   ! should evenutally use user specified format?

--- a/modules/moordyn/src/MoorDyn_Registry.txt
+++ b/modules/moordyn/src/MoorDyn_Registry.txt
@@ -162,7 +162,7 @@ typedef  ^            ^                IntKi              TopA           {10}   
 typedef  ^            ^                IntKi              TopB           {10}    -  -   "list of ints specifying whether each line is attached at 1 = top/fairlead(end B), 0 = bottom/anchor(end A)"
 typedef  ^            ^                IntKi              nAttachedA     -       -  -   "number of attached lines to Rod end A"
 typedef  ^            ^                IntKi              nAttachedB     -       -  -   "number of attached lines to Rod end B"
-typedef  ^            ^                IntKi              OutFlagList   {20}     -  -   "array specifying what line quantities should be output (1 vs 0)"   -
+typedef  ^            ^                IntKi              OutFlagList   {55}     -  -   "array specifying what line quantities should be output (1 vs 0)"   -
 typedef  ^            ^                IntKi              N             -        -  -   "The number of elements in the line"              -
 typedef  ^            ^                IntKi              endTypeA      -        -  -   "type of point at end A: 0=pinned to Point, 1=cantilevered to Rod."  -
 typedef  ^            ^                IntKi              endTypeB      -        -  -   "type of point at end B: 0=pinned to Point, 1=cantilevered to Rod."  -
@@ -216,7 +216,7 @@ typedef  ^            ^                DbKi               RodWrOutput  {:}      
 typedef  ^            ^                DbKi               FextU        {3}      -  -   "vector of user-defined external force on the rod end A always in the local body-fixed frame" "[N]"
 typedef  ^            ^                DbKi               Blin         {2}      -  -   "linear damping, transverse damping for rod element always in the local body-fixed frame" "[N/(m/s)]"
 typedef  ^            ^                DbKi               Bquad        {2}      -  -   "quadratic damping, transverse damping for rod element always in the local body-fixed frame" "[N/(m/s)^2]"
-
+typedef  ^            ^                DbKi               VOF          {:}       -  -   "Node-based volume-of-fluid for submergence"
 
 
 # this is the Line type, which holds data for each line object

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -105,12 +105,15 @@ CONTAINS
       ! allocate mass and inverse mass matrices for each node (including ends)
       ALLOCATE(Rod%M(3, 3, 0:N), STAT=ErrStat2);  if(AllocateFailed("Rod: M")) return
 
+      ALLOCATE(Rod%VOF(0:N), STAT=ErrStat2)  ! allocate VOF array (volume of fluid) for each node
+
 
       ! set to zero initially (important of wave kinematics are not being used)
       Rod%U    = 0.0_DbKi
       Rod%Ud   = 0.0_DbKi
       Rod%zeta = 0.0_DbKi
       Rod%PDyn = 0.0_DbKi
+      Rod%VOF = 0.0_DbKi
 
       ! ------------------------- set some geometric properties and the starting kinematics -------------------------
 
@@ -212,11 +215,6 @@ CONTAINS
       end if
       
       ! note: this may also be called by a coupled rod (type = -1) in which case states will be empty
-      
-      if (.not. allocated(Rod%VOF)) then
-         allocate(Rod%VOF(0:Rod%N))
-         Rod%VOF = 0.0_DbKi
-      end if
       
    END SUBROUTINE Rod_Initialize
    !--------------------------------------------------------------
@@ -714,6 +712,7 @@ CONTAINS
          end if
          
          VOF = VOF0*cosPhi**2 + A/(0.25*Pi*Rod%d**2)*sinPhi**2  ! this is a more refined VOF-type measure that can work for any incline
+        
          Rod%VOF(I) = VOF
 
 

--- a/modules/moordyn/src/MoorDyn_Rod.f90
+++ b/modules/moordyn/src/MoorDyn_Rod.f90
@@ -213,6 +213,10 @@ CONTAINS
       
       ! note: this may also be called by a coupled rod (type = -1) in which case states will be empty
       
+      if (.not. allocated(Rod%VOF)) then
+         allocate(Rod%VOF(0:Rod%N))
+         Rod%VOF = 0.0_DbKi
+      end if
       
    END SUBROUTINE Rod_Initialize
    !--------------------------------------------------------------
@@ -682,7 +686,7 @@ CONTAINS
                VOF0 = 0.0_DbKi
             END IF
          end if
-         
+
          Lsum = Lsum + dL            ! add length attributed to this node to the total
 
          ! get submerged cross sectional area and centroid for each node
@@ -710,6 +714,7 @@ CONTAINS
          end if
          
          VOF = VOF0*cosPhi**2 + A/(0.25*Pi*Rod%d**2)*sinPhi**2  ! this is a more refined VOF-type measure that can work for any incline
+         Rod%VOF(I) = VOF
 
 
          ! build mass and added mass matrix

--- a/modules/moordyn/src/MoorDyn_Types.f90
+++ b/modules/moordyn/src/MoorDyn_Types.f90
@@ -186,7 +186,7 @@ IMPLICIT NONE
     INTEGER(IntKi) , DIMENSION(1:10)  :: TopB = 0_IntKi      !< list of ints specifying whether each line is attached at 1 = top/fairlead(end B), 0 = bottom/anchor(end A) [-]
     INTEGER(IntKi)  :: nAttachedA = 0_IntKi      !< number of attached lines to Rod end A [-]
     INTEGER(IntKi)  :: nAttachedB = 0_IntKi      !< number of attached lines to Rod end B [-]
-    INTEGER(IntKi) , DIMENSION(1:20)  :: OutFlagList = 0_IntKi      !< array specifying what line quantities should be output (1 vs 0) [-]
+    INTEGER(IntKi) , DIMENSION(1:55)  :: OutFlagList = 0_IntKi      !< array specifying what line quantities should be output (1 vs 0) [-]
     INTEGER(IntKi)  :: N = 0_IntKi      !< The number of elements in the line [-]
     INTEGER(IntKi)  :: endTypeA = 0_IntKi      !< type of point at end A: 0=pinned to Point, 1=cantilevered to Rod. [-]
     INTEGER(IntKi)  :: endTypeB = 0_IntKi      !< type of point at end B: 0=pinned to Point, 1=cantilevered to Rod. [-]
@@ -240,6 +240,7 @@ IMPLICIT NONE
     REAL(DbKi) , DIMENSION(1:3)  :: FextU = 0.0_R8Ki      !< vector of user-defined external force on the rod end A always in the local body-fixed frame [[N]]
     REAL(DbKi) , DIMENSION(1:2)  :: Blin = 0.0_R8Ki      !< linear damping, transverse damping for rod element always in the local body-fixed frame [[N/(m/s)]]
     REAL(DbKi) , DIMENSION(1:2)  :: Bquad = 0.0_R8Ki      !< quadratic damping, transverse damping for rod element always in the local body-fixed frame [[N/(m/s)^2]]
+    REAL(DbKi), ALLOCATABLE :: VOF(:)   ! Node-based volume-of-fluid for submergence
   END TYPE MD_Rod
 ! =======================
 ! =========  MD_Line  =======


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
Tests md_float, md_waterkin2 and md_waterkin3 will fail due to the new submergence calculation.
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Submergence calculation change from length wise (h0/RodLength) to average (VOFsum/RodLength) due to some orientations not being consider submerged. 

Added more outputs for rods in the input file for additional analysis of data to compare with C version: 
Tangential drag forces (Ap)
Axial fluid inertia force (Aq)
Transverse drag forces (Dp)
Tangential drag forces (Dq)

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
MoorDyn
**Additional supporting information**
<!-- Add any other context about the problem here. -->


**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->
<img width="1200" height="675" alt="image" src="https://github.com/user-attachments/assets/b35ba979-738a-4730-b08a-ce6ac9e863cb" />

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
