### PR TITLE
Add new r-tests for the AeroDyn generalized support structure potential-flow and shadow influence models

### DIFF
--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -457,6 +457,7 @@ ad_regression("ad_VerticalAxis_OLAF"        "aerodyn;bem")
 ad_regression("ad_MHK_RM1_Fixed"            "aerodyn;bem;mhk")
 ad_regression("ad_MHK_RM1_Floating"         "aerodyn;bem;mhk")
 ad_regression("ad_5MW_GSPotent"             "aerodyn;bem;GS")
+ad_regression("ad_AWT_GSShadow"             "aerodyn;bem;GS")
 ad_regression("ad_BAR_CombinedCases"        "aerodyn;bem") # NOTE: doing BAR at the end to avoid copy errors
 ad_regression("ad_BAR_OLAF"                 "aerodyn;bem")
 ad_regression("ad_BAR_SineMotion"           "aerodyn;bem")

--- a/reg_tests/CTestList.cmake
+++ b/reg_tests/CTestList.cmake
@@ -456,6 +456,7 @@ ad_regression("ad_QuadRotor_OLAF"           "aerodyn;bem")
 ad_regression("ad_VerticalAxis_OLAF"        "aerodyn;bem")
 ad_regression("ad_MHK_RM1_Fixed"            "aerodyn;bem;mhk")
 ad_regression("ad_MHK_RM1_Floating"         "aerodyn;bem;mhk")
+ad_regression("ad_5MW_GSPotent"             "aerodyn;bem;GS")
 ad_regression("ad_BAR_CombinedCases"        "aerodyn;bem") # NOTE: doing BAR at the end to avoid copy errors
 ad_regression("ad_BAR_OLAF"                 "aerodyn;bem")
 ad_regression("ad_BAR_SineMotion"           "aerodyn;bem")

--- a/reg_tests/executeAerodynRegressionCase.py
+++ b/reg_tests/executeAerodynRegressionCase.py
@@ -95,6 +95,12 @@ src = os.path.join(moduleDirectory, "BAR_Baseline")
 if not os.path.isdir(dst):
     rtl.copyTree(src, dst)
 
+# Special case, stage the shared 5MW_Baseline files (airfoils/blade referenced by ad_5MW_* cases)
+dst = os.path.join(buildDirectory, os.pardir, os.pardir, "glue-codes", "openfast", "5MW_Baseline")
+src = os.path.join(rtest, "glue-codes", "openfast", "5MW_Baseline")
+if os.path.isdir(src) and not os.path.isdir(dst):
+    rtl.copyTree(src, dst)
+
 # create the local output directory and initialize it with input files 
 if not os.path.isdir(testBuildDirectory):
     rtl.copyTree(inputsDirectory, testBuildDirectory, renameDict={'ad_driver.outb':'ad_driver_ref.outb'})

--- a/reg_tests/executeAerodynRegressionCase.py
+++ b/reg_tests/executeAerodynRegressionCase.py
@@ -101,6 +101,12 @@ src = os.path.join(rtest, "glue-codes", "openfast", "5MW_Baseline")
 if os.path.isdir(src) and not os.path.isdir(dst):
     rtl.copyTree(src, dst)
 
+# Special case, stage the shared AWT27 files (airfoils/blade referenced by ad_AWT_* cases)
+dst = os.path.join(buildDirectory, os.pardir, os.pardir, "glue-codes", "openfast", "AWT27")
+src = os.path.join(rtest, "glue-codes", "openfast", "AWT27")
+if os.path.isdir(src) and not os.path.isdir(dst):
+    rtl.copyTree(src, dst)
+
 # create the local output directory and initialize it with input files 
 if not os.path.isdir(testBuildDirectory):
     rtl.copyTree(inputsDirectory, testBuildDirectory, renameDict={'ad_driver.outb':'ad_driver_ref.outb'})


### PR DESCRIPTION
**This PR is ready to be merged.**

**Feature or improvement description**
Adds two AeroDyn driver regression tests that verify the generalized support (GS) structure influence models reproduce the corresponding classic tower influence models:

* `ad_5MW_GSPotent` — GS potential-flow influence vs. the classic tower potential-flow influence. A single GS member is made geometrically coincident with an NREL 5 MW tower.
* `ad_AWT_GSShadow` — GS shadow (viscous wake) influence vs. the classic tower shadow influence, using the 2-blade downwind AWT-27 rotor so the blades pass directly through the support-structure wake once per revolution.

Both tests use a cross-baseline: the committed `ad_driver.outb` is the tower-model output and the case actually runs the GS-model deck, so a pass means GS ≡ tower within tolerance.

The `ad_5MW_GSPotent` test runs steady 8 m/s uniform inflow with the rotor spinning at 9.16 rpm; the once-per-revolution support-structure passage drives the unsteady blade loads, so the comparison exercises the load path (not just the inflow field). The 5-MW airfoils/blade are referenced from the shared `5MW_Baseline` rather than duplicated. Note that each GS member assumes linear tapering. A tower with two sections of different taper rates would require two GS members meeting at a shared joint — but the GS formulation blends adjacent members' contributions near that joint, producing a slightly different influence there than the classic tower model. To keep the tower and GS influences exactly equivalent here, only the top tower node diameter was changed (3.870 m → 3.81174 m) to make the tower a single clean linear taper that one GS member matches exactly.

For `ad_AWT_GSShadow`, the AWT-27 tower is a uniform cylinder, so a single GS member with matching end diameters and drag coefficient (the Powles shadow scales with Cd) reproduces it exactly. The case runs sheared inflow (`PLExp=0.2`) at 12 m/s with the rotor at 53.333 rpm; the once-per-rev wake crossing plus shear drive the unsteady blade loads (`UA_Mod=3`), so the comparison exercises the load path, not just the inflow field. The AWT-27 airfoils/blade are referenced from the shared `glue-codes/openfast/AWT27` folder rather than duplicated.

**Related issue, if one exists**
PR #3311 

**Impacted areas of the software**
r-test

**Additional supporting information**
`executeAerodynRegressionCase.py` now stages both the shared `5MW_Baseline` and `AWT27` folders into the build tree (mirroring the existing `BAR_Baseline` special-case), since AeroDyn tests run from a copied build directory where the referenced airfoils/blade would otherwise not resolve.

**Generative AI usage**
Test case, driver decks, and harness change were developed with AI assistance.
Co-authored-by: Microsoft Copilot [copilot@microsoft.com](mailto:copilot@microsoft.com)
Co-authored-by: Anthropic Claude [claude@anthropic.com](mailto:claude@anthropic.com)

**Test results, if applicable**
* `ctest -R ad_5MW_GSPotent` passes (100%, ~4 s); all 219 channels pass at default tolerance; GS and tower runs confirmed distinct with ~1e‑5 relative deviation.
* `ctest -R ad_AWT_GSShadow` passes (100%, ~2 s); all 243 channels pass at default tolerance; GS vs. tower differ by max ~6.49 absolute under shear (a genuine, non-trivial match); a no-support control run differs from the tower baseline by up to ~24843 across 133 channels, confirming the shadow effect is large and real (not a false pass).
- [ ] r-test branch merging required
