### PR TITLE
Fix GitHub Copilot identified issues in rc-5.0.1 cross-merge

### DIFF
--- a/modules/aerodyn/src/AeroAcoustics.f90
+++ b/modules/aerodyn/src/AeroAcoustics.f90
@@ -165,6 +165,7 @@ subroutine SetParameters( InitInp, InputFileData, p, AFInfo, ErrStat, ErrMsg )
     character(*), parameter :: RoutineName = 'SetParameters'
     REAL(ReKi)              :: val1,val10,f2,f4, dist1, dist10
     REAL(ReKi)              :: BladeSpanUsedForNoise
+    REAL(ReKi)              :: LastElemPct
     
     ! Initialize variables for this routine
     ErrStat  = ErrID_None
@@ -271,7 +272,14 @@ subroutine SetParameters( InitInp, InputFileData, p, AFInfo, ErrStat, ErrMsg )
     p%BlSpn   = InitInp%BlSpn
     p%BlChord = InitInp%BlChord
 
-    IF (InputFileData%AA_Bl_Prcntge .lt. (100.*(p%BlSpn(p%NumBlNds,1) - p%BlSpn(p%NumBlNds-1,1))/p%BlSpn(p%NumBlNds,1))) THEN
+    ! Calculate last element size as percentage of blade span
+    IF (p%NumBlNds > 1) THEN
+        LastElemPct = 100.0 * (p%BlSpn(p%NumBlNds,1) - p%BlSpn(p%NumBlNds-1,1)) / p%BlSpn(p%NumBlNds,1)
+    ELSE
+        LastElemPct = 100.0  ! Single node means element spans entire blade
+    ENDIF
+
+    IF (InputFileData%AA_Bl_Prcntge .lt. LastElemPct) THEN
         CALL SetErrStat(ErrID_Warn, 'BldPrcnt is smaller than the last blade element size. '// &
             'OpenFAST will move on assuming the last blade element, which is the minimum blade span used for noise calculations. '// &
             'Either increase BldPrcnt in your aeroacoustic input file '// &

--- a/modules/aerodyn/src/FVW_IO.f90
+++ b/modules/aerodyn/src/FVW_IO.f90
@@ -458,7 +458,13 @@ CONTAINS
          return
       endif
       do j = 1, n
-         read(UnList, *) Pts(j)
+         read(UnList, *, iostat=IOS) Pts(j)
+         if (IOS /= 0) then
+            call SetErrStat(ErrID_Fatal, 'ResolveGridAxis: error reading value at line '//trim(Num2LStr(j))//' from grid point list file "'//trim(FullFile)//'".', &
+                             ErrStat, ErrMsg, 'ResolveGridAxis')
+            close(UnList)
+            return
+         end if
       enddo
       close(UnList)
 

--- a/modules/aerodyn/src/FVW_IO.f90
+++ b/modules/aerodyn/src/FVW_IO.f90
@@ -460,7 +460,7 @@ CONTAINS
       do j = 1, n
          read(UnList, *, iostat=IOS) Pts(j)
          if (IOS /= 0) then
-            call SetErrStat(ErrID_Fatal, 'ResolveGridAxis: error reading value at line '//trim(Num2LStr(j))//' from grid point list file "'//trim(FullFile)//'".', &
+            call SetErrStat(ErrID_Fatal, 'ResolveGridAxis: error reading grid point #'//trim(Num2LStr(j))//' from grid point list file "'//trim(FullFile)//'" (iostat='//trim(Num2LStr(IOS))//').', &
                              ErrStat, ErrMsg, 'ResolveGridAxis')
             close(UnList)
             return

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -82,13 +82,13 @@ subroutine IfW_FlowField_GetVelAcc(FF, IStart, Time, PositionXYZ, VelocityUVW, A
    ! since its formula uses the derivative data even when acceleration output is not requested.
    if ((OutputAccel .or. FF%VelInterpCubic) .and. .not. FF%AccFieldValid) then
       if (OutputAccel .and. FF%VelInterpCubic) then
-         call SetErrStat(ErrID_Fatal, "Acceleration output and cubic velocity interpolation both require a valid acceleration field, but accel field is not valid", &
+         call SetErrStat(ErrID_Fatal, "Acceleration output and cubic velocity interpolation both require a valid acceleration field, but the acceleration field is not valid", &
                          ErrStat, ErrMsg, RoutineName)
       else if (OutputAccel) then
-         call SetErrStat(ErrID_Fatal, "Acceleration output requested, but accel field is not valid", &
+         call SetErrStat(ErrID_Fatal, "Acceleration output requested, but the acceleration field is not valid", &
                          ErrStat, ErrMsg, RoutineName)
       else  ! FF%VelInterpCubic
-         call SetErrStat(ErrID_Fatal, "Cubic velocity interpolation requires a valid acceleration field, but accel field is not valid", &
+         call SetErrStat(ErrID_Fatal, "Cubic velocity interpolation requires a valid acceleration field, but the acceleration field is not valid", &
                          ErrStat, ErrMsg, RoutineName)
       end if
       return

--- a/modules/inflowwind/src/IfW_FlowField.f90
+++ b/modules/inflowwind/src/IfW_FlowField.f90
@@ -78,11 +78,19 @@ subroutine IfW_FlowField_GetVelAcc(FF, IStart, Time, PositionXYZ, VelocityUVW, A
 
    ! Determine if acceleration should be calculated and returned
    OutputAccel = allocated(AccelUVW)
-   ! Cubic velocity interpolation also requires a valid acceleration field, since its
-   ! formula uses the derivative data even when acceleration output is not requested.
+   ! Cubic velocity interpolation also requires a valid acceleration field,
+   ! since its formula uses the derivative data even when acceleration output is not requested.
    if ((OutputAccel .or. FF%VelInterpCubic) .and. .not. FF%AccFieldValid) then
-      call SetErrStat(ErrID_Fatal, "Accel output requested, but accel field is not valid", &
-                      ErrStat, ErrMsg, RoutineName)
+      if (OutputAccel .and. FF%VelInterpCubic) then
+         call SetErrStat(ErrID_Fatal, "Acceleration output and cubic velocity interpolation both require a valid acceleration field, but accel field is not valid", &
+                         ErrStat, ErrMsg, RoutineName)
+      else if (OutputAccel) then
+         call SetErrStat(ErrID_Fatal, "Acceleration output requested, but accel field is not valid", &
+                         ErrStat, ErrMsg, RoutineName)
+      else  ! FF%VelInterpCubic
+         call SetErrStat(ErrID_Fatal, "Cubic velocity interpolation requires a valid acceleration field, but accel field is not valid", &
+                         ErrStat, ErrMsg, RoutineName)
+      end if
       return
    end if
 


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**

Fix three code quality issues identified by GitHub Copilot in PR #3432:

1. AeroAcoustics.f90: Prevent out-of-bounds array access
   - Add guard for single-node case (NumBlNds==1)
   - Calculate LastElemPct safely without accessing NumBlNds-1 index
   - When NumBlNds==1, treat element as spanning entire blade (100%)

2. IfW_FlowField.f90: Improve error messaging for cubic interpolation
   - Clarify why acceleration field is required for cubic velocity interpolation
   - Provide context-specific error messages for three scenarios:
     * Both acceleration output and cubic interpolation enabled
     * Only acceleration output requested * Only cubic velocity interpolation enabled

3. FVW_IO.f90: Add I/O error handling in ResolveGridAxis
   - Add iostat check to grid point list file read loop
   - Return controlled error with line number and filename on read failure
   - Prevent unhandled runtime crashes from malformed/truncated files




**Additional supporting information**
These issues were found during review of a cross-merge from `rc-5.0.1` to `dev` with PR #3482

**Generative AI usage**
Co-authored-by: GitHub Copilot <noreply@github.com>
Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>

**Test results, if applicable**
No results affected