### PR TITLE
InflowWind Hub Velocity Mapping for MHKs

### DIFF
--- a/modules/openfast-library/src/FAST_Mapping.f90
+++ b/modules/openfast-library/src/FAST_Mapping.f90
@@ -3474,6 +3474,11 @@ subroutine Custom_InputSolve(Mapping, ModSrc, ModDst, iInput, T, ErrStat, ErrMsg
                                         T%ED%y(ModSrc%Ins)%HubPtMotion%TranslationDisp(:, 1)
       T%IfW%Input(iInput)%HubOrientation = T%ED%y(ModSrc%Ins)%HubPtMotion%Orientation(:, :, 1)
 
+      ! MHK: shift hub position from MSL frame to seabed frame for InflowWind
+      if (T%p_FAST%MHK /= MHK_None) then
+         T%IfW%Input(iInput)%HubPosition(3) = T%IfW%Input(iInput)%HubPosition(3) + T%p_FAST%WtrDpth
+      end if
+
       ! Set Lidar position directly from hub motion mesh
       T%IfW%Input(iInput)%lidar%HubDisplacementX = T%ED%y(ModSrc%Ins)%HubPtMotion%TranslationDisp(1, 1)
       T%IfW%Input(iInput)%lidar%HubDisplacementY = T%ED%y(ModSrc%Ins)%HubPtMotion%TranslationDisp(2, 1)
@@ -3485,6 +3490,11 @@ subroutine Custom_InputSolve(Mapping, ModSrc, ModDst, iInput, T, ErrStat, ErrMsg
       T%IfW%Input(iInput)%HubPosition = T%SED%y%HubPtMotion%Position(:, 1) + &
                                         T%SED%y%HubPtMotion%TranslationDisp(:, 1)
       T%IfW%Input(iInput)%HubOrientation = T%SED%y%HubPtMotion%Orientation(:, :, 1)
+
+      ! MHK: shift hub position from MSL frame to seabed frame for InflowWind
+      if (T%p_FAST%MHK /= MHK_None) then
+         T%IfW%Input(iInput)%HubPosition(3) = T%IfW%Input(iInput)%HubPosition(3) + T%p_FAST%WtrDpth
+      end if
 
       ! Set Lidar position directly from hub motion mesh
       T%IfW%Input(iInput)%lidar%HubDisplacementX = T%SED%y%HubPtMotion%TranslationDisp(1, 1)

--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -519,6 +519,11 @@ SUBROUTINE FAST_InitializeAll( t_initial, m_Glue, p_FAST, y_FAST, m_FAST, ED, SE
          Init%InData_IfW%RadAvg = Init%InData_IfW%RadAvg / p_FAST%NumBD
       end select
 
+      ! MHK: shift hub position from MSL frame to seabed frame for InflowWind
+      if (p_FAST%MHK /= MHK_None) then
+         Init%InData_IfW%HubPosition(3) = Init%InData_IfW%HubPosition(3) + p_FAST%WtrDpth
+      end if
+
       IF (PRESENT(ExternInitData)) THEN
          Init%InData_IfW%Use4Dext = ExternInitData%FarmIntegration
 


### PR DESCRIPTION
**Feature or improvement description**

Fix MHK hub-height wind speed (`HorWindV` / `avrSWAP(27)`) and InflowWind hub velocity outputs (`WindHubVelX/Y/Z`) reporting zero for MHK turbines.

For MHK turbines, ElastoDyn reports the hub position in the MSL reference frame (e.g., Z = -24 m for the RM1 floating turbine). When this position is passed to InflowWind for the hub velocity query, `IfW_FlowField_GetVelAcc` checks `Position(3) > 0` and returns zero velocity for any point at or below Z = 0. Since no coordinate offset was applied, the hub was seen as "underground" and the velocity was zeroed out.

AeroDyn already handles this correctly by adding `PosOffset = [0, 0, WtrDpth]` when querying InflowWind for blade/hub inflow. However, the separate hub velocity path used by ServoDyn (`InflowWind_GetHubValues` → `HorWindV` → `avrSWAP(27)`) did not apply this offset.

This PR adds the `WtrDpth` offset to `HubPosition(3)` at the glue-code level before it is passed to InflowWind, consistent with the InflowWind documentation stating that all parameters should be "defined relative to the seabed" for MHK turbines. The fix is applied in:

- `FAST_Mapping.f90`: Both `Custom_ED_to_IfW` and `Custom_SED_to_IfW` mappings
- `FAST_Subs.f90`: The InflowWind initialization path where `HubPosition` is first set

This ensures all downstream InflowWind queries (HubVel, DiskVel, Lidar) receive the hub position in the seabed-referenced frame.

**Related issue, if one exists**


**Impacted areas of the software**

- `modules/openfast-library/src/FAST_Mapping.f90` — ED→IfW and SED→IfW custom input solve
- `modules/openfast-library/src/FAST_Subs.f90` — InflowWind initialization
- ServoDyn Bladed-style DLL interface (`avrSWAP(27)`)
- InflowWind hub velocity, disk velocity, and Lidar outputs for MHK turbines

**Additional supporting information**

Root cause trace:

1. `FAST_Mapping.f90` maps `HubPtMotion%Position` (MSL frame, Z = -24 m for RM1) directly to `IfW%Input%HubPosition`
2. `InflowWind_GetHubValues` passes `HubPosition` to `IfW_FlowField_GetVelAcc` with no `PosOffset`
3. `IfW_FlowField.f90` ~line 160: `if (Position(3, i) > 0.0)` → false → returns `VelocityUVW = 0`
4. `FAST_Mapping.f90` ~line 3627: `HorWindV = sqrt(HubVel(1)^2 + HubVel(2)^2)` = 0
5. `BladedInterface.f90` ~line 933: `avrSWAP(27) = u%HorWindV` = 0

AeroDyn does not have this problem because it applies `PosOffset = [0, 0, WtrDpth]` in `AD_CalcWind_Rotor`.

After fix, `WindHubVelX` reports ~1.93 m/s (the expected current speed at hub height) for the MHK_RM1_Floating test case, instead of 0.

I have a branch with `MHK_RM1_Floating` and `MHK_RM1_Fixed` regression tests updated to include `WindHubVelX/Y/Z` in the InflowWind `OutList` to capture this behavior going forward.

**Generative AI usage**

Assisted by: GitHub Copilot <support@github.com>

**Test results, if applicable**

- [x] r-test branch merging required — `MHK_RM1_Floating` and `MHK_RM1_Fixed` baselines need updating due to:
  1. New `WindHubVelX/Y/Z` output channels added to InflowWind OutList
  2. Changed simulation results from corrected hub position (hub velocity now non-zero, which may affect any coupled dynamics)
