### PR TITLE
SubDyn: JSON output file with local x_e axis for circular beams

### DIFF
--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -4210,10 +4210,10 @@ SUBROUTINE WriteJSONCommon(FileName, Init, p, m, InitInput, FileKind, UnSum, Err
    do i = 1, size(p%ElemProps)
       if (p%ElemProps(i)%eType == idMemberBeamRect) then
          ! Rectangular beam: MType = 1r. eType = -1
-         write(UnSum, '(A,I0,A,F8.4,A,F8.4,A,F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "rectangle", "type": ',p%ElemProps(i)%eType, ', "SideA":',p%ElemProps(i)%Sa(1), ', "SideB":',p%ElemProps(i)%Sb(1), ', "SideA_dir":[',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
+         write(UnSum, '(A,I0,A,F8.4,A,F8.4,A,F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "rectangle", "type": ',p%ElemProps(i)%eType, ', "SideA":',p%ElemProps(i)%Sa(1), ', "SideB":',p%ElemProps(i)%Sb(1), ', "SideA_dir": [',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
       else
          ! Cylindrical shapes (MType = 1 or 1c [cylindrical beam], 2 [cable element], 3 [rigid link]. eType = 1, 2, 3)
-         write(UnSum, '(A,I0,A,F8.4,A,F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1), ', "x_e":[',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
+         write(UnSum, '(A,I0,A,F8.4,A,F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1), ', "x_e": [',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
       endif
       if (i<size(p%ElemProps)) write(UnSum, '(A)', advance='no')','//NewLine 
    enddo

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -4210,10 +4210,10 @@ SUBROUTINE WriteJSONCommon(FileName, Init, p, m, InitInput, FileKind, UnSum, Err
    do i = 1, size(p%ElemProps)
       if (p%ElemProps(i)%eType == idMemberBeamRect) then
          ! Rectangular beam: MType = 1r. eType = -1
-         write(UnSum, '(A,I0,A,F8.4,A,F8.4,A, F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "rectangle", "type": ',p%ElemProps(i)%eType, ', "SideA":',p%ElemProps(i)%Sa(1), ', "SideB":',p%ElemProps(i)%Sb(1), ', "SideA_dir":[',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
+         write(UnSum, '(A,I0,A,F8.4,A,F8.4,A,F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "rectangle", "type": ',p%ElemProps(i)%eType, ', "SideA":',p%ElemProps(i)%Sa(1), ', "SideB":',p%ElemProps(i)%Sb(1), ', "SideA_dir":[',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
       else
          ! Cylindrical shapes (MType = 1 or 1c [cylindrical beam], 2 [cable element], 3 [rigid link]. eType = 1, 2, 3)
-         write(UnSum, '(A,I0,A,F8.4,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1),'}'
+         write(UnSum, '(A,I0,A,F8.4,A,F10.6,A,F10.6,A,F10.6,A)', advance='no') '  {"shape": "cylinder", "type": ',p%ElemProps(i)%eType, ', "Diam":',p%ElemProps(i)%D(1), ', "x_e":[',p%ElemProps(i)%DirCos(1,1), ',',p%ElemProps(i)%DirCos(2,1), ',',p%ElemProps(i)%DirCos(3,1),']}'
       endif
       if (i<size(p%ElemProps)) write(UnSum, '(A)', advance='no')','//NewLine 
    enddo


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
The proposed code modifies the JSON output file from SubDyn. Now, the local _x_e_ local axis for circular beams is also written down in the output file (similar to what we do with the rectangular beams using _SideA_dir_). This allows to visualize the local coordinate system in viz3Danim (see for reference: https://github.com/ebranlard/viz3Danim/pull/9).
<img width="1598" height="343" alt="image" src="https://github.com/user-attachments/assets/38691561-85c6-45c7-ae38-6f1ade834eec" />

With this modification, the user can orientate the local _x_e_ and _y_e_ axes for circular beams using the spin angle (`MSpin`) in SubDyn. Till now, we were computing the default _x_e_ and _y_e_ axes in circular beams within viz3Danim without accounting for the spin angle because we didn't have visibility about it. Now, this information is available for viz3Danim and it can be parsed.

**Related issue, if one exists**
https://github.com/ebranlard/viz3Danim/issues/10

**Impacted areas of the software**
JSON output file from SubDyn.