### PR TITLE
Add in missing passing of SS pointer to MD during FAST init

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1108,6 +1108,9 @@ SUBROUTINE FAST_InitializeAll( t_initial, m_Glue, p_FAST, y_FAST, m_FAST, ED, SE
       Init%InData_MD%Linearize = p_FAST%Linearize
       if (p_FAST%WrVTK /= VTK_None) Init%InData_MD%VisMeshes = .true.
 
+      ! Assign the seastate pointer here
+      Init%InData_MD%WaveField => Init%OutData_SeaSt%WaveField
+
       ! Call module initialization routine
       dt_module = p_FAST%DT
       CALL MD_Init(Init%InData_MD, MD%Input(INPUT_CURR), MD%p, &


### PR DESCRIPTION
Adds in passing of the SS pointer to MD during FAST init. This was causing MD to throw a fatal error when called with either the hybrid or full SeaState methods for water kinematics. I believe this was missed when bringing over the SS-MD coupling from the dev branch. Thanks @RBergua for calling it out. 
