### PR TITLE
Fall back to git rev-parse for version info on shallow clones

### DIFF
--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -116,7 +116,36 @@ function(git_describe _var)
 		ERROR_QUIET
 		OUTPUT_STRIP_TRAILING_WHITESPACE)
 	if(NOT res EQUAL 0)
-		set(out "${out}-${res}-NOTFOUND")
+		# git describe failed (e.g. shallow clone with no reachable tags).
+		# Fall back to the short commit hash.
+		execute_process(COMMAND
+			"${GIT_EXECUTABLE}"
+			rev-parse --short=8 HEAD
+			WORKING_DIRECTORY
+			"${CMAKE_CURRENT_SOURCE_DIR}"
+			RESULT_VARIABLE
+			res_hash
+			OUTPUT_VARIABLE
+			out_hash
+			ERROR_QUIET
+			OUTPUT_STRIP_TRAILING_WHITESPACE)
+		if(res_hash EQUAL 0)
+			# Check for dirty working tree
+			execute_process(COMMAND
+				"${GIT_EXECUTABLE}"
+				diff-index --quiet HEAD --
+				WORKING_DIRECTORY
+				"${CMAKE_CURRENT_SOURCE_DIR}"
+				RESULT_VARIABLE
+				res_dirty)
+			if(res_dirty EQUAL 0)
+				set(out "${out_hash}")
+			else()
+				set(out "${out_hash}-dirty")
+			endif()
+		else()
+			set(out "${out}-${res}-NOTFOUND")
+		endif()
 	endif()
 
 	set(${_var} "${out}" PARENT_SCOPE)

--- a/cmake/GetGitRevisionDescription.cmake
+++ b/cmake/GetGitRevisionDescription.cmake
@@ -137,7 +137,8 @@ function(git_describe _var)
 				WORKING_DIRECTORY
 				"${CMAKE_CURRENT_SOURCE_DIR}"
 				RESULT_VARIABLE
-				res_dirty)
+				res_dirty
+				ERROR_QUIET)
 			if(res_dirty EQUAL 0)
 				set(out "${out_hash}")
 			else()

--- a/vs-build/CreateGitVersion.bat
+++ b/vs-build/CreateGitVersion.bat
@@ -3,14 +3,14 @@ SETLOCAL ENABLEDELAYEDEXPANSION
 SET IncludeFile=..\gitVersionInfo.h
 
 <NUL SET /p IncludeTxt=#define GIT_VERSION_INFO '> %IncludeFile%
-FOR /f %%a IN ('git describe --abbrev^=8 --always --tags --dirty') DO <NUL SET /p IncludeTxt=%%a>> %IncludeFile%
+FOR /f %%a IN ('git describe --abbrev^=8 --always --tags --dirty 2^>NUL') DO <NUL SET /p IncludeTxt=%%a>> %IncludeFile%
 git describe --abbrev^=8 --always --tags --dirty > NUL 2>&1
 IF !ERRORLEVEL!==0 (
     ECHO '>> %IncludeFile%
 ) ELSE (
     REM git describe failed (e.g. shallow clone). Fall back to short commit hash.
     SET GitHash=
-    FOR /f %%a IN ('git rev-parse --short^=8 HEAD') DO (
+    FOR /f %%a IN ('git rev-parse --short^=8 HEAD 2^>NUL') DO (
         SET GitHash=%%a
     )
     IF DEFINED GitHash (

--- a/vs-build/CreateGitVersion.bat
+++ b/vs-build/CreateGitVersion.bat
@@ -1,9 +1,30 @@
 @ECHO off
+SETLOCAL ENABLEDELAYEDEXPANSION
 SET IncludeFile=..\gitVersionInfo.h
 
 <NUL SET /p IncludeTxt=#define GIT_VERSION_INFO '> %IncludeFile%
 FOR /f %%a IN ('git describe --abbrev^=8 --always --tags --dirty') DO <NUL SET /p IncludeTxt=%%a>> %IncludeFile%
-git describe --abbrev^=8 --always --tags --dirty > NUL
-IF %ERRORLEVEL%==0 ( ECHO '>> %IncludeFile% ) else ( ECHO Unversioned from $Format:%H$ '>> %IncludeFile% )
+git describe --abbrev^=8 --always --tags --dirty > NUL 2>&1
+IF !ERRORLEVEL!==0 (
+    ECHO '>> %IncludeFile%
+) ELSE (
+    REM git describe failed (e.g. shallow clone). Fall back to short commit hash.
+    SET GitHash=
+    FOR /f %%a IN ('git rev-parse --short^=8 HEAD') DO (
+        SET GitHash=%%a
+    )
+    IF DEFINED GitHash (
+        git diff-index --quiet HEAD -- > NUL 2>&1
+        IF !ERRORLEVEL!==0 (
+            <NUL SET /p IncludeTxt=!GitHash!>> %IncludeFile%
+        ) ELSE (
+            <NUL SET /p IncludeTxt=!GitHash!-dirty>> %IncludeFile%
+        )
+        ECHO '>> %IncludeFile%
+    ) ELSE (
+        ECHO Unversioned from $Format:%H$ '>> %IncludeFile%
+    )
+)
 
+ENDLOCAL
 EXIT /B 0


### PR DESCRIPTION
Ready to merge 

**Feature or improvement description**

When OpenFAST is built from a shallow clone (e.g. `git clone --depth 1`), `git describe --tags` fails because no upstream tag is reachable in the truncated history. This causes the version string to be set to a `NOTFOUND` value.

This PR adds a fallback so that when `git describe` fails, the build system retrieves the short commit hash via `git rev-parse --short=8 HEAD` and appends `-dirty` if the working tree has uncommitted changes. The full `git describe` output is still preferred when available.

**Related issue, if one exists**

None.

**Impacted areas of the software**

- GetGitRevisionDescription.cmake — CMake version retrieval used by all builds
- CreateGitVersion.bat — Windows Visual Studio build version retrieval

No runtime code or module behavior is affected. The change only impacts the version string embedded at compile time.

**Additional supporting information**

Fallback behavior by scenario:

| Scenario | Version string |
|---|---|
| Normal clone (tags reachable) | `v5.0.0-109-gfb80e5e4` (unchanged) |
| Shallow clone (no tags) | `fb80e5e4` or `fb80e5e4-dirty` (new) |
| No git / tarball | `GIT-NOTFOUND` or externally set `GIT_DESCRIBE` (unchanged) |

**Generative AI usage**

Co-authored-by: Claude <noreply@anthropic.com>
Co-authored-by: GitHub Copilot <noreply@github.com>

**Test results, if applicable**

No regression or unit tests are affected — the change is build-system only and does not alter any compiled source or test infrastructure.


**ToDo**

- [x] verify batch script works as expected (untested in development)