### PR TITLE
FASTlib: missing error handling on FAST_CFD_WriteOutput

### DIFF
--- a/modules/openfast-library/src/FAST_Library.f90
+++ b/modules/openfast-library/src/FAST_Library.f90
@@ -1200,6 +1200,10 @@ subroutine FAST_CFD_WriteOutput(iTurb_c, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAS
 
    CALL FAST_WriteOutput_T( t_initial, n_t_global, Turbine(iTurb), ErrStat, ErrMsg )
 
+   ErrStat_c = ErrStat
+   ErrMsg = TRIM(ErrMsg)//C_NULL_CHAR
+   ErrMsg_c  = TRANSFER( ErrMsg//C_NULL_CHAR, ErrMsg_c )
+
 end subroutine FAST_CFD_WriteOutput
 !==================================================================================================================================
 subroutine FAST_CFD_Step(iTurb_c, ErrStat_c, ErrMsg_c) BIND (C, NAME='FAST_CFD_Step')


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**

This could create issues for FSI coupling.  Noticed this in compilation warnings.

Consider backporting:
- backport to v4.0.7 (if we do one)
- backport to v4.1.3 (if we do one)

**Related issue, if one exists**
None

**Impacted areas of the software**
CFD coupling from AMR-Wind / NALU-Wind for FSI


**Test results, if applicable**
No test results affected