### PR TITLE
SubDyn: add rectangular beam properties to JSON output

### DIFF
--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -4208,7 +4208,13 @@ SUBROUTINE WriteJSONCommon(FileName, Init, p, m, InitInput, FileKind, UnSum, Err
    ! --- Elem props
    write(UnSum, '(A)') '"ElemProps": ['
    do i = 1, size(p%ElemProps)
-      write(UnSum, '(A,I0,A,F8.4,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1),'}'
+      if (p%ElemProps(i)%eType == idMemberBeamRect) then
+         ! Rectangular beam: MType = 1r. eType = -1
+         write(UnSum, '(A,I0,A,F8.4,A,F8.4,A, F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "rectangle", "type": ',p%ElemProps(i)%eType, ', "SideA":',p%ElemProps(i)%Sa(1), ', "SideB":',p%ElemProps(i)%Sb(1), ', "SideA_dir":[',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
+      else
+         ! Cylindrical shapes (MType = 1 or 1c [cylindrical beam], 2 [cable element], 3 [rigid link]. eType = 1, 2, 3)
+         write(UnSum, '(A,I0,A,F8.4,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1),'}'
+      endif
       if (i<size(p%ElemProps)) write(UnSum, '(A)', advance='no')','//NewLine 
    enddo
    write(UnSum, '(A)') ']'


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
SubDyn allows to model rectangular beam elements. Unfortunately, it’s not possible to visualize them with the 3D visualization tool from Emmanuel Branlard (https://ebranlard.github.io/viz3Danim/)

Currently, when rectangular beams are modeled in SubDyn (see for example: https://github.com/OpenFAST/r-test/blob/main/modules/subdyn/SD_CantileverBeam_Rectangular/SD_CantileverBeam_Rectangular.dat), and the user requests the JSON output files (i.e., `OutCBModes` = 1 and/or `OutFEMModes` = 1), SubDyn does not recognize the rectangular element and writes:
<img width="639" height="244" alt="image" src="https://github.com/user-attachments/assets/aadf443f-2114-4cd6-921a-1c26b74e6bbd" />

Example of current visualization:
<img width="816" height="564" alt="image" src="https://github.com/user-attachments/assets/9779fd45-33f4-45cf-a2bf-7e209994b129" />

To visualize rectangular elements, it is necessary to update the “shape” value and add new keys like “SideA”, “SideB”, and “SideA_dir” instead of “Diam”. For reference, the “SideA_dir” key corresponds to a vector used to orientate the SideA of the rectangle (local beam x_e axis). In this case, we work with the “SideA_dir” instead of the spin angle (`MSpin`) for simplicity. This “SideA_dir” is useful for SubDyn and HydroDyn as both modules use the same convention.

Example of new output ([SD_CantileverBeam_Rectangular.SD.CBmodes.json](https://github.com/user-attachments/files/25221830/SD_CantileverBeam_Rectangular.SD.CBmodes.json)):
<img width="900" height="159" alt="image" src="https://github.com/user-attachments/assets/cdfca04c-cb04-4d15-97c8-ebc145654f47" />

The current modification writes the necessary outputs and it does not break the current parser of viz3Danim. 

Another PR has been opened at the viz3Danim side (https://github.com/ebranlard/viz3Danim/pull/1) to visualize the rectangular elements.
<img width="947" height="701" alt="image" src="https://github.com/user-attachments/assets/f25ce014-131e-4666-8d4e-e62840596978" />