### PR TITLE
SeaState: Small change in WaveTp logic

### DIFF
--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -697,11 +697,16 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
 
 
       ! WaveTp - Peak spectral period.
-   if ( InputFileData%Waves%WaveTp <= 0.0 )  then
-      call SetErrStat( ErrID_Fatal,'WaveTp must be greater than zero.',ErrStat,ErrMsg,RoutineName)
-      return
-   end if
+   if ( InputFileData%WaveMod == WaveMod_Regular      .OR. &
+        InputFileData%WaveMod == WaveMod_RegularUsrPh .OR. &
+        InputFileData%WaveMod == WaveMod_JONSWAP ) then
 
+      if ( InputFileData%Waves%WaveTp <= 0.0 )  then
+         call SetErrStat( ErrID_Fatal,'WaveTp must be greater than zero.',ErrStat,ErrMsg,RoutineName)
+         return
+      end if
+
+   end if
 
 
        ! WavePkShp - Peak shape parameter

--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -701,7 +701,7 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
         InputFileData%WaveMod == WaveMod_RegularUsrPh .OR. &
         InputFileData%WaveMod == WaveMod_JONSWAP ) then
 
-      if ( InputFileData%Waves%WaveTp <= 0.0 )  then
+      if ( InputFileData%Waves%WaveTp <= 0.0_SiKi )  then
          call SetErrStat( ErrID_Fatal,'WaveTp must be greater than zero.',ErrStat,ErrMsg,RoutineName)
          return
       end if


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
In SeaState, the peak-spectral period parameter (`WaveTp`) should only play a role when using `WaveMod` = 1 or 2 (regular or irregular waves).
<img width="1387" height="147" alt="image" src="https://github.com/user-attachments/assets/b844fc26-06a8-42f4-81a7-53851d39ff8f" />

However, nowadays, there is a check regardless of the wave option selected. For example, when using `WaveMod` = 5 (externally generated wave-elevation time series), I get:
<img width="846" height="125" alt="image" src="https://github.com/user-attachments/assets/e0449d7a-6684-4cfc-9208-93024587c0bc" />

This modification checks for a valid `WaveTp` only if `WaveMod` = 1 or 2.