### PR TITLE
SeaState: Logic for near-surface current

### DIFF
--- a/modules/seastate/src/SeaState_Input.f90
+++ b/modules/seastate/src/SeaState_Input.f90
@@ -983,8 +983,8 @@ subroutine SeaStateInput_ProcessInitData( InitInp, p, InputFileData, ErrStat, Er
       !------------------------- Near-surface current ------------------------
 
       ! CurrNSRef - Near-surface current reference depth.
-      if ( InputFileData%Current%CurrNSRef <= 0.0 ) then
-         call SetErrStat( ErrID_Fatal,'CurrNSRef must be greater than zero.',ErrStat,ErrMsg,RoutineName)
+      if ( InputFileData%Current%CurrNSV0 /= 0.0_SiKi .AND. InputFileData%Current%CurrNSRef <= 0.0_SiKi ) then
+         call SetErrStat( ErrID_Fatal,'CurrNSRef must be greater than zero when CurrNSV0 is nonzero.',ErrStat,ErrMsg,RoutineName)
          return
       end if
 


### PR DESCRIPTION
This PR is ready to be merged

**Feature or improvement description**
SeaState has three sub-models for current. From [readthedocs](https://openfast.readthedocs.io/en/main/source/user/seastate/input_files.html#current):

<img width="711" height="490" alt="image" src="https://github.com/user-attachments/assets/57e3cc3e-e1f9-4ad8-b9ef-1c2249b76779" />

In my case, I wanted to use only the depth-independent sub-model. So, I defined the input file as follows:
<img width="985" height="142" alt="image" src="https://github.com/user-attachments/assets/e94804f0-19c4-49e0-b091-c9a7ceffa67d" />

However, OpenFAST aborted complaining that the near-surface current reference depth (CurrNSRef) [sub-model that I'm not using] had to be greater than zero. 
<img width="879" height="185" alt="image" src="https://github.com/user-attachments/assets/1690ccce-1ab7-427f-9248-fc0cc5aad21e" />

This is because SeaState is using an internal logic that checks some input parameters even if there any not used.

The proposed change should fix this by using a logic that applies only if the user is using the near-surface sub-model. For example: checking for the near-surface current reference depth, **only if** the near-surface current velocity at still water level is different than zero.