### PR TITLE
FF: align initial wake grid with the blades

### DIFF
--- a/glue-codes/fast-farm/src/FASTWrapper.f90
+++ b/glue-codes/fast-farm/src/FASTWrapper.f90
@@ -77,6 +77,7 @@ SUBROUTINE FWrap_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Init
    TYPE(FAST_ExternInitType)                       :: ExternInitData 
    INTEGER(IntKi)                                  :: j,k,nb      
    REAL(ReKi)                                      :: p0(3)       ! hub location (in FAST with 0,0,0 as turbine reference)
+   REAL(R8Ki)                                      :: orientation(3,3)  ! temp orientation array
    
    INTEGER(IntKi)                                  :: ErrStat2    ! local error status
    CHARACTER(ErrMsgLen)                            :: ErrMsg2     ! local error message
@@ -198,15 +199,18 @@ SUBROUTINE FWrap_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, Init
             if (Failed()) return;
             
          ! set node initial position/orientation
-         ! NOTE:  the mesh data for ADRotorDisk gets overwritten later, but should be aligned somewhat with
-         !        the blade during initialization to avoid mesh mapping errors. This puts it aligned with
-         !        the blade pitch axis now, but no calculations will be done until after it is reset properly
-         !        later.
-         do j=1,size(p%r)
-            m%ADRotorDisk(k)%Position(1:3,j) = m%Turbine%AD%u%rotors(1)%BladeRootMotion(k)%Position(1:3,1) + m%Turbine%AD%u%rotors(1)%BladeRootMotion(k)%TranslationDisp(1:3,1) + m%Turbine%AD%u%rotors(1)%BladeRootMotion(k)%Orientation(3,1:3,1) * p%r(j)
-         enddo
+         ! NOTE:  the mesh data for ADRotorDisk gets overwritten before use so it isn't actually important
+         !        that this match the method used later in the code.  We can't use the method from later
+         !        in the code since the `hub_theta_x_root` is not known at this point.  So instead, we
+         !        will use the input blade root orientation to set the direction.  This does not result
+         !        in a flat disk, but should allow the mesh mapping to work.
+         p0 = m%Turbine%AD%Input(1)%rotors(1)%HubMotion%Position(:,1) + m%Turbine%AD%Input(1)%rotors(1)%HubMotion%TranslationDisp(:,1) 
+         m%ADRotorDisk(k)%RefOrientation(:,:,1) = m%Turbine%AD%Input(1)%rotors(1)%BladeRootMotion(k)%Orientation(:,:,1)
+         do j=1,p%nr
+            m%ADRotorDisk(k)%Position(:,j) = p0 + p%r(j)*m%ADRotorDisk(k)%RefOrientation(3,:,1)
+         end do
          m%ADRotorDisk(k)%TranslationDisp = 0.0_R8Ki ! this happens by default, anyway....
-         
+
             ! create line2 elements
          do j=1,p%nr-1
             call MeshConstructElement( m%ADRotorDisk(k), ELEMENT_LINE2, errStat2, errMsg2, p1=j, p2=j+1 );   if (Failed()) return;


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
We have seen occasional mesh mapping errors during initialization of _FAST.Farm_.  This may be due to the initial position of the `m%ADRotorDisk` meshes getting set based only on the wake grid sitting on the ground.  However, the wake grid should be centered on the hub as it is in later calculations.  If the grid is less than the distance from the ground to the top of whatever blade is pointed vertically (blade 1 typically), a mesh mapping error was occurring.  This change now aligns the wake grid meshes with the blade axis during init - not technically correct, but will avoid mesh mapping issues.

**Related issue, if one exists**
#2027 
#1613 
#1044

**Impacted areas of the software**
_FAST.Farm_ initialization in the _AWAE_ module only.

**Additional supporting information**
This PR came about after some internal discussions about an issue with a tall model where the number of wake radii was set too low.

**Test results, if applicable**
No test results are affected.