### PR TITLE
SoilDyn/SubDyn: reaction loads when REDWIN is used

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -907,6 +907,9 @@ SUBROUTINE FAST_InitializeAll( t_initial, m_Glue, p_FAST, y_FAST, m_FAST, ED, SE
                     SlD%y, SlD%m, dt_module, Init%OutData_SlD, ErrStat2, ErrMsg2)
       if (Failed()) return
 
+      ! Pass nonlinear flag to SubDyn: true only when REDWIN DLL is active (CalcOption=3)
+      Init%InData_SD%SlDNonLinear = SlD%p%UseREDWINinterface ! REDWIN DLL returning nonlinear soil reaction forces      
+
       ! Add module to list of modules, return on error
       CALL MV_AddModule(m_Glue%ModData, Module_SlD, 'SlD', 1, dt_module, p_FAST%DT, &
                         Init%OutData_SlD%Vars, p_FAST%Linearize, ErrStat2, ErrMsg2)

--- a/modules/soildyn/src/SoilDyn.f90
+++ b/modules/soildyn/src/SoilDyn.f90
@@ -109,9 +109,11 @@ subroutine SlD_Init(InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitOut
    z%DummyConstrState = 0.0_ReKi
    OtherState%DummyOtherState = 0.0_ReKi
 
-   ! are the returned reaction forces only the non-linear portion (used when SubDyn is calculating the linear portion)
+   ! The linear soil stiffness is passed directly to SubDyn as a stiffness matrix (not as a load)
+   ! The nonlinear portion of reaction forces is only computed when REDWIN DLL is active and passed as loads.
    p%SlDNonLinearForcePortionOnly = InitInp%SlDNonLinearForcePortionOnly
-   if (p%SlDNonLinearForcePortionOnly) call WrScr(' SoilDyn returning only non-linear portion of reaction forces')
+   call WrScr(' SoilDyn: linear stiffness passed directly to SubDyn as a stiffness matrix')
+   if (p%CalcOption == Calc_REDWIN) call WrScr(' SoilDyn: nonlinear soil reaction loads computed by REDWIN')
 
    ! If the module does not implement the four Jacobian routines at the end of this template, or the module cannot
    ! linearize with the features that are enabled, stop the simulation if InitInp%Linearize is true.

--- a/modules/subdyn/src/SubDyn.f90
+++ b/modules/subdyn/src/SubDyn.f90
@@ -479,6 +479,9 @@ SUBROUTINE SD_Init( InitInput, u, p, x, xd, z, OtherState, y, m, Interval, InitO
    ! Initialize the outputs & Store mapping between nodes and elements  
    CALL SDOUT_Init( Init, y, p, m, InitOut, InitInput%WtrDpth, ErrStat2, ErrMsg2 ); if(Failed()) return
    
+   ! Flag from glue code: if SoilDyn is returning nonlinear loads
+   p%SlDNonLinear = InitInput%SlDNonLinear
+
    ! Determine if we need to perform output file handling
    IF ( p%OutSwtch == 1 .OR. p%OutSwtch == 3 ) THEN  
        CALL SDOUT_OpenOutput( SD_ProgDesc, Init%RootName, p, InitOut, ErrStat2, ErrMsg2 ); if(Failed()) return

--- a/modules/subdyn/src/SubDyn_Output.f90
+++ b/modules/subdyn/src/SubDyn_Output.f90
@@ -476,6 +476,9 @@ SUBROUTINE SDOut_MapOutputs(u,p,x, y, m, AllOuts, ErrStat, ErrMsg )
       ENDDO
       ! Store into AllOuts
       AllOuts( ReactSS(1:nDOFL_TP) ) = matmul(p%TIreact,ReactNs)
+      ! When SoilDyn nonlinear loads are active (e.g., SoilDyn CalcOption = 3), SubDyn reaction loads are incomplete (only the linear part is included)
+      ! The total reaction at each base reaction joint is available in the SoilDyn output sensors (e.g., "Sld1Fxg Sld1Fyg Sld1Fzg Sld1Mxg Sld1Myg Sld1Mzg")
+      IF (p%SlDNonLinear) AllOuts( ReactSS(1:nDOFL_TP) ) = NaN
    ENDIF
    if (allocated(ReactNs)) deallocate(ReactNs)
 contains

--- a/modules/subdyn/src/SubDyn_Output.f90
+++ b/modules/subdyn/src/SubDyn_Output.f90
@@ -443,42 +443,45 @@ SUBROUTINE SDOut_MapOutputs(u,p,x, y, m, AllOuts, ErrStat, ErrMsg )
    ! --------------------------------------------------------------------------------{
    ! Total base reaction forces and moments at the (0.,0.,-WtrDpth) location in SS coordinate system
    !    "ReactFXss, ReactFYss, ReactFZss, ReactMXss, ReactMYss, ReactMZss"
-   IF (p%OutReact) THEN 
-      ALLOCATE ( ReactNs(6*p%nNodes_C), STAT = ErrStat )
-      IF ( ErrStat /= ErrID_None ) THEN
-         ErrMsg  = ' Error allocating space for ReactNs array.'
-         ErrStat = ErrID_Fatal
-         RETURN
-      END IF
-      ReactNs = 0.0_ReKi !Initialize
-      DO I=1,p%nNodes_C   !Do for each constrained node, they are ordered as given in the input file and so as in the order of y2mesh
-         FK_elm2=0._ReKi !Initialize for cumulative force
-         FM_elm2=0._ReKi !Initialize
-         pLst => p%MOutLst3(I)
-         !Find the joint forces
-         DO J=1,SIZE(pLst%ElmIDs(1,:))  !for all the elements connected (normally 1)
-            iiNode = 1
-            call ElementForce(pLst, iiNode, J, FM_elm, FK_elm, sgn, DIRCOS, .false.)
-            !transform back to global, need to do 3 at a time since cosine matrix is 3x3
-            DO L=1,2  
-               FM_elm2((L-1)*3+1:L*3) = FM_elm2((L-1)*3+1:L*3) + matmul(transpose(DIRCOS),FM_elm((L-1)*3+1:L*3))  !sum forces at joint in GLOBAL REF
-               FK_elm2((L-1)*3+1:L*3) = FK_elm2((L-1)*3+1:L*3) + matmul(transpose(DIRCOS),FK_elm((L-1)*3+1:L*3))  !signs may be wrong, we will fix that later;  
-               ! I believe this is all fixed in terms of signs now ,RRD 5/20/13
-            ENDDO           
+   IF (p%OutReact) THEN
+      IF (p%SlDNonLinear) THEN
+         ! When SoilDyn nonlinear loads are active (e.g., SoilDyn CalcOption = 3), SubDyn reaction loads are incomplete (only the linear part is included)
+         ! The total reaction at each base reaction joint is available in the SoilDyn output sensors (e.g., "Sld1Fxg Sld1Fyg Sld1Fzg Sld1Mxg Sld1Myg Sld1Mzg")
+         AllOuts( ReactSS(1:nDOFL_TP) ) = NaN
+      ELSE
+         ALLOCATE ( ReactNs(6*p%nNodes_C), STAT = ErrStat )
+         IF ( ErrStat /= ErrID_None ) THEN
+            ErrMsg  = ' Error allocating space for ReactNs array.'
+            ErrStat = ErrID_Fatal
+            RETURN
+         END IF
+         ReactNs = 0.0_ReKi !Initialize
+         DO I=1,p%nNodes_C   !Do for each constrained node, they are ordered as given in the input file and so as in the order of y2mesh
+            FK_elm2=0._ReKi !Initialize for cumulative force
+            FM_elm2=0._ReKi !Initialize
+            pLst => p%MOutLst3(I)
+            !Find the joint forces
+            DO J=1,SIZE(pLst%ElmIDs(1,:))  !for all the elements connected (normally 1)
+               iiNode = 1
+               call ElementForce(pLst, iiNode, J, FM_elm, FK_elm, sgn, DIRCOS, .false.)
+               !transform back to global, need to do 3 at a time since cosine matrix is 3x3
+               DO L=1,2
+                  FM_elm2((L-1)*3+1:L*3) = FM_elm2((L-1)*3+1:L*3) + matmul(transpose(DIRCOS),FM_elm((L-1)*3+1:L*3))  !sum forces at joint in GLOBAL REF
+                  FK_elm2((L-1)*3+1:L*3) = FK_elm2((L-1)*3+1:L*3) + matmul(transpose(DIRCOS),FK_elm((L-1)*3+1:L*3))  !signs may be wrong, we will fix that later;
+                  ! I believe this is all fixed in terms of signs now ,RRD 5/20/13
+               ENDDO
+            ENDDO
+            ! FK_elm2 ! + FM_elm2  !removed the inertial component 12/13 !Not sure why I need an intermediate step here, but the sum would not work otherwise
+            ! NEED TO ADD HYDRODYNAMIC FORCES AT THE RESTRAINT NODES
+            iSDNode   = p%Nodes_C(I,1)
+            iMeshNode = iSDNode ! input and Y2 mesh nodes are the same as subdyn
+            Fext =  (/ u%LMesh%Force(:,iMeshNode), u%LMesh%Moment(:,iMeshNode) /) + p%FG(p%NodesDOF(iMeshNode)%List(1:6))
+            Fext(1:3) = Fext(1:3) + p%FC(p%NodesDOF(iMeshNode)%List(1:3))
+            ReactNs((I-1)*6+1:6*I) = FK_elm2 - Fext  !Accumulate reactions from all nodes in GLOBAL COORDINATES
          ENDDO
-         ! FK_elm2 ! + FM_elm2  !removed the inertial component 12/13 !Not sure why I need an intermediate step here, but the sum would not work otherwise
-         ! NEED TO ADD HYDRODYNAMIC FORCES AT THE RESTRAINT NODES
-         iSDNode   = p%Nodes_C(I,1) 
-         iMeshNode = iSDNode ! input and Y2 mesh nodes are the same as subdyn
-         Fext =  (/ u%LMesh%Force(:,iMeshNode), u%LMesh%Moment(:,iMeshNode) /) + p%FG(p%NodesDOF(iMeshNode)%List(1:6))
-         Fext(1:3) = Fext(1:3) + p%FC(p%NodesDOF(iMeshNode)%List(1:3))
-         ReactNs((I-1)*6+1:6*I) = FK_elm2 - Fext  !Accumulate reactions from all nodes in GLOBAL COORDINATES
-      ENDDO
-      ! Store into AllOuts
-      AllOuts( ReactSS(1:nDOFL_TP) ) = matmul(p%TIreact,ReactNs)
-      ! When SoilDyn nonlinear loads are active (e.g., SoilDyn CalcOption = 3), SubDyn reaction loads are incomplete (only the linear part is included)
-      ! The total reaction at each base reaction joint is available in the SoilDyn output sensors (e.g., "Sld1Fxg Sld1Fyg Sld1Fzg Sld1Mxg Sld1Myg Sld1Mzg")
-      IF (p%SlDNonLinear) AllOuts( ReactSS(1:nDOFL_TP) ) = NaN
+         ! Store into AllOuts
+         AllOuts( ReactSS(1:nDOFL_TP) ) = matmul(p%TIreact,ReactNs)
+      ENDIF
    ENDIF
    if (allocated(ReactNs)) deallocate(ReactNs)
 contains

--- a/modules/subdyn/src/SubDyn_Registry.txt
+++ b/modules/subdyn/src/SubDyn_Registry.txt
@@ -78,6 +78,7 @@ typedef  ^  InitInputType  ReKi             TP_RefPoint  {3}{:} - -  "global pos
 typedef  ^  InitInputType  ReKi             SubRotateZ   - - -       "Rotation angle in degrees about global Z"
 typedef  ^  InitInputType  ReKi             SoilStiffness ::: - -    "Soil stiffness matrices from SoilDyn" '(N/m, N-m/rad)'
 typedef  ^  InitInputType  MeshType         SoilMesh     - - -       "Mesh for soil stiffness locations" -
+typedef  ^  InitInputType  Logical          SlDNonLinear - - -       "Flag indicating that SoilDyn is returning nonlinear loads"
 typedef  ^  InitInputType  Logical          Linearize    - .FALSE. - "Flag that tells this module if the glue code wants to linearize." -
 
 # ============================== Initialization outputs ============================================================================================================================================
@@ -208,6 +209,7 @@ typedef  ^  ParameterType  IntKi   nDOFM        -  -  -  "retained degrees of fr
 typedef  ^  ParameterType  IntKi   nDOFRB       -  -  -  "number of rigid-body modes"
 typedef  ^  ParameterType  IntKi   SttcSolve    -  -  -  "Solve dynamics about static equilibrium point (flag)"
 typedef  ^  ParameterType  Logical Floating     -  -  -  "True if floating bottom (the 6 DOF are free at all reaction nodes)"
+typedef  ^  ParameterType  Logical SlDNonLinear -  -  -  "Flag indicating that SoilDyn is returning nonlinear loads"
 typedef  ^  ParameterType  ReKi    KMMDiag  {:}    -  -  "Diagonal coefficients of Kmm (OmegaM squared)"
 typedef  ^  ParameterType  ReKi    CMMDiag  {:}    -  -  "Diagonal coefficients of Cmm (~2 Zeta OmegaM))"
 typedef  ^  ParameterType  ReKi    MMB  {:}{:}     -  -  "Matrix after C-B reduction (transpose of MBM"

--- a/modules/subdyn/src/SubDyn_Types.f90
+++ b/modules/subdyn/src/SubDyn_Types.f90
@@ -115,6 +115,7 @@ IMPLICIT NONE
     REAL(ReKi)  :: SubRotateZ = 0.0_ReKi      !< Rotation angle in degrees about global Z [-]
     REAL(ReKi) , DIMENSION(:,:,:), ALLOCATABLE  :: SoilStiffness      !< Soil stiffness matrices from SoilDyn ['(N/m,]
     TYPE(MeshType)  :: SoilMesh      !< Mesh for soil stiffness locations [-]
+    LOGICAL  :: SlDNonLinear = .false.      !< Flag indicating that SoilDyn is returning nonlinear loads [-]
     LOGICAL  :: Linearize = .FALSE.      !< Flag that tells this module if the glue code wants to linearize. [-]
   END TYPE SD_InitInputType
 ! =======================
@@ -258,6 +259,7 @@ IMPLICIT NONE
     INTEGER(IntKi)  :: nDOFRB = 0_IntKi      !< number of rigid-body modes [-]
     INTEGER(IntKi)  :: SttcSolve = 0_IntKi      !< Solve dynamics about static equilibrium point (flag) [-]
     LOGICAL  :: Floating = .false.      !< True if floating bottom (the 6 DOF are free at all reaction nodes) [-]
+    LOGICAL  :: SlDNonLinear = .false.      !< Flag indicating that SoilDyn is returning nonlinear loads [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: KMMDiag      !< Diagonal coefficients of Kmm (OmegaM squared) [-]
     REAL(ReKi) , DIMENSION(:), ALLOCATABLE  :: CMMDiag      !< Diagonal coefficients of Cmm (~2 Zeta OmegaM)) [-]
     REAL(ReKi) , DIMENSION(:,:), ALLOCATABLE  :: MMB      !< Matrix after C-B reduction (transpose of MBM [-]
@@ -987,6 +989,7 @@ subroutine SD_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, ErrSta
    call MeshCopy(SrcInitInputData%SoilMesh, DstInitInputData%SoilMesh, CtrlCode, ErrStat2, ErrMsg2 )
    call SetErrStat(ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
+   DstInitInputData%SlDNonLinear = SrcInitInputData%SlDNonLinear
    DstInitInputData%Linearize = SrcInitInputData%Linearize
 end subroutine
 
@@ -1023,6 +1026,7 @@ subroutine SD_PackInitInput(RF, Indata)
    call RegPack(RF, InData%SubRotateZ)
    call RegPackAlloc(RF, InData%SoilStiffness)
    call MeshPack(RF, InData%SoilMesh) 
+   call RegPack(RF, InData%SlDNonLinear)
    call RegPack(RF, InData%Linearize)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
@@ -1044,6 +1048,7 @@ subroutine SD_UnPackInitInput(RF, OutData)
    call RegUnpack(RF, OutData%SubRotateZ); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%SoilStiffness); if (RegCheckErr(RF, RoutineName)) return
    call MeshUnpack(RF, OutData%SoilMesh) ! SoilMesh 
+   call RegUnpack(RF, OutData%SlDNonLinear); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%Linearize); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -2413,6 +2418,7 @@ subroutine SD_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
    DstParamData%nDOFRB = SrcParamData%nDOFRB
    DstParamData%SttcSolve = SrcParamData%SttcSolve
    DstParamData%Floating = SrcParamData%Floating
+   DstParamData%SlDNonLinear = SrcParamData%SlDNonLinear
    if (allocated(SrcParamData%KMMDiag)) then
       LB(1:1) = lbound(SrcParamData%KMMDiag)
       UB(1:1) = ubound(SrcParamData%KMMDiag)
@@ -3466,6 +3472,7 @@ subroutine SD_PackParam(RF, Indata)
    call RegPack(RF, InData%nDOFRB)
    call RegPack(RF, InData%SttcSolve)
    call RegPack(RF, InData%Floating)
+   call RegPack(RF, InData%SlDNonLinear)
    call RegPackAlloc(RF, InData%KMMDiag)
    call RegPackAlloc(RF, InData%CMMDiag)
    call RegPackAlloc(RF, InData%MMB)
@@ -3666,6 +3673,7 @@ subroutine SD_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%nDOFRB); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%SttcSolve); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%Floating); if (RegCheckErr(RF, RoutineName)) return
+   call RegUnpack(RF, OutData%SlDNonLinear); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%KMMDiag); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%CMMDiag); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%MMB); if (RegCheckErr(RF, RoutineName)) return


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
The proposed code introduces a new flag (`SlDNonLinear`) to pass from SoilDyn to SubDyn in order to correctly identify when SoilDyn is computing nonlinear soil reaction forces (REDWIN DLL, `CalcOption`=3).

The new flag `SlDNonLinear` is set internally in SoilDyn based on `CalcOption`, ensuring it is only TRUE when the REDWIN DLL is active. When nonlinear forces are active, SubDyn reaction outputs (`ReactSS`) are set to NaN to prevent the user from using reaction loads that only have the linear part. Users should instead use the SoilDyn output sensors (e.g., `Sld1Fxg`, `Sld1Fyg`) which correctly account for the total soil reaction at each node.

Additionally, the linear soil stiffness transfer from SoilDyn to SubDyn is now better documented in the console (`SoilDyn: linear stiffness passed directly to SubDyn as a stiffness matrix`).

For reference, in the current code before these changes, `SlDNonLinearForcePortionOnly` seems to be defined as TRUE whenever SoilDyn is called, regardless of whether nonlinear forces are actually being computed. This seems a bit confusing. See at the bottom the "Future improvements?" part. 

**Related issue, if one exists**
This PR addresses issues https://github.com/OpenFAST/openfast/issues/3317 and https://github.com/OpenFAST/openfast/issues/3318

**Impacted areas of the software**
SubDyn reaction load sensor when REDWIN (`CalcOption` = 3 in SoilDyn) is used.
SoilDyn messages in the console at run time.

**Test results, if applicable**
This PR impacts the SubDyn outputs `ReactFXss`, `ReactFYss`, `ReactFZss`, `ReactMXss`, `ReactMYss`, `ReactMZss`. However, there are no r-test cases with REDWIN. So, no differences are expected.

For verification purposes, you can find examples of the new messages and results below:
`CalcOption` = 1 uses a linear stiffness matrix.
<img width="731" height="346" alt="image" src="https://github.com/user-attachments/assets/b44cb968-0549-40b5-9d0b-fe15f61a65b2" />

In this case all sensors (SubDyn and SoilDyn) are available:
<img width="840" height="504" alt="image" src="https://github.com/user-attachments/assets/2650574d-62a2-4ba1-894f-29498f04ee6f" />

`CalcOption`: 3 uses a linear stiffness matrix AND non-linear forces computed by REDWIN.
<img width="829" height="422" alt="image" src="https://github.com/user-attachments/assets/ae1db23b-81c5-4dfb-a02c-c3af7de99b86" />

In this case, the reaction loads from SubDyn return NaN. The proper results (including the linear and nonlinear part) are available in SoilDyn.
<img width="837" height="502" alt="image" src="https://github.com/user-attachments/assets/d61aa848-8fd1-483b-954c-28e1de1518ea" />

**Additional information: some drama compiling OpenFAST...**
I tried to compile OpenFAST in Visual Studio Code by means of GCC. Although I could compile without issues, when I executed the code I ended up with the issues reported here: https://github.com/OpenFAST/openfast/issues/3301

Then I decided to move to GitHub Actions and compile with Intel Fortran Compiler. @andrew-platt Somehow, when running the `deploy.yml`, GitHub was not generating from scratch the `SubDyn_Types.f90` file based on my updated `SubDyn_Registry.txt`. I'm not sure if this is a limitation of the `deploy.yml` approach. To overcome this, I took the updated `SubDyn_Types.f90` from my local run in Visual Studio Code and added it to my branch: 67db890217cd67fbb595e7feac9119d9e697ea03.

**Future improvements?**
When looking at the `Calc_StiffDamp` and `Calc_REDWIN` in the SoilDyn.f90 file, the linear and nonlinear loads are computed as expected. However, we can find the condition: `if (p%SlDNonLinearForcePortionOnly) then ` in several places. I do believe this is indeed always TRUE and could be removed. But I'm not sure if there was a reason for it during the development. 
<img width="1004" height="592" alt="image" src="https://github.com/user-attachments/assets/d4c1ff11-1b77-497c-a53e-fae131327974" />