### PR TITLE
Fix #3421: Guard DT_mooring validation with mooring enabled check

### DIFF
--- a/glue-codes/fast-farm/src/FAST_Farm_IO.f90
+++ b/glue-codes/fast-farm/src/FAST_Farm_IO.f90
@@ -1047,6 +1047,7 @@ SUBROUTINE Farm_ValidateInput( p, WD_InitInp, AWAE_InitInp, ErrStat, ErrMsg )
    CHARACTER(*),   PARAMETER     :: RoutineName = 'Farm_ValidateInput'
    INTEGER(IntKi)                :: n_disDT_dt
    character(60)                 :: tmpStr
+   logical                       :: file_exists                               ! Flag for file existence check
 
    ErrStat = ErrID_None
    ErrMsg  = ""
@@ -1066,8 +1067,11 @@ SUBROUTINE Farm_ValidateInput( p, WD_InitInp, AWAE_InitInp, ErrStat, ErrMsg )
    ! TODO : Verify that the DLL file exists
 
    ! --- SHARED MOORING SYSTEM ---
-   ! TODO : Verify that p%MD_FileName file exists
-   if ((p%DT_mooring <= 0.0_ReKi) .or. (p%DT_mooring > p%DT_high)) CALL SetErrStat(ErrID_Fatal,'DT_mooring must be greater than zero and no greater than dt_high.',ErrStat,ErrMsg,RoutineName)
+   if (p%MooringMod == 3) then
+      inquire(file=trim(p%MD_FileName), exist=file_exists)
+      if (.not. file_exists) call SetErrStat(ErrID_Fatal,'Cannot find MoorDyn input file '//trim(p%MD_FileName),ErrStat,ErrMsg,RoutineName)
+      if ((p%DT_mooring <= 0.0_ReKi) .or. (p%DT_mooring > p%DT_high)) CALL SetErrStat(ErrID_Fatal,'DT_mooring must be greater than zero and no greater than dt_high.',ErrStat,ErrMsg,RoutineName)
+   end if
 
    ! --- AMBIENT WIND: INFLOWWIND MODULE --- [used only for Mod_AmbWind=2 or 3] ---
    ! FIXME: this really should be checked with the turbine specific size diameter -- maybe relocate this check to AWAE or in FF after initializing all turbines?


### PR DESCRIPTION
Ready to merge


**Feature or improvement description**

This PR fixes a bug in FAST.Farm where `DT_mooring` validation was incorrectly executed regardless of whether shared mooring was enabled, causing fatal errors for users running cases with `Mod_SharedMooring = 0`.

The fix adds conditional guards around mooring-related validations so they only execute when mooring is actually enabled (`Mod_SharedMooring = 3`). Additionally, this implements the TODO for verifying that the MoorDyn input file exists.

**Changes made:**
- Wrapped `DT_mooring` validation in `if (p%MooringMod == 3)` conditional
- Added file existence check for `MD_FileName` when mooring is enabled
- Added `file_exists` logical variable declaration to support the validation

**Before:**
```fortran
! --- SHARED MOORING SYSTEM ---
! TODO : Verify that p%MD_FileName file exists
if ((p%DT_mooring <= 0.0_ReKi) .or. (p%DT_mooring > p%DT_high)) CALL SetErrStat(ErrID_Fatal,'DT_mooring must be greater than zero and no greater than dt_high.',ErrStat,ErrMsg,RoutineName)
```

**After:**
```fortran
! --- SHARED MOORING SYSTEM ---
if (p%MooringMod == 3) then
   inquire(file=trim(p%MD_FileName), exist=file_exists)
   if (.not. file_exists) call SetErrStat(ErrID_Fatal,'Cannot find MoorDyn input file '//trim(p%MD_FileName),ErrStat,ErrMsg,RoutineName)
   if ((p%DT_mooring <= 0.0_ReKi) .or. (p%DT_mooring > p%DT_high)) CALL SetErrStat(ErrID_Fatal,'DT_mooring must be greater than zero and no greater than dt_high.',ErrStat,ErrMsg,RoutineName)
end if
```

**Related issue, if one exists**

Fixes #3421

**Impacted areas of the software**

- FAST.Farm input file validation (`glue-codes/fast-farm/src/FAST_Farm_IO.f90`)
- Specifically the `Farm_ValidateInput()` subroutine

**Additional supporting information**

The implementation follows established OpenFAST patterns:
- Module-specific conditional validation (similar to `CompMooring` checks in `FAST_Subs.f90`)
- File existence checks (similar to pattern in `WaveTank_IO.f90`)

This is a non-breaking change that:
- ✅ Allows cases with `Mod_SharedMooring = 0` to run without spurious DT_mooring validation errors
- ✅ Maintains strict validation when mooring is enabled (`Mod_SharedMooring = 3`)
- ✅ Adds better error reporting for missing MoorDyn input files

**Generative AI usage**

Co-authored-by: GitHub Copilot <noreply@github.com>
Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>

**Test results, if applicable**

- [ ] r-test branch merging required

No r-test changes needed. This is a validation-only fix that:
1. Removes false-positive errors when mooring is disabled
2. Adds file existence validation when mooring is enabled

Existing regression tests with mooring enabled should continue to pass. Cases with `Mod_SharedMooring = 0` will no longer fail validation unnecessarily.