### PR TITLE
Fix FAST_Reader bug when ElastoDyn tower file path is absolute

### DIFF
--- a/openfast_io/openfast_io/FAST_reader.py
+++ b/openfast_io/openfast_io/FAST_reader.py
@@ -3478,6 +3478,8 @@ class InputReader_OpenFAST(object):
 
             if not os.path.isabs(self.fst_vt['ElastoDyn']['TwrFile']):
                 ed_tower_file = os.path.join(os.path.dirname(ed_file), self.fst_vt['ElastoDyn']['TwrFile'])
+            else:
+                ed_tower_file = self.fst_vt['ElastoDyn']['TwrFile']
             self.read_ElastoDynTower(ed_tower_file)
         
         if self.fst_vt['Fst']['CompInflow'] == 1:


### PR DESCRIPTION
Fix FAST_Reader bug when ElastoDyn tower file path is absolute because an else condition was missing. Works if path is relative.

No known issue.