### PR TITLE
HD: Fixed a bug with PtfmRefztRot

### DIFF
--- a/modules/hydrodyn/src/WAMIT.f90
+++ b/modules/hydrodyn/src/WAMIT.f90
@@ -1100,16 +1100,18 @@ end if
                      ! Apply rotation only for NBodyMod = 1,3
                   do J = 1, NInpWvDir  
                      do I = 1, NInpFreq
+                        do iBody = 1, p%NBody
+                           K = 6*(iBody-1)
+                           Ctmp1 = ( HdroExctn(I,J,K+1)*cos(InitInp%PtfmRefztRot(iBody)) ) - ( HdroExctn(I,J,K+2)*sin(InitInp%PtfmRefztRot(iBody)) )
+                           Ctmp2 = ( HdroExctn(I,J,K+1)*sin(InitInp%PtfmRefztRot(iBody)) ) + ( HdroExctn(I,J,K+2)*cos(InitInp%PtfmRefztRot(iBody)) )
+                           Ctmp4 = ( HdroExctn(I,J,K+4)*cos(InitInp%PtfmRefztRot(iBody)) ) - ( HdroExctn(I,J,K+5)*sin(InitInp%PtfmRefztRot(iBody)) )
+                           Ctmp5 = ( HdroExctn(I,J,K+4)*sin(InitInp%PtfmRefztRot(iBody)) ) + ( HdroExctn(I,J,K+5)*cos(InitInp%PtfmRefztRot(iBody)) )
 
-                        Ctmp1 = ( HdroExctn(I,J,1)*cos(InitInp%PtfmRefztRot(1)) ) - ( HdroExctn(I,J,2)*sin(InitInp%PtfmRefztRot(1)) )
-                        Ctmp2 = ( HdroExctn(I,J,1)*sin(InitInp%PtfmRefztRot(1)) ) + ( HdroExctn(I,J,2)*cos(InitInp%PtfmRefztRot(1)) )  
-                        Ctmp4 = ( HdroExctn(I,J,4)*cos(InitInp%PtfmRefztRot(1)) ) - ( HdroExctn(I,J,5)*sin(InitInp%PtfmRefztRot(1)) )
-                        Ctmp5 = ( HdroExctn(I,J,4)*sin(InitInp%PtfmRefztRot(1)) ) + ( HdroExctn(I,J,5)*cos(InitInp%PtfmRefztRot(1)) )
-
-                        HdroExctn(I,J,1) = Ctmp1
-                        HdroExctn(I,J,2) = Ctmp2
-                        HdroExctn(I,J,4) = Ctmp4
-                        HdroExctn(I,J,5) = Ctmp5
+                           HdroExctn(I,J,K+1) = Ctmp1
+                           HdroExctn(I,J,K+2) = Ctmp2
+                           HdroExctn(I,J,K+4) = Ctmp4
+                           HdroExctn(I,J,K+5) = Ctmp5
+                        end do
                      end do
                   end do  
                   


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
Previously, when `NBodyMod=1`, only the potential-flow wave excitation of the first body is rotated according to `PtfmRefztRot`. This bug is now fixed.

Note that this bug only affected the results when `NBodyMod=1`, `NBody>1`, and `PtfmRefztRot/=0` for the second body and onward. This combination of user inputs is rarely encountered.

**Impacted areas of the software**
HydroDyn

**Test results, if applicable**
No change to existing test results.
