### PR TITLE
SoilDyn: Remove flag SlDNonLinearForcePortionOnly

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -893,10 +893,9 @@ SUBROUTINE FAST_InitializeAll( t_initial, m_Glue, p_FAST, y_FAST, m_FAST, ED, SE
          return
       end if
 
-      ! Initialization input   
+      ! Initialization input
       Init%InData_SlD%InputFile = p_FAST%SoilFile
       Init%InData_SlD%RootName = p_FAST%OutFileRoot
-      Init%InData_SlD%SlDNonLinearForcePortionOnly = .true. ! SoilDyn will only return the Non-Linear portion of the reaction force
       Init%InData_SlD%WtrDpth = p_FAST%WtrDpth
 
       ! Initialize SoilDyn
@@ -908,13 +907,13 @@ SUBROUTINE FAST_InitializeAll( t_initial, m_Glue, p_FAST, y_FAST, m_FAST, ED, SE
       if (Failed()) return
 
       ! Pass nonlinear flag to SubDyn: true only when REDWIN DLL is active (CalcOption=3)
-      Init%InData_SD%SlDNonLinear = SlD%p%UseREDWINinterface ! REDWIN DLL returning nonlinear soil reaction forces      
+      Init%InData_SD%SlDNonLinear = SlD%p%UseREDWINinterface ! REDWIN DLL returning nonlinear soil reaction forces
 
       ! Add module to list of modules, return on error
       CALL MV_AddModule(m_Glue%ModData, Module_SlD, 'SlD', 1, dt_module, p_FAST%DT, &
                         Init%OutData_SlD%Vars, p_FAST%Linearize, ErrStat2, ErrMsg2)
       if (Failed()) return
-      
+
    end select
 
    !----------------------------------------------------------------------------

--- a/modules/soildyn/src/SoilDyn.f90
+++ b/modules/soildyn/src/SoilDyn.f90
@@ -111,7 +111,6 @@ subroutine SlD_Init(InitInp, u, p, x, xd, z, OtherState, y, m, Interval, InitOut
 
    ! The linear soil stiffness is passed directly to SubDyn as a stiffness matrix (not as a load)
    ! The nonlinear portion of reaction forces is only computed when REDWIN DLL is active and passed as loads.
-   p%SlDNonLinearForcePortionOnly = InitInp%SlDNonLinearForcePortionOnly
    call WrScr(' SoilDyn: linear stiffness passed directly to SubDyn as a stiffness matrix')
    if (p%CalcOption == Calc_REDWIN) call WrScr(' SoilDyn: nonlinear soil reaction loads computed by REDWIN')
 
@@ -589,9 +588,7 @@ subroutine SlD_CalcOutput(t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg)
          Displacement(4:6) = GetSmllRotAngs(u%SoilMesh%Orientation(1:3, 1:3, i), ErrStat2, ErrMsg2); if (Failed()) return; 
          ! Calculate reaction with F = k*dX
          m%ForceTotal(1:6, i) = matmul(p%Stiffness(1:6, 1:6, i), Displacement)
-         if (p%SlDNonLinearForcePortionOnly) then
-            ForceLinear = matmul(p%Stiffness(1:6, 1:6, i), Displacement)
-         end if
+         ForceLinear = matmul(p%Stiffness(1:6, 1:6, i), Displacement)
 
          ! TODO: add damping term effects here
 
@@ -600,10 +597,8 @@ subroutine SlD_CalcOutput(t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg)
          y%SoilMesh%Moment(1:3, i) = -real(m%ForceTotal(4:6, i), ReKi)
 
          ! Subtract out the linear piece here
-         if (p%SlDNonLinearForcePortionOnly) then
-            y%SoilMesh%Force(1:3, i) = y%SoilMesh%Force(1:3, i) + real(ForceLinear(1:3), ReKi)
-            y%SoilMesh%Moment(1:3, i) = y%SoilMesh%Moment(1:3, i) + real(ForceLinear(4:6), ReKi)
-         end if
+         y%SoilMesh%Force(1:3, i) = y%SoilMesh%Force(1:3, i) + real(ForceLinear(1:3), ReKi)
+         y%SoilMesh%Moment(1:3, i) = y%SoilMesh%Moment(1:3, i) + real(ForceLinear(4:6), ReKi)
       end do
 
    case (Calc_PYcurve)
@@ -622,9 +617,7 @@ subroutine SlD_CalcOutput(t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg)
          Displacement(4:6) = GetSmllRotAngs(u%SoilMesh%Orientation(1:3, 1:3, i), ErrStat2, ErrMsg2); if (Failed()) return; ! Small angle assumption should be valid here -- Note we are assuming reforientation is identity
 
          ! Linear portion of the stiffness reaction (NOTE: the DLL stiffness info is stored in parameters
-         if (p%SlDNonLinearForcePortionOnly) then
-            ForceLinear = matmul(p%Stiffness(1:6, 1:6, i), Displacement)
-         end if
+         ForceLinear = matmul(p%Stiffness(1:6, 1:6, i), Displacement)
 
          call REDWINinterface_CalcOutput(p%DLL_Trgt, p%DLL_Model, Displacement, m%ForceTotal(1:6, i), m%dll_data(i), ErrStat2, ErrMsg2); if (Failed()) return; 
          ! Return reaction force onto the resulting point mesh
@@ -632,10 +625,8 @@ subroutine SlD_CalcOutput(t, u, p, x, xd, z, OtherState, y, m, ErrStat, ErrMsg)
          y%SoilMesh%Moment(1:3, i) = -real(m%ForceTotal(4:6, i), ReKi)
 
          ! Subtract out the linear piece here
-         if (p%SlDNonLinearForcePortionOnly) then
-            y%SoilMesh%Force(1:3, i) = y%SoilMesh%Force(1:3, i) + real(ForceLinear(1:3), ReKi)
-            y%SoilMesh%Moment(1:3, i) = y%SoilMesh%Moment(1:3, i) + real(ForceLinear(4:6), ReKi)
-         end if
+         y%SoilMesh%Force(1:3, i) = y%SoilMesh%Force(1:3, i) + real(ForceLinear(1:3), ReKi)
+         y%SoilMesh%Moment(1:3, i) = y%SoilMesh%Moment(1:3, i) + real(ForceLinear(4:6), ReKi)
       end do
    end select
 

--- a/modules/soildyn/src/SoilDyn_Registry.txt
+++ b/modules/soildyn/src/SoilDyn_Registry.txt
@@ -70,7 +70,6 @@ typedef  ^  InitInputType       CHARACTER(1024)      InputFile      - - -       
 typedef  ^  ^                   CHARACTER(1024)      RootName       - - -       "Root name of the input file" -
 typedef  ^  ^                   LOGICAL              Linearize      - F -       "Flag that tells this module if the glue code wants to linearize." -
 typedef  ^  ^                   ReKi                 WtrDpth        - - -       "Water depth to mudline (global coordinates)" '(m)'
-typedef  ^  ^                   logical              SlDNonLinearForcePortionOnly - F - "Only the non-linear portion of the reaction forces is returned" -
 
 # Define outputs from the initialization routine here:
 typedef  ^  InitOutputType      ModVarsType           Vars             - - -    "Module Variables"
@@ -111,7 +110,6 @@ typedef  ^  ^                   IntKi             NumPoints            - - -    
 typedef  ^  ^                   ReKi              WtrDepth             - - -    "Water depth to mudline (global coordinates)" '(m)'
 typedef  ^  ^                   R8Ki              Stiffness          ::: - -    "Stiffness matrix" '(N/m, N-m/rad)'
 typedef  ^  ^                   logical           DLL_OnlyStiff        - - -    "Use only the stiffness matrix in calculating the restoring forces" -
-typedef  ^  ^                   logical           SlDNonLinearForcePortionOnly - F - "Only the non-linear portion of the reaction forces is returned" -
 
 # Inputs ....................................................................................................................
 typedef ^   InputType           MeshType          SoilMesh             - - -    "Mesh of soil contact points" -

--- a/modules/soildyn/src/SoilDyn_Types.f90
+++ b/modules/soildyn/src/SoilDyn_Types.f90
@@ -90,7 +90,6 @@ IMPLICIT NONE
     CHARACTER(1024)  :: RootName      !< Root name of the input file [-]
     LOGICAL  :: Linearize = .false.      !< Flag that tells this module if the glue code wants to linearize. [-]
     REAL(ReKi)  :: WtrDpth = 0.0_ReKi      !< Water depth to mudline (global coordinates) ['(m)']
-    LOGICAL  :: SlDNonLinearForcePortionOnly = .false.      !< Only the non-linear portion of the reaction forces is returned [-]
   END TYPE SlD_InitInputType
 ! =======================
 ! =========  SlD_InitOutputType  =======
@@ -140,7 +139,6 @@ IMPLICIT NONE
     REAL(ReKi)  :: WtrDepth = 0.0_ReKi      !< Water depth to mudline (global coordinates) ['(m)']
     REAL(R8Ki) , DIMENSION(:,:,:), ALLOCATABLE  :: Stiffness      !< Stiffness matrix ['(N/m,]
     LOGICAL  :: DLL_OnlyStiff = .false.      !< Use only the stiffness matrix in calculating the restoring forces [-]
-    LOGICAL  :: SlDNonLinearForcePortionOnly = .false.      !< Only the non-linear portion of the reaction forces is returned [-]
   END TYPE SlD_ParameterType
 ! =======================
 ! =========  SlD_InputType  =======
@@ -529,7 +527,6 @@ subroutine SlD_CopyInitInput(SrcInitInputData, DstInitInputData, CtrlCode, ErrSt
    DstInitInputData%RootName = SrcInitInputData%RootName
    DstInitInputData%Linearize = SrcInitInputData%Linearize
    DstInitInputData%WtrDpth = SrcInitInputData%WtrDpth
-   DstInitInputData%SlDNonLinearForcePortionOnly = SrcInitInputData%SlDNonLinearForcePortionOnly
 end subroutine
 
 subroutine SlD_DestroyInitInput(InitInputData, ErrStat, ErrMsg)
@@ -550,7 +547,6 @@ subroutine SlD_PackInitInput(RF, Indata)
    call RegPack(RF, InData%RootName)
    call RegPack(RF, InData%Linearize)
    call RegPack(RF, InData%WtrDpth)
-   call RegPack(RF, InData%SlDNonLinearForcePortionOnly)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -563,7 +559,6 @@ subroutine SlD_UnPackInitInput(RF, OutData)
    call RegUnpack(RF, OutData%RootName); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%Linearize); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%WtrDpth); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%SlDNonLinearForcePortionOnly); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine SlD_CopyInitOutput(SrcInitOutputData, DstInitOutputData, CtrlCode, ErrStat, ErrMsg)
@@ -939,7 +934,6 @@ subroutine SlD_CopyParam(SrcParamData, DstParamData, CtrlCode, ErrStat, ErrMsg)
       DstParamData%Stiffness = SrcParamData%Stiffness
    end if
    DstParamData%DLL_OnlyStiff = SrcParamData%DLL_OnlyStiff
-   DstParamData%SlDNonLinearForcePortionOnly = SrcParamData%SlDNonLinearForcePortionOnly
 end subroutine
 
 subroutine SlD_DestroyParam(ParamData, ErrStat, ErrMsg)
@@ -1000,7 +994,6 @@ subroutine SlD_PackParam(RF, Indata)
    call RegPack(RF, InData%WtrDepth)
    call RegPackAlloc(RF, InData%Stiffness)
    call RegPack(RF, InData%DLL_OnlyStiff)
-   call RegPack(RF, InData%SlDNonLinearForcePortionOnly)
    if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
@@ -1041,7 +1034,6 @@ subroutine SlD_UnPackParam(RF, OutData)
    call RegUnpack(RF, OutData%WtrDepth); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpackAlloc(RF, OutData%Stiffness); if (RegCheckErr(RF, RoutineName)) return
    call RegUnpack(RF, OutData%DLL_OnlyStiff); if (RegCheckErr(RF, RoutineName)) return
-   call RegUnpack(RF, OutData%SlDNonLinearForcePortionOnly); if (RegCheckErr(RF, RoutineName)) return
 end subroutine
 
 subroutine SlD_CopyInput(SrcInputData, DstInputData, CtrlCode, ErrStat, ErrMsg)

--- a/modules/soildyn/src/driver/SoilDyn_Driver.f90
+++ b/modules/soildyn/src/driver/SoilDyn_Driver.f90
@@ -260,7 +260,6 @@ PROGRAM SoilDyn_Driver
    !...............................................................................................................................
 
    InitInData%InputFile = Settings%SldIptFileName
-   InitInData%SlDNonLinearForcePortionOnly = SettingsFlags%SlDNonLinearForcePortionOnly
 
       ! Initialize the module
    CALL SlD_Init( InitInData, u(1), p,  x, xd, z, OtherState, y, misc, TimeInterval, InitOutData, ErrStat, ErrMsg )

--- a/modules/soildyn/src/driver/SoilDyn_Driver_Subs.f90
+++ b/modules/soildyn/src/driver/SoilDyn_Driver_Subs.f90
@@ -86,7 +86,6 @@ subroutine InitSettingsFlags( ProgInfo, CLSettings, CLFlags )
    CLFlags%DTDefault           =  .FALSE.        ! specified 'DEFAULT' for resolution in time
    CLFlags%Verbose             =  .FALSE.        ! Turn on verbose error reporting?
    CLFlags%VVerbose            =  .FALSE.        ! Turn on very verbose error reporting?
-   CLFlags%SlDNonLinearForcePortionOnly =  .FALSE. ! Report only non-linear portion of forces
 
 end subroutine InitSettingsFlags
 
@@ -278,10 +277,7 @@ SUBROUTINE RetrieveArgs( CLSettings, CLFlags, ErrStat, ErrMsg )
          ! If no delimeters were given, than this option is simply a flag
       IF ( Delim1 == 0_IntKi ) THEN
             ! check to see if the filename is the name of the SlD input file
-         IF   ( ThisArgUC(1:9) == "NONLINEAR"   )   THEN
-            CLFlags%SlDNonLinearForcePortionOnly = .TRUE.
-            RETURN
-         ELSEIF   ( ThisArgUC(1:3) == "SLD" )   THEN
+         IF   ( ThisArgUC(1:3) == "SLD" )   THEN
             sldFlagSet              = .TRUE.             ! More logic in the routine that calls this one to set things.
             RETURN
          ELSEIF   ( ThisArgUC(1:2) == "VV"  )   THEN
@@ -544,11 +540,6 @@ SUBROUTINE ReadDvrIptFile( DvrFileName, DvrFlags, DvrSettings, ProgInfo, ErrStat
 
       ! Stiffness matrix
    CALL ReadVar( UnIn, FileName,DvrFlags%StiffMatOut,'StiffMatOut',' Output stiffness matrices at start and end',   &
-      ErrStatTmp,ErrMsgTmp, UnEchoLocal )
-   if (Failed()) return
-
-      ! Non-linear reaction portion only
-   CALL ReadVar( UnIn, FileName,DvrFlags%SlDNonLinearForcePortionOnly,'SlDNonLinearForcePortionOnly',' Only report the non-linear portion of the reaction force.',   &
       ErrStatTmp,ErrMsgTmp, UnEchoLocal )
    if (Failed()) return
 

--- a/modules/soildyn/src/driver/SoilDyn_Driver_Types.f90
+++ b/modules/soildyn/src/driver/SoilDyn_Driver_Types.f90
@@ -45,7 +45,6 @@ MODULE SoilDyn_Driver_Types
       LOGICAL                 :: DTDefault            = .FALSE.      !< specified a 'DEFAULT' for the time resolution
       LOGICAL                 :: Verbose              = .FALSE.      !< Verbose error reporting
       LOGICAL                 :: VVerbose             = .FALSE.      !< Very Verbose error reporting
-      LOGICAL                 :: SlDNonLinearForcePortionOnly = .FALSE. !< To only return the non-linear portion of the reaction force
    END TYPE    SlDDriver_Flags
 
 


### PR DESCRIPTION
This PR is ready to be merged.

**Feature or improvement description**
As noted in PR https://github.com/OpenFAST/openfast/pull/3319, the `SlDNonLinearForcePortionOnly` flag was previously hardcoded to TRUE and had no functional effect. This PR removes that legacy flag from the SoilDyn code to improve clarity.

The updated logic is straightforward:
1. The 6x6 linear stiffness matrix defined in SoilDyn (e.g., `CalcOption` = 1 or 3) is always passed to and included in SubDyn.
2. Only nonlinear loads are transferred from SoilDyn to SubDyn. 

The `SlDNonLinear` flag is now exclusively used when `CalcOption` = 3 (REDWIN) and it affects only reaction load outputs in SubDyn (sensor-written values, not physical behavior).

**Impacted areas of the software**
SoilDyn.

**Test results, if applicable**
No changes expected.