### PR TITLE
Remove unused registry entries (leftover from old lin method)

### DIFF
--- a/modules/elastodyn/src/ElastoDyn_Registry.txt
+++ b/modules/elastodyn/src/ElastoDyn_Registry.txt
@@ -768,8 +768,6 @@ typedef ^       ParameterType   R8Ki    M_MCSMAX -      -       -       "Maximum
 typedef ^       ParameterType   R8Ki    sig_v   -       -       -       "Linear viscous friction coefficient"     N-m/(rad/s)
 typedef ^       ParameterType   R8Ki    sig_v2  -       -       -       "Quadratic viscous friction coefficient"  N-m/(rad/s)^2
 typedef ^       ParameterType   R8Ki    OmgCut  -       -       -       "Nacelle yaw angular velocity cutoff below which viscous friction is to be linearized"  rad/s
-#typedef        ^       ParameterType   R8Ki    thr_omg -       -       -       "Yaw rate stiction threshold"   rad/s
-#typedef        ^       ParameterType   R8Ki    thr_omgdot      -       -       -       "Yaw acceleration stiction threshold"   rad/s^2
 
 # .... ED_AllBlNds option ........................................................................................................
 typedef  ^  ParameterType  IntKi   BldNd_NumOuts        -  -  -  "Number of requested output channels per blade node (ED_AllBldNdOuts)"  -
@@ -778,16 +776,7 @@ typedef  ^  ParameterType  OutParmType BldNd_OutParam  {:} -  -  "Names and unit
 #typedef  ^  ParameterType  IntKi BldNd_BlOutNd {:} - - "The blade nodes to actually output (ED_AllBldNdOuts)" -
 typedef  ^  ParameterType  IntKi BldNd_BladesOut - - - "The blades to output (ED_AllBldNdOuts)" -
 
-typedef	^	ParameterType	Integer	Jac_u_indx	{:}{:}	-	-	"matrix to help fill/pack the u vector in computing the jacobian"	-
-typedef	^	ParameterType	R8Ki	du	{:}	-	-	"vector that determines size of perturbation for u (inputs)"
-typedef	^	ParameterType	R8Ki	dx	{:}	-	-	"vector that determines size of perturbation for x (continuous states)"
-typedef	^	ParameterType	Integer	Jac_ny	-	-	-	"number of outputs in jacobian matrix"	-
 typedef	^	ParameterType	Logical	CompAeroMaps	-	-	-	"number of outputs in jacobian matrix"	-
-typedef	^	ParameterType	Integer	NumExtendedInputs	-	-	-	"number of extended inputs for linearization"	-
-typedef	^	ParameterType	Integer	NumBl_Lin	-	-	-	"number of blades in the jacobian"	-
-typedef	^	ParameterType	Integer	NActvVelDOF_Lin	-	-	-	"number of velocity states in the jacobian"	-
-typedef	^	ParameterType	Integer	NActvDOF_Lin	-	-	-	"number of active DOFs to use in the jacobian"	-
-typedef	^	ParameterType	Integer	NActvDOF_Stride	-	-	-	"stride for active DOFs to use in the jacobian"	-
 
 # ..... Inputs ....................................................................................................................
 # Define inputs that are contained on the mesh here:

--- a/modules/elastodyn/src/ElastoDyn_Types.f90
+++ b/modules/elastodyn/src/ElastoDyn_Types.f90
@@ -777,16 +777,7 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: BldNd_TotNumOuts = 0_IntKi      !< Total number of requested output channels of blade node information (BldNd_NumOuts * BldNd_BlOutNd * BldNd_BladesOut -- ED_AllBldNdOuts) [-]
     TYPE(OutParmType) , DIMENSION(:), ALLOCATABLE  :: BldNd_OutParam      !< Names and units (and other characteristics) of all requested output parameters [-]
     INTEGER(IntKi)  :: BldNd_BladesOut = 0_IntKi      !< The blades to output (ED_AllBldNdOuts) [-]
-    INTEGER(IntKi) , DIMENSION(:,:), ALLOCATABLE  :: Jac_u_indx      !< matrix to help fill/pack the u vector in computing the jacobian [-]
-    REAL(R8Ki) , DIMENSION(:), ALLOCATABLE  :: du      !< vector that determines size of perturbation for u (inputs) [-]
-    REAL(R8Ki) , DIMENSION(:), ALLOCATABLE  :: dx      !< vector that determines size of perturbation for x (continuous states) [-]
-    INTEGER(IntKi)  :: Jac_ny = 0_IntKi      !< number of outputs in jacobian matrix [-]
     LOGICAL  :: CompAeroMaps = .false.      !< number of outputs in jacobian matrix [-]
-    INTEGER(IntKi)  :: NumExtendedInputs = 0_IntKi      !< number of extended inputs for linearization [-]
-    INTEGER(IntKi)  :: NumBl_Lin = 0_IntKi      !< number of blades in the jacobian [-]
-    INTEGER(IntKi)  :: NActvVelDOF_Lin = 0_IntKi      !< number of velocity states in the jacobian [-]
-    INTEGER(IntKi)  :: NActvDOF_Lin = 0_IntKi      !< number of active DOFs to use in the jacobian [-]
-    INTEGER(IntKi)  :: NActvDOF_Stride = 0_IntKi      !< stride for active DOFs to use in the jacobian [-]
   END TYPE ED_ParameterType
 ! =======================
 ! =========  ED_InputType  =======
@@ -5669,49 +5660,7 @@ subroutine ED_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
       end do
    end if
    DstParamData%BldNd_BladesOut = SrcParamData%BldNd_BladesOut
-   if (allocated(SrcParamData%Jac_u_indx)) then
-      LB(1:2) = lbound(SrcParamData%Jac_u_indx)
-      UB(1:2) = ubound(SrcParamData%Jac_u_indx)
-      if (.not. allocated(DstParamData%Jac_u_indx)) then
-         allocate(DstParamData%Jac_u_indx(LB(1):UB(1),LB(2):UB(2)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%Jac_u_indx.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstParamData%Jac_u_indx = SrcParamData%Jac_u_indx
-   end if
-   if (allocated(SrcParamData%du)) then
-      LB(1:1) = lbound(SrcParamData%du)
-      UB(1:1) = ubound(SrcParamData%du)
-      if (.not. allocated(DstParamData%du)) then
-         allocate(DstParamData%du(LB(1):UB(1)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%du.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstParamData%du = SrcParamData%du
-   end if
-   if (allocated(SrcParamData%dx)) then
-      LB(1:1) = lbound(SrcParamData%dx)
-      UB(1:1) = ubound(SrcParamData%dx)
-      if (.not. allocated(DstParamData%dx)) then
-         allocate(DstParamData%dx(LB(1):UB(1)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%dx.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstParamData%dx = SrcParamData%dx
-   end if
-   DstParamData%Jac_ny = SrcParamData%Jac_ny
    DstParamData%CompAeroMaps = SrcParamData%CompAeroMaps
-   DstParamData%NumExtendedInputs = SrcParamData%NumExtendedInputs
-   DstParamData%NumBl_Lin = SrcParamData%NumBl_Lin
-   DstParamData%NActvVelDOF_Lin = SrcParamData%NActvVelDOF_Lin
-   DstParamData%NActvDOF_Lin = SrcParamData%NActvDOF_Lin
-   DstParamData%NActvDOF_Stride = SrcParamData%NActvDOF_Stride
 end subroutine
 
 subroutine ED_DestroyParam(ParamData, ErrStat, ErrMsg)
@@ -5897,15 +5846,6 @@ subroutine ED_DestroyParam(ParamData, ErrStat, ErrMsg)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       end do
       deallocate(ParamData%BldNd_OutParam)
-   end if
-   if (allocated(ParamData%Jac_u_indx)) then
-      deallocate(ParamData%Jac_u_indx)
-   end if
-   if (allocated(ParamData%du)) then
-      deallocate(ParamData%du)
-   end if
-   if (allocated(ParamData%dx)) then
-      deallocate(ParamData%dx)
    end if
 end subroutine
 
@@ -6161,16 +6101,7 @@ subroutine ED_PackParam(RF, Indata)
       end do
    end if
    call RegPack(RF, InData%BldNd_BladesOut)
-   call RegPackAlloc(RF, InData%Jac_u_indx)
-   call RegPackAlloc(RF, InData%du)
-   call RegPackAlloc(RF, InData%dx)
-   call RegPack(RF, InData%Jac_ny)
    call RegPack(RF, InData%CompAeroMaps)
-   call RegPack(RF, InData%NumExtendedInputs)
-   call RegPack(RF, InData%NumBl_Lin)
-   call RegPack(RF, InData%NActvVelDOF_Lin)
-   call RegPack(RF, InData%NActvDOF_Lin)
-   call RegPack(RF, InData%NActvDOF_Stride)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -6436,16 +6367,7 @@ subroutine ED_UnPackParam(RF, OutData)
       end do
    end if
    call RegUnpack(RF, OutData%BldNd_BladesOut); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%Jac_u_indx); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%du); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%dx); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%Jac_ny); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%CompAeroMaps); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%NumExtendedInputs); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%NumBl_Lin); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%NActvVelDOF_Lin); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%NActvDOF_Lin); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%NActvDOF_Stride); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine ED_CopyInput(SrcInputData, DstInputData, CtrlCode, ErrStat, ErrMsg)

--- a/modules/hydrodyn/src/HydroDyn.txt
+++ b/modules/hydrodyn/src/HydroDyn.txt
@@ -153,10 +153,6 @@ typedef   ^                            ^                             CHARACTER(2
 typedef   ^                            ^                             CHARACTER(ChanLen)       Delim                           -          -          -         "Delimiter string for outputs, defaults to tab-delimiters"        -
 typedef   ^                            ^                             INTEGER                  UnOutFile                       -          -          -         "File unit for the HydroDyn outputs"        -
 typedef   ^                            ^                             INTEGER                  OutDec                          -          -          -         "Write every OutDec time steps"  -
-typedef	  ^                            ^                             Integer	              Jac_u_indx                  {:}{:}         -          -	      "matrix to help fill/pack the u vector in computing the jacobian"	-
-typedef	  ^                            ^                             R8Ki	              du                             {:}         -          -	      "vector that determines size of perturbation for u (inputs)" -
-typedef	  ^                            ^                             R8Ki	              dx                             {:}         -          -	      "vector that determines size of perturbation for x (continuous states)" -
-typedef	  ^                            ^                             Integer	              Jac_ny	                      -	         -          -	      "number of outputs in jacobian matrix"	-
 typedef   ^                            ^                             logical                  VisMeshes                       -       .false.       -         "Output visualization meshes" -
 typedef   ^                            ^                             SeaSt_WaveFieldType     *WaveField                       -          -          -         "Pointer to SeaState wave field" -
 typedef   ^                            ^                             INTEGER                  PtfmYMod                        -          -          -         "Large yaw model" - 

--- a/modules/hydrodyn/src/HydroDyn_Types.f90
+++ b/modules/hydrodyn/src/HydroDyn_Types.f90
@@ -170,10 +170,6 @@ IMPLICIT NONE
     CHARACTER(ChanLen)  :: Delim      !< Delimiter string for outputs, defaults to tab-delimiters [-]
     INTEGER(IntKi)  :: UnOutFile = 0_IntKi      !< File unit for the HydroDyn outputs [-]
     INTEGER(IntKi)  :: OutDec = 0_IntKi      !< Write every OutDec time steps [-]
-    INTEGER(IntKi) , DIMENSION(:,:), ALLOCATABLE  :: Jac_u_indx      !< matrix to help fill/pack the u vector in computing the jacobian [-]
-    REAL(R8Ki) , DIMENSION(:), ALLOCATABLE  :: du      !< vector that determines size of perturbation for u (inputs) [-]
-    REAL(R8Ki) , DIMENSION(:), ALLOCATABLE  :: dx      !< vector that determines size of perturbation for x (continuous states) [-]
-    INTEGER(IntKi)  :: Jac_ny = 0_IntKi      !< number of outputs in jacobian matrix [-]
     LOGICAL  :: VisMeshes = .false.      !< Output visualization meshes [-]
     TYPE(SeaSt_WaveFieldType) , POINTER :: WaveField => NULL()      !< Pointer to SeaState wave field [-]
     INTEGER(IntKi)  :: PtfmYMod = 0_IntKi      !< Large yaw model [-]
@@ -1384,43 +1380,6 @@ subroutine HydroDyn_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, Err
    DstParamData%Delim = SrcParamData%Delim
    DstParamData%UnOutFile = SrcParamData%UnOutFile
    DstParamData%OutDec = SrcParamData%OutDec
-   if (allocated(SrcParamData%Jac_u_indx)) then
-      LB(1:2) = lbound(SrcParamData%Jac_u_indx)
-      UB(1:2) = ubound(SrcParamData%Jac_u_indx)
-      if (.not. allocated(DstParamData%Jac_u_indx)) then
-         allocate(DstParamData%Jac_u_indx(LB(1):UB(1),LB(2):UB(2)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%Jac_u_indx.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstParamData%Jac_u_indx = SrcParamData%Jac_u_indx
-   end if
-   if (allocated(SrcParamData%du)) then
-      LB(1:1) = lbound(SrcParamData%du)
-      UB(1:1) = ubound(SrcParamData%du)
-      if (.not. allocated(DstParamData%du)) then
-         allocate(DstParamData%du(LB(1):UB(1)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%du.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstParamData%du = SrcParamData%du
-   end if
-   if (allocated(SrcParamData%dx)) then
-      LB(1:1) = lbound(SrcParamData%dx)
-      UB(1:1) = ubound(SrcParamData%dx)
-      if (.not. allocated(DstParamData%dx)) then
-         allocate(DstParamData%dx(LB(1):UB(1)), stat=ErrStat2)
-         if (ErrStat2 /= 0) then
-            call SetErrStat(ErrID_Fatal, 'Error allocating DstParamData%dx.', ErrStat, ErrMsg, RoutineName)
-            return
-         end if
-      end if
-      DstParamData%dx = SrcParamData%dx
-   end if
-   DstParamData%Jac_ny = SrcParamData%Jac_ny
    DstParamData%VisMeshes = SrcParamData%VisMeshes
    DstParamData%WaveField => SrcParamData%WaveField
    DstParamData%PtfmYMod = SrcParamData%PtfmYMod
@@ -1478,15 +1437,6 @@ subroutine HydroDyn_DestroyParam(ParamData, ErrStat, ErrMsg)
          call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
       end do
       deallocate(ParamData%OutParam)
-   end if
-   if (allocated(ParamData%Jac_u_indx)) then
-      deallocate(ParamData%Jac_u_indx)
-   end if
-   if (allocated(ParamData%du)) then
-      deallocate(ParamData%du)
-   end if
-   if (allocated(ParamData%dx)) then
-      deallocate(ParamData%dx)
    end if
    nullify(ParamData%WaveField)
 end subroutine
@@ -1549,10 +1499,6 @@ subroutine HydroDyn_PackParam(RF, Indata)
    call RegPack(RF, InData%Delim)
    call RegPack(RF, InData%UnOutFile)
    call RegPack(RF, InData%OutDec)
-   call RegPackAlloc(RF, InData%Jac_u_indx)
-   call RegPackAlloc(RF, InData%du)
-   call RegPackAlloc(RF, InData%dx)
-   call RegPack(RF, InData%Jac_ny)
    call RegPack(RF, InData%VisMeshes)
    call RegPack(RF, associated(InData%WaveField))
    if (associated(InData%WaveField)) then
@@ -1639,10 +1585,6 @@ subroutine HydroDyn_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%Delim); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%UnOutFile); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%OutDec); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%Jac_u_indx); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%du); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpackAlloc(RF, OutData%dx); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%Jac_ny); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%VisMeshes); if (RegCheckErr(RF, RoutineName)) return
    if (associated(OutData%WaveField)) deallocate(OutData%WaveField)
    call RegUnpack(RF, IsAllocAssoc); if (RegCheckErr(RF, RoutineName)) return

--- a/modules/seastate/src/SeaState.txt
+++ b/modules/seastate/src/SeaState.txt
@@ -174,14 +174,3 @@ typedef   ^                  ^                      GridInterp_MiscVarType      
 typedef   ^                  ^                      ModJacType                     Jac                -       -      -  "Values corresponding to module variables"  -
 typedef	  ^                  ^                      SeaSt_InputType                u_perturb          -       -      -  "Input type for linearization perturbation"   -
 typedef	  ^                  ^                      SeaSt_OutputType               y_lin              -       -      -  "Output type for linearization perturbation"   -
-
-# typedef   ^                  Jac_u_idxStarts        IntKi                          Extended           -       1      -  "Index to first point in u jacobian for Extended" -
-# typedef   ^                  Jac_y_idxStarts        IntKi                          Extended           -       1      -  "Index to first point in y jacobian for Extended" -
-# typedef   ^                  Jac_y_idxStarts        IntKi                          WrOuts             -       2      -  "Index to first point in y jacobian for WrOuts" -
-# typedef   ^                  SeaSt_LinParams        IntKi                          NumExtendedInputs  -       1      -  "number of extended inputs" -
-# typedef   ^                  ^                      IntKi                          NumExtendedOutputs -       1      -  "number of extended outputs" -
-# typedef   ^                  ^                      Jac_u_idxStarts                Jac_u_idxStartList -       -      -  "Starting indices for all Jac_u components" -
-# typedef   ^                  ^                      Jac_y_idxStarts                Jac_y_idxStartList -       -      -  "Starting indices for all Jac_y components" -
-# typedef   ^                  ^                      ReKi                           du                 {:}     -      -  "vector that determines size of perturbation for u (inputs)"
-# typedef   ^                  ^                      IntKi                          Jac_nu             -       -      -  "number of inputs  in jacobian matrix"   -
-# typedef   ^                  ^                      IntKi                          Jac_ny             -       -      -  "number of outputs in jacobian matrix"   -


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
There are a few unused variables leftover from the tight coupling updates.  This removes a few of them.

**Related issue, if one exists**
Probably a half dozen... but whatever

**Impacted areas of the software**
No impacts to functionality.  Just a bit cleaner.

The following registry files are impacted:
* ED
* HD
* SS

**Generative AI usage**
None

**Test results, if applicable**
No results change