### PR TITLE
Allow separate teeter inertia for 2-bladed turbines

### DIFF
--- a/modules/elastodyn/src/ElastoDyn.f90
+++ b/modules/elastodyn/src/ElastoDyn.f90
@@ -3270,6 +3270,7 @@ SUBROUTINE SetPrimaryParameters( InitInp, p, InputFileData, ErrStat, ErrMsg  )
 
    !p%Twr2Shft  = InputFileData%Twr2Shft
    !p%HubIner   = InputFileData%HubIner
+   !p%HubIner_Teeter   = InputFileData%HubIner_Teeter
    !p%NacYIner  = InputFileData%NacYIner
 
 
@@ -4538,7 +4539,7 @@ END SUBROUTINE SetOutParam
 !> This routine is used to compute rotor (blade and hub) properties:
 !!   KBF(), KBE(), CBF(), CBE(), FreqBF(), FreqBE(), AxRedBld(),
 !!   TwistedSF(), BldMass(), FirstMom(), SecondMom(), BldCG(),
-!!   RotMass, RotIner, Hubg1Iner, Hubg2Iner, rSAerCenn1(), and
+!!   RotMass, RotIner, Hubf1Iner, Hubf2Iner, rSAerCenn1(), and
 !!   rSAerCenn2(), BElmtMass()
 !! tower properties:
 !!   KTFA(), KTSS(), CTFA(), CTSS(), FreqTFA(), FreqTSS(),
@@ -4665,28 +4666,32 @@ SUBROUTINE Coeff(p,InputFileData, ErrStat, ErrMsg)
    END IF
 
       ! Calculate hub inertia about its centerline passing through its c.g..
-      !   This calculation assumes that the hub for a 2-blader is essentially
-      !   a uniform cylinder whose centerline is transverse through the cylinder
-      !   passing through its c.g..  That is, for a 2-blader, Hubg1Iner =
-      !   Hubg2Iner is the inertia of the hub about both the g1- and g2- axes.  For
-      !   3-bladers, Hubg1Iner is simply equal to HubIner and Hubg2Iner is zero.
+      ! For a 2-bladed turbine:
+      !   - Hub interia about the rotor axis: Hubf1Iner is equal to HubIner
+      !   - Hub inertia about the teeter axis: Hubf2Iner is obtained by applying
+      !     parallel-axis theorem to HubIner_Teeter
+      !   Note that f-axes are used and therefore, inertias are not corrected
+      !   for the delta-3 angle
+      ! For a 3-bladed turbine:
+      !   - Hub interia about the rotor axis: Hubf1Iner is equal to HubIner
+      !   - Hub inertia about the teeter axis: Hubf2Iner is zero
       ! Also, Initialize RotMass and RotIner to associated hub properties:
 
    IF ( p%NumBl == 2 )  THEN ! 2-blader
-      p%Hubg1Iner = ( InputFileData%HubIner - p%HubMass*( ( p%UndSling - p%HubCM )**2 ) )/( p%CosDel3**2 )
-      p%Hubg2Iner = p%Hubg1Iner
-      IF ( p%Hubg1Iner < 0.0 ) THEN
+      p%Hubf1Iner = InputFileData%HubIner
+      p%Hubf2Iner = InputFileData%HubIner_Teeter - p%HubMass*( ( p%UndSling - p%HubCM )**2 )
+      IF ( p%Hubf1Iner < 0.0 ) THEN
          ErrStat = ErrID_Fatal
-         ErrMsg = ' HubIner must not be less than HubMass*( UndSling - HubCM )^2 for 2-blader.'
+         ErrMsg = ' HubIner_Teeter must not be less than HubMass*( UndSling - HubCM )^2 for 2-blader.'
          RETURN
       END IF
    ELSE                    ! 3-blader
-      p%Hubg1Iner = InputFileData%HubIner
-      p%Hubg2Iner = 0.0
+      p%Hubf1Iner = InputFileData%HubIner
+      p%Hubf2Iner = 0.0
    ENDIF
 
    p%RotMass   = p%HubMass
-   p%RotIner   = p%Hubg1Iner
+   p%RotIner   = p%Hubf1Iner
 
 
    !...............................................................................................................................
@@ -7580,8 +7585,8 @@ DO K = 1,p%NumBl ! Loop through all blades
       TmpVec2 = CROSS_PRODUCT( RtHSdat%rPC, TmpVec1 )      ! The portion of PMomLPRot associated with the HubMass
 
       RtHSdat%PFrcPRot (:,p%DOFs%PCE(I)) = TmpVec1
-      RtHSdat%PMomLPRot(:,p%DOFs%PCE(I)) = TmpVec2 - p%Hubg1Iner*CoordSys%g1*DOT_PRODUCT( CoordSys%g1, RtHSdat%PAngVelEH(p%DOFs%PCE(I),0,:) ) &
-                                                   - p%Hubg2Iner*CoordSys%g2*DOT_PRODUCT( CoordSys%g2, RtHSdat%PAngVelEH(p%DOFs%PCE(I),0,:) )
+      RtHSdat%PMomLPRot(:,p%DOFs%PCE(I)) = TmpVec2 - p%Hubf1Iner*CoordSys%f1*DOT_PRODUCT( CoordSys%f1, RtHSdat%PAngVelEH(p%DOFs%PCE(I),0,:) ) &
+                                                   - p%Hubf2Iner*CoordSys%f2*DOT_PRODUCT( CoordSys%f2, RtHSdat%PAngVelEH(p%DOFs%PCE(I),0,:) )
 
    ENDDO          ! I - All active (enabled) DOFs that contribute to the QD2T-related linear accelerations of the hub center of mass (point C)
 
@@ -7614,16 +7619,16 @@ DO K = 1,p%NumBl ! Loop through all blades
 
    TmpVec1 = -p%HubMass*( p%Gravity*CoordSys%z2 + RtHSdat%LinAccECt )                     ! The portion of FrcPRott  associated with the HubMass
    TmpVec2 = CROSS_PRODUCT( RtHSdat%rPC, TmpVec1 )                                        ! The portion of MomLPRott associated with the HubMass
-   TmpVec  = p%Hubg1Iner*CoordSys%g1*DOT_PRODUCT( CoordSys%g1, RtHSdat%AngVelEH ) &       ! = ( Hub inertia dyadic ) dot ( angular velocity of hub in the inertia frame )
-           + p%Hubg2Iner*CoordSys%g2*DOT_PRODUCT( CoordSys%g2, RtHSdat%AngVelEH )
+   TmpVec  = p%Hubf1Iner*CoordSys%f1*DOT_PRODUCT( CoordSys%f1, RtHSdat%AngVelEH ) &       ! = ( Hub inertia dyadic ) dot ( angular velocity of hub in the inertia frame )
+           + p%Hubf2Iner*CoordSys%f2*DOT_PRODUCT( CoordSys%f2, RtHSdat%AngVelEH )
    TmpVec3 = CROSS_PRODUCT( -RtHSdat%AngVelEH, TmpVec )                                   ! = ( -angular velocity of hub in the inertia frame ) cross ( TmpVec )
 
    RtHSdat%FrcPRott(1)  = TmpVec1(1) + u%HubPtLoad%Force(1,1)
    RtHSdat%FrcPRott(2)  = TmpVec1(2) + u%HubPtLoad%Force(3,1)
    RtHSdat%FrcPRott(3)  = TmpVec1(3) - u%HubPtLoad%Force(2,1)
    
-   RtHSdat%MomLPRott    = TmpVec2 + TmpVec3 - p%Hubg1Iner*CoordSys%g1*DOT_PRODUCT( CoordSys%g1, RtHSdat%AngAccEHt ) &
-                                            - p%Hubg2Iner*CoordSys%g2*DOT_PRODUCT( CoordSys%g2, RtHSdat%AngAccEHt )                                          
+   RtHSdat%MomLPRott    = TmpVec2 + TmpVec3 - p%Hubf1Iner*CoordSys%f1*DOT_PRODUCT( CoordSys%f1, RtHSdat%AngAccEHt ) &
+                                            - p%Hubf2Iner*CoordSys%f2*DOT_PRODUCT( CoordSys%f2, RtHSdat%AngAccEHt )                                          
       
    RtHSdat%MomLPRott(1) = RtHSdat%MomLPRott(1) + u%HubPtLoad%Moment(1,1)
    RtHSdat%MomLPRott(2) = RtHSdat%MomLPRott(2) + u%HubPtLoad%Moment(3,1)

--- a/modules/elastodyn/src/ElastoDyn_IO.f90
+++ b/modules/elastodyn/src/ElastoDyn_IO.f90
@@ -3124,8 +3124,16 @@ SUBROUTINE ReadPrimaryFile( InputFile, InputFileData, BldFile, FurlFile, TwrFile
          RETURN
       END IF
 
-      ! HubIner - Hub inertia about teeter axis (2-blader) or rotor axis (3-blader) (kg m^2):
-   CALL ReadVar( UnIn, InputFile, InputFileData%HubIner, "HubIner", "Hub inertia about teeter axis (2-blader) or rotor axis (3-blader) (kg m^2)", ErrStat2, ErrMsg2, UnEc)
+      ! HubIner - Hub inertia about rotor axis (2 or 3-blader) (kg m^2):
+   CALL ReadVar( UnIn, InputFile, InputFileData%HubIner, "HubIner", "Hub inertia about rotor axis (2 or 3-blader) (kg m^2)", ErrStat2, ErrMsg2, UnEc)
+      CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
+      IF ( ErrStat >= AbortErrLev ) THEN
+         CALL Cleanup()
+         RETURN
+      END IF
+      
+      ! HubIner_teeter - Hub inertia about teeter axis (2-blader) (kg m^2):
+   CALL ReadVar( UnIn, InputFile, InputFileData%HubIner_Teeter, "HubIner_Teeter", "Hub inertia about teeter axis (2-blader) (kg m^2)", ErrStat2, ErrMsg2, UnEc)
       CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName )
       IF ( ErrStat >= AbortErrLev ) THEN
          CALL Cleanup()
@@ -4297,6 +4305,7 @@ SUBROUTINE ValidatePrimaryData( InputFileData, BD4Blades, Linearize, MHK, ErrSta
    IF ( InputFileData%NacYIner < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'NacYIner must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF ( InputFileData%GenIner  < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'GenIner must not be negative.',ErrStat,ErrMsg,RoutineName)
    IF ( InputFileData%HubIner  < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'HubIner must not be negative.',ErrStat,ErrMsg,RoutineName)
+   IF ( InputFileData%HubIner_Teeter  < 0.0_ReKi) call SetErrStat(ErrID_Fatal,'HubIner_Teeter must not be negative.',ErrStat,ErrMsg,RoutineName)
 
       ! Check that TowerHt is in the range [0,inf):
    IF ( MHK /= MHK_Floating ) THEN

--- a/modules/elastodyn/src/ElastoDyn_Registry.txt
+++ b/modules/elastodyn/src/ElastoDyn_Registry.txt
@@ -144,7 +144,8 @@ typedef	^	ED_InputFile	ReKi	PtfmCMzt	-	-	-	"Vertical distance from the ground le
 typedef	^	ED_InputFile	ReKi	PtfmRefzt	-	-	-	"Vertical distance from the ground level [onshore], MSL [offshore wind or floating MHK], or seabed [fixed MHK] to the platform reference point"	meters
 typedef	^	ED_InputFile	ReKi	TipMass	{:}	-	-	"Tip-brake masses"	kg
 typedef	^	ED_InputFile	ReKi	HubMass	-	-	-	"Hub mass"	kg
-typedef	^	ED_InputFile	ReKi	HubIner	-	-	-	"Hub inertia about teeter axis (2-blader) or rotor axis (3-blader)"	"kg m^2"
+typedef	^	ED_InputFile	ReKi	HubIner	-	-	-	"Hub inertia about rotor axis (2 or 3-blader)"	"kg m^2"
+typedef	^	ED_InputFile	ReKi	HubIner_Teeter	-	-	-	"Hub inertia about teeter axis (2-blader)"	"kg m^2"
 typedef	^	ED_InputFile	ReKi	GenIner	-	-	-	"Generator inertia about HSS"	"kg m^2"
 typedef	^	ED_InputFile	ReKi	NacMass	-	-	-	"Nacelle mass"	kg
 typedef	^	ED_InputFile	ReKi	NacYIner	-	-	-	"Nacelle yaw inertia"	"kg m^2"

--- a/modules/elastodyn/src/ElastoDyn_Types.f90
+++ b/modules/elastodyn/src/ElastoDyn_Types.f90
@@ -166,7 +166,8 @@ IMPLICIT NONE
     REAL(ReKi)  :: PtfmRefzt = 0.0_ReKi      !< Vertical distance from the ground level [onshore], MSL [offshore wind or floating MHK], or seabed [fixed MHK] to the platform reference point [meters]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: TipMass      !< Tip-brake masses [kg]
     REAL(ReKi)  :: HubMass = 0.0_ReKi      !< Hub mass [kg]
-    REAL(ReKi)  :: HubIner = 0.0_ReKi      !< Hub inertia about teeter axis (2-blader) or rotor axis (3-blader) [kg m^2]
+    REAL(ReKi)  :: HubIner = 0.0_ReKi      !< Hub inertia about rotor axis (2 or 3-blader) [kg m^2]
+    REAL(ReKi)  :: HubIner_Teeter = 0.0_ReKi      !< Hub inertia about teeter axis (2-blader) [kg m^2]
     REAL(ReKi)  :: GenIner = 0.0_ReKi      !< Generator inertia about HSS [kg m^2]
     REAL(ReKi)  :: NacMass = 0.0_ReKi      !< Nacelle mass [kg]
     REAL(ReKi)  :: NacYIner = 0.0_ReKi      !< Nacelle yaw inertia [kg m^2]
@@ -1671,6 +1672,7 @@ subroutine ED_CopyInputFile(SrcInputFileData, DstInputFileData, CtrlCode, ErrSta
    end if
    DstInputFileData%HubMass = SrcInputFileData%HubMass
    DstInputFileData%HubIner = SrcInputFileData%HubIner
+   DstInputFileData%HubIner_Teeter = SrcInputFileData%HubIner_Teeter
    DstInputFileData%GenIner = SrcInputFileData%GenIner
    DstInputFileData%NacMass = SrcInputFileData%NacMass
    DstInputFileData%NacYIner = SrcInputFileData%NacYIner
@@ -2091,6 +2093,7 @@ subroutine ED_PackInputFile(RF, Indata)
    call RegPackAlloc(RF, InData%TipMass)
    call RegPack(RF, InData%HubMass)
    call RegPack(RF, InData%HubIner)
+   call RegPack(RF, InData%HubIner_Teeter)
    call RegPack(RF, InData%GenIner)
    call RegPack(RF, InData%NacMass)
    call RegPack(RF, InData%NacYIner)
@@ -2292,6 +2295,7 @@ subroutine ED_UnPackInputFile(RF, OutData)
    call RegUnpackAlloc(RF, OutData%TipMass); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%HubMass); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%HubIner); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%HubIner_Teeter); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%GenIner); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%NacMass); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%NacYIner); if (RegCheckErr(RF, RoutineName)) return


### PR DESCRIPTION
Not ready to be merged
Tests pass
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
OpenFAST assumes that hub for a two-bladed turbine is a rod and the hub-inertia about the rotor axis and the teeter axis is the same. This PR addresses this shortcoming allowing users to provide the two inertia's separate.
Computation for three-bladed turbines are not affected.

**Related issue, if one exists**


**Impacted areas of the software**
ElastoDyn

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [x] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
