### PR TITLE
FAST.Farm: fix indexing on dropping wake planes that get dropped

### DIFF
--- a/glue-codes/fast-farm/src/FAST_Farm_IO.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_IO.f90
@@ -775,11 +775,11 @@ SUBROUTINE Farm_ReadPrimaryFile( InputFile, p, WD_InitInp, AWAE_InitInp, OutList
 
    CALL ReadVarWDefault( UnIn, InputFile, WD_InitInp%NumDFull, "NumDFull", &
       "Distance of full wake propagation, expressed as a multiple of RotorDiamRef [>0.0] or DEFAULT [DEFAULT=15]", &
-      15_IntKi, ErrStat2, ErrMsg2, UnEc); if (Failed()) return
+      15.0_ReKi, ErrStat2, ErrMsg2, UnEc); if (Failed()) return
 
    CALL ReadVarWDefault( UnIn, InputFile, WD_InitInp%NumDBuff, "NumDBuff", &
       "Length of wake propagation buffer region, expressed as a multiple of RotorDiamRef [>=0.0] or DEFAULT [DEFAULT=5]", &
-       5_IntKi, ErrStat2, ErrMsg2, UnEc); if (Failed()) return
+       5.0_ReKi, ErrStat2, ErrMsg2, UnEc); if (Failed()) return
 
    WD_InitInp%RotorDiamRef = p%RotorDiamRef
 

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -211,7 +211,7 @@ SUBROUTINE Farm_Initialize( farm, InputFile, ErrStat, ErrMsg )
    call AllocAry( farm%p%MaxNumPlanes, farm%p%NumTurbines, 'farm%p%MaxNumPlanes', ErrStat2, ErrMsg2);  CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName); if (Failed()) return
    do i=1,farm%p%NumTurbines
       ! Eventually, we will have different settings for different rotors
-      farm%p%MaxNumPlanes(i) = ceiling( 15.0 * Real( WD_InitInput%InputFileData%NumDFull + WD_InitInput%InputFileData%NumDBuff , ReKi ) / AWAE_InitInput%InputFileData%C_Meander )
+      farm%p%MaxNumPlanes(i) = ceiling( 15.0 * ( WD_InitInput%InputFileData%NumDFull + WD_InitInput%InputFileData%NumDBuff ) / AWAE_InitInput%InputFileData%C_Meander )
       farm%p%MaxNumPlanes(i) = max( 2, min( farm%p%MaxNumPlanes(i) , farm%p%n_TMax + 2 ) )
    end do
 

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -211,7 +211,7 @@ SUBROUTINE Farm_Initialize( farm, InputFile, ErrStat, ErrMsg )
    call AllocAry( farm%p%MaxNumPlanes, farm%p%NumTurbines, 'farm%p%MaxNumPlanes', ErrStat2, ErrMsg2);  CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName); if (Failed()) return
    do i=1,farm%p%NumTurbines
       ! Eventually, we will have different settings for different rotors
-      farm%p%MaxNumPlanes(i) = ceiling( 15.0 * ( WD_InitInput%InputFileData%NumDFull + WD_InitInput%InputFileData%NumDBuff ) / AWAE_InitInput%InputFileData%C_Meander )
+      farm%p%MaxNumPlanes(i) = ceiling( 30.0 * ( WD_InitInput%InputFileData%NumDFull + WD_InitInput%InputFileData%NumDBuff ) / AWAE_InitInput%InputFileData%C_Meander )
       farm%p%MaxNumPlanes(i) = max( 2, min( farm%p%MaxNumPlanes(i) , farm%p%n_TMax + 2 ) )
    end do
 

--- a/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_Subs.f90
@@ -211,7 +211,7 @@ SUBROUTINE Farm_Initialize( farm, InputFile, ErrStat, ErrMsg )
    call AllocAry( farm%p%MaxNumPlanes, farm%p%NumTurbines, 'farm%p%MaxNumPlanes', ErrStat2, ErrMsg2);  CALL SetErrStat( ErrStat2, ErrMsg2, ErrStat, ErrMsg, RoutineName); if (Failed()) return
    do i=1,farm%p%NumTurbines
       ! Eventually, we will have different settings for different rotors
-      farm%p%MaxNumPlanes(i) = ceiling( 30.0 * ( WD_InitInput%InputFileData%NumDFull + WD_InitInput%InputFileData%NumDBuff ) / AWAE_InitInput%InputFileData%C_Meander )
+      farm%p%MaxNumPlanes(i) = ceiling( 15.0 * ( WD_InitInput%InputFileData%NumDFull + WD_InitInput%InputFileData%NumDBuff ) / AWAE_InitInput%InputFileData%C_Meander )
       farm%p%MaxNumPlanes(i) = max( 2, min( farm%p%MaxNumPlanes(i) , farm%p%n_TMax + 2 ) )
    end do
 

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -972,8 +972,9 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
 
       if ( xd%x_plane(i) > p%x_Buff ) then
 
-         xd%NumPlanes = max( xd%NumPlanes - 1.0, 2.0 )
+         xd%NumPlanes = max( xd%NumPlanes - 1.0, 2.0 )   ! Plane indexing includes 0, hence the -1.0
 
+      ! If a plane overtakes another plane, drop the plane that is doing the overtaking and shift all remaining planes forward. We skip checking the last plane since it can't overtake anything.
       else if ( i+1 < NINT(xd%NumPlanes) .and. xd%x_plane(i) >= xd%x_plane(i+1) ) then
 
          call SetErrStat(ErrID_Warn, ' Turbine '//trim(num2lstr(p%TurbNum))//' wake plane '//trim(num2lstr(i))//' (x_plane='//trim(num2lstr(xd%x_plane(i)))//') has overtaken wake plane '//trim(num2lstr(i+1))//' (x_plane='//trim(num2lstr(xd%x_plane(i+1)))//'). Offending wake plane removed. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
@@ -982,14 +983,9 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
             return
          end if
 
-         ! Remove offending plane and shift everything behind up
-
-         xd%NumPlanes = xd%NumPlanes - 1.0
-
-         ! Didn't check xd%NumPlanes >= 2 here. The first wake plane is unlikely to move upwind of the rotor.
-
+         ! Overwrite the i plane that is passing with the i+1 plane, and shift all following planes back by one plane.
+         ! Didn't check xd%NumPlanes >= 2 here. The first wake plane is unlikely to pass the second plane.
          do j = i+1,NINT(xd%NumPlanes)-1
-
              xd%Vx_wind_disk_filt(j-1) = xd%Vx_wind_disk_filt(j)
              xd%x_plane      (    j-1) = xd%x_plane      (    j)
              xd%TI_amb_filt  (    j-1) = xd%TI_amb_filt  (    j)
@@ -1003,8 +999,10 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
              xd%Vx_wake2     (:,:,j-1) = xd%Vx_wake2     (:,:,j)
              xd%Vy_wake2     (:,:,j-1) = xd%Vy_wake2     (:,:,j)
              xd%Vz_wake2     (:,:,j-1) = xd%Vz_wake2     (:,:,j)
-
          end do
+
+         ! Now that we shifted the planes up, remove the last one
+         xd%NumPlanes = xd%NumPlanes - 1.0
 
       end if
 

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -970,40 +970,55 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
 
    do i=maxPln,0,-1
 
+      ! if a plane is beyond the buffer, simply drop it and all following planes (it should only be the last plane that gets dropped)
       if ( xd%x_plane(i) > p%x_Buff ) then
          xd%NumPlanes = max( xd%NumPlanes - 1.0, 2.0 )   ! Plane indexing includes 0, hence the -1.0
          cycle
       endif
 
-      ! If a plane overtakes another plane, drop the plane that is doing the overtaking and shift all remaining planes forward. We skip checking the last plane since it can't overtake anything.
-      if ( i+1 < NINT(xd%NumPlanes)) then
+      ! If a plane overtakes another plane, merge the planes by averaging, then shift all remaining planes forward.
+      if ( i+1 < NINT(xd%NumPlanes)) then    ! don't overstep bounds with i+1 indexing
          if (xd%x_plane(i) >= xd%x_plane(i+1) ) then
 
             call SetErrStat(ErrID_Warn, ' Turbine '//trim(num2lstr(p%TurbNum))//' wake plane '//trim(num2lstr(i))// &
                         ' (x_plane='//trim(num2lstr(xd%x_plane(i)))//') has overtaken wake plane '//trim(num2lstr(i+1))// &
                         ' (x_plane='//trim(num2lstr(xd%x_plane(i+1)))// &
-                        '). Overtaking wake plane removed. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
+                        '). Merging planes by averaging. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
             if (errStat >= AbortErrLev) then
                call Cleanup()
                return
             end if
 
-            ! Overwrite the i plane that is passing with the i+1 plane, and shift all following planes back by one plane.
-            ! Didn't check xd%NumPlanes >= 2 here. The first wake plane is unlikely to pass the second plane.
-            do j = i+1,NINT(xd%NumPlanes)-1
-                xd%Vx_wind_disk_filt(j-1) = xd%Vx_wind_disk_filt(j)
-                xd%x_plane      (    j-1) = xd%x_plane      (    j)
-                xd%TI_amb_filt  (    j-1) = xd%TI_amb_filt  (    j)
-                xd%D_rotor_filt (    j-1) = xd%D_rotor_filt (    j)
-                xd%YawErr_filt  (    j-1) = xd%YawErr_filt  (    j)
-                xd%p_plane      (  :,j-1) = xd%p_plane      (  :,j)
-                xd%xhat_plane   (  :,j-1) = xd%xhat_plane   (  :,j)
-                xd%V_plane_filt (  :,j-1) = xd%V_plane_filt (  :,j)
-                xd%Vx_wake      (  :,j-1) = xd%Vx_wake      (  :,j)
-                xd%Vr_wake      (  :,j-1) = xd%Vr_wake      (  :,j)
-                xd%Vx_wake2     (:,:,j-1) = xd%Vx_wake2     (:,:,j)
-                xd%Vy_wake2     (:,:,j-1) = xd%Vy_wake2     (:,:,j)
-                xd%Vz_wake2     (:,:,j-1) = xd%Vz_wake2     (:,:,j)
+            ! Merge the i and i+1 plane by averaging them together
+            xd%Vx_wind_disk_filt(i) = (xd%Vx_wind_disk_filt(i) + xd%Vx_wind_disk_filt(i+1)) / 2.0_ReKi
+            xd%x_plane      (    i) = (xd%x_plane      (    i) + xd%x_plane      (    i+1)) / 2.0_ReKi
+            xd%TI_amb_filt  (    i) = (xd%TI_amb_filt  (    i) + xd%TI_amb_filt  (    i+1)) / 2.0_ReKi
+            xd%D_rotor_filt (    i) = (xd%D_rotor_filt (    i) + xd%D_rotor_filt (    i+1)) / 2.0_ReKi
+            xd%YawErr_filt  (    i) = (xd%YawErr_filt  (    i) + xd%YawErr_filt  (    i+1)) / 2.0_ReKi
+            xd%p_plane      (  :,i) = (xd%p_plane      (  :,i) + xd%p_plane      (  :,i+1)) / 2.0_ReKi
+            xd%xhat_plane   (  :,i) = (xd%xhat_plane   (  :,i) + xd%xhat_plane   (  :,i+1)) / 2.0_ReKi
+            xd%V_plane_filt (  :,i) = (xd%V_plane_filt (  :,i) + xd%V_plane_filt (  :,i+1)) / 2.0_ReKi
+            xd%Vx_wake      (  :,i) = (xd%Vx_wake      (  :,i) + xd%Vx_wake      (  :,i+1)) / 2.0_ReKi
+            xd%Vr_wake      (  :,i) = (xd%Vr_wake      (  :,i) + xd%Vr_wake      (  :,i+1)) / 2.0_ReKi
+            xd%Vx_wake2     (:,:,i) = (xd%Vx_wake2     (:,:,i) + xd%Vx_wake2     (:,:,i+1)) / 2.0_ReKi
+            xd%Vy_wake2     (:,:,i) = (xd%Vy_wake2     (:,:,i) + xd%Vy_wake2     (:,:,i+1)) / 2.0_ReKi
+            xd%Vz_wake2     (:,:,i) = (xd%Vz_wake2     (:,:,i) + xd%Vz_wake2     (:,:,i+1)) / 2.0_ReKi
+
+            ! Since i and i+1 planes are now merged effectively dropping a plane, shift all planes that follow forward
+            do j = i+1,NINT(xd%NumPlanes)-2        ! NumPlanes includes 0 index plane, so last valid index is NumPlanes-1.
+                xd%Vx_wind_disk_filt(j) = xd%Vx_wind_disk_filt(j+1)
+                xd%x_plane      (    j) = xd%x_plane      (    j+1)
+                xd%TI_amb_filt  (    j) = xd%TI_amb_filt  (    j+1)
+                xd%D_rotor_filt (    j) = xd%D_rotor_filt (    j+1)
+                xd%YawErr_filt  (    j) = xd%YawErr_filt  (    j+1)
+                xd%p_plane      (  :,j) = xd%p_plane      (  :,j+1)
+                xd%xhat_plane   (  :,j) = xd%xhat_plane   (  :,j+1)
+                xd%V_plane_filt (  :,j) = xd%V_plane_filt (  :,j+1)
+                xd%Vx_wake      (  :,j) = xd%Vx_wake      (  :,j+1)
+                xd%Vr_wake      (  :,j) = xd%Vr_wake      (  :,j+1)
+                xd%Vx_wake2     (:,:,j) = xd%Vx_wake2     (:,:,j+1)
+                xd%Vy_wake2     (:,:,j) = xd%Vy_wake2     (:,:,j+1)
+                xd%Vz_wake2     (:,:,j) = xd%Vz_wake2     (:,:,j+1)
             end do
 
             ! Now that we shifted the planes up, remove the last one

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -996,7 +996,7 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
             xd%D_rotor_filt (    i) = (xd%D_rotor_filt (    i) + xd%D_rotor_filt (    i+1)) / 2.0_ReKi
             xd%YawErr_filt  (    i) = (xd%YawErr_filt  (    i) + xd%YawErr_filt  (    i+1)) / 2.0_ReKi
             xd%p_plane      (  :,i) = (xd%p_plane      (  :,i) + xd%p_plane      (  :,i+1)) / 2.0_ReKi
-            xd%xhat_plane   (  :,i) = (xd%xhat_plane   (  :,i) + xd%xhat_plane   (  :,i+1)) / 2.0_ReKi
+            xd%xhat_plane   (  :,i) = TwoNorm(xd%xhat_plane   (  :,i) + xd%xhat_plane   (  :,i+1))       ! renormalize
             xd%V_plane_filt (  :,i) = (xd%V_plane_filt (  :,i) + xd%V_plane_filt (  :,i+1)) / 2.0_ReKi
             xd%Vx_wake      (  :,i) = (xd%Vx_wake      (  :,i) + xd%Vx_wake      (  :,i+1)) / 2.0_ReKi
             xd%Vr_wake      (  :,i) = (xd%Vr_wake      (  :,i) + xd%Vr_wake      (  :,i+1)) / 2.0_ReKi

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -996,7 +996,8 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
             xd%D_rotor_filt (    i) = (xd%D_rotor_filt (    i) + xd%D_rotor_filt (    i+1)) / 2.0_ReKi
             xd%YawErr_filt  (    i) = (xd%YawErr_filt  (    i) + xd%YawErr_filt  (    i+1)) / 2.0_ReKi
             xd%p_plane      (  :,i) = (xd%p_plane      (  :,i) + xd%p_plane      (  :,i+1)) / 2.0_ReKi
-            xd%xhat_plane   (  :,i) = TwoNorm(xd%xhat_plane   (  :,i) + xd%xhat_plane   (  :,i+1))       ! renormalize
+            xd%xhat_plane   (  :,i) = (xd%xhat_plane   (  :,i) + xd%xhat_plane   (  :,i+1)) / 2.0_ReKi
+            xd%xhat_plane   (  :,i) =  xd%xhat_plane   (  :,i) / TwoNorm(xd%xhat_plane(  :,i))           ! renormalize
             xd%V_plane_filt (  :,i) = (xd%V_plane_filt (  :,i) + xd%V_plane_filt (  :,i+1)) / 2.0_ReKi
             xd%Vx_wake      (  :,i) = (xd%Vx_wake      (  :,i) + xd%Vx_wake      (  :,i+1)) / 2.0_ReKi
             xd%Vr_wake      (  :,i) = (xd%Vr_wake      (  :,i) + xd%Vr_wake      (  :,i+1)) / 2.0_ReKi

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -971,39 +971,42 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
    do i=maxPln,0,-1
 
       if ( xd%x_plane(i) > p%x_Buff ) then
-
          xd%NumPlanes = max( xd%NumPlanes - 1.0, 2.0 )   ! Plane indexing includes 0, hence the -1.0
+         cycle
+      endif
 
       ! If a plane overtakes another plane, drop the plane that is doing the overtaking and shift all remaining planes forward. We skip checking the last plane since it can't overtake anything.
-      else if ( i+1 < NINT(xd%NumPlanes) .and. xd%x_plane(i) >= xd%x_plane(i+1) ) then
+      if ( i+1 < NINT(xd%NumPlanes)) then
+         if (xd%x_plane(i) >= xd%x_plane(i+1) ) then
 
-         call SetErrStat(ErrID_Warn, ' Turbine '//trim(num2lstr(p%TurbNum))//' wake plane '//trim(num2lstr(i))//' (x_plane='//trim(num2lstr(xd%x_plane(i)))//') has overtaken wake plane '//trim(num2lstr(i+1))//' (x_plane='//trim(num2lstr(xd%x_plane(i+1)))//'). Offending wake plane removed. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
-         if (errStat >= AbortErrLev) then
-            call Cleanup()
-            return
+            call SetErrStat(ErrID_Warn, ' Turbine '//trim(num2lstr(p%TurbNum))//' wake plane '//trim(num2lstr(i))//' (x_plane='//trim(num2lstr(xd%x_plane(i)))//') has overtaken wake plane '//trim(num2lstr(i+1))//' (x_plane='//trim(num2lstr(xd%x_plane(i+1)))//'). Offending wake plane removed. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
+            if (errStat >= AbortErrLev) then
+               call Cleanup()
+               return
+            end if
+
+            ! Overwrite the i plane that is passing with the i+1 plane, and shift all following planes back by one plane.
+            ! Didn't check xd%NumPlanes >= 2 here. The first wake plane is unlikely to pass the second plane.
+            do j = i+1,NINT(xd%NumPlanes)-1
+                xd%Vx_wind_disk_filt(j-1) = xd%Vx_wind_disk_filt(j)
+                xd%x_plane      (    j-1) = xd%x_plane      (    j)
+                xd%TI_amb_filt  (    j-1) = xd%TI_amb_filt  (    j)
+                xd%D_rotor_filt (    j-1) = xd%D_rotor_filt (    j)
+                xd%YawErr_filt  (    j-1) = xd%YawErr_filt  (    j)
+                xd%p_plane      (  :,j-1) = xd%p_plane      (  :,j)
+                xd%xhat_plane   (  :,j-1) = xd%xhat_plane   (  :,j)
+                xd%V_plane_filt (  :,j-1) = xd%V_plane_filt (  :,j)
+                xd%Vx_wake      (  :,j-1) = xd%Vx_wake      (  :,j)
+                xd%Vr_wake      (  :,j-1) = xd%Vr_wake      (  :,j)
+                xd%Vx_wake2     (:,:,j-1) = xd%Vx_wake2     (:,:,j)
+                xd%Vy_wake2     (:,:,j-1) = xd%Vy_wake2     (:,:,j)
+                xd%Vz_wake2     (:,:,j-1) = xd%Vz_wake2     (:,:,j)
+            end do
+
+            ! Now that we shifted the planes up, remove the last one
+            xd%NumPlanes = xd%NumPlanes - 1.0
+
          end if
-
-         ! Overwrite the i plane that is passing with the i+1 plane, and shift all following planes back by one plane.
-         ! Didn't check xd%NumPlanes >= 2 here. The first wake plane is unlikely to pass the second plane.
-         do j = i+1,NINT(xd%NumPlanes)-1
-             xd%Vx_wind_disk_filt(j-1) = xd%Vx_wind_disk_filt(j)
-             xd%x_plane      (    j-1) = xd%x_plane      (    j)
-             xd%TI_amb_filt  (    j-1) = xd%TI_amb_filt  (    j)
-             xd%D_rotor_filt (    j-1) = xd%D_rotor_filt (    j)
-             xd%YawErr_filt  (    j-1) = xd%YawErr_filt  (    j)
-             xd%p_plane      (  :,j-1) = xd%p_plane      (  :,j)
-             xd%xhat_plane   (  :,j-1) = xd%xhat_plane   (  :,j)
-             xd%V_plane_filt (  :,j-1) = xd%V_plane_filt (  :,j)
-             xd%Vx_wake      (  :,j-1) = xd%Vx_wake      (  :,j)
-             xd%Vr_wake      (  :,j-1) = xd%Vr_wake      (  :,j)
-             xd%Vx_wake2     (:,:,j-1) = xd%Vx_wake2     (:,:,j)
-             xd%Vy_wake2     (:,:,j-1) = xd%Vy_wake2     (:,:,j)
-             xd%Vz_wake2     (:,:,j-1) = xd%Vz_wake2     (:,:,j)
-         end do
-
-         ! Now that we shifted the planes up, remove the last one
-         xd%NumPlanes = xd%NumPlanes - 1.0
-
       end if
 
    end do

--- a/modules/wakedynamics/src/WakeDynamics.f90
+++ b/modules/wakedynamics/src/WakeDynamics.f90
@@ -979,7 +979,10 @@ subroutine WD_UpdateStates( t, n, u, p, x, xd, z, OtherState, m, errStat, errMsg
       if ( i+1 < NINT(xd%NumPlanes)) then
          if (xd%x_plane(i) >= xd%x_plane(i+1) ) then
 
-            call SetErrStat(ErrID_Warn, ' Turbine '//trim(num2lstr(p%TurbNum))//' wake plane '//trim(num2lstr(i))//' (x_plane='//trim(num2lstr(xd%x_plane(i)))//') has overtaken wake plane '//trim(num2lstr(i+1))//' (x_plane='//trim(num2lstr(xd%x_plane(i+1)))//'). Offending wake plane removed. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
+            call SetErrStat(ErrID_Warn, ' Turbine '//trim(num2lstr(p%TurbNum))//' wake plane '//trim(num2lstr(i))// &
+                        ' (x_plane='//trim(num2lstr(xd%x_plane(i)))//') has overtaken wake plane '//trim(num2lstr(i+1))// &
+                        ' (x_plane='//trim(num2lstr(xd%x_plane(i+1)))// &
+                        '). Overtaking wake plane removed. Reduce f_c to prevent planes from passing each other. ', errStat, errMsg, RoutineName)
             if (errStat >= AbortErrLev) then
                call Cleanup()
                return

--- a/modules/wakedynamics/src/WakeDynamics_Registry.txt
+++ b/modules/wakedynamics/src/WakeDynamics_Registry.txt
@@ -25,8 +25,8 @@ param ^                    -               INTEGER         Mod_Wake_Cartesian   
 # ..... InputFile Data .......................................................................................................
 typedef  ^                 WD_InputFileType  ReKi            dr             - - -  "Radial increment of radial finite-difference grid [>0.0]" m
 typedef  ^                 WD_InputFileType  IntKi           NumRadii       - - -  "Number of radii in the radial finite-difference grid [>=2]" -
-typedef  ^                 WD_InputFileType  IntKi           NumDFull       - - -  "Distance of full wake propagation as a multiple of RotorDiamRef" -
-typedef  ^                 WD_InputFileType  IntKi           NumDBuff       - - -  "Length of wake propagation buffer region as a multiple of RotorDiamRef" -
+typedef  ^                 WD_InputFileType  ReKi            NumDFull       - - -  "Distance of full wake propagation as a multiple of RotorDiamRef" -
+typedef  ^                 WD_InputFileType  ReKi            NumDBuff       - - -  "Length of wake propagation buffer region as a multiple of RotorDiamRef" -
 typedef  ^                 WD_InputFileType  IntKi           Mod_Wake       - - -  "Switch between wake formulations 1=Polar, 2=Cartesian, 3=Curl" -
 typedef  ^                 WD_InputFileType  ReKi            f_c            - - -  "Cut-off frequency of the low-pass time-filter for the wake advection, deflection, and meandering model [>0.0]" Hz
 typedef  ^                 WD_InputFileType  ReKi            C_HWkDfl_O     - - -  "Calibrated parameter in the correction for wake deflection defining the horizontal offset at the rotor" m

--- a/modules/wakedynamics/src/WakeDynamics_Types.f90
+++ b/modules/wakedynamics/src/WakeDynamics_Types.f90
@@ -44,8 +44,8 @@ IMPLICIT NONE
   TYPE, PUBLIC :: WD_InputFileType
     REAL(ReKi)  :: dr = 0.0_ReKi      !< Radial increment of radial finite-difference grid [>0.0] [m]
     INTEGER(IntKi)  :: NumRadii = 0_IntKi      !< Number of radii in the radial finite-difference grid [>=2] [-]
-    INTEGER(IntKi)  :: NumDFull = 0_IntKi      !< Distance of full wake propagation as a multiple of RotorDiamRef [-]
-    INTEGER(IntKi)  :: NumDBuff = 0_IntKi      !< Length of wake propagation buffer region as a multiple of RotorDiamRef [-]
+    REAL(ReKi)  :: NumDFull = 0.0_ReKi      !< Distance of full wake propagation as a multiple of RotorDiamRef [-]
+    REAL(ReKi)  :: NumDBuff = 0.0_ReKi      !< Length of wake propagation buffer region as a multiple of RotorDiamRef [-]
     INTEGER(IntKi)  :: Mod_Wake = 0_IntKi      !< Switch between wake formulations 1=Polar, 2=Cartesian, 3=Curl [-]
     REAL(ReKi)  :: f_c = 0.0_ReKi      !< Cut-off frequency of the low-pass time-filter for the wake advection, deflection, and meandering model [>0.0] [Hz]
     REAL(ReKi)  :: C_HWkDfl_O = 0.0_ReKi      !< Calibrated parameter in the correction for wake deflection defining the horizontal offset at the rotor [m]


### PR DESCRIPTION
Ready to merge

### Feature or improvement description
If a _FAST.Farm_ wake plane passes another, an error in the indexing was causing the wake plane getting passed to be dropped, but also causing the very last wake plane to get dropped as well.  This would result in the end of the wake jumping backwards whenever a wake was dropped from the middle of the sequence.


https://github.com/user-attachments/assets/6ad85fa8-2cc7-4208-bd20-b7a4748af6fd
Figure 1: single turbine case before bugfix.



https://github.com/user-attachments/assets/5a3ac9c8-aa62-4de2-b0b8-8cc58cc2ab46
Figure 2: single turbine case after bugfix.  Note the artifacts from the first wake plane - these will be addressed in a separate PR.


In the above simulations, the fast moving plane that is catching up to a slower moving plane is dropped.  ~This could be modified in a later PR.~ This method was dropped in favor of merging wake planes by averaging.


#### Solution: averaging of wake planes

As a fast moving plane catches up with a slow moving plane, the two planes are averaged together and saved.  Older planes are then shifted forward in indexing to account for the now missing plane.

https://github.com/user-attachments/assets/9386a301-e294-4994-badd-c49a42f364ff
Figure 3: A fast moving wake plane catching up to a slow moving wake plane is now merged together instead of simply dropping the fast moving plane.


#### Incidental changes

In addition to fixing the above issue, a couple other minor modifications are included in this PR:

* ~in calculating `MaxNumPlanes`, increased coefficient from 15 to 30.  One of the test cases run during diagnostics unexpectedly hit this limit.  The calculation itself should be looked at sometime as it doesn't appear to account for the low res timestep between planes, which is likely why this limit was hit.~. Will diagnose this later
* changed `NumDFull` and `NumDBuff` from integer to real.  There was no reason for these to be integers.



### Related issue, if one exists
#3277 -- this was due to this bug

### Impacted areas of the software
_FAST.Farm_ wake, but only in cases where the simulation is setup poorly and wake planes are passing each other and getting dropped as a result.

### Additional supporting information
Note that the are some strange artifacts in the first plane.  These will be corrected in different PR.

### Generative AI usage
Bug diagnostics assisted by Anthropic Claude <claude@anthropic.com>

### Test results, if applicable
Regression tests are properly setup, so they did not show this behavior, 