### PR TITLE
FAST.Farm: skip writing invalid VTK slices

### DIFF
--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1004,26 +1004,35 @@ subroutine AWAE_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitO
 
    ! Test the request output wind locations against grid information
       ! XY plane slices
+   call AllocAry(p%OutDisWindZvalid,p%NOutDisWindXY,'p%OutDisWindZvalid', ErrStat2, ErrMsg2); if(Failed()) return;
+   p%OutDisWindZvalid = .true.
    do i = 1,p%NOutDisWindXY
       gridLoc = (p%OutDisWindZ(i) - p%Z0_low) / p%dZ_low
       if ( ( gridLoc < 0.0_ReKi ) .or. ( gridLoc > real(p%nZ_low-1, ReKi) ) ) then
-         call SetErrStat(ErrID_Fatal, "The requested low-resolution XY output slice location, Z="//TRIM(Num2LStr(p%OutDisWindZ(i)))//", is outside of the low-resolution grid.", errStat, errMsg, RoutineName )
+         call SetErrStat(ErrID_Warn, "The requested low-resolution XY output slice location, Z="//TRIM(Num2LStr(p%OutDisWindZ(i)))//", is outside of the low-resolution grid. Ignoring this slice.", errStat, errMsg, RoutineName )
+         p%OutDisWindZvalid(i) = .false.
       end if
    end do
 
       ! XZ plane slices
+   call AllocAry(p%OutDisWindYvalid,p%NOutDisWindXZ,'p%OutDisWindYvalid', ErrStat2, ErrMsg2); if(Failed()) return;
+   p%OutDisWindYvalid = .true.
    do i = 1,p%NOutDisWindXZ
       gridLoc = (p%OutDisWindY(i) - p%Y0_low) / p%dY_low
       if ( ( gridLoc < 0.0_ReKi ) .or. ( gridLoc > real(p%nY_low-1, ReKi) ) ) then
-         call SetErrStat(ErrID_Fatal, "The requested low-resolution XZ output slice location, Y="//TRIM(Num2LStr(p%OutDisWindY(i)))//", is outside of the low-resolution grid.", errStat, errMsg, RoutineName )
+         call SetErrStat(ErrID_Warn, "The requested low-resolution XZ output slice location, Y="//TRIM(Num2LStr(p%OutDisWindY(i)))//", is outside of the low-resolution grid. Ignoring this slice.", errStat, errMsg, RoutineName )
+         p%OutDisWindYvalid(i) = .false.
       end if
    end do
 
       ! XZ plane slices
+   call AllocAry(p%OutDisWindXvalid,p%NOutDisWindYZ,'p%OutDisWindXvalid', ErrStat2, ErrMsg2); if(Failed()) return;
+   p%OutDisWindXvalid = .true.
    do i = 1,p%NOutDisWindYZ
       gridLoc = (p%OutDisWindX(i) - p%X0_low) / p%dX_low
       if ( ( gridLoc < 0.0_ReKi ) .or. ( gridLoc > real(p%nX_low-1, ReKi) ) ) then
-         call SetErrStat(ErrID_Fatal, "The requested low-resolution YZ output slice location, X="//TRIM(Num2LStr(p%OutDisWindX(i)))//", is outside of the low-resolution grid.", errStat, errMsg, RoutineName )
+         call SetErrStat(ErrID_Warn, "The requested low-resolution YZ output slice location, X="//TRIM(Num2LStr(p%OutDisWindX(i)))//", is outside of the low-resolution grid. Ignoring this slice.", errStat, errMsg, RoutineName )
+         p%OutDisWindXvalid(i) = .false.
       end if
    end do
    if (errStat >= AbortErrLev) return
@@ -1464,6 +1473,7 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
 
          ! XY plane slices
       do k = 1,p%NOutDisWindXY
+         if (.not. p%OutDisWindZvalid(k)) cycle    ! skip if invalid
          write(PlaneNumStr, '(i3.3)') k
          call ExtractSlice( XYSlice, p%OutDisWindZ(k), p%Z0_low, p%nZ_low, p%nX_low, p%nY_low, p%dZ_low, m%Vdist_low_full, m%outVizXYPlane(:,:,:,1))
             ! Create the output vtk file with naming <WindFilePath>/Low/DisXY<k>.t<n/p%WrDisSkp1>.vtk
@@ -1474,6 +1484,7 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
 
          ! YZ plane slices
       do k = 1,p%NOutDisWindYZ
+         if (.not. p%OutDisWindXvalid(k)) cycle    ! skip if invalid
          write(PlaneNumStr, '(i3.3)') k
          call ExtractSlice( YZSlice, p%OutDisWindX(k), p%X0_low, p%nX_low, p%nY_low, p%nZ_low, p%dX_low, m%Vdist_low_full, m%outVizYZPlane(:,:,:,1))
             ! Create the output vtk file with naming <WindFilePath>/Low/DisYZ<k>.t<n/p%WrDisSkp1>.vtk
@@ -1484,6 +1495,7 @@ subroutine AWAE_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, errStat, errMsg
 
          ! XZ plane slices
       do k = 1,p%NOutDisWindXZ
+         if (.not. p%OutDisWindYvalid(k)) cycle    ! skip if invalid
          write(PlaneNumStr, '(i3.3)') k
          call ExtractSlice( XZSlice, p%OutDisWindY(k), p%Y0_low, p%nY_low, p%nX_low, p%nZ_low, p%dY_low, m%Vdist_low_full, m%outVizXZPlane(:,:,:,1))
             ! Create the output vtk file with naming <WindFilePath>/Low/DisXZ<k>.t<n/p%WrDisSkp1>.vtk

--- a/modules/awae/src/AWAE.f90
+++ b/modules/awae/src/AWAE.f90
@@ -1025,7 +1025,7 @@ subroutine AWAE_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitO
       end if
    end do
 
-      ! XZ plane slices
+      ! YZ plane slices
    call AllocAry(p%OutDisWindXvalid,p%NOutDisWindYZ,'p%OutDisWindXvalid', ErrStat2, ErrMsg2); if(Failed()) return;
    p%OutDisWindXvalid = .true.
    do i = 1,p%NOutDisWindYZ

--- a/modules/awae/src/AWAE_Registry.txt
+++ b/modules/awae/src/AWAE_Registry.txt
@@ -201,10 +201,13 @@ typedef  ^  ParameterType  IntKi            WrDisSkp1          -  - -   "Number 
 typedef  ^  ParameterType  LOGICAL          WrDisWind          -  - -   "Write disturbed wind data to <WindFilePath>/Low/Dis.t<n>.vtk etc.?" -
 typedef  ^  ParameterType  IntKi            NOutDisWindXY      -  - -   "Number of XY planes for output of disturbed wind data across the low-resolution domain to <WindFilePath>/Low/DisXY.<n_out>.t<n>.vtk [0 to 9]" -
 typedef  ^  ParameterType  ReKi             OutDisWindZ       {:} - -   "Z coordinates of XY planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXY]" meters
+typedef  ^  ParameterType  LOGICAL          OutDisWindZvalid  {:}   - - "Valid XY planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXY]" -
 typedef  ^  ParameterType  IntKi            NOutDisWindYZ      -  - -   "Number of YZ planes for output of disturbed wind data across the low-resolution domain to <WindFilePath>/Low/DisYZ.<n_out>.t<n>.vtk [0 to 9]" -
 typedef  ^  ParameterType  ReKi             OutDisWindX       {:} - -   "X coordinates of YZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindYZ]" meters
+typedef  ^  ParameterType  LOGICAL          OutDisWindXvalid  {:}   - - "Valid YZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindYZ]" -
 typedef  ^  ParameterType  IntKi            NOutDisWindXZ      -  - -   "Number of XZ planes for output of disturbed wind data across the low-resolution domain to <WindFilePath>/Low/DisXZ.<n_out>.t<n>.vtk [0 to 9]" -
 typedef  ^  ParameterType  ReKi             OutDisWindY       {:} - -   "Y coordinates of XZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXZ]" meters
+typedef  ^  ParameterType  LOGICAL          OutDisWindYvalid  {:}   - - "Valid XZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXZ]" -
 typedef  ^  ParameterType  CHARACTER(1024)  OutFileRoot        -  - -   "The root name derived from the primary FAST.Farm input file" -
 typedef  ^  ParameterType  CHARACTER(1024)  OutFileVTKRoot     -  - -   "The root name for VTK outputs" -
 typedef  ^  ParameterType  IntKi            VTK_tWidth         -  - -   "Number of characters for VTK timestamp outputs" -

--- a/modules/awae/src/AWAE_Types.f90
+++ b/modules/awae/src/AWAE_Types.f90
@@ -222,10 +222,13 @@ IMPLICIT NONE
     LOGICAL  :: WrDisWind = .false.      !< Write disturbed wind data to <WindFilePath>/Low/Dis.t<n>.vtk etc.? [-]
     INTEGER(IntKi)  :: NOutDisWindXY = 0_IntKi      !< Number of XY planes for output of disturbed wind data across the low-resolution domain to <WindFilePath>/Low/DisXY.<n_out>.t<n>.vtk [0 to 9] [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: OutDisWindZ      !< Z coordinates of XY planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXY] [meters]
+    LOGICAL , DIMENSION(:), ALLOCATABLE  :: OutDisWindZvalid      !< Valid XY planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXY] [-]
     INTEGER(IntKi)  :: NOutDisWindYZ = 0_IntKi      !< Number of YZ planes for output of disturbed wind data across the low-resolution domain to <WindFilePath>/Low/DisYZ.<n_out>.t<n>.vtk [0 to 9] [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: OutDisWindX      !< X coordinates of YZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindYZ] [meters]
+    LOGICAL , DIMENSION(:), ALLOCATABLE  :: OutDisWindXvalid      !< Valid YZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindYZ] [-]
     INTEGER(IntKi)  :: NOutDisWindXZ = 0_IntKi      !< Number of XZ planes for output of disturbed wind data across the low-resolution domain to <WindFilePath>/Low/DisXZ.<n_out>.t<n>.vtk [0 to 9] [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: OutDisWindY      !< Y coordinates of XZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXZ] [meters]
+    LOGICAL , DIMENSION(:), ALLOCATABLE  :: OutDisWindYvalid      !< Valid XZ planes for output of disturbed wind data across the low-resolution domain [1 to NOutDisWindXZ] [-]
     CHARACTER(1024)  :: OutFileRoot      !< The root name derived from the primary FAST.Farm input file [-]
     CHARACTER(1024)  :: OutFileVTKRoot      !< The root name for VTK outputs [-]
     INTEGER(IntKi)  :: VTK_tWidth = 0_IntKi      !< Number of characters for VTK timestamp outputs [-]
@@ -2016,6 +2019,18 @@ subroutine AWAE_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
       end if
       DstParamData%OutDisWindZ = SrcParamData%OutDisWindZ
    end if
+   if (allocated(SrcParamData%OutDisWindZvalid)) then
+      LB(1:1) = lbound(SrcParamData%OutDisWindZvalid)
+      UB(1:1) = ubound(SrcParamData%OutDisWindZvalid)
+      if (.not. allocated(DstParamData%OutDisWindZvalid)) then
+         allocate(DstParamData%OutDisWindZvalid(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%OutDisWindZvalid.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstParamData%OutDisWindZvalid = SrcParamData%OutDisWindZvalid
+   end if
    DstParamData%NOutDisWindYZ = SrcParamData%NOutDisWindYZ
    if (allocated(SrcParamData%OutDisWindX)) then
       LB(1:1) = lbound(SrcParamData%OutDisWindX)
@@ -2029,6 +2044,18 @@ subroutine AWAE_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
       end if
       DstParamData%OutDisWindX = SrcParamData%OutDisWindX
    end if
+   if (allocated(SrcParamData%OutDisWindXvalid)) then
+      LB(1:1) = lbound(SrcParamData%OutDisWindXvalid)
+      UB(1:1) = ubound(SrcParamData%OutDisWindXvalid)
+      if (.not. allocated(DstParamData%OutDisWindXvalid)) then
+         allocate(DstParamData%OutDisWindXvalid(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%OutDisWindXvalid.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstParamData%OutDisWindXvalid = SrcParamData%OutDisWindXvalid
+   end if
    DstParamData%NOutDisWindXZ = SrcParamData%NOutDisWindXZ
    if (allocated(SrcParamData%OutDisWindY)) then
       LB(1:1) = lbound(SrcParamData%OutDisWindY)
@@ -2041,6 +2068,18 @@ subroutine AWAE_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
          end if
       end if
       DstParamData%OutDisWindY = SrcParamData%OutDisWindY
+   end if
+   if (allocated(SrcParamData%OutDisWindYvalid)) then
+      LB(1:1) = lbound(SrcParamData%OutDisWindYvalid)
+      UB(1:1) = ubound(SrcParamData%OutDisWindYvalid)
+      if (.not. allocated(DstParamData%OutDisWindYvalid)) then
+         allocate(DstParamData%OutDisWindYvalid(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%OutDisWindYvalid.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstParamData%OutDisWindYvalid = SrcParamData%OutDisWindYvalid
    end if
    DstParamData%OutFileRoot = SrcParamData%OutFileRoot
    DstParamData%OutFileVTKRoot = SrcParamData%OutFileVTKRoot
@@ -2105,11 +2144,20 @@ subroutine AWAE_DestroyParam(ParamData, ErrStat, ErrMsg)
    if (allocated(ParamData%OutDisWindZ)) then
       deallocate(ParamData%OutDisWindZ)
    end if
+   if (allocated(ParamData%OutDisWindZvalid)) then
+      deallocate(ParamData%OutDisWindZvalid)
+   end if
    if (allocated(ParamData%OutDisWindX)) then
       deallocate(ParamData%OutDisWindX)
    end if
+   if (allocated(ParamData%OutDisWindXvalid)) then
+      deallocate(ParamData%OutDisWindXvalid)
+   end if
    if (allocated(ParamData%OutDisWindY)) then
       deallocate(ParamData%OutDisWindY)
+   end if
+   if (allocated(ParamData%OutDisWindYvalid)) then
+      deallocate(ParamData%OutDisWindYvalid)
    end if
    nullify(ParamData%WAT_FlowField)
 end subroutine
@@ -2175,10 +2223,13 @@ subroutine AWAE_PackParam(RF, Indata)
    call RegPack(RF, InData%WrDisWind)
    call RegPack(RF, InData%NOutDisWindXY)
    call RegPackAlloc(RF, InData%OutDisWindZ)
+   call RegPackAlloc(RF, InData%OutDisWindZvalid)
    call RegPack(RF, InData%NOutDisWindYZ)
    call RegPackAlloc(RF, InData%OutDisWindX)
+   call RegPackAlloc(RF, InData%OutDisWindXvalid)
    call RegPack(RF, InData%NOutDisWindXZ)
    call RegPackAlloc(RF, InData%OutDisWindY)
+   call RegPackAlloc(RF, InData%OutDisWindYvalid)
    call RegPack(RF, InData%OutFileRoot)
    call RegPack(RF, InData%OutFileVTKRoot)
    call RegPack(RF, InData%VTK_tWidth)
@@ -2261,10 +2312,13 @@ subroutine AWAE_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%WrDisWind); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%NOutDisWindXY); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%OutDisWindZ); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%OutDisWindZvalid); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%NOutDisWindYZ); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%OutDisWindX); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%OutDisWindXvalid); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%NOutDisWindXZ); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%OutDisWindY); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%OutDisWindYvalid); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%OutFileRoot); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%OutFileVTKRoot); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%VTK_tWidth); if (RegCheckErr(RF, RoutineName)) return


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
Old behavior: fatal error if outside grid
New behavior: skip that slice, keep number of slices the same as input file request
How: new array of logicals for `valid` slice.  Cycle on invalid slices


**Related issue, if one exists**
#2951 

**Impacted areas of the software**
_FAST.Farm_ vtk slice writing only

**Additional supporting information**
With terrain, it gets a little less obvious if a requested slice is actually valid during preliminary setup.  @rthedin requested this feature.

**Test results, if applicable**
No test results change