### PR TITLE
Fix GNU Debug build of fftpack5.1.f

### DIFF
--- a/modules/nwtc-library/CMakeLists.txt
+++ b/modules/nwtc-library/CMakeLists.txt
@@ -126,9 +126,11 @@ get_filename_component(FCNAME ${CMAKE_Fortran_COMPILER} NAME)
 
 # FFTPACK 5.1 uses legacy Fortran 77 type punning (COMPLEX<->REAL) and must
 # NOT be promoted to double precision (its callers pass explicit SiKi/R4Ki arrays).
+# -Wno-pedantic is required because -pedantic (added for Debug builds) promotes the
+# argument mismatches back to errors, overriding -fallow-argument-mismatch.
 if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
    set_source_files_properties(src/NetLib/fftpack/fftpack5.1.f PROPERTIES COMPILE_FLAGS
-      "-fallow-argument-mismatch -fno-default-real-8 -fno-default-double-8")
+      "-fallow-argument-mismatch -Wno-pedantic -fno-default-real-8 -fno-default-double-8")
 endif()
 
 # Recursive use of routine in qk61/dqk61 will trigger errors in debug


### PR DESCRIPTION
Ready to merge


**Feature or improvement description**

Debug builds with gfortran fail to compile fftpack5.1.f with 64 hard errors:

```
  Error: Type mismatch in argument 'dsum' at (1); passed REAL(4) to REAL(8)
  Error: Type mismatch in argument 'c' at (1); passed REAL(4) to COMPLEX(4)
```


These mismatches are intentional: _FFTPACK 5.1_ uses legacy Fortran 77 type punning and is deliberately compiled with `-fno-default-real-8` while the rest of the build uses `-fdefault-real-8`, so its callers can pass explicit `SiKi/R4Ki` arrays. `-fallow-argument-mismatch` is already applied to downgrade them to warnings.

However, Debug builds add `-pedantic`, which promotes the argument mismatches back to errors and overrides `-fallow-argument-mismatch`. Appending `-Wno-pedantic` to this file's compile flags restores the intended behaviour. The suppression is scoped to this single legacy source; Release builds are unaffected as they do not pass -pedantic.

Verified on gfortran 12.2.0 (linux) and 15.2.0 (macosx) with

`cmake -DDOUBLE_PRECISION=On -DCMAKE_BUILD_TYPE=Debug -DGENERATE_TYPES=On ..`

Isolation test on the exact compile line:
| Build Flags | Results |
| :--- | :--- |
| `-pedantic` | 64 errors |
| `-pedantic -std=legacy` | 64 errors |
| `-pedantic -Wno-argument-mismatch` | 64 errors |
| `-pedantic -Wno-pedantic` | 0 errors (object builds) |



**Related issue, if one exists**
Introduced in PR #3412 

**Impacted areas of the software**
Compilation with certain compilers on linux and macosx

**Additional supporting information**
caught by ai during testing for a new feature.

**Generative AI usage**
Co-authored-by: GitHub Copilot <copilot@github.com>
Co-authored-by: Claude Opus 5 <noreply@anthropic.com>

**Test results, if applicable**
None affected