### PR TITLE
Add error message when using BeamDyn with AeroMap

### DIFF
--- a/modules/openfast-library/src/FAST_SS_Subs.f90
+++ b/modules/openfast-library/src/FAST_SS_Subs.f90
@@ -102,6 +102,7 @@ SUBROUTINE FAST_InitializeSteadyState_T( Turbine, ErrStat, ErrMsg )
                      Turbine%ED, Turbine%SED, Turbine%BD, Turbine%SrvD, Turbine%AD, Turbine%ADsk, Turbine%ExtLd, Turbine%IfW, Turbine%ExtInfw, &
                      Turbine%SeaSt, Turbine%HD, Turbine%SD, Turbine%ExtPtfm, Turbine%MAP, Turbine%FEAM, Turbine%MD, Turbine%Orca, &
                      Turbine%IceF, Turbine%IceD, Turbine%MeshMapData, CompAeroMaps, ErrStat, ErrMsg )
+      if (ErrStat >= AbortErrLev) return
 
       ! If BeamDyn blades are being used, return error
       if (Turbine%p_FAST%CompElast == Module_BD) then


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to merge

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR adds an error message if the user attempts to use BeamDyn with AeroMap which is not currently possible. Support for this combination of features will be added in the OpenFAST 5.x series.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

AeroMap (`FAST_SS_Subs.f90`)

