### PR TITLE
FASTlib: fix typo in error message

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -2087,7 +2087,7 @@ SUBROUTINE ValidateInputData(p, m_FAST, ErrStat, ErrMsg)
    IF ( p%TMax < 0.0_DbKi  )  THEN
       CALL SetErrStat( ErrID_Fatal, 'TMax must not be a negative number.', ErrStat, ErrMsg, RoutineName )
    ELSE IF ( p%TMax < p%TStart )  THEN
-      CALL SetErrStat( ErrID_Fatal, 'TStart ('//trim(num2lstr(p%TStart))//') should be greater than TMax ('//trim(num2lstr(p%TMax))//') in OpenFAST input file.', ErrStat, ErrMsg, RoutineName )
+      CALL SetErrStat( ErrID_Fatal, 'TMax ('//trim(num2lstr(p%TMax))//') should be greater than TStart ('//trim(num2lstr(p%TStart))//') in the OpenFAST input file.', ErrStat, ErrMsg, RoutineName )
    END IF
 
    IF ( p%n_ChkptTime < p%n_TMax_m1 ) THEN


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
There was a typo in an error message about `TMax` and `TStart` in the `OpenFAST` input file parsing.

**Related issue, if one exists**
Reported by @hfchen20 in #3057

**Impacted areas of the software**
Error message only.

**Test results, if applicable**
No tests are affected.