### PR TITLE
Fix SED crashes: VTK segfault and zero-inertia NaN propagation

### DIFF
--- a/modules/openfast-library/src/FAST_Subs.f90
+++ b/modules/openfast-library/src/FAST_Subs.f90
@@ -1524,7 +1524,13 @@ SUBROUTINE FAST_InitializeAll( t_initial, m_Glue, p_FAST, y_FAST, m_FAST, ED, SE
 
    if ( p_FAST%WrVTK > VTK_None ) then
       ! TODO: support multiple ElastoDyns
-      call SetVTKParameters(p_FAST, Init%OutData_ED(1), Init%OutData_SED, Init%OutData_AD, Init%OutData_SeaSt, Init%OutData_HD, ED, SED, BD, AD, HD, ErrStat2, ErrMsg2)
+      if (allocated(Init%OutData_ED)) then
+         call SetVTKParameters(p_FAST, Init%OutData_ED(1), Init%OutData_SED, Init%OutData_AD, Init%OutData_SeaSt, Init%OutData_HD, ED, SED, BD, AD, HD, ErrStat2, ErrMsg2)
+      else
+         call SetVTKParameters(p_FAST, InitOutData_SED=Init%OutData_SED, InitOutData_AD=Init%OutData_AD, &
+                               InitOutData_SeaSt=Init%OutData_SeaSt, InitOutData_HD=Init%OutData_HD, &
+                               ED=ED, SED=SED, BD=BD, AD=AD, HD=HD, ErrStat=ErrStat2, ErrMsg=ErrMsg2)
+      end if
          call SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
    end if
 
@@ -3797,13 +3803,13 @@ END SUBROUTINE FAST_ReadSteadyStateFile
 SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_SED, InitOutData_AD, InitOutData_SeaSt, InitOutData_HD, ED, SED, BD, AD, HD, ErrStat, ErrMsg)
 
    TYPE(FAST_ParameterType),     INTENT(INOUT) :: p_FAST           !< The parameters of the glue code
-   TYPE(ED_InitOutputType),      INTENT(IN   ) :: InitOutData_ED   !< The initialization output from structural dynamics module
+   TYPE(ED_InitOutputType), OPTIONAL, INTENT(IN) :: InitOutData_ED  !< The initialization output from structural dynamics module
    TYPE(SED_InitOutputType),     INTENT(IN   ) :: InitOutData_SED  !< The initialization output from structural dynamics module
    TYPE(AD_InitOutputType),      INTENT(INOUT) :: InitOutData_AD   !< The initialization output from AeroDyn
    TYPE(SeaSt_InitOutputType),   INTENT(INOUT) :: InitOutData_SeaSt   !< The initialization output from SeaState
    TYPE(HydroDyn_InitOutputType),INTENT(INOUT) :: InitOutData_HD   !< The initialization output from HydroDyn
    TYPE(ElastoDyn_Data), TARGET, INTENT(IN   ) :: ED               !< ElastoDyn data
-   TYPE(SED_Data),               INTENT(IN   ) :: SED              !< Simplified-ElastoDyn data
+   TYPE(SED_Data),        TARGET, INTENT(IN   ) :: SED              !< Simplified-ElastoDyn data
    TYPE(BeamDyn_Data),           INTENT(IN   ) :: BD               !< BeamDyn data
    TYPE(AeroDyn_Data),           INTENT(IN   ) :: AD               !< AeroDyn data
    TYPE(HydroDyn_Data),          INTENT(IN   ) :: HD               !< HydroDyn data
@@ -3862,6 +3868,9 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_SED, InitOutData
    if ( p_FAST%CompElast == Module_BD ) then
       BladeLength = TwoNorm(BD%y(1)%BldMotion%Position(:,1) - BD%y(1)%BldMotion%Position(:,BD%y(1)%BldMotion%Nnodes))
       HubRad = InitOutData_ED%HubRad
+   else if ( p_FAST%CompElast == Module_SED ) then
+      BladeLength = InitOutData_SED%BladeLength
+      HubRad = InitOutData_SED%HubRad
    else
       BladeLength = InitOutData_ED%BladeLength
       HubRad = InitOutData_ED%HubRad
@@ -3916,7 +3925,11 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_SED, InitOutData
    ! Create the tower surface data
    !.......................
    ! TODO: Support multiple towers
-   TowerMotionMesh => ED%y(1)%TowerLn2Mesh
+   if (p_FAST%CompElast == Module_SED) then
+      TowerMotionMesh => SED%y%TowerLn2Mesh
+   else
+      TowerMotionMesh => ED%y(1)%TowerLn2Mesh
+   end if
 
    CALL AllocAry(p_FAST%VTK_Surface%TowerRad,TowerMotionMesh%NNodes,'VTK_Surface%TowerRad',ErrStat2,ErrMsg2)
       CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
@@ -4001,7 +4014,9 @@ SUBROUTINE SetVTKParameters(p_FAST, InitOutData_ED, InitOutData_SED, InitOutData
             CALL SetErrStat(ErrStat2,ErrMsg2,ErrStat,ErrMsg,RoutineName)
             IF (ErrStat >= AbortErrLev) RETURN
       END DO
-!   ELSE IF (p_FAST%CompElast == Module_SED) THEN     ! no blade surface info from SED
+   ELSE IF (p_FAST%CompElast == Module_SED) THEN
+      ! SED has no blade line2 mesh; skip generic blade surface generation
+      call WrScr('Skipping generic blade surfaces for Simplified ElastoDyn (no blade mesh available).')
    ELSE
       call WrScr('Using generic blade surfaces for ElastoDyn (rectangular airfoil, constant chord). ') ! TODO make this an option
       DO K=1,NumBl

--- a/modules/simple-elastodyn/src/SED.f90
+++ b/modules/simple-elastodyn/src/SED.f90
@@ -190,6 +190,14 @@ contains
       ! system inertia
       p%J_DT   = p%RotIner + p%GBoxRatio**2_IntKi * p%GenIner
 
+      ! Check for zero inertia with GenDOF enabled (would cause division by zero in CalcContStateDeriv)
+      if (p%GenDOF .and. EqualRealNos(real(p%J_DT, ReKi), 0.0_ReKi)) then
+         ErrStat3 = ErrID_Fatal
+         ErrMsg3 = 'GenDOF is enabled but drivetrain inertia (RotIner + GBoxRatio^2*GenIner) is zero. '// &
+                   'This would result in a division by zero. Set RotIner or GenIner to a non-zero value, or disable GenDOF.'
+         return
+      end if
+
       ! Set the outputs
       call SetOutParam(InputFileData%OutList, p, ErrStat3, ErrMsg3 )
    end subroutine SED_SetParameters


### PR DESCRIPTION
**Feature or improvement description**

Fixes two crashes when using Simplified ElastoDyn (CompElast=3):

1. **VTK segfault during initialization** — When VTK output is enabled (`WrVTK > 0`), `SetVTKParameters` unconditionally accessed `Init%OutData_ED(1)` which is never allocated for SED. Fixed by guarding the call site with `allocated()` and adding SED-specific paths for blade length, hub radius, tower mesh, and blade surfaces inside `SetVTKParameters`.

2. **NaN propagation from zero drivetrain inertia** — When `GenDOF=True` with `RotIner=0` and `GenIner=0`, the angular acceleration calculation divides by zero inertia, producing NaN that propagates through the hub orientation into InflowWind as a cryptic "GF wind array exhausted at NaN seconds" error. Fixed by adding an initialization validation that reports a clear fatal error.

**Related issue, if one exists**

Depends on #3405

**Impacted areas of the software**

- `modules/openfast-library/src/FAST_Subs.f90` — VTK initialization with SED
- `modules/simple-elastodyn/src/SED.f90` — Input validation for drivetrain inertia

**Additional supporting information**

Tested with a SED+AeroDyn+InflowWind model (OC7 WP3.1 configuration) that previously segfaulted during initialization. After fixes, initialization completes and the zero-inertia case produces a clear error message.

**Generative AI usage**

Co-authored-by: GitHub Copilot (Claude Opus 4) <noreply@github.com>
Co-authored-by: Claude <noreply@anthropic.com>

**Test results, if applicable**

No regression test changes required — these are bug fixes for previously-crashing configurations.
- [ ] r-test branch merging required