### PR TITLE
Fix #3431: Add missing str() cast in write_ElastoDynBlade

### DIFF
--- a/openfast_io/openfast_io/FAST_writer.py
+++ b/openfast_io/openfast_io/FAST_writer.py
@@ -617,7 +617,7 @@ class InputWriter_OpenFAST(object):
             blade_file = os.path.join(self.FAST_runDirectory,self.fst_vt['ElastoDyn']['BldFile1'])
         else:
             EDbld_dict = self.fst_vt['ElastoDynBlade'][bldInd]
-            blade_file = os.path.join(self.FAST_runDirectory,self.fst_vt['ElastoDyn']['BldFile'+(bldInd+1)])
+            blade_file = os.path.join(self.FAST_runDirectory,self.fst_vt['ElastoDyn']['BldFile'+str(bldInd+1)])
 
         f = open(blade_file, 'w')
 


### PR DESCRIPTION
Ready to merge

*Feature or improvement description**

This PR fixes a TypeError in `FAST_writer.py` when writing ElastoDyn blade files with a blade index. The issue occurred at line 620 where string concatenation with an integer was performed without proper type casting.

**Changes:**
- Added `str()` cast around `(bldInd+1)` to properly convert integer to string before concatenation
- Fixes the crash in `writer.execute()` when `write_ElastoDynBlade()` is called with a blade index parameter

**Related issue, if one exists**

Fixes #3431

**Impacted areas of the software**

- `openfast_io/FAST_writer.py` - ElastoDyn blade file writer
- Specifically affects the `write_ElastoDynBlade()` method when writing blade files for indices 1 and 2

**Additional supporting information**

The bug was reported by @jcvem and caused a TypeError when trying to write ElastoDyn blade input files. The issue was that when `bldInd` is not None, the code attempted to concatenate a string `'BldFile'` with an integer `(bldInd+1)` without converting it to a string first.

**Before:**
```python
blade_file = os.path.join(self.FAST_runDirectory,self.fst_vt['ElastoDyn']['BldFile'+(bldInd+1)])
```

**After:**
```python
blade_file = os.path.join(self.FAST_runDirectory,self.fst_vt['ElastoDyn']['BldFile'+str(bldInd+1)])
```

**Generative AI usage**

Co-authored-by: GitHub Copilot <noreply@github.com>
Co-authored-by: Claude Sonnet 4.5 <noreply@anthropic.com>

**Test results, if applicable**

This is a simple type cast fix that does not affect the logic or output of the code, only prevents a runtime error. No regression test updates are expected to be necessary.