### PR TITLE
Updated the .gitignore for vscode containers / workspaces

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,8 @@ varcache
 # Python cache files
 openfast_io/dist/
 openfast_io/openfast_io/_version.py
+
+# docker with VScode config
+*.code-workspace
+docker-compose.yml
+.devcontainer/


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**
Adds a few other file types to ignore.  These are commonly used in docker containerized vscode environments and sometimes located in the cloned repository.

Files ignored:
* `*.code-workspace`
* `docker-compose.yml`
* `.devcontainer/`


**Related issue, if one exists**
None

**Impacted areas of the software**
None

**Additional supporting information**
This helps minimize the number of stray file commits that might occur.

**Generative AI usage**
None

**Test results, if applicable**
No tests affected.