### PR TITLE
Fix InflowWind Grid3D cubic velocity interpolation NaN bug

### DIFF
--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -78,7 +78,9 @@ subroutine IfW_FlowField_GetVelAcc(FF, IStart, Time, PositionXYZ, VelocityUVW, A
 
    ! Determine if acceleration should be calculated and returned
    OutputAccel = allocated(AccelUVW)
-   if (OutputAccel .and. .not. FF%AccFieldValid) then
+   ! Cubic velocity interpolation also requires a valid acceleration field, since its
+   ! formula uses the derivative data even when acceleration output is not requested.
+   if ((OutputAccel .or. FF%VelInterpCubic) .and. .not. FF%AccFieldValid) then
       call SetErrStat(ErrID_Fatal, "Accel output requested, but accel field is not valid", &
                       ErrStat, ErrMsg, RoutineName)
       return
@@ -224,8 +226,10 @@ subroutine IfW_FlowField_GetVelAcc(FF, IStart, Time, PositionXYZ, VelocityUVW, A
 
          ! Calculate grid cells for interpolation, returns velocity and acceleration
          ! components at corners of grid cell containing time and position. Also
-         ! returns interpolation values Xi.
-         call Grid3DField_GetCell(FF%Grid3D, Time, Position(:, i), OutputAccel, GridExceedAllow, &
+         ! returns interpolation values Xi. AccCell is required whenever cubic
+         ! velocity interpolation is used (its formula uses the derivative data),
+         ! not only when acceleration is explicitly requested as an output.
+         call Grid3DField_GetCell(FF%Grid3D, Time, Position(:, i), OutputAccel .or. FF%VelInterpCubic, GridExceedAllow, &
                                   VelCell, AccCell, Xi, Is3D, TmpErrStat, TmpErrMsg)
          if (TmpErrStat >= AbortErrLev) then
             call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
@@ -1442,9 +1446,18 @@ subroutine IfW_Grid3DField_CalcAccel(G3D, ErrStat, ErrMsg)
    call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
 
-   ! If number of time grids is 1 or 2, set all accelerations to zero, return
-   if (G3D%NTGrids < 3) then
+   ! If number of time steps is 1 or 2, set all accelerations to zero, return
+   if (G3D%NSteps < 3) then
       G3D%Acc = 0.0_SiKi
+      ! Also allocate/zero tower acceleration so GetCellInTower has a valid array to reference
+      if (G3D%NTGrids > 0) then
+         call AllocAry(G3D%AccTower, size(G3D%VelTower, dim=1), &
+                       size(G3D%VelTower, dim=2), size(G3D%VelTower, dim=3), &
+                       'tower wind acceleration data.', TmpErrStat, TmpErrMsg)
+         call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
+         if (ErrStat >= AbortErrLev) return
+         G3D%AccTower = 0.0_SiKi
+      end if
       return
    end if
 

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -1490,16 +1490,14 @@ subroutine IfW_Grid3DField_CalcAccel(G3D, ErrStat, ErrMsg)
    call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
 
-   ! If number of time grids is 1 or 2, set all accelerations to zero
-   if (G3D%NTGrids < 3) then
-      G3D%Acc = 0.0_SiKi
-   else  ! Otherwise, calculate acceleration at each grid point
-      do iz = 1, G3D%NTGrids
-         do ic = 1, G3D%NComp
-            call CalcCubicSplineDeriv(G3D%NSteps, G3D%DTime, G3D%VelTower(ic, iz, :), G3D%AccTower(ic, iz, :))
-         end do
+   ! Calculate acceleration at each tower grid point. NSteps < 3 is already handled by the
+   ! early return above, and each tower height is interpolated independently in time, so no
+   ! minimum tower height count is required here.
+   do iz = 1, G3D%NTGrids
+      do ic = 1, G3D%NComp
+         call CalcCubicSplineDeriv(G3D%NSteps, G3D%DTime, G3D%VelTower(ic, iz, :), G3D%AccTower(ic, iz, :))
       end do
-   end if
+   end do
 
 contains
 

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -224,8 +224,10 @@ subroutine IfW_FlowField_GetVelAcc(FF, IStart, Time, PositionXYZ, VelocityUVW, A
 
          ! Calculate grid cells for interpolation, returns velocity and acceleration
          ! components at corners of grid cell containing time and position. Also
-         ! returns interpolation values Xi.
-         call Grid3DField_GetCell(FF%Grid3D, Time, Position(:, i), OutputAccel, GridExceedAllow, &
+         ! returns interpolation values Xi. AccCell is required whenever cubic
+         ! velocity interpolation is used (its formula uses the derivative data),
+         ! not only when acceleration is explicitly requested as an output.
+         call Grid3DField_GetCell(FF%Grid3D, Time, Position(:, i), OutputAccel .or. FF%VelInterpCubic, GridExceedAllow, &
                                   VelCell, AccCell, Xi, Is3D, TmpErrStat, TmpErrMsg)
          if (TmpErrStat >= AbortErrLev) then
             call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
@@ -1442,8 +1444,8 @@ subroutine IfW_Grid3DField_CalcAccel(G3D, ErrStat, ErrMsg)
    call SetErrStat(TmpErrStat, TmpErrMsg, ErrStat, ErrMsg, RoutineName)
    if (ErrStat >= AbortErrLev) return
 
-   ! If number of time grids is 1 or 2, set all accelerations to zero, return
-   if (G3D%NTGrids < 3) then
+   ! If number of time steps is 1 or 2, set all accelerations to zero, return
+   if (G3D%NSteps < 3) then
       G3D%Acc = 0.0_SiKi
       return
    end if

--- a/modules/inflowwind/tests/inflowwind_utest.F90
+++ b/modules/inflowwind/tests/inflowwind_utest.F90
@@ -3,6 +3,7 @@ use, intrinsic :: iso_fortran_env, only: error_unit
 use testdrive, only: run_testsuite, new_testsuite, testsuite_type
 
 use test_bladed_wind, only: test_bladed_wind_suite
+use test_grid3d_field, only: test_grid3d_field_suite
 use test_hawc_wind, only: test_hawc_wind_suite
 use test_outputs, only: test_outputs_suite
 use test_steady_wind, only: test_steady_wind_suite
@@ -21,6 +22,7 @@ call SetConstants()
 
 testsuites = [ &
              new_testsuite("Bladed Wind", test_bladed_wind_suite), &
+             new_testsuite("Grid3D Field", test_grid3d_field_suite), &
              new_testsuite("HAWC Wind", test_hawc_wind_suite), &
              new_testsuite("Outputs", test_outputs_suite), &
              new_testsuite("Steady Wind", test_steady_wind_suite), &

--- a/modules/inflowwind/tests/test_grid3d_field.F90
+++ b/modules/inflowwind/tests/test_grid3d_field.F90
@@ -1,0 +1,163 @@
+module test_grid3d_field
+
+use, intrinsic :: ieee_arithmetic, only: ieee_is_finite
+use testdrive, only: new_unittest, unittest_type, error_type, check
+use ifw_test_tools
+use IfW_FlowField
+use IfW_FlowField_Types
+use NWTC_Library
+
+implicit none
+private
+public :: test_grid3d_field_suite
+
+integer(IntKi), parameter :: NY = 4, NZ = 4, NT = 10
+real(ReKi), parameter     :: DTIME = 0.1_ReKi
+
+contains
+
+!> Collect all exported unit tests
+subroutine test_grid3d_field_suite(testsuite)
+   type(unittest_type), allocatable, intent(out) :: testsuite(:)
+   testsuite = [ &
+               new_unittest("test_grid3d_cubic_vel_only", test_grid3d_cubic_vel_only), &
+               new_unittest("test_grid3d_calcaccel_no_tower", test_grid3d_calcaccel_no_tower) &
+               ]
+end subroutine
+
+!> Reproduces a bug in IfW_FlowField_GetVelAcc: when VelInterpCubic is enabled and the
+!! caller does not request acceleration output (AccelUVW left unallocated), the local
+!! AccCell array used by the cubic Hermite velocity formula is never populated, so the
+!! returned velocity is computed from uninitialized memory. This test builds a minimal
+!! Grid3D flow field with a velocity that is a known linear ramp in time (spatially
+!! uniform), so the exact correct answer at any query time is known, and checks that
+!! querying velocity without requesting acceleration gives the same (finite, correct)
+!! answer as querying with acceleration requested.
+subroutine test_grid3d_cubic_vel_only(error)
+   type(error_type), allocatable, intent(out) :: error
+
+   type(FlowFieldType)       :: FF
+   real(ReKi), allocatable   :: Position(:, :), VelNoAcc(:, :), VelWithAcc(:, :)
+   real(ReKi), allocatable   :: AccelUVW(:, :)
+   integer(IntKi)            :: it, iy, iz
+   integer(IntKi)            :: TmpErrStat
+   character(ErrMsgLen)      :: TmpErrMsg
+   real(DbKi)                :: QueryTime
+   real(ReKi)                :: Expected
+
+   ! Build minimal Grid3D field: NY x NZ spatial points, NT time steps, no tower grid.
+   FF%FieldType = Grid3D_FieldType
+   FF%VelInterpCubic = .true.
+   FF%RotateWindBox = .false.
+
+   FF%Grid3D%NComp = 3
+   FF%Grid3D%NYGrids = NY
+   FF%Grid3D%NZGrids = NZ
+   FF%Grid3D%NTGrids = 0
+   FF%Grid3D%NSteps = NT
+   FF%Grid3D%DTime = DTIME
+   FF%Grid3D%Rate = 1.0_ReKi/DTIME
+   FF%Grid3D%YHWid = 5.0_ReKi
+   FF%Grid3D%ZHWid = 5.0_ReKi
+   FF%Grid3D%GridBase = 5.0_ReKi
+   FF%Grid3D%InvDY = real(NY - 1, ReKi)/(2.0_ReKi*FF%Grid3D%YHWid)
+   FF%Grid3D%InvDZ = real(NZ - 1, ReKi)/(2.0_ReKi*FF%Grid3D%ZHWid)
+   FF%Grid3D%MeanWS = 8.0_ReKi
+   FF%Grid3D%InvMWS = 1.0_ReKi/FF%Grid3D%MeanWS
+   FF%Grid3D%InitXPosition = 0.0_ReKi
+   FF%Grid3D%TotalTime = real(NT - 1, ReKi)*DTIME
+   FF%Grid3D%Periodic = .false.
+   FF%Grid3D%InterpTower = .false.
+
+   allocate (FF%Grid3D%Vel(3, NY, NZ, NT))
+   FF%Grid3D%Vel = 0.0_SiKi
+   ! U component is a spatially-uniform linear ramp in time: U(t) = t (seconds -> m/s)
+   do it = 1, NT
+      do iz = 1, NZ
+         do iy = 1, NY
+            FF%Grid3D%Vel(1, iy, iz, it) = real((it - 1), SiKi)*real(DTIME, SiKi)
+         end do
+      end do
+   end do
+
+   ! Set the true time-derivative (dU/dt = 1, dV/dt = dW/dt = 0) directly rather than via
+   ! IfW_Grid3DField_CalcAccel so this test isolates the IfW_FlowField_GetVelAcc behavior.
+   ! (test_grid3d_calcaccel_no_tower below covers IfW_Grid3DField_CalcAccel itself.)
+   allocate (FF%Grid3D%Acc(3, NY, NZ, NT))
+   FF%Grid3D%Acc = 0.0_SiKi
+   FF%Grid3D%Acc(1, :, :, :) = 1.0_SiKi
+   FF%AccFieldValid = .true.
+
+   ! Query at a position centered in the grid, at a time between samples
+   allocate (Position(3, 1))
+   Position(:, 1) = [0.0_ReKi, 0.0_ReKi, FF%Grid3D%GridBase + FF%Grid3D%ZHWid]
+   QueryTime = 0.25_DbKi
+   Expected = real(QueryTime, ReKi)
+
+   ! Case 1: acceleration NOT requested (AccelUVW left unallocated) - buggy path
+   allocate (VelNoAcc(3, 1))
+   call IfW_FlowField_GetVelAcc(FF, 1, QueryTime, Position, VelNoAcc, AccelUVW, TmpErrStat, TmpErrMsg)
+   call check(error, TmpErrStat, ErrID_None, message='GetVelAcc (no accel) error: '//trim(TmpErrMsg)); if (allocated(error)) return
+
+   call check(error, ieee_is_finite(VelNoAcc(1, 1)), message='Velocity (no accel requested) is not finite (NaN/Inf)'); if (allocated(error)) return
+   call check(error, VelNoAcc(1, 1), Expected, thr=1.0e-3_ReKi); if (allocated(error)) return
+
+   ! Case 2: acceleration requested (AccelUVW allocated) - reference path
+   allocate (VelWithAcc(3, 1))
+   allocate (AccelUVW(3, 1))
+   call IfW_FlowField_GetVelAcc(FF, 1, QueryTime, Position, VelWithAcc, AccelUVW, TmpErrStat, TmpErrMsg)
+   call check(error, TmpErrStat, ErrID_None, message='GetVelAcc (with accel) error: '//trim(TmpErrMsg)); if (allocated(error)) return
+
+   call check(error, ieee_is_finite(VelWithAcc(1, 1)), message='Velocity (accel requested) is not finite (NaN/Inf)'); if (allocated(error)) return
+   call check(error, VelWithAcc(1, 1), Expected, thr=1.0e-3_ReKi); if (allocated(error)) return
+
+   ! The two calls must agree: requesting acceleration must not change the velocity result
+   call check(error, VelNoAcc(1, 1), VelWithAcc(1, 1), thr=1.0e-6_ReKi); if (allocated(error)) return
+
+end subroutine
+
+!> Reproduces a bug in IfW_Grid3DField_CalcAccel: it checks G3D%NTGrids (the tower-grid
+!! point count) instead of G3D%NSteps (the number of time samples) to decide whether to
+!! compute real cubic-spline time derivatives. For the common case of no tower file
+!! (NTGrids=0), this unconditionally zeroes G3D%Acc regardless of how many time steps
+!! are actually available, silently defeating cubic-in-time interpolation. This test
+!! uses a spatially-uniform linear velocity ramp in time (dU/dt = 1 exactly), so the
+!! correct computed derivative is known, and checks that it is recovered when there is
+!! no tower grid but plenty of time steps.
+subroutine test_grid3d_calcaccel_no_tower(error)
+   type(error_type), allocatable, intent(out) :: error
+
+   type(Grid3DFieldType)  :: G3D
+   integer(IntKi)          :: it, iy, iz
+   integer(IntKi)          :: TmpErrStat
+   character(ErrMsgLen)    :: TmpErrMsg
+
+   G3D%NComp = 3
+   G3D%NYGrids = NY
+   G3D%NZGrids = NZ
+   G3D%NTGrids = 0
+   G3D%NSteps = NT
+   G3D%DTime = DTIME
+   G3D%Periodic = .false.
+
+   allocate (G3D%Vel(3, NY, NZ, NT))
+   G3D%Vel = 0.0_SiKi
+   do it = 1, NT
+      do iz = 1, NZ
+         do iy = 1, NY
+            G3D%Vel(1, iy, iz, it) = real((it - 1), SiKi)*real(DTIME, SiKi)
+         end do
+      end do
+   end do
+
+   call IfW_Grid3DField_CalcAccel(G3D, TmpErrStat, TmpErrMsg)
+   call check(error, TmpErrStat, ErrID_None, message='CalcAccel error: '//trim(TmpErrMsg)); if (allocated(error)) return
+
+   ! Interior time points should recover close to the true derivative (dU/dt = 1); a
+   ! natural cubic spline has some boundary-driven error, but zero here would indicate
+   ! the NTGrids-vs-NSteps bug has regressed (computation skipped entirely).
+   call check(error, real(G3D%Acc(1, 2, 2, 5), ReKi), 1.0_ReKi, thr=0.01_ReKi); if (allocated(error)) return
+
+end subroutine
+
+end module

--- a/modules/inflowwind/tests/test_grid3d_field.F90
+++ b/modules/inflowwind/tests/test_grid3d_field.F90
@@ -21,7 +21,8 @@ subroutine test_grid3d_field_suite(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
    testsuite = [ &
                new_unittest("test_grid3d_cubic_vel_only", test_grid3d_cubic_vel_only), &
-               new_unittest("test_grid3d_calcaccel_no_tower", test_grid3d_calcaccel_no_tower) &
+               new_unittest("test_grid3d_calcaccel_no_tower", test_grid3d_calcaccel_no_tower), &
+               new_unittest("test_grid3d_calcaccel_few_tower_points", test_grid3d_calcaccel_few_tower_points) &
                ]
 end subroutine
 
@@ -157,6 +158,60 @@ subroutine test_grid3d_calcaccel_no_tower(error)
    ! natural cubic spline has some boundary-driven error, but zero here would indicate
    ! the NTGrids-vs-NSteps bug has regressed (computation skipped entirely).
    call check(error, real(G3D%Acc(1, 2, 2, 5), ReKi), 1.0_ReKi, thr=0.01_ReKi); if (allocated(error)) return
+
+end subroutine
+
+!> Reproduces the mirror-image bug in IfW_Grid3DField_CalcAccel's tower branch: it checked
+!! G3D%NTGrids (tower height count) against the same <3 threshold meant for time-step counts,
+!! zeroing out tower acceleration whenever there were only 1 or 2 tower grid points, even though
+!! each tower height's time derivative is computed independently and only needs G3D%NSteps >= 3
+!! (already guaranteed by the earlier NSteps<3 early return). This test uses NTGrids=2 with a
+!! spatially-uniform linear velocity ramp in time (dU/dt = 1 exactly) and checks that the tower
+!! acceleration is actually computed rather than silently zeroed.
+subroutine test_grid3d_calcaccel_few_tower_points(error)
+   type(error_type), allocatable, intent(out) :: error
+
+   integer(IntKi), parameter :: NTWR = 2
+   type(Grid3DFieldType)  :: G3D
+   integer(IntKi)          :: it, iy, iz
+   integer(IntKi)          :: TmpErrStat
+   character(ErrMsgLen)    :: TmpErrMsg
+
+   G3D%NComp = 3
+   G3D%NYGrids = NY
+   G3D%NZGrids = NZ
+   G3D%NTGrids = NTWR
+   G3D%NSteps = NT
+   G3D%DTime = DTIME
+   G3D%Periodic = .false.
+
+   allocate (G3D%Vel(3, NY, NZ, NT))
+   G3D%Vel = 0.0_SiKi
+   do it = 1, NT
+      do iz = 1, NZ
+         do iy = 1, NY
+            G3D%Vel(1, iy, iz, it) = real((it - 1), SiKi)*real(DTIME, SiKi)
+         end do
+      end do
+   end do
+
+   allocate (G3D%VelTower(3, NTWR, NT))
+   G3D%VelTower = 0.0_SiKi
+   do it = 1, NT
+      do iz = 1, NTWR
+         G3D%VelTower(1, iz, it) = real((it - 1), SiKi)*real(DTIME, SiKi)
+      end do
+   end do
+
+   call IfW_Grid3DField_CalcAccel(G3D, TmpErrStat, TmpErrMsg)
+   call check(error, TmpErrStat, ErrID_None, message='CalcAccel error: '//trim(TmpErrMsg)); if (allocated(error)) return
+
+   call check(error, allocated(G3D%AccTower), message='AccTower was not allocated'); if (allocated(error)) return
+
+   ! Interior time point at either tower height should recover close to the true derivative
+   ! (dU/dt = 1); zero here would indicate the NTGrids<3 tower guard bug has regressed.
+   call check(error, real(G3D%AccTower(1, 1, 5), ReKi), 1.0_ReKi, thr=0.01_ReKi); if (allocated(error)) return
+   call check(error, real(G3D%AccTower(1, 2, 5), ReKi), 1.0_ReKi, thr=0.01_ReKi); if (allocated(error)) return
 
 end subroutine
 

--- a/unit_tests/CMakeLists.txt
+++ b/unit_tests/CMakeLists.txt
@@ -51,6 +51,7 @@ add_test(NAME beamdyn_utest COMMAND beamdyn_utest)
 add_executable(inflowwind_utest 
   ${PROJECT_SOURCE_DIR}/modules/inflowwind/tests/inflowwind_utest.F90
   ${PROJECT_SOURCE_DIR}/modules/inflowwind/tests/test_bladed_wind.F90
+  ${PROJECT_SOURCE_DIR}/modules/inflowwind/tests/test_grid3d_field.F90
   ${PROJECT_SOURCE_DIR}/modules/inflowwind/tests/test_hawc_wind.F90
   ${PROJECT_SOURCE_DIR}/modules/inflowwind/tests/test_outputs.F90
   ${PROJECT_SOURCE_DIR}/modules/inflowwind/tests/test_steady_wind.F90


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**

This is a bug fix targeting `rc-5.0.1`, not a feature. It fixes long-standing defects in InflowWind's `Grid3D` flow field (TurbSim/Bladed/HAWC full-field wind files, `WindType=3` and similar) that produce **NaN wind velocities** whenever `VelInterpCubic = True` is set in the InflowWind input file and the calling code queries velocity without also requesting acceleration output. FAST.Farm's AWAE module is exactly such a caller: it samples ambient wind velocity for its high-resolution grid without asking for acceleration, so any FAST.Farm case with `VelInterpCubic = True` returns a 100%-NaN ambient wind field and fails immediately at t=0 with:

```
FARM_InitialCO: ... the rotor plane has left the low-resolution domain
```

**Root cause**

`IfW_FlowField_GetVelAcc` (in `modules/inflowwind/src/IfW_FlowField.f90`) determines whether the caller wants acceleration output from whether it allocated the optional `AccelUVW` output array:

```fortran
OutputAccel = allocated(AccelUVW)
```

For the `Grid3D_FieldType` case, this flag (combined with `VelInterpCubic`) selects one of four interpolation code paths. When `VelInterpCubic = True` and `OutputAccel = False` ("cubic velocity, no acceleration"), `Grid3DField_GetCell` is called with `CalcAccel = OutputAccel = .false.`, which causes it to **skip populating the local `AccCell(8,3)` array entirely** — it is only filled `if (CalcAccel) then ...`.

The velocity is then computed by `Grid3DField_GetVelAccCubic`, which implements a cubic Hermite spline in time. Critically, the Hermite **value** formula (not just the optional acceleration output) depends on `AccCell`, since a proper cubic-in-time interpolant needs derivative (tangent) information at both time endpoints to compute the interpolated value itself:

```fortran
Velocity = C1*P(:, 1) + C2*PP(:, 1) + C3*P(:, 2) + C4*PP(:, 2)
```

where `PP` is derived from `AccCell`. Since `AccCell` is a local, stack-allocated array that is never initialized in this code path, `PP` is computed from garbage memory, corrupting `Velocity` for every single query — confirmed via debugger to contain `Inf` in every element for this test case, while the companion `VelCell` (actual wind data) was fully valid. This explains why the reported failure showed a 100%-NaN velocity array with a 100%-valid position array: the defect is purely a function of which interpolation-flag combination is selected, not of any particular spatial location.

Two further, related defects were found in the same area, both stemming from `IfW_Grid3DField_CalcAccel` (which precomputes the time-derivative arrays `G3D%Acc`/`G3D%AccTower` needed for cubic interpolation) confusing a **spatial** grid-point count with the **temporal** step count needed by the cubic-spline-in-time derivative calculation:

1. The main-grid guard checked `G3D%NTGrids < 3` (`NTGrids` = number of *tower* grid points) instead of `G3D%NSteps < 3` (number of *time* steps):
   ```fortran
   if (G3D%NTGrids < 3) then
      G3D%Acc = 0.0_SiKi
      return
   end if
   ```
   For the very common case of no tower file (`NTGrids = 0`), this unconditionally forced `G3D%Acc` to zero and skipped the real cubic-spline derivative calculation — regardless of how many time steps were actually available (4004 in the reported case, 300 in the `ifw_BoxExceed` reg test). This doesn't itself produce NaN (zero is well-defined), but it silently defeats cubic-in-time interpolation whenever no tower file is present, which is likely most cases that use `VelInterpCubic = True`.
2. The tower-grid branch further down had the identical mix-up, checking `G3D%NTGrids < 3` to decide whether to compute `G3D%AccTower`, even though each tower height's time-derivative is computed independently and has no minimum spatial-count requirement (the temporal `NSteps < 3` case is already handled by the earlier guard). This incorrectly zeroed valid tower acceleration whenever a wind file had only 1 or 2 tower grid points.

Both original defects are pre-existing in `rc-5.0.1` (and earlier) — reproduced and confirmed on an unmodified `rc-5.0.1` checkout with identical input files, so this is not a regression from any other branch. It is essentially untested in the existing test suite because every other reg-test input file in the repository sets `VelInterpCubic = False`; the reported case is the only one using `True`.

**Fix**

1. `IfW_FlowField_GetVelAcc`: pass `OutputAccel .or. FF%VelInterpCubic` as the `CalcAccel` argument to `Grid3DField_GetCell`, so `AccCell` is always populated whenever cubic-in-time interpolation is active, independent of whether the caller also wants acceleration returned. Also widened the existing `AccFieldValid` guard to fire whenever `OutputAccel .or. FF%VelInterpCubic` is true but the acceleration field hasn't actually been computed, so a misconfigured caller gets a clear fatal error instead of dereferencing an unallocated array.
2. `IfW_Grid3DField_CalcAccel`: changed the main-grid early-return guard from `G3D%NTGrids < 3` to `G3D%NSteps < 3`, so real time derivatives are computed whenever enough time samples exist, regardless of whether a tower file is present. This early-return path now also allocates and zeroes `G3D%AccTower` (when a tower grid is present) so downstream tower interpolation always has a valid array to reference.
3. `IfW_Grid3DField_CalcAccel`: removed the erroneous `G3D%NTGrids < 3` guard in the tower-grid branch entirely — `G3D%NSteps >= 3` is already guaranteed by fix #2's early return, and there's no minimum tower-height-count requirement for the per-height time derivative.

**Related issue, if one exists**

None filed yet; found during investigation of a reported FAST.Farm `FARM_InitialCO` fatal error ("rotor plane has left the low-resolution domain") on a 2-turbine wind-tunnel test case.

**Impacted areas of the software**

- `modules/inflowwind/src/IfW_FlowField.f90` (`IfW_FlowField_GetVelAcc`, `IfW_Grid3DField_CalcAccel`)
- Any glue code or driver using InflowWind's `Grid3D` flow field type (TurbSim, Bladed, HAWC full-field wind, `WindType = 3, 4, 5, 7`) with `VelInterpCubic = True`: FAST.Farm (AWAE ambient-wind sampling and per-turbine InflowWind instances), OpenFAST, InflowWind driver, AeroDyn driver.
- No effect on the (much more common) `VelInterpCubic = False` linear-interpolation path.

**Additional supporting information**

Diagnosed via GDB by tracing a NaN observed in AeroDyn's `RotInflow%Blade%InflowVel` backwards through `FASTWrapper`, AWAE's ambient-wind fill, and into InflowWind's `Grid3D` cubic interpolation, where `AccCell` was directly observed to contain `Inf` in all elements at the point of use. Confirmed the same failure reproduces on an unmodified `rc-5.0.1` build with AMReX disabled, ruling out any connection to unrelated work-in-progress changes on another branch (including a separately-identified, unrelated `WakeDynamics` array-bounds issue, which is not part of this PR).

**Generative AI usage**

Root-cause investigation (GDB tracing, source review), the code fixes, and the new unit tests were developed with substantial assistance from AI coding agents (GitHub Copilot chat agent, running Claude Sonnet 5), including responding to GitHub Copilot's automated PR review comments across two review rounds.

Co-authored-by: GitHub Copilot <175728472+Copilot@users.noreply.github.com>
Co-authored-by: Claude Sonnet 5 <noreply@anthropic.com>
Reviewed by: Google Gemini <gemini@google.com>

**Testing**

- Added `modules/inflowwind/tests/test_grid3d_field.F90` with three new unit tests, registered in `inflowwind_utest`:
  - `test_grid3d_cubic_vel_only` — builds a minimal synthetic `Grid3D` field with a spatially-uniform, linear-in-time velocity ramp and `VelInterpCubic = True`; queries velocity both with and without requesting acceleration output. Fails today with "not finite (NaN/Inf)" without fix #1; passes with it.
  - `test_grid3d_calcaccel_no_tower` — calls `IfW_Grid3DField_CalcAccel` directly on a field with no tower grid and checks that the computed derivative recovers the known true value. Fails today (derivative forced to zero) without fix #2; passes with it.
  - `test_grid3d_calcaccel_few_tower_points` — calls `IfW_Grid3DField_CalcAccel` on a field with only 2 tower grid points and checks that the tower acceleration is actually computed rather than zeroed. Fails today without fix #3; passes with it.
- Full `inflowwind_utest` suite passes with no regressions in any pre-existing test.
- Rebuilt `FAST.Farm` with the fix and reran the original, unmodified reported test case (`VelInterpCubic = True`): the instant t=0 `FARM_InitialCO` fatal error no longer occurs; the simulation progresses normally through simulated time.
- `ifw_BoxExceed` regression baseline updated to reflect corrected (previously erroneously-zeroed) acceleration values; other InflowWind regression tests unaffected.
- Three MHK regression cases also need baseline updates: `ad_MHK_RM1_Fixed` (`RtFldMyg`), `MHK_RM1_Floating` (`B2FldMx`, `RtFldFzg`, `RtFldMxh`), and `MHK_RM1_Floating_MR` (`R2HbMbx`, `R2HbMby`). All three set `VelInterpCubic = False` but are MHK cases, where `OutputAccel` is always forced `True` — so `IfW_Grid3DField_CalcAccel` has always run for them, independent of fix #1. All three also use a TurbSim wind file with no tower extension (`WrADTWR = False`, i.e. `NTGrids = 0`), which is exactly the condition fix #2 addresses: previously `G3D%Acc` was forced to zero for the whole run regardless of the ~700 available time steps, silently feeding zero fluid acceleration into AeroDyn's MHK added-mass/inertial force terms (`InflowAcc` → `aFBTemp`/`aFTTemp`). No other regression cases are affected.
- [ ] r-test branch merge required (pointer updated to include corrected `ifw_BoxExceed` baseline)