### PR TITLE
Fix format issue preventing fields from appearing in BeamDyn YAML summary file

### DIFF
--- a/modules/beamdyn/src/BeamDyn_IO.f90
+++ b/modules/beamdyn/src/BeamDyn_IO.f90
@@ -2057,7 +2057,7 @@ SUBROUTINE BD_PrintSum( p, x, OtherState, m, InitInp, ErrStat, ErrMsg )
    WRITE (UnSu, '("#", 6(2x,A))') '    -----------------','-----------------','-----------------','-----------------','-----------------','-----------------'
    DO i=1,p%elem_total
        WRITE (UnSu, '("#", 1x,A,I4)') 'Element number: ',i
-       call yaml_write_array(UnSu, 'Init_Nodes_E'//num2lstr(i), transpose(p%uuN0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt='5(ES18.5,","),ES18.5')
+       call yaml_write_array(UnSu, 'Init_Nodes_E'//num2lstr(i), transpose(p%uuN0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt=' 5(ES18.5, ","), ES18.5, ')
    ENDDO
 
    WRITE (UnSu,'(/,A)')  '# Quadrature points position and rotation vectors'
@@ -2065,7 +2065,7 @@ SUBROUTINE BD_PrintSum( p, x, OtherState, m, InitInp, ErrStat, ErrMsg )
    WRITE (UnSu, '("#", 6(2x,A))') '    -----------------','-----------------','-----------------','-----------------','-----------------','-----------------'
    DO i=1,p%elem_total
        WRITE (UnSu, '("#", 1x,A,I4)')  'Element number: ',i
-       call yaml_write_array(UnSu, 'Init_QP_E'//num2lstr(i), transpose(p%uu0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt='5(ES18.5,","),ES18.5')
+       call yaml_write_array(UnSu, 'Init_QP_E'//num2lstr(i), transpose(p%uu0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt=' 5(ES18.5, ","), ES18.5, ')
    ENDDO
 
    WRITE (UnSu,'(/,A)')  '# Sectional stiffness and mass matrices at quadrature points (in IEC coordinates)'

--- a/modules/beamdyn/src/BeamDyn_IO.f90
+++ b/modules/beamdyn/src/BeamDyn_IO.f90
@@ -2057,7 +2057,7 @@ SUBROUTINE BD_PrintSum( p, x, OtherState, m, InitInp, ErrStat, ErrMsg )
    WRITE (UnSu, '("#", 6(2x,A))') '    -----------------','-----------------','-----------------','-----------------','-----------------','-----------------'
    DO i=1,p%elem_total
        WRITE (UnSu, '("#", 1x,A,I4)') 'Element number: ',i
-       call yaml_write_array(UnSu, 'Init_Nodes_E'//num2lstr(i), transpose(p%uuN0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt=' 5(ES18.5, ","), ES18.5, ')
+       call yaml_write_array(UnSu, 'Init_Nodes_E'//num2lstr(i), transpose(p%uuN0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt=' 5(ES18.5, ","), ES18.5')
    ENDDO
 
    WRITE (UnSu,'(/,A)')  '# Quadrature points position and rotation vectors'
@@ -2065,7 +2065,7 @@ SUBROUTINE BD_PrintSum( p, x, OtherState, m, InitInp, ErrStat, ErrMsg )
    WRITE (UnSu, '("#", 6(2x,A))') '    -----------------','-----------------','-----------------','-----------------','-----------------','-----------------'
    DO i=1,p%elem_total
        WRITE (UnSu, '("#", 1x,A,I4)')  'Element number: ',i
-       call yaml_write_array(UnSu, 'Init_QP_E'//num2lstr(i), transpose(p%uu0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt=' 5(ES18.5, ","), ES18.5, ')
+       call yaml_write_array(UnSu, 'Init_QP_E'//num2lstr(i), transpose(p%uu0(1:6,:,i)), 'DummyFmt', ErrStat, ErrMsg, AllFmt=' 5(ES18.5, ","), ES18.5')
    ENDDO
 
    WRITE (UnSu,'(/,A)')  '# Sectional stiffness and mass matrices at quadrature points (in IEC coordinates)'

--- a/modules/nwtc-library/src/YAML.f90
+++ b/modules/nwtc-library/src/YAML.f90
@@ -536,7 +536,7 @@ subroutine yaml_write_array2R4(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    else
       ! YAML Line format
       if (present(AllFmt)) then
-         Fmt = '('//trim(Fmt)//'"- [",'//trim(AllFmt)//'"]")'   
+         Fmt = '('//trim(Fmt)//'"- [",'//trim(AllFmt)//', "]")'   
       elseif (nc==1) then
          Fmt = '('//trim(Fmt)//'"- [", '//trim(Num2LStr(nc))//'('//VarFmt//'), "]")'   
       else
@@ -589,7 +589,7 @@ subroutine yaml_write_array2R8(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    else
       ! YAML Line format
       if (present(AllFmt)) then
-         Fmt = '('//trim(Fmt)//'"- [",'//trim(AllFmt)//'"]")'   
+         Fmt = '('//trim(Fmt)//'"- [",'//trim(AllFmt)//', "]")'   
       elseif (nc==1) then
          Fmt = '('//trim(Fmt)//'"- [", '//trim(Num2LStr(nc))//'('//VarFmt//'), "]")'   
       else

--- a/modules/nwtc-library/src/YAML.f90
+++ b/modules/nwtc-library/src/YAML.f90
@@ -519,7 +519,6 @@ subroutine yaml_write_array2R4(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    Fmt=''
 
    ! Indent and Key
-   if (present(level)) Fmt = trim(Num2LStr(level*INDENT_SPACES))//'X,'
    if (present(comment)) then
       write(fid, '('//trim(Fmt)//'A,": # ",I0," x ",I0,1X,A)', iostat=ErrStat ) trim(key), nr, nc, trim(comment)
    else
@@ -572,7 +571,6 @@ subroutine yaml_write_array2R8(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    Fmt=''
 
    ! Indent and Key
-   if (present(level)) Fmt = trim(Num2LStr(level*INDENT_SPACES))//'X,'
    if (present(comment)) then
       write(fid, '('//trim(Fmt)//'A,": # ",I0," x ",I0,1X,A)', iostat=ErrStat ) trim(key), nr, nc, trim(comment)
    else

--- a/modules/nwtc-library/src/YAML.f90
+++ b/modules/nwtc-library/src/YAML.f90
@@ -519,6 +519,7 @@ subroutine yaml_write_array2R4(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    Fmt=''
 
    ! Indent and Key
+   if (present(level)) Fmt = trim(Num2LStr(level*INDENT_SPACES))//'X,'
    if (present(comment)) then
       write(fid, '('//trim(Fmt)//'A,": # ",I0," x ",I0,1X,A)', iostat=ErrStat ) trim(key), nr, nc, trim(comment)
    else
@@ -571,6 +572,7 @@ subroutine yaml_write_array2R8(fid, key, A, VarFmt, ErrStat, ErrMsg, level, comm
    Fmt=''
 
    ! Indent and Key
+   if (present(level)) Fmt = trim(Num2LStr(level*INDENT_SPACES))//'X,'
    if (present(comment)) then
       write(fid, '('//trim(Fmt)//'A,": # ",I0," x ",I0,1X,A)', iostat=ErrStat ) trim(key), nr, nc, trim(comment)
    else


### PR DESCRIPTION
Ready to merge


<!-- Is this pull request ready to be merged? -->
<!-- i.e. tests pass or are expected to fail; all development is finished; appropriate documentation is included. -->
<!-- If not but opening the pull request will facilitate development, make it a "draft" pull request -->

**Feature or improvement description**
Update `AllFmt` format strings in `BeamDyn_IO.f90` for `Init_Nodes` and `Init_QP` were missing a comma at the end.  This was preventing writing of this information.

~Also removed redundant format statement from yaml_write_array2R[48]~

**Related issue, if one exists**
Reported internally

**Impacted areas of the software**
_BeamDyn_ summary file only

**Additional supporting information**
It's unclear if this ever worked correctly.

**Generative AI usage**
Attempted to generate the commit message by ai.  It really didn't understand the changes at all.

**Test results, if applicable**
No changes