### PR TITLE
SeaState: Small change in WavePkShp logic

### DIFF
--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -707,7 +707,7 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
        ! WavePkShp - Peak shape parameter
    if ( InputFileData%WaveMod == WaveMod_JONSWAP ) then   ! Only used for JONSWAP/Pierson-Moskowitz spectrum
 
-      if ( ( InputFileData%Waves%WavePkShp < 1.0 ) .OR. ( InputFileData%Waves%WavePkShp > 7.0 ) )  then
+      if ( ( InputFileData%Waves%WavePkShp < 1.0_SiKi ) .OR. ( InputFileData%Waves%WavePkShp > 7.0_SiKi ) )  then
          call SetErrStat( ErrID_Fatal,'WavePkShp must be greater than or equal to 1 and less than or equal to 7.',ErrStat,ErrMsg,RoutineName)
          return
       end if
@@ -715,7 +715,7 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
    else
 
       ! For nonJONSWAP/Pierson-Moskowitz spectrum, WavePkShp is not used. Force it to 1.0.
-      InputFileData%Waves%WavePkShp = 1.0
+      InputFileData%Waves%WavePkShp = 1.0_SiKi
 
    end if
 

--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -714,7 +714,7 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
 
    else
 
-      ! For nonJONSWAP/Pieson-Moskowitz spectrum, WavePkShp is not used. Force it to 1.0.
+      ! For nonJONSWAP/Pierson-Moskowitz spectrum, WavePkShp is not used. Force it to 1.0.
       InputFileData%Waves%WavePkShp = 1.0
 
    end if

--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -705,9 +705,18 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
 
 
        ! WavePkShp - Peak shape parameter
-   if ( ( InputFileData%Waves%WavePkShp < 1.0 ) .OR. ( InputFileData%Waves%WavePkShp > 7.0 ) )  then
-      call SetErrStat( ErrID_Fatal,'WavePkShp must be greater than or equal to 1 and less than or equal to 7.',ErrStat,ErrMsg,RoutineName)
-      return
+   if ( InputFileData%WaveMod == WaveMod_JONSWAP ) then   ! Only used for JONSWAP/Pierson-Moskowitz spectrum
+
+      if ( ( InputFileData%Waves%WavePkShp < 1.0 ) .OR. ( InputFileData%Waves%WavePkShp > 7.0 ) )  then
+         call SetErrStat( ErrID_Fatal,'WavePkShp must be greater than or equal to 1 and less than or equal to 7.',ErrStat,ErrMsg,RoutineName)
+         return
+      end if
+
+   else
+
+      ! For nonJONSWAP/Pieson-Moskowitz spectrum, WavePkShp is not used. Force it to 1.0.
+      InputFileData%Waves%WavePkShp = 1.0
+
    end if
 
 


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
In SeaState, the peak-shape parameter only plays a role when using `WaveMod` = 2 (JONSWAP/Pierson-Moskowitz spectrum (irregular)).
<img width="1498" height="161" alt="image" src="https://github.com/user-attachments/assets/dfb59455-842f-4dcd-82f8-cfc4fe39fbf5" />

However, nowadays, there is no logic that checks this. For example, if the user defines still water (`WaveMod` = 0) or a regular wave (e.g., `WaveMod` = 1), SeaState still checks internally for a valid `WavePkShp` input value and it aborts the program if the criteria is not met.
<img width="975" height="230" alt="image" src="https://github.com/user-attachments/assets/37997eb7-35e7-4e1c-89a1-e2a7433d35ca" />

This modification, checks for a valid `WavePkShp` only if `WaveMod` = 2.

@luwang00: Internally, if the user is not using `WaveMod` = 2, I'm assigning a _dummy_ value of `WavePkShp` = 1. I don't know if you use this `WavePkShp` somewhere else and not having a 'valid' `WavePkShp` could break the code down the road. If there is no need to have a `WavePkShp`, I could remove the else statement in the proposed code. I did this change to have something robust. 