### PR TITLE
docs: Remove references to `pfunit` from docs (no longer used)

### DIFF
--- a/docs/source/testing/index.rst
+++ b/docs/source/testing/index.rst
@@ -38,10 +38,9 @@ pushing new commits will trigger the tests.
 Obtaining and configuring the test suite
 ----------------------------------------
 Portions of the test suite are linked to the OpenFAST repository through a
-`git submodule`. Specifically, the following two repositories are included:
+`git submodule`. Specifically, the following repository is included:
 
 - `r-test <https://github.com/openfast/r-test>`__
-- `pFUnit <https://github.com/Goddard-Fortran-Ecosystem/pFUnit>`__
 
 .. tip::
 
@@ -56,8 +55,8 @@ build process with an additional CMake flag:
     # BUILD_TESTING     - Build the testing tree (Default: OFF)
     cmake .. -DBUILD_TESTING:BOOL=ON
 
-Aside from this flag, the default CMake configuration is suitable for most systems.
-See the :ref:`understanding_cmake` section for more details on configuring
-the CMake targets. While the unit tests must be built with CMake due to its external
-dependencies, the regression test may be executed without CMake, as described in
-:ref:`python_driver`.
+Aside from this flag, the default CMake configuration is suitable for most
+systems.  See the :ref:`understanding_cmake` section for more details on
+configuring the CMake targets. While the unit tests must be built with CMake due
+to its dependency on `test_drive` (included in the source code), the regression
+test may be executed without CMake, as described in :ref:`python_driver`.

--- a/docs/source/testing/unit_test.rst
+++ b/docs/source/testing/unit_test.rst
@@ -113,4 +113,3 @@ Some useful topics to consider when developing and testing for OpenFAST are:
 
 - `Test driven development <https://en.wikipedia.org/wiki/Test-driven_development#Test-driven_development_cycle>`__
 - `Separation of concerns <https://en.wikipedia.org/wiki/Separation_of_concerns>`__
-- `pFUnit usage <http://pfunit.sourceforge.net/page_Usage.html>`__


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The `pfunit` unit testing infrastructure was removed in 4.0.0, but a few stray references still existed in the documentation.  This PR removes all but one of the remaining references (there is one reference left in the `source/user/fast_to_openfast.rst` document.

**Related issue, if one exists**
#2276 and #2329

Closes #2979

**Impacted areas of the software**
Documentation only.


**Test results, if applicable**
None