### PR TITLE
Allow upto MaxStC outputs

### DIFF
--- a/modules/servodyn/src/ServoDyn_IO.f90
+++ b/modules/servodyn/src/ServoDyn_IO.f90
@@ -820,7 +820,7 @@ subroutine Set_NStC_Outs_Instance( i, x, m, y, AllOuts )     ! Nacelle single St
    real(ReKi),                      intent(inout)  :: AllOuts(0:MaxOutPts) ! All the available output channels
    integer  :: j
    j=1
-   if (i < MaxStC) then
+   if (i <= MaxStC) then
       AllOuts(NStC_XQ( i)) = x%StC_x(1,1)                ! x
       AllOuts(NStC_XQD(i)) = x%StC_x(2,1)                ! x-dot
       AllOuts(NStC_YQ( i)) = x%StC_x(3,1)                ! y
@@ -864,7 +864,7 @@ subroutine Set_TStC_Outs_Instance( i, x, m, y, AllOuts )     ! Tower single StC 
    real(ReKi),                      intent(inout)  :: AllOuts(0:MaxOutPts) ! All the available output channels
    integer  :: j
    j=1
-   if (i < MaxStC) then
+   if (i <= MaxStC) then
       AllOuts(TStC_XQ( i)) = x%StC_x(1,1)                ! x
       AllOuts(TStC_XQD(i)) = x%StC_x(2,1)                ! x-dot
       AllOuts(TStC_YQ( i)) = x%StC_x(3,1)                ! y
@@ -908,7 +908,7 @@ subroutine Set_BStC_Outs_Instance( i, numBl, x, m, y, AllOuts )        ! Single 
    type(StC_OutputType),            intent(in   )  :: y                    !< Outputs computed at Time
    real(ReKi),                      intent(inout)  :: AllOuts(0:MaxOutPts) ! All the available output channels
    integer  :: j
-   if (i < MaxStC) then
+   if (i <= MaxStC) then
       do j=1,min(NumBl,MaxBlOuts)
          AllOuts(BStC_XQ( i,j)) = x%StC_x(1,j)                ! x
          AllOuts(BStC_XQD(i,j)) = x%StC_x(2,j)                ! x-dot
@@ -954,7 +954,7 @@ subroutine Set_SStC_Outs_Instance( i, x, m, y, AllOuts )     ! Platform
    real(ReKi),                      intent(inout)  :: AllOuts(0:MaxOutPts) ! All the available output channels
    integer  :: j
    j=1
-   if (i < MaxStC) then
+   if (i <= MaxStC) then
       AllOuts(SStC_XQ( i)) = x%StC_x(1,1)                ! x
       AllOuts(SStC_XQD(i)) = x%StC_x(2,1)                ! x-dot
       AllOuts(SStC_YQ( i)) = x%StC_x(3,1)                ! y


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

Structural Control currently limits outputs to a max of 4 points per component (`MaxStC=4`). But the logic implemented in ServoDyn_IO limits it to three.

This has been fixed by changing `(i < MaxStC)` to `(i <= MaxStC)`.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

None

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

ServoDyn/StC

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
