### PR TITLE
prepping for py314 and making requirements less restrictrive

### DIFF
--- a/glue-codes/python/pyproject.toml
+++ b/glue-codes/python/pyproject.toml
@@ -27,16 +27,16 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy"
 ]
 dependencies = [
-    "numpy>=2.0",
-    "matplotlib>=3.0",
+    "numpy",
+    "matplotlib",
 ]
 
 [project.optional-dependencies]
 windio = [
-    "windio>=1.0",
+    "windio",
 ]
 develop = [
-    "pytest>=8.0",
+    "pytest",
 ]
 
 [tool.setuptools.packages.find]

--- a/glue-codes/python/pyproject.toml
+++ b/glue-codes/python/pyproject.toml
@@ -22,20 +22,21 @@ classifiers = [
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy"
 ]
 dependencies = [
-    "numpy~=2.0",
-    "matplotlib~=3.0",
+    "numpy>=2.0",
+    "matplotlib>=3.0",
 ]
 
 [project.optional-dependencies]
 windio = [
-    "windio~=1.0",
+    "windio>=1.0",
 ]
 develop = [
-    "pytest~=8.0",
+    "pytest>=8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/glue-codes/python/pyproject.toml
+++ b/glue-codes/python/pyproject.toml
@@ -27,8 +27,8 @@ classifiers = [
     "Programming Language :: Python :: Implementation :: PyPy"
 ]
 dependencies = [
-    "numpy",
-    "matplotlib",
+    "numpy>=1.26",
+    "matplotlib>=3.0",
 ]
 
 [project.optional-dependencies]
@@ -36,7 +36,7 @@ windio = [
     "windio",
 ]
 develop = [
-    "pytest",
+    "pytest>=8.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/openfast_io/openfast_io/FAST_writer.py
+++ b/openfast_io/openfast_io/FAST_writer.py
@@ -822,6 +822,9 @@ class InputWriter_OpenFAST(object):
             f.write('\n')
 
         f.write('\n')
+        f.flush()
+        os.fsync(f)
+        f.close()
 
     def write_InflowWind(self):
         self.fst_vt['Fst']['InflowFile'] = self.FAST_namingOut + '_InflowWind.dat'

--- a/openfast_io/pyproject.toml
+++ b/openfast_io/pyproject.toml
@@ -42,6 +42,8 @@ classifiers = [  # Optional
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
 ]
 

--- a/openfast_io/pyproject.toml
+++ b/openfast_io/pyproject.toml
@@ -50,7 +50,7 @@ classifiers = [  # Optional
 dependencies = [
     "numpy>1.0",
     "pandas>2.0",
-    "ruamel_yaml>0.18",
+    "ruamel_yaml>0.15",
     "deepdiff>8.0",
     ]
     

--- a/openfast_io/pyproject.toml
+++ b/openfast_io/pyproject.toml
@@ -50,10 +50,10 @@ classifiers = [  # Optional
 ]
 
 dependencies = [
-    "numpy",
-    "pandas",
-    "ruamel_yaml",
-    "deepdiff",
+    "numpy>1.0",
+    "pandas>2.0",
+    "ruamel_yaml>0.18",
+    "deepdiff>8.0",
     ]
     
 [project.urls]
@@ -66,9 +66,9 @@ Issues = "https://github.com/OpenFAST/openfast/issues"
 
 [project.optional-dependencies]
 
-rosco = ["rosco"]
-xlrd = ["xlrd"]
-all = ["rosco", "xlrd"]
+rosco = ["rosco>2.9.2"]
+xlrd = ["xlrd>2.0"]
+all = ["rosco>2.9.2", "xlrd>2.0"]
 
 [tool.hatch.version]
 source = "vcs"

--- a/openfast_io/pyproject.toml
+++ b/openfast_io/pyproject.toml
@@ -45,13 +45,15 @@ classifiers = [  # Optional
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3",
+  "Programming Language :: Python",
 ]
 
 dependencies = [
-    "numpy>1.0",
-    "pandas>2.0",
-    "ruamel_yaml>0.15",
-    "deepdiff>8.0",
+    "numpy",
+    "pandas",
+    "ruamel_yaml",
+    "deepdiff",
     ]
     
 [project.urls]
@@ -64,9 +66,9 @@ Issues = "https://github.com/OpenFAST/openfast/issues"
 
 [project.optional-dependencies]
 
-rosco = ["rosco>2.9.2"]
-xlrd = ["xlrd>2"]
-all = ["rosco>2.9.2", "xlrd>2"]
+rosco = ["rosco"]
+xlrd = ["xlrd"]
+all = ["rosco", "xlrd"]
 
 [tool.hatch.version]
 source = "vcs"


### PR DESCRIPTION
Conda already has a py314 upgrade bot, so it's appropriate to be ready for it.

Also, the third party apps are advancing in version faster than the `pyproject.toml` files can keep up if versions are hard-pegged, creating environment conflicts.  Changing '~=' to '>=' for the `pyopenfast` project.

<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

**Additional supporting information**
<!-- Add any other context about the problem here. -->

**Test results, if applicable**
<!-- Add the results from unit tests and regression tests here along with justification for any failing test cases. -->

<!-- Release checklist:
- [ ] Update the documentation version in docs/conf.py
- [ ] Update the versions in docs/source/user/api_change.rst
- [ ] Verify readthedocs builds correctly
- [ ] Create a tag in OpenFAST
- [ ] Create a merge commit in r-test and add a corresponding tag
- [ ] Compile executables for Windows builds
    - [ ] FAST_SFunc.mexw64
    - [ ] OpenFAST-Simulink_x64.dll
    - [ ] openfast_x64.exe
    - [ ] DISCON.dll
-->
