### PR TITLE
Fix TurbSim compile with OpenMP and IFX compiler

### DIFF
--- a/modules/turbsim/src/TSsubs.f90
+++ b/modules/turbsim/src/TSsubs.f90
@@ -55,8 +55,8 @@ REAL(ReKi),                  INTENT(INOUT)  :: TRH_in(:)                       !
 INTEGER(IntKi),              INTENT(OUT)    :: ErrStat
 CHARACTER(*),                INTENT(OUT)    :: ErrMsg
 
-!$OMP THREADPRIVATE(TRH)
 REAL(ReKi), allocatable, save :: TRH(:)         ! Each OMP thread gets its own copy of this array
+!$OMP THREADPRIVATE(TRH)
 REAL(ReKi), ALLOCATABLE       :: Dist(:)        ! The distance between points
 REAL(ReKi), ALLOCATABLE       :: DistU(:)
    


### PR DESCRIPTION
<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

This PR is ready to merge.

**Feature or improvement description**
<!-- A clear and concise description of the new code. -->

This PR corrects a compile error that occurs in TurbSim when using the IFX compiler with OpenMP enabled due to the incorrect placement of the `!$OMP` directive before the variable declaration instead of after it.

**Impacted areas of the software**
<!-- List any modules or other areas which should be impacted by this pull request. This helps to determine the verification tests. -->

`TSsubs.f90` in TurbSim

**Additional supporting information**
<!-- Add any other context about the problem here. -->

The OpenMP features that were added to TurbSim just before 4.2.0 was released were not tested with the IFX compiler, TurbSim was compiled without OpenMP enabled. It was later found that the OpenMP directive for the `TRH` variable, making it thread private, needed to be placed after the declaration for the IFX compiler. Gfortran did not give a warning or error. 

