### PR TITLE
Fixed SeaState initialization in AeroDyn driver

### DIFF
--- a/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
+++ b/modules/aerodyn/src/AeroDyn_Driver_Subs.f90
@@ -260,21 +260,13 @@ subroutine Dvr_InitCase(iCase, dvr, ADI, FED, SeaSt, errStat, errMsg )
 
       IF ( dvr%MHK .NE. 0_IntKi .AND. dvr%IW_InitInp%CompInflow == 1) THEN
          SeaSt%InitInp%hasCurrField = .TRUE.
+         SeaSt%InitInp%CurrField => ADI%p%AD%FlowField
       ELSE
          SeaSt%InitInp%hasCurrField = .FALSE.
       END IF
 
       CALL SeaSt_Init( SeaSt%InitInp, SeaSt%u, SeaSt%p, SeaSt%x, SeaSt%xd, SeaSt%z, SeaSt%OtherState, SeaSt%y, SeaSt%m, dvr%dt, SeaSt%InitOut, ErrStat, ErrMsg )
-      
-      IF ( dvr%MHK .NE. 0_IntKi .AND. dvr%IW_InitInp%CompInflow == 1 ) THEN ! MHK turbine
-         ! Simulating an MHK turbine; load dynamic current from IfW
-         SeaSt%p%WaveField%CurrField  => ADI%p%AD%FlowField
-         SeaSt%p%WaveField%hasCurrField = .TRUE.
-         ! Set AD pointers to wavefield
-         ADI%p%AD%WaveField => SeaSt%InitOut%WaveField
-      ELSE ! Wind turbine
-         SeaSt%p%WaveField%hasCurrField = .FALSE.
-      END IF
+      ADI%p%AD%WaveField => SeaSt%InitOut%WaveField
 
       if (iCase==1) then
          call concatOutputHeaders(dvr%out%WriteOutputHdr, dvr%out%WriteOutputUnt, SeaSt%InitOut%WriteOutputHdr, SeaSt%InitOut%WriteOutputUnt, errStat2, errMsg2); if(Failed()) return


### PR DESCRIPTION
This PR is ready.

**Feature or improvement description**
Fixed a bug with SeaState initialization in the AeroDyn driver code. The IfW `FlowField` pointer must be assigned before calling `SeaSt_Init`. Otherwise, SeaState cannot estimate the current speed needed for `WvCrntMod>0`.

**Impacted areas of the software**
AeroDyn driver

**Test results, if applicable**
No change to test results. Merging r-test not required.

