### PR TITLE
ED: Implemented the ability to add concentrated masses to the tower

### DIFF
--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -3023,7 +3023,7 @@ SUBROUTINE SetTowerParameters( p, InputFileData, ErrStat, ErrMsg )
 
    ! Local variables:
    REAL(ReKi)                               :: x                            ! Fractional location between two points in linear interpolation
-   INTEGER(IntKi )                          :: J                            ! Index for the node arrays
+   INTEGER(IntKi)                           :: I, J                         ! Index for the node arrays
    INTEGER(IntKi)                           :: InterpInd                    ! Index for the interpolation routine
 
 
@@ -3074,7 +3074,23 @@ SUBROUTINE SetTowerParameters( p, InputFileData, ErrStat, ErrMsg )
       p%MassT     (J) = InterpStp( p%HNodesNorm(J), InputFileData%HtFract, InputFileData%TMassDen, InterpInd, InputFileData%NTwInpSt )
       p%StiffTFA  (J) = InterpStp( p%HNodesNorm(J), InputFileData%HtFract, InputFileData%TwFAStif, InterpInd, InputFileData%NTwInpSt )
       p%StiffTSS  (J) = InterpStp( p%HNodesNorm(J), InputFileData%HtFract, InputFileData%TwSSStif, InterpInd, InputFileData%NTwInpSt )
+
    END DO ! J
+
+   DO J=1,InputFileData%NTwCMass
+
+         ! Add contributions from concentrated masses. Find the tower element on which the concentrated mass is located.
+      DO I=1,p%TwrNodes
+         IF ( (p%HNodesNorm(I)+0.5*p%DHNodes(I)/p%TwrFlexL) > InputFileData%TwCMassHtFract(J) ) THEN
+            EXIT
+         END IF
+      END DO
+
+         ! Modify the linear density of the tower element by adding the contribution from the concentrated mass.
+      p%MassT(I) = p%MassT(I) + InputFileData%TwCMass(J) / p%DHNodes(I)
+
+   END DO ! J
+
    p%MassT = abs(p%MassT)
    p%StiffTFA = abs(p%StiffTFA)
    p%StiffTSS = abs(p%StiffTSS)

--- a/modules/elastodyn/src/ElastoDyn_Registry.txt
+++ b/modules/elastodyn/src/ElastoDyn_Registry.txt
@@ -211,6 +211,9 @@ typedef	^	ED_InputFile	ReKi	TwFAM1Sh	{:}	-	-	"Tower fore-aft mode-1 shape coeffi
 typedef	^	ED_InputFile	ReKi	TwFAM2Sh	{:}	-	-	"Tower fore-aft mode-2 shape coefficients"	-
 typedef	^	ED_InputFile	ReKi	TwSSM1Sh	{:}	-	-	"Tower side-to-side mode-1 shape coefficients"	-
 typedef	^	ED_InputFile	ReKi	TwSSM2Sh	{:}	-	-	"Tower side-to-side mode-2 shape coefficients"	-
+typedef ^       ED_InputFile    IntKi   NTwCMass	-	-	-	"Number of tower concentrated masses"	-
+typedef ^       ED_InputFile    ReKi    TwCMassHtFract	{:}	-	-	"Fractional heights of tower concentrated masses"	-
+typedef ^       ED_InputFile    ReKi    TwCMass	{:}	-	-	"List of concentrated masses on the tower"	kg
 # ..... Furling Input file data ...........................................................................................................
 typedef	^	ED_InputFile	LOGICAL	RFrlDOF	-	-	-	"Rotor-furl DOF"	-
 typedef	^	ED_InputFile	LOGICAL	TFrlDOF	-	-	-	"Tail-furl DOF"	-

--- a/modules/elastodyn/src/ElastoDyn_Types.f90
+++ b/modules/elastodyn/src/ElastoDyn_Types.f90
@@ -230,6 +230,9 @@ IMPLICIT NONE
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TwFAM2Sh      !< Tower fore-aft mode-2 shape coefficients [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TwSSM1Sh      !< Tower side-to-side mode-1 shape coefficients [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TwSSM2Sh      !< Tower side-to-side mode-2 shape coefficients [-]
+    INTEGER(IntKi)  :: NTwCMass = 0_IntKi      !< Number of tower concentrated masses [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TwCMassHtFract      !< Fractional heights of tower concentrated masses [-]
+    REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TwCMass      !< List of concentrated masses on the tower [kg]
     LOGICAL  :: RFrlDOF = .false.      !< Rotor-furl DOF [-]
     LOGICAL  :: TFrlDOF = .false.      !< Tail-furl DOF [-]
     REAL(ReKi)  :: RotFurl = 0.0_ReKi      !< Initial or fixed rotor-furl angle [radians]
@@ -1860,6 +1863,31 @@ subroutine ED_CopyInputFile(SrcInputFileData, DstInputFileData, CtrlCode, ErrSta
       end if
       DstInputFileData%TwSSM2Sh = SrcInputFileData%TwSSM2Sh
    end if
+   DstInputFileData%NTwCMass = SrcInputFileData%NTwCMass
+   if (allocated(SrcInputFileData%TwCMassHtFract)) then
+      LB(1:1) = lbound(SrcInputFileData%TwCMassHtFract)
+      UB(1:1) = ubound(SrcInputFileData%TwCMassHtFract)
+      if (.not. allocated(DstInputFileData%TwCMassHtFract)) then
+         allocate(DstInputFileData%TwCMassHtFract(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstInputFileData%TwCMassHtFract.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstInputFileData%TwCMassHtFract = SrcInputFileData%TwCMassHtFract
+   end if
+   if (allocated(SrcInputFileData%TwCMass)) then
+      LB(1:1) = lbound(SrcInputFileData%TwCMass)
+      UB(1:1) = ubound(SrcInputFileData%TwCMass)
+      if (.not. allocated(DstInputFileData%TwCMass)) then
+         allocate(DstInputFileData%TwCMass(LB(1):UB(1)), stat=ErrStat2)
+         if (ErrStat2 /= 0) then
+            call SetErrStat(ErrID_Fatal, 'Error allocating DstInputFileData%TwCMass.', ErrStat, ErrMsg, RoutineName)
+            return
+         end if
+      end if
+      DstInputFileData%TwCMass = SrcInputFileData%TwCMass
+   end if
    DstInputFileData%RFrlDOF = SrcInputFileData%RFrlDOF
    DstInputFileData%TFrlDOF = SrcInputFileData%TFrlDOF
    DstInputFileData%RotFurl = SrcInputFileData%RotFurl
@@ -1984,6 +2012,12 @@ subroutine ED_DestroyInputFile(InputFileData, ErrStat, ErrMsg)
    end if
    if (allocated(InputFileData%TwSSM2Sh)) then
       deallocate(InputFileData%TwSSM2Sh)
+   end if
+   if (allocated(InputFileData%TwCMassHtFract)) then
+      deallocate(InputFileData%TwCMassHtFract)
+   end if
+   if (allocated(InputFileData%TwCMass)) then
+      deallocate(InputFileData%TwCMass)
    end if
    if (allocated(InputFileData%BldNd_OutList)) then
       deallocate(InputFileData%BldNd_OutList)
@@ -2136,6 +2170,9 @@ subroutine ED_PackInputFile(RF, Indata)
    call RegPackAlloc(RF, InData%TwFAM2Sh)
    call RegPackAlloc(RF, InData%TwSSM1Sh)
    call RegPackAlloc(RF, InData%TwSSM2Sh)
+   call RegPack(RF, InData%NTwCMass)
+   call RegPackAlloc(RF, InData%TwCMassHtFract)
+   call RegPackAlloc(RF, InData%TwCMass)
    call RegPack(RF, InData%RFrlDOF)
    call RegPack(RF, InData%TFrlDOF)
    call RegPack(RF, InData%RotFurl)
@@ -2342,6 +2379,9 @@ subroutine ED_UnPackInputFile(RF, OutData)
    call RegUnpackAlloc(RF, OutData%TwFAM2Sh); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%TwSSM1Sh); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%TwSSM2Sh); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%NTwCMass); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%TwCMassHtFract); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpackAlloc(RF, OutData%TwCMass); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%RFrlDOF); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%TFrlDOF); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%RotFurl); if (RegCheckErr(RF, RoutineName)) return


### PR DESCRIPTION
**Feature or improvement description**
This PR adds the ability to prescribe concentrated masses for the tower in ElastoDyn for convenience. Note that this is based on an approximated formulation where each concentrated mass is evenly spread over the discretized tower element it is located on. To more accurately localize the additional mass on the tower, finer tower discretization (increased `TwrNodes`) in the primary ElastoDyn input file is necessary. 

A list of concentrated masses for the tower can be specified at the end of the ElastoDyn tower input file in an optional section that comes after TOWER SIDE-TO-SIDE MODE SHAPES. An example with two concentrated masses (`NTwCMass` = 2) on the tower is shown below. The height fraction `HtFract` must be in the range of [0,1], and the mass `TwCMass` must be non-negative. The entries do not have to follow any particular order, and multiple entries can be assigned to the same `HtFract`.
```
---------------------- TOWER CONCENTRATED MASSES ------------------------------
          2   NTwCMass    - Number of tower concentrated masses
  HtFract       TwCMass
   (-)            (kg)
  0.324           6700
  0.727          10300
```
If this optional section is omitted, no concentrated mass is included, allowing existing ElastoDyn input files to work as normal.

**Impacted areas of the software**
ElastoDyn

**Test results, if applicable**
No change to existing input files or test results. No verification was performed. However, through the ElastoDyn summary file, it is confirmed that the addition of concentrated masses does modify the total tower mass and the local tower node mass density correctly.
