### PR TITLE
Update project description from NREL to NLR

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,7 +16,7 @@ OpenFAST is a wind turbine simulation tool which builds on FAST v8. FAST.Farm
 extends the capability of OpenFAST to simulate multi-turbine wind farms. They were
 created with the goal of being community models developed and used by research
 laboratories, academia, and industry. They are managed by a dedicated team at the
-National Renewable Energy Lab. Our objective is to ensure that OpenFAST and FAST.Farm
+National Laboratory of the Rockies. Our objective is to ensure that OpenFAST and FAST.Farm
 are sustainable software that are well tested and well documented. If you'd like
 to contribute, see the `Developer Documentation <https://openfast.readthedocs.io/en/dev/source/dev/index.html>`_
 and any open GitHub issues with the
@@ -30,11 +30,11 @@ tag.
 Part of the WETO Stack
 ----------------------
 
-OpenFAST is primarily developed with the support of the U.S. Department of Energy and is part of the `WETO Software Stack <https://nrel.github.io/WETOStack>`_. For more information and other integrated modeling software, see:
+OpenFAST is primarily developed with the support of the U.S. Department of Energy and is part of the `WETO Software Stack <https://NatLabRockies.github.io/WETOStack>`_. For more information and other integrated modeling software, see:
 
-* `Portfolio Overview <https://nrel.github.io/WETOStack/portfolio_analysis/overview.html>`_
-* `Entry Guide <https://nrel.github.io/WETOStack/_static/entry_guide/index.html>`_
-* `OpenFAST Workshop <https://nrel.github.io/WETOStack/workshops/user_workshops_2024.html#openfast-ecosystem>`_
+* `Portfolio Overview <https://NatLabRockies.github.io/WETOStack/portfolio_analysis/overview.html>`_
+* `Entry Guide <https://NatLabRockies.github.io/WETOStack/_static/entry_guide/index.html>`_
+* `OpenFAST Workshop <https://NatLabRockies.github.io/WETOStack/workshops/user_workshops_2024.html#openfast-ecosystem>`_
 
 
 FAST v8 - OpenFAST
@@ -155,8 +155,8 @@ Please use `GitHub Issues <https://github.com/OpenFAST/OpenFAST/issues>`_ to:
 * report bugs
 * request code enhancements
 
-Users and developers may also be interested in the NREL National Wind
-Technology Center (NWTC) `phpBB Forum <https://wind.nrel.gov/forum/wind/>`_,
+Users and developers may also be interested in the NLR National Wind
+Technology Center (NWTC) `Forum <https://forums.nrel.gov/>`_,
 which is still maintained and has a long history of FAST-related questions
 and answers.
 
@@ -164,9 +164,9 @@ Acknowledgments
 ---------------
 
 OpenFAST and FAST.Farm are maintained and developed by researchers and software
-engineers at the `National Renewable Energy Laboratory <http://www.nrel.gov/>`_
-(NREL), with support from the US Department of Energy's Wind Energy Technology
-Office. NREL gratefully acknowledges development contributions from the following
+engineers at the `National Laboratory of the Rockies <http://www.nlr.gov/>`_
+(NLR), with support from the US Department of Energy's Wind Energy Technology
+Office. NLR gratefully acknowledges development contributions from the following
 organizations:
 
 * Envision Energy USA, Ltd

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ and underlying modules are mostly written in Fortran
 (adhering to the 2003 standard), and modules can also be written in C or
 C++. It was created with the goal of being a community model developed
 and used by research laboratories, academia, and industry. It is
-managed by a dedicated team at the National Renewable Energy Lab.
+managed by a dedicated team at the National Lab of the Rockies.
 Our objective is to ensure that OpenFAST is well tested, well
 documented, and self-sustaining software. To that end, we are continually
 improving the documentation and test coverage for existing code, and we

--- a/openfast_io/README.md
+++ b/openfast_io/README.md
@@ -38,7 +38,7 @@ These instructions are for interaction directly with the `openfast_io` source co
     ```
 
 ### Extra options
-[ROSCO](https://github.com/NREL/ROSCO) can be installed as an optional dependency. Run either
+[ROSCO](https://github.com/NatLabRockies/ROSCO) can be installed as an optional dependency. Run either
 ```shell
 pip install openfast_io[rosco]
 ```

--- a/openfast_io/pyproject.toml
+++ b/openfast_io/pyproject.toml
@@ -9,15 +9,15 @@ version = "4.1.2"
 description = "Readers and writers for OpenFAST files."
 license = {file = "../LICENSE"}
 authors = [
-    {name = "Mayank Chetan", email = "mayank.chetan@nrel.gov"      },
-    {name = "Andy Platt", email = "andy.platt@nrel.gov"            },
-    {name = "Derek Slaughter", email = "derek.slaughter@nrel.gov"  },
-    { name = "NREL WISDEM Team", email = "systems.engineering@nrel.gov"    },
+    {name = "Mayank Chetan", email = "mayank.chetan@nlr.gov"      },
+    {name = "Andy Platt", email = "andy.platt@nlr.gov"            },
+    {name = "Derek Slaughter", email = "derek.slaughter@nlr.gov"  },
+    { name = "NLR WISDEM Team", email = "systems.engineering@nlr.gov"    },
 ]
 maintainers = [
-    {name = "Mayank Chetan", email = "mayank.chetan@nrel.gov"      },
-    {name = "Andy Platt", email = "andy.platt@nrel.gov"            },
-    {name = "Derek Slaughter", email = "derek.slaughter@nrel.gov"  },
+    {name = "Mayank Chetan", email = "mayank.chetan@nlr.gov"      },
+    {name = "Andy Platt", email = "andy.platt@nlr.gov"            },
+    {name = "Derek Slaughter", email = "derek.slaughter@nlr.gov"  },
 ]  
 readme = "README.md"
 requires-python = ">3.10"

--- a/vs-build/ReadMe.md
+++ b/vs-build/ReadMe.md
@@ -20,7 +20,7 @@ The following solution files are available for code development on Windows using
       - [SeaState driver](SeaState/SeaStateDriver.sln) Waves and currents
 - Other:
   - [Discon](Discon/Discon.sln) 
-    This solution file contains all 3 controllers used in the OpenFAST r-test (with the NREL 5MW model).
+    This solution file contains all 3 controllers used in the OpenFAST r-test (with the historical NREL 5MW model).
     It also contains the controller used with the FAST.Farm super-controller.
   - [SC_DLL](SC_DLL.sln) This solution file builds a template supercontroller to be used with FAST.Farm.
   - [OpenFAST Registry](Registry/Registry.sln)


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
This PR updates some top level GH and readthedocs landing pages to reflect the lab name change from NREL to NLR.

**Related issue, if one exists**
None

**Impacted areas of the software**
Documentation only.

**Additional supporting information**
Note that there are additional instances of NREL / National Renewable Energy Lab in source code.  These will be updated at a later date in a later release.

Note: models such as the NREL 5MW turbine will remain named as such; they are historic models known throughout the world.

**Test results, if applicable**
None