### PR TITLE
F/gcc speedup compile

### DIFF
--- a/glue-codes/fast-farm/CMakeLists.txt
+++ b/glue-codes/fast-farm/CMakeLists.txt
@@ -46,8 +46,16 @@ if (${_compiler_id} STREQUAL "GNU" AND NOT ${VARIABLE_TRACKING})
 endif()
 if (${_build_type} STREQUAL "RELEASE" AND NOT WIN32)
   # Compilation hangs on FAST_Farm_Types.f90 with -O3 on linux (on some hardware)
+  set_source_files_properties(src/FASTWrapper_Types.f90 PROPERTIES COMPILE_FLAGS "-O2")
   set_source_files_properties(src/FAST_Farm_Types.f90 PROPERTIES COMPILE_FLAGS "-O2")
 endif()
+
+# turn of some optimizations for _Types files with gfortran
+if (${_build_type} STREQUAL "RELEASE" AND ${_compiler_id} STREQUAL "GNU")
+  set_source_files_properties(src/FASTWrapper_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
+  set_source_files_properties(src/FAST_Farm_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
+endif()
+
 
 install(TARGETS FAST.Farm
   RUNTIME DESTINATION bin

--- a/glue-codes/fast-farm/CMakeLists.txt
+++ b/glue-codes/fast-farm/CMakeLists.txt
@@ -50,7 +50,7 @@ if (${_build_type} STREQUAL "RELEASE" AND NOT WIN32)
   set_source_files_properties(src/FAST_Farm_Types.f90 PROPERTIES COMPILE_FLAGS "-O2")
 endif()
 
-# turn of some optimizations for _Types files with gfortran
+# turn off some optimizations for _Types files with gfortran
 if (${_build_type} STREQUAL "RELEASE" AND ${_compiler_id} STREQUAL "GNU")
   set_source_files_properties(src/FASTWrapper_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
   set_source_files_properties(src/FAST_Farm_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")

--- a/glue-codes/openfast/CMakeLists.txt
+++ b/glue-codes/openfast/CMakeLists.txt
@@ -30,7 +30,7 @@ if (${_compiler_id} STREQUAL "GNU" AND NOT ${VARIABLE_TRACKING})
   set_source_files_properties(src/FAST_Prog.f90 PROPERTIES COMPILE_FLAGS "-fno-var-tracking -fno-var-tracking-assignments")
 endif()
 
-# turn of some optimizations for _Types files with gfortran
+# turn off some optimizations for _Types files with gfortran
 if (${_build_type} STREQUAL "RELEASE" AND ${_compiler_id} STREQUAL "GNU")
   set_source_files_properties(src/FAST_Prog.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
 endif()

--- a/glue-codes/openfast/CMakeLists.txt
+++ b/glue-codes/openfast/CMakeLists.txt
@@ -30,6 +30,11 @@ if (${_compiler_id} STREQUAL "GNU" AND NOT ${VARIABLE_TRACKING})
   set_source_files_properties(src/FAST_Prog.f90 PROPERTIES COMPILE_FLAGS "-fno-var-tracking -fno-var-tracking-assignments")
 endif()
 
+# turn of some optimizations for _Types files with gfortran
+if (${_build_type} STREQUAL "RELEASE" AND ${_compiler_id} STREQUAL "GNU")
+  set_source_files_properties(src/FAST_Prog.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
+endif()
+
 install(TARGETS openfast
   RUNTIME DESTINATION bin)
 

--- a/modules/openfast-library/CMakeLists.txt
+++ b/modules/openfast-library/CMakeLists.txt
@@ -38,7 +38,7 @@ if (${_build_type} STREQUAL "RELEASE" AND NOT WIN32)
   set_source_files_properties(src/FAST_Types.f90 PROPERTIES COMPILE_FLAGS "-O2")
 endif()
 
-# turn of some optimizations for _Types files with gfortran
+# turn off some optimizations for _Types files with gfortran
 if (${_build_type} STREQUAL "RELEASE" AND ${_compiler_id} STREQUAL "GNU")
   set_source_files_properties(src/FAST_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
 endif()

--- a/modules/openfast-library/CMakeLists.txt
+++ b/modules/openfast-library/CMakeLists.txt
@@ -38,6 +38,11 @@ if (${_build_type} STREQUAL "RELEASE" AND NOT WIN32)
   set_source_files_properties(src/FAST_Types.f90 PROPERTIES COMPILE_FLAGS "-O2")
 endif()
 
+# turn of some optimizations for _Types files with gfortran
+if (${_build_type} STREQUAL "RELEASE" AND ${_compiler_id} STREQUAL "GNU")
+  set_source_files_properties(src/FAST_Types.f90 PROPERTIES COMPILE_FLAGS "-fno-schedule-insns -fno-inline-functions -fno-ipa-cp")
+endif()
+
 add_library(openfast_prelib STATIC
   src/FAST_Types.f90
 )


### PR DESCRIPTION
This is a draft for testing.  There may be some unintended consequences we need to understand first.

**Feature or improvement description**
Compilation with `gfortran` can be extremely slow.  Checking the compile times of each file using the `-ftime-report` flag on `gfortran` showed some of the optimization procedures are very slow for certain files.  This PR turns off certain compile options.

Changes were made for the compilation flags on the following files:
- `FAST_Types.f90` - `-O2 -fno-schedule-insns -fno-inline-functions -fno-ipa-cp`
- `FAST_Prog.f90` - `-fno-schedule-insns -fno-inline-functions -fno-ipa-cp`
- `FASTWrapper_Tupes.f90` - `-O2 -fno-schedule-insns -fno-inline-functions -fno-ipa-cp`
- `FAST_Farm_Types.f90` - `-O2 -fno-schedule-insns -fno-inline-functions -fno-ipa-cp`

My current suspicion is that a lot of time is spent attempting to optimize pack and unpack routines (I saw this once before, but can't find the details now).  These routines at the glue code levels are only used during checkpoint file writing and restarts, which is very infrequent.  So if the pack/unpack routines are a bit slower, it won't affect run time performance for most cases (and likely won't be noticeable in cases it does affect).

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
Compile time only... we think.  There may be some performance losses.

**Additional supporting information**
The `-ftime-report` showed lots of time spent in the following areas:
* `phase opt and generate`
* `scheduling`
* `callgraph functions expansion`

Google Gemini provided the following suggestions based on a time report for the `FAST_Types.f90` build:

> Here are some optimization flags to consider disabling to reduce compile time in these specific areas:
    * `-fno-inline-functions`: This flag disables automatic inlining of functions by the compiler. Inlining can sometimes improve performance but might increase compilation time, especially for complex functions. This might directly impact the "callgraph functions expansion" phase.
    * `-fno-schedule-insns`: This flag disables instruction scheduling, a compiler optimization aiming to reorder instructions to improve execution speed on modern processors. Disabling it could potentially reduce the time spent in the "scheduling" phase at the cost of potential runtime performance degradation.
    * `-fno-ipa-cp`: This flag disables interprocedural constant propagation, which is part of interprocedural analysis (IPA). IPA passes, including constant propagation, can be computationally expensive and impact compile time.
   * If "alias stmt walking" is also contributing significantly, you can consider disabling alias analysis by using flags like `-fno-alias` or related options. However, this could significantly affect the correctness and performance of the generated code. 



**Test results, if applicable**
No test results should be affected.