### PR TITLE
Reenable writing check point files when using the MAP module

### DIFF
--- a/modules/elastodyn/src/ElastoDyn_Types.f90
+++ b/modules/elastodyn/src/ElastoDyn_Types.f90
@@ -700,7 +700,7 @@ IMPLICIT NONE
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: FirstMom      !< First mass moment of inertia of blades wrt the root [-]
     REAL(ReKi)  :: GenIner = 0.0_ReKi      !< Generator inertia about HSS [-]
     REAL(ReKi)  :: Hubf1Iner = 0.0_ReKi      !< Inertia of hub about f1-axis (rotor centerline) [-]
-    REAL(ReKi)  :: Hubf2Iner = 0.0_ReKi      !< Inertia of hub about f2-axis (transverse to the hub and passing through its c.g.) [-]
+    REAL(ReKi)  :: Hubf2Iner = 0.0_ReKi      !< Inertia of hub about f2-axis (teeter axis) [-]
     REAL(ReKi)  :: HubMass = 0.0_ReKi      !< Hub mass [-]
     REAL(ReKi)  :: Nacd2Iner = 0.0_ReKi      !< Inertia of nacelle about the d2-axis whose origin is the nacelle center of mass [-]
     REAL(ReKi)  :: NacMass = 0.0_ReKi      !< Nacelle mass [-]

--- a/modules/externalinflow/src/ExternalInflow_Types.f90
+++ b/modules/externalinflow/src/ExternalInflow_Types.f90
@@ -288,11 +288,6 @@ subroutine ExtInfw_PackInitInput(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtInfw_PackInitInput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%NumActForcePtsBlade)
    call RegPack(RF, InData%NumActForcePtsTower)
    call RegPackPtr(RF, InData%StructBldRNodes)
@@ -494,11 +489,6 @@ subroutine ExtInfw_PackInitOutput(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtInfw_PackInitOutput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackAlloc(RF, InData%WriteOutputHdr)
    call RegPackAlloc(RF, InData%WriteOutputUnt)
    call NWTC_Library_PackProgDesc(RF, InData%Ver) 
@@ -733,11 +723,6 @@ subroutine ExtInfw_PackMisc(RF, Indata)
    integer(B4Ki)   :: LB(1), UB(1)
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, allocated(InData%ActForceMotionsPoints))
    if (allocated(InData%ActForceMotionsPoints)) then
       call RegPackBounds(RF, 1, lbound(InData%ActForceMotionsPoints), ubound(InData%ActForceMotionsPoints))
@@ -993,11 +978,6 @@ subroutine ExtInfw_PackParam(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtInfw_PackParam'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%AirDens)
    call RegPack(RF, InData%NumBl)
    call RegPack(RF, InData%NMappings)
@@ -1541,11 +1521,6 @@ subroutine ExtInfw_PackInput(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtInfw_PackInput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%pxVel)
    call RegPackPtr(RF, InData%pyVel)
    call RegPackPtr(RF, InData%pzVel)
@@ -2160,11 +2135,6 @@ subroutine ExtInfw_PackOutput(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtInfw_PackOutput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%u)
    call RegPackPtr(RF, InData%v)
    call RegPackPtr(RF, InData%w)

--- a/modules/extloads/src/ExtLoadsDX_Types.f90
+++ b/modules/extloads/src/ExtLoadsDX_Types.f90
@@ -273,11 +273,6 @@ subroutine ExtLdDX_PackInput(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtLdDX_PackInput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%twrDef)
    call RegPackPtr(RF, InData%bldDef)
    call RegPackPtr(RF, InData%hubDef)
@@ -769,11 +764,6 @@ subroutine ExtLdDX_PackParam(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtLdDX_PackParam'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%nBlades)
    call RegPackPtr(RF, InData%nBladeNodes)
    call RegPackPtr(RF, InData%nTowerNodes)
@@ -1217,11 +1207,6 @@ subroutine ExtLdDX_PackOutput(RF, Indata)
    character(*), parameter         :: RoutineName = 'ExtLdDX_PackOutput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%twrLd)
    call RegPackPtr(RF, InData%bldLd)
    if (RegCheckErr(RF, RoutineName)) return

--- a/modules/map/src/MAP_Types.f90
+++ b/modules/map/src/MAP_Types.f90
@@ -299,11 +299,6 @@ subroutine MAP_PackInitInput(RF, Indata)
    type(MAP_InitInputType), intent(in) :: InData
    character(*), parameter         :: RoutineName = 'MAP_PackInitInput'
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%gravity)
    call RegPack(RF, InData%sea_density)
    call RegPack(RF, InData%depth)
@@ -471,11 +466,6 @@ subroutine MAP_PackInitOutput(RF, Indata)
    type(MAP_InitOutputType), intent(in) :: InData
    character(*), parameter         :: RoutineName = 'MAP_PackInitOutput'
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%progName)
    call RegPack(RF, InData%version)
    call RegPack(RF, InData%compilingData)
@@ -573,11 +563,6 @@ subroutine MAP_PackContState(RF, Indata)
    type(MAP_ContinuousStateType), intent(in) :: InData
    character(*), parameter         :: RoutineName = 'MAP_PackContState'
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%dummy)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
@@ -654,11 +639,6 @@ subroutine MAP_PackDiscState(RF, Indata)
    type(MAP_DiscreteStateType), intent(in) :: InData
    character(*), parameter         :: RoutineName = 'MAP_PackDiscState'
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%dummy)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
@@ -1072,11 +1052,6 @@ subroutine MAP_PackOtherState(RF, Indata)
    character(*), parameter         :: RoutineName = 'MAP_PackOtherState'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%H)
    call RegPackPtr(RF, InData%V)
    call RegPackPtr(RF, InData%Ha)
@@ -1691,11 +1666,6 @@ subroutine MAP_PackConstrState(RF, Indata)
    character(*), parameter         :: RoutineName = 'MAP_PackConstrState'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%H)
    call RegPackPtr(RF, InData%V)
    call RegPackPtr(RF, InData%x)
@@ -1926,11 +1896,6 @@ subroutine MAP_PackParam(RF, Indata)
    type(MAP_ParameterType), intent(in) :: InData
    character(*), parameter         :: RoutineName = 'MAP_PackParam'
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPack(RF, InData%g)
    call RegPack(RF, InData%depth)
    call RegPack(RF, InData%rho_sea)
@@ -2105,11 +2070,6 @@ subroutine MAP_PackInput(RF, Indata)
    character(*), parameter         :: RoutineName = 'MAP_PackInput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%x)
    call RegPackPtr(RF, InData%y)
    call RegPackPtr(RF, InData%z)
@@ -2377,11 +2337,6 @@ subroutine MAP_PackOutput(RF, Indata)
    character(*), parameter         :: RoutineName = 'MAP_PackOutput'
    logical         :: PtrInIndex
    if (RF%ErrStat >= AbortErrLev) return
-   if (c_associated(InData%C_obj%object)) then
-      RF%ErrStat = ErrID_Fatal
-      RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'
-      return
-   end if
    call RegPackPtr(RF, InData%Fx)
    call RegPackPtr(RF, InData%Fy)
    call RegPackPtr(RF, InData%Fz)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1133,13 +1133,6 @@ SUBROUTINE FAST_InitializeAll( t_initial, p_FAST, y_FAST, m_FAST, ED, SED, BD, S
    IF (p_FAST%CompMooring == Module_MAP) THEN
       !bjj: until we modify this, MAP requires HydroDyn to be used. (perhaps we could send air density from AeroDyn or something...)
 
-      ! If mode shape visualization requested when MAP is active, set error and return
-      if (p_FAST%WrVTK == VTK_ModeShapes) then
-         call SetErrStat(ErrID_Fatal, "Mode shape visualization is not supported when using MAP.", ErrStat, ErrMsg, RoutineName)
-         call Cleanup()
-         return
-      end if
-
       CALL WrScr(NewLine) !bjj: I'm printing two blank lines here because MAP seems to be writing over the last line on the screen.
 
 !      Init%InData_MAP%rootname          =  p_FAST%OutFileRoot        ! Output file name
@@ -10002,13 +9995,7 @@ SUBROUTINE FAST_CreateCheckpoint_T(t_initial, n_t_global, NumTurbines, Turbine, 
       ! init error status
    ErrStat = ErrID_None
    ErrMsg  = ""
-
-   ! Writing checkpoint files is not supported when using MAP
-   if (Turbine%p_FAST%CompMooring == Module_MAP) then
-      call SetErrStat(ErrID_Fatal, "Writing checkpoint files is not supported when using MAP.", ErrStat, ErrMsg, RoutineName)
-      return
-   end if
-      
+     
    FileName    = TRIM(CheckpointRoot)//'.chkp'
    DLLFileName = TRIM(CheckpointRoot)//'.dll.chkp'
 

--- a/modules/openfast-registry/src/registry_gen_fortran.cpp
+++ b/modules/openfast-registry/src/registry_gen_fortran.cpp
@@ -677,15 +677,6 @@ void gen_pack(std::ostream &w, const Module &mod, const DataType::Derived &ddt,
 
     w << indent << "if (RF%ErrStat >= AbortErrLev) return";
 
-    if (gen_c_code)
-    {
-        w << indent << "if (c_associated(InData%C_obj%object)) then";
-        w << indent << "   RF%ErrStat = ErrID_Fatal";
-        w << indent << "   RF%ErrMsg = RoutineName//': C_obj%object cannot be packed.'";
-        w << indent << "   return";
-        w << indent << "end if";
-    }
-
     // Pack data
     for (auto &field : ddt.fields)
     {


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to merge

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR closes #2947 where checkpoint file writing was disabled when the MAP module was used. This was due to a misunderstanding about how the MAP_Restore function works in re-initializing the C memory within the module. Once all the previous checks were removed, the code worked as intended.

**Related issue, if one exists**
<!-- Link to a related GitHub Issue. -->

#2947

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`FAST_Subs.f90` and several `_Types.f90` files

**Additional supporting information**
<!-- Add any other context about the problem here. -->
