### PR TITLE
SubDyn: Y3 mesh

### DIFF
--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -887,7 +887,7 @@ SUBROUTINE SD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
             ! Construct the direction cosine matrix given the output angles
             CALL SmllRotTrans( 'UR_bar input angles', m%U_full_NS(DOFList(4)), m%U_full_NS(DOFList(5)), m%U_full_NS(DOFList(6)), DCM, '', ErrStat2, ErrMsg2); if(Failed()) return
             y%Y2mesh%Orientation     (:,:,iSDNode)   = DCM
-            y%Y2mesh%TranslationDisp (:,iSDNode)     = m%U_full_NS     (DOFList(1:3)) !Y2: Guyan+CB (but no SIM) displacements
+            y%Y2mesh%TranslationDisp (:,iSDNode)     = m%U_full        (DOFList(1:3)) !Y2: Guyan+CB (with SIM) displacements
             y%Y2mesh%TranslationVel  (:,iSDNode)     = m%U_full_dot    (DOFList(1:3))
             y%Y2mesh%TranslationAcc  (:,iSDNode)     = m%U_full_dotdot (DOFList(1:3))
             y%Y2mesh%RotationVel     (:,iSDNode)     = m%U_full_dot    (DOFList(4:6))

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -869,7 +869,7 @@ SUBROUTINE SD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
             ! --- Rigid body displacements for hydrodyn
             y%Y2mesh%Orientation     (:,:,iSDNode)   = Rg2b
             y%Y2mesh%TranslationDisp (:,iSDNode)     = duP(1:3)                       ! Y2: NOTE: only the rigid-body displacements for floating
-            ! --- Full elastic displacements for others (moordyn)
+            ! --- Elastic displacements without SIM for others (Moordyn)
             y%Y3mesh%Orientation     (:,:,iSDNode)   = EulerConstructZYX(m%U_full_NS(DOFList(4:6)))
             y%Y3mesh%TranslationDisp (:,iSDNode)     = m%U_full_NS     (DOFList(1:3)) ! Y3: Guyan+CB (but no SIM) displacements
             ! --- Elastic velocities and accelerations 
@@ -880,22 +880,32 @@ SUBROUTINE SD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
             end associate
          enddo
       else
-         ! --- Fixed bottom - Y3 and Y2 meshes are identical in this case
+         ! --- Fixed bottom
+         ! Y2: Guyan+CB displacements without SIM
+         ! Y3 = Y2 for all nodes (Guyan+CB, no SIM), then overwrite reaction node(s) with SIM correction for SoilDyn
          do iSDNode = 1,p%nNodes
             associate(DOFList => p%NodesDOF(iSDNode)%List)  ! Alias to shorten notations
             ! TODO TODO which orientation to give for joints with more than 6 dofs?
             ! Construct the direction cosine matrix given the output angles
             CALL SmllRotTrans( 'UR_bar input angles', m%U_full_NS(DOFList(4)), m%U_full_NS(DOFList(5)), m%U_full_NS(DOFList(6)), DCM, '', ErrStat2, ErrMsg2); if(Failed()) return
             y%Y2mesh%Orientation     (:,:,iSDNode)   = DCM
-            y%Y2mesh%TranslationDisp (:,iSDNode)     = m%U_full        (DOFList(1:3)) !Y2: Guyan+CB (with SIM) displacements
+            y%Y2mesh%TranslationDisp (:,iSDNode)     = m%U_full_NS     (DOFList(1:3)) !Y2: Guyan+CB (but no SIM) displacements
             y%Y2mesh%TranslationVel  (:,iSDNode)     = m%U_full_dot    (DOFList(1:3))
             y%Y2mesh%TranslationAcc  (:,iSDNode)     = m%U_full_dotdot (DOFList(1:3))
             y%Y2mesh%RotationVel     (:,iSDNode)     = m%U_full_dot    (DOFList(4:6))
             y%Y2mesh%RotationAcc     (:,iSDNode)     = m%U_full_dotdot (DOFList(4:6))
+            if (any(p%Nodes_C(:,1) == iSDNode)) then
+               ! Reaction node: Y3 gets Guyan+CB+SIM displacements (for SoilDyn)
+               CALL SmllRotTrans( 'UR_bar input angles', m%U_full(DOFList(4)), m%U_full(DOFList(5)), m%U_full(DOFList(6)), DCM, '', ErrStat2, ErrMsg2); if(Failed()) return
+               y%Y3mesh%Orientation     (:,:,iSDNode)   = DCM
+               y%Y3mesh%TranslationDisp (:,iSDNode)     = m%U_full        (DOFList(1:3)) ! Y3: Guyan+CB+SIM displacements
+            else
+               ! Non-reaction node: Y3 = Y2
+               y%Y3mesh%Orientation     (:,:,iSDNode) = y%Y2mesh%Orientation     (:,:,iSDNode)
+               y%Y3mesh%TranslationDisp (:,iSDNode)   = y%Y2mesh%TranslationDisp (:,iSDNode)
+            end if
             end associate
          enddo
-         y%Y3mesh%TranslationDisp = y%Y2mesh%TranslationDisp
-         y%Y3mesh%Orientation     = y%Y2mesh%Orientation
       endif
       ! --- Y3 mesh and Y2 mesh both have elastic (Guyan+CB) velocities and accelerations
       y%Y3mesh%TranslationVel = y%Y2mesh%TranslationVel

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -894,16 +894,18 @@ SUBROUTINE SD_CalcOutput( t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg )
             y%Y2mesh%TranslationAcc  (:,iSDNode)     = m%U_full_dotdot (DOFList(1:3))
             y%Y2mesh%RotationVel     (:,iSDNode)     = m%U_full_dot    (DOFList(4:6))
             y%Y2mesh%RotationAcc     (:,iSDNode)     = m%U_full_dotdot (DOFList(4:6))
-            if (any(p%Nodes_C(:,1) == iSDNode)) then
-               ! Reaction node: Y3 gets Guyan+CB+SIM displacements (for SoilDyn)
-               CALL SmllRotTrans( 'UR_bar input angles', m%U_full(DOFList(4)), m%U_full(DOFList(5)), m%U_full(DOFList(6)), DCM, '', ErrStat2, ErrMsg2); if(Failed()) return
-               y%Y3mesh%Orientation     (:,:,iSDNode)   = DCM
-               y%Y3mesh%TranslationDisp (:,iSDNode)     = m%U_full        (DOFList(1:3)) ! Y3: Guyan+CB+SIM displacements
-            else
-               ! Non-reaction node: Y3 = Y2
-               y%Y3mesh%Orientation     (:,:,iSDNode) = y%Y2mesh%Orientation     (:,:,iSDNode)
-               y%Y3mesh%TranslationDisp (:,iSDNode)   = y%Y2mesh%TranslationDisp (:,iSDNode)
-            end if
+            end associate
+         enddo
+         ! Y3 = Y2 for all nodes (Guyan+CB, no SIM)
+         y%Y3mesh%TranslationDisp = y%Y2mesh%TranslationDisp
+         y%Y3mesh%Orientation     = y%Y2mesh%Orientation
+         ! Overwrite reaction node(s) in Y3 mesh with full elastic displacements including SIM (for SoilDyn) 
+         do i = 1, p%nNodes_C
+            iSDNode = p%Nodes_C(i,1)
+            associate(DOFList => p%NodesDOF(iSDNode)%List)  ! Alias to shorten notations
+            CALL SmllRotTrans( 'UR_bar input angles', m%U_full(DOFList(4)), m%U_full(DOFList(5)), m%U_full(DOFList(6)), DCM, '', ErrStat2, ErrMsg2); if(Failed()) return
+            y%Y3mesh%Orientation     (:,:,iSDNode)   = DCM
+            y%Y3mesh%TranslationDisp (:,iSDNode)     = m%U_full        (DOFList(1:3)) ! Y3: Guyan+CB+SIM displacements
             end associate
          enddo
       endif


### PR DESCRIPTION
I believe this PR is ready to be merged. 

r-tests using SoilDyn are expected to return different results.

**Feature or improvement description**
In PR https://github.com/OpenFAST/openfast/pull/1526, the static improvement method (SIM) was removed from the elastic displacement output in SubDyn's Y3 mesh. The rationale was that SIM-corrected displacements were not consistent with the elastic velocities and accelerations, which do not account for SIM contributions from truncated higher modes. This change was introduced to avoid issues with MoorDyn in floating systems.

However, this change introduced an inconsistency for fixed-bottom systems: the full elastic displacement at the reaction node in SubDyn (Guyan + CB + SIM) differs from the displacement passed to SoilDyn via the Y3 mesh (Guyan + CB only, no SIM).

To overcome this limitation, the Y3 mesh for fixed-bottom systems has been modified. The proposed code **modifies only the displacements of the reaction node(s) to include the full elastic displacements (Guyan+CB+SIM)**.  All other nodes in the Y3 mesh retain their existing Guyan + CB displacements, preserving consistency between displacements and their time derivatives (velocities and accelerations). This should also ensure correctness for MoorDyn connections to non-reaction nodes in fixed-bottom systems. The only unaddressed edge case is a MoorDyn connection directly to a SubDyn reaction node, which is not an expected configuration.

**Related issue, if one exists**
Extensive documentation and testing can be found here: https://github.com/OpenFAST/openfast/issues/3293

**Impacted areas of the software**
SubDyn Y3 mesh output for fixed-bottom systems. I believe this mesh is currently used by SoilDyn and MoorDyn.