### PR TITLE
vs-build: change OpenFAST-Simulink target name

### DIFF
--- a/vs-build/glue-codes/OpenFAST-Simulink.vfproj
+++ b/vs-build/glue-codes/OpenFAST-Simulink.vfproj
@@ -15,7 +15,7 @@
 			<Tool Name="VFPostBuildEventTool"/>
 			<Tool Name="VFManifestTool" SuppressStartupBanner="true"/>
 		</Configuration>
-		<Configuration Name="Matlab_Release|x64" UseCompiler="ifxCompiler" OutputDirectory="..\..\build\bin\" IntermediateDirectory="..\..\build\$(Configuration)_$(Platform)\$(ProjectName)\" TargetName="$(ProjectName)_$(Configuration)" ConfigurationType="typeDynamicLibrary" WholeProgramOptimization="true">
+		<Configuration Name="Matlab_Release|x64" UseCompiler="ifxCompiler" OutputDirectory="..\..\build\bin\" IntermediateDirectory="..\..\build\$(Configuration)_$(Platform)\$(ProjectName)\" TargetName="$(ProjectName)" ConfigurationType="typeDynamicLibrary" WholeProgramOptimization="true">
 			<Tool Name="VFFortranCompilerTool" SuppressStartupBanner="true" MultiProcessorCompilation="true" Preprocess="preprocessYes" PreprocessorDefinitions="COMPILE_SIMULINK" StandardWarnings="standardWarningsF03" DisableSpecificDiagnostics="5268,5199"/>
 			<Tool Name="VFLinkerTool" SuppressStartupBanner="true" GenerateManifest="false" SubSystem="subSystemWindows" LinkDLL="true" AdditionalDependencies="&quot;$(MATLAB_ROOT)\extern\lib\win64\microsoft\libmex.lib&quot;"/>
 			<Tool Name="VFResourceCompilerTool"/>


### PR DESCRIPTION
Ready to merge.

**Feature or improvement description**
Changed build target release name from `OpenFAST-Simulink_Matlab_Release.dll` to `OpenFAST-Simulink.dll`

During the `deploy` step on GitHub, the `mex` function build call uses the `OpenFAST-Simulink_Matlab_Release.lib` file to set the name of the linked DLL.  However, we rename the DLL itself to not include `_Matlab_Release` in the name, but the .lib file still contains this. This causes a discrepancy between the linked name in the mexw64 and the provided DLL.

Rather than hack the .lib file to change the name in there, we'll simply modify the vfproj file to produce the `OpenFAST-Simulink.dll` and corresponding `.lib` file with the correct name information in it.


**Related issue, if one exists**
This fixes issue #3274

**Impacted areas of the software**
This really only affects the automated Windows builds for the Matlab Simulink mex function.

**Additional supporting information**
The alternative approach would be to not rename the resulting `dll` file for Simulink, but this approach is simpler.

**Generative AI usage**
None

**Test results, if applicable**
No changes