### PR TITLE
fix bug in bldprcnt following issue #3416

### DIFF
--- a/modules/aerodyn/src/AeroAcoustics.f90
+++ b/modules/aerodyn/src/AeroAcoustics.f90
@@ -271,7 +271,15 @@ subroutine SetParameters( InitInp, InputFileData, p, AFInfo, ErrStat, ErrMsg )
     p%BlSpn   = InitInp%BlSpn
     p%BlChord = InitInp%BlChord
 
-    p%startnode = max(1, p%NumBlNds - 1)
+    IF (InputFileData%AA_Bl_Prcntge .lt. (100.*(p%BlSpn(p%NumBlNds,1) - p%BlSpn(p%NumBlNds-1,1))/p%BlSpn(p%NumBlNds,1)) THEN
+        CALL SetErrStat(ErrID_Warn, 'AA_Bl_Prcntge is smaller than the last blade element size. '// &
+            'OpenFAST will move on assuming the last blade element, which is the minimum blade span used for noise calculations. '// &
+            'Either increase BldPrcnt in your aeroacoustic input file '// &
+            'or refine the aerodynamic mesh in your blade AeroDyn input file.', ErrStat2, ErrMsg2, RoutineName )
+        if(Failed()) return
+    endif
+
+    p%startnode = min(p%NumBlNds, 2)
     BladeSpanUsedForNoise = p%BlSpn(p%NumBlNds,1)*(1.0 - InputFileData%AA_Bl_Prcntge/100.0)
     do j=p%NumBlNds-1,2,-1
         IF ( p%BlSpn(j,1) .lt. BladeSpanUsedForNoise )THEN
@@ -279,7 +287,7 @@ subroutine SetParameters( InitInp, InputFileData, p, AFInfo, ErrStat, ErrMsg )
             exit ! exit the loop
         endif
     enddo
-    p%startnode = max(min(p%NumBlNds,2),p%startnode)
+
     
    p%BlElemSpn = 0;
    DO I = 1,p%numBlades

--- a/modules/aerodyn/src/AeroAcoustics.f90
+++ b/modules/aerodyn/src/AeroAcoustics.f90
@@ -271,7 +271,7 @@ subroutine SetParameters( InitInp, InputFileData, p, AFInfo, ErrStat, ErrMsg )
     p%BlSpn   = InitInp%BlSpn
     p%BlChord = InitInp%BlChord
 
-    IF (InputFileData%AA_Bl_Prcntge .lt. (100.*(p%BlSpn(p%NumBlNds,1) - p%BlSpn(p%NumBlNds-1,1))/p%BlSpn(p%NumBlNds,1)) THEN
+    IF (InputFileData%AA_Bl_Prcntge .lt. (100.*(p%BlSpn(p%NumBlNds,1) - p%BlSpn(p%NumBlNds-1,1))/p%BlSpn(p%NumBlNds,1))) THEN
         CALL SetErrStat(ErrID_Warn, 'AA_Bl_Prcntge is smaller than the last blade element size. '// &
             'OpenFAST will move on assuming the last blade element, which is the minimum blade span used for noise calculations. '// &
             'Either increase BldPrcnt in your aeroacoustic input file '// &

--- a/modules/aerodyn/src/AeroAcoustics.f90
+++ b/modules/aerodyn/src/AeroAcoustics.f90
@@ -272,7 +272,7 @@ subroutine SetParameters( InitInp, InputFileData, p, AFInfo, ErrStat, ErrMsg )
     p%BlChord = InitInp%BlChord
 
     IF (InputFileData%AA_Bl_Prcntge .lt. (100.*(p%BlSpn(p%NumBlNds,1) - p%BlSpn(p%NumBlNds-1,1))/p%BlSpn(p%NumBlNds,1))) THEN
-        CALL SetErrStat(ErrID_Warn, 'AA_Bl_Prcntge is smaller than the last blade element size. '// &
+        CALL SetErrStat(ErrID_Warn, 'BldPrcnt is smaller than the last blade element size. '// &
             'OpenFAST will move on assuming the last blade element, which is the minimum blade span used for noise calculations. '// &
             'Either increase BldPrcnt in your aeroacoustic input file '// &
             'or refine the aerodynamic mesh in your blade AeroDyn input file.', ErrStat2, ErrMsg2, RoutineName )


### PR DESCRIPTION
Work on issue #3416

Thank you @Sparsh-Sharma for the detailed issue. You are very right that the code breaks for `BldPrcnt=100`. Surprisingly enough, we never set it to 100%, and we never noticed the problem.

I've adopted your suggestion of setting `p%startnode = min(p%NumBlNds, 2)` instead of `p%startnode = max(1, p%NumBlNds - 1)`.

Next, I think I am good to remove the check `p%startnode = max(min(p%NumBlNds,2),p%startnode)`, which should never be triggered

Lastly, I added a warning if `BldPrcnt` is smaller than the last element size. I think that's the warning you were recommending. You wrote 'A warning if `BldPrcnt` is large enough that no node satisfies the threshold might also be worth adding, since the condition is silent today.', but I was a little lost. I think this happens when `BldPrcnt` is too small, not 'large enough'. Let me know if I am still missing something.

I will also improve the documentation in the r-tests now

