### PR TITLE
Linear Trim Solution: update range calculation when NLinTimes=1

### DIFF
--- a/modules/openfast-library/src/FAST_Lin.f90
+++ b/modules/openfast-library/src/FAST_Lin.f90
@@ -6928,10 +6928,16 @@ SUBROUTINE ComputeOutputRanges(p_FAST, y_FAST, m_FAST, y_SrvD)
    
    ! note that op_y may be larger than SizeLin if there are orientations; also, we are NOT including the WriteOutputs
 
-   do indx = 1,y_FAST%Lin%Glue%SizeLin(LIN_OUTPUT_COL)
-      m_FAST%Lin%y_ref(indx) = maxval( m_FAST%Lin%Y_prevRot( indx, : ) ) - minval( m_FAST%Lin%Y_prevRot( indx, : ) )
-      m_FAST%Lin%y_ref(indx) = max( m_FAST%Lin%y_ref(indx), 0.01_ReKi )
-   end do
+   if (p_FAST%NLinTimes == 1) then ! NOTE: maxval( m_FAST%Lin%Y_prevRot( indx, : ) ) - minval( m_FAST%Lin%Y_prevRot( indx, : ) ) = 0 in this case
+      do indx = 1,y_FAST%Lin%Glue%SizeLin(LIN_OUTPUT_COL)
+         m_FAST%Lin%y_ref(indx) = max( abs(m_FAST%Lin%Y_prevRot( indx, p_FAST%NLinTimes )), 0.01_ReKi )
+      end do
+   else
+      do indx = 1,y_FAST%Lin%Glue%SizeLin(LIN_OUTPUT_COL)
+         m_FAST%Lin%y_ref(indx) = maxval( m_FAST%Lin%Y_prevRot( indx, : ) ) - minval( m_FAST%Lin%Y_prevRot( indx, : ) )
+         m_FAST%Lin%y_ref(indx) = max( m_FAST%Lin%y_ref(indx), 0.01_ReKi )
+      end do
+   end if
    
    ! special case for angles:
       indx = Indx_y_Yaw_Start(y_FAST, Module_ED)  ! start of ED where Yaw, YawRate, HSS_Spd occur (right before WriteOutputs)


### PR DESCRIPTION
**Feature or improvement description**
When linearizing with a trim solution and NLinTimes=1, the range of the reference outputs was always 0.01. Now it uses the channel value. This could probably be modified further, but for now, it gives a slightly better range for the convergence calculation.

**Related issue, if one exists**
Possibly related to https://github.com/OpenFAST/openfast/issues/857, though I don't think this will fix that issue. 

**Impacted areas of the software**
Linearizing with Trim Solution and NLinTimes = 1.

**Additional supporting information**
Due to the check in https://github.com/OpenFAST/openfast/pull/1707 that makes NLinTimes at least 2, this fix won't actually do anything in the current code.

**Test results, if applicable**
This doesn't affect any current regression tests.