### PR TITLE
SoilDyn initialization crash: stack overflow with MinGW

### DIFF
--- a/cmake/OpenfastFortranOptions.cmake
+++ b/cmake/OpenfastFortranOptions.cmake
@@ -133,10 +133,10 @@ macro(set_fast_gfortran)
     set( CMAKE_Fortran_FLAGS_DEBUG "${CMAKE_Fortran_FLAGS_DEBUG} -fcheck=all,no-array-temps -pedantic -fbacktrace -finit-real=inf -finit-integer=9999." )
   endif()
 
-  if(CYGWIN)
-    # increase the default 2MB stack size to 16 MB
+  if(CYGWIN OR MINGW)
+    # increase the default 1-2 MB stack size to 16 MB
     MATH(EXPR stack_size "16 * 1024 * 1024")
-    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS},--stack,${stack_size}")
+    set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} -Wl,--stack,${stack_size}")
   endif()
 
   # Profiling


### PR DESCRIPTION
**Feature or improvement description**
OpenFAST crashes silently with no error message when using SoilDyn (`CalcOption=1`, stiffness matrix mode) compiled with GCC/MinGW on Windows.

The program stops after printing `SoilDyn: linear stiffness passed directly to SubDyn as a stiffness matrix` and before SubDyn initializes. The same build works fine with Intel Fortran (e.g., compiling with GitHub Actions).
<img width="963" height="453" alt="image" src="https://github.com/user-attachments/assets/1407d338-2ddf-4a28-aefd-157c920ae35e" />

This SoilDyn's initialization crash is due to a **stack overflow** error.

The project's CMake already has a logic to avoid this stack overflow in the file `OpenfastFortranOptions.cmake`. But it’s inside a condition that only includes `CYGWIN`. If the user tries to compile using `MinGW-w64`, there is no increase in stack size. I just modified the condition:
`if(CYGWIN OR MINGW)`

Behavior after the fix:

1. GCC 15.2.0:
<img width="967" height="833" alt="image" src="https://github.com/user-attachments/assets/af88e8ef-a561-461b-8250-773ba34a7eb4" />

2. Intel Fortran compiler:
<img width="960" height="830" alt="image" src="https://github.com/user-attachments/assets/6d757e83-4578-4a6f-a601-9d3d4cf5d43c" />

**Related issue, if one exists**
Fixes https://github.com/OpenFAST/openfast/issues/3301