### PR TITLE
[BugFix] AD driver: hub acceleration value incorrect in RotMotionType==1

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -820,7 +820,7 @@ subroutine Set_Mesh_Motion(nt, dvr, ADI, FED, errStat, errMsg)
          call interpTimeValue(wt%hub%motion, time, wt%hub%iMotion, hubMotion)
          !print*,hubMotion
          wt%hub%rotSpeed  = hubMotion(2)
-         wt%hub%rotAcc    = hubMotion(2)
+         wt%hub%rotAcc    = hubMotion(3)
          wt%hub%azimuth = MODULO(hubMotion(1)*R2D, 360.0_ReKi )
       else if (wt%hub%motionType == idHubMotionUserFunction) then
          ! We call a user-defined function to determined the azimuth, speed (and potentially acceleration...)


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
The rotor acceleration reported by the _AeroDyn_ driver was incorrect when `RotMotionType=1` was used.

**Related issue, if one exists**
closes #3187 

**Impacted areas of the software**
_AeroDyn_ driver only

**Generative AI usage**
None

**Test results, if applicable**
No changes