### PR TITLE
FAST_reader.py fix for ServoDyn.dat GenTrq_TLU read

### DIFF
--- a/openfast_io/openfast_io/FAST_reader.py
+++ b/openfast_io/openfast_io/FAST_reader.py
@@ -1645,7 +1645,7 @@ class InputReader_OpenFAST(object):
         for i in range(self.fst_vt['ServoDyn']['DLL_NumTrq']):
             data = f.readline().split()
             self.fst_vt['ServoDyn']['GenSpd_TLU'][i]  = float_read(data[0])
-            self.fst_vt['ServoDyn']['GenTrq_TLU'][i]  = float_read(data[0])
+            self.fst_vt['ServoDyn']['GenTrq_TLU'][i]  = float_read(data[1])
 
         # ServoDyn Output Params (sd_out_params)
         f.readline()


### PR DESCRIPTION
fixes access to the 2nd column (GenTrq_TLU) in the DLL_NumTrq related table for the read_ServoDyn method.

Ready to merge.

Related issue: https://github.com/OpenFAST/openfast/issues/3150

impacted software: openfast_io Python scripts

preferred reviewer: mayankchetan
