### PR TITLE
[BugFix] Error in `Quaternion_to_DCM` calculation

### DIFF
--- a/modules/nwtc-library/src/NWTC_Num.f90
+++ b/modules/nwtc-library/src/NWTC_Num.f90
@@ -4818,7 +4818,7 @@ end function Rad2M180to180Deg
    q2q2 = q%v(2)**2
    q2q3 = q%v(2)    * q%v(3)
    
-   q3q3 = q%v(2)**2
+   q3q3 = q%v(3)**2
    
    
    Quaternion_to_DCM(1,1) =          q0q0 +          q1q1 - q2q2 - q3q3  ! Eq.  9


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**

Part of the third term in the calculation was incorrect.  



**Related issue, if one exists**
This was reported by [Alban.Leroyer](https://forums.nlr.gov/u/alban.leroyer) on the forum here: https://forums.nlr.gov/t/beamdyn-questions/9518/3

**Impacted areas of the software**
This routine has not been used since it was added in 2014, so no results will be affected.

**Generative AI usage**
Calculation checked by: Google Gemini <gemini@google.com>

**Test results, if applicable**
None