### PR TITLE
[BugFix] AD: DTAero from input file was ignored

### DIFF
--- a/modules/aerodyn/src/AeroDyn.f90
+++ b/modules/aerodyn/src/AeroDyn.f90
@@ -370,7 +370,7 @@ subroutine AD_Init( InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitOut
       if (Failed()) return;
       ! -----------------------------------------------------------------
       ! Read the AeroDyn blade files, or copy from passed input
-   call ReadInputFiles( InitInp%InputFile, InputFileData, interval, p%RootName, NumBlades, AeroProjMod, UnEcho, calcCrvAngle, ErrStat2, ErrMsg2 )
+   call ReadInputFiles( InitInp%InputFile, InputFileData, p%RootName, NumBlades, AeroProjMod, UnEcho, calcCrvAngle, ErrStat2, ErrMsg2 )
       if (Failed()) return;
          
       ! override some parameters to simplify for aero maps

--- a/modules/aerodyn/src/AeroDyn_IO.f90
+++ b/modules/aerodyn/src/AeroDyn_IO.f90
@@ -588,14 +588,12 @@ CONTAINS
    
 END SUBROUTINE Calc_WriteOutput
 !----------------------------------------------------------------------------------------------------------------------------------
-SUBROUTINE ReadInputFiles( InputFileName, InputFileData, Default_DT, OutFileRoot, NumBlades, AeroProjMod, UnEcho, calcCrvAngle, ErrStat, ErrMsg )
+SUBROUTINE ReadInputFiles( InputFileName, InputFileData, OutFileRoot, NumBlades, AeroProjMod, UnEcho, calcCrvAngle, ErrStat, ErrMsg )
 ! This subroutine reads the input file and stores all the data in the AD_InputFile structure.
 ! It does not perform data validation.
 !..................................................................................................................................
 
       ! Passed variables
-   REAL(DbKi),              INTENT(IN)    :: Default_DT      ! The default DT (from glue code)
-
    CHARACTER(*),            INTENT(IN)    :: InputFileName   ! Name of the input file
    CHARACTER(*),            INTENT(IN)    :: OutFileRoot     ! The rootname of all the output files written by this routine.
 
@@ -624,7 +622,6 @@ SUBROUTINE ReadInputFiles( InputFileName, InputFileData, Default_DT, OutFileRoot
    ErrStat = ErrID_None
    ErrMsg  = ''
 
-   InputFileData%DTAero = Default_DT  ! the glue code's suggested DT for the module (may be overwritten in ReadPrimaryFile())
    calcCrvAngle = .false.             ! initialize in case of early return
 
       ! get the blade input-file data


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
When converting _AeroDyn_ to use the _FileInfoType_ for file parsing with PR #643, the primary input file reading was split from the `ReadInputFiles` routine.  The value for `DTAero` is then read with `ParseVarWDefault` to populate `InputFileData%DTAero`.  However, this `DTAero` was getting overwritten during at the beginning of the `ReadInputFiles` call with the `Interval` passed from the glue code.  The result was  `DTAero` from the input file was always replaced with the glue code timestep, so sub-cycling could not occur.

This affects all _OpenFAST_ versions from 3.0.0 until now.

**Related GitHub Issue/PR**
#643 

**Impacted areas of the software**
_AeroDyn_ _DTAero_ and sub-cycling of _AeroDyn_ within _OpenFAST_.

**Additional supporting information**
None

**Generative AI usage**
None

**Test results, if applicable**
None