### PR TITLE
FFTPACK 5.1: suppress default-real promotion for Intel and Flang builds

### DIFF
--- a/modules/nwtc-library/CMakeLists.txt
+++ b/modules/nwtc-library/CMakeLists.txt
@@ -99,6 +99,7 @@ set(NWTCLIBS_SOURCES
   
   # NetLib sources
   src/NetLib/fftpack/fftpack5.1.f
+  src/NetLib/fftpack/fftpack_kind.f
   src/NetLib/scalapack/dlasrt2.f
   src/NetLib/scalapack/slasrt2.f
   src/NetLib/fftpack/NWTC_FFTPACK.f90
@@ -126,11 +127,49 @@ get_filename_component(FCNAME ${CMAKE_Fortran_COMPILER} NAME)
 
 # FFTPACK 5.1 uses legacy Fortran 77 type punning (COMPLEX<->REAL) and must
 # NOT be promoted to double precision (its callers pass explicit SiKi/R4Ki arrays).
-# -Wno-pedantic is required because -pedantic (added for Debug builds) promotes the
-# argument mismatches back to errors, overriding -fallow-argument-mismatch.
+#
+# fftpack5.1.f declares all of its arrays as bare REAL/COMPLEX, but NWTC_FFTPACK.f90
+# hands it explicitly kinded REAL(SiKi)/COMPLEX(SiKi) buffers and passes their element
+# counts as LENSAV/LENWRK.  If DOUBLE_PRECISION promotes the default REAL to 8 bytes in
+# these files, FFTPACK writes twice as many bytes as those buffers hold, silently
+# corrupting the heap and stack (observed as SIGBUS/SIGSEGV far from the FFT call).
+# fftpack_kind.f reports the kind actually used so NWTC_FFTPACK can verify it at run
+# time; it must therefore be compiled with exactly the same flags as fftpack5.1.f.
+#
+# The Visual Studio build does the same thing via RealKIND="realKIND4" on both files
+# in vs-build/modules/NWTC-Library.vfproj.
+set(FFTPACK_SOURCES
+   src/NetLib/fftpack/fftpack5.1.f
+   src/NetLib/fftpack/fftpack_kind.f
+)
 if (${CMAKE_Fortran_COMPILER_ID} STREQUAL "GNU")
-   set_source_files_properties(src/NetLib/fftpack/fftpack5.1.f PROPERTIES COMPILE_FLAGS
+   # -Wno-pedantic is required because -pedantic (added for Debug builds) promotes the
+   # argument mismatches back to errors, overriding -fallow-argument-mismatch.
+   set_source_files_properties(${FFTPACK_SOURCES} PROPERTIES COMPILE_FLAGS
       "-fallow-argument-mismatch -Wno-pedantic -fno-default-real-8 -fno-default-double-8")
+elseif (${CMAKE_Fortran_COMPILER_ID} MATCHES "^Intel")
+   # Intel's -real-size 64 promotes REAL->REAL(8) *and* COMPLEX->COMPLEX(8), so it must be
+   # undone here.  -double-size 64 restores the Intel default so the genuine DOUBLE
+   # PRECISION accumulators in fftpack5.1.f (DSUM, TPI, ARGH, ...) stay 8 bytes, matching
+   # gfortran's -fno-default-double-8.  Intel needs no -fallow-argument-mismatch analogue:
+   # these are F77 externals with no explicit interfaces, so it never diagnoses them.
+   if("${CMAKE_Fortran_COMPILER_VERSION}" VERSION_GREATER "19")
+      if (WIN32)
+         set(FFTPACK_REAL4_FLAGS "/real-size:32 /double-size:64")
+      else()
+         set(FFTPACK_REAL4_FLAGS "-real-size 32 -double-size 64")
+      endif()
+   else()   # the hyphenated spelling above is only supported from version 19 onwards
+      if (WIN32)
+         set(FFTPACK_REAL4_FLAGS "/real_size:32 /double_size:64")
+      else()
+         set(FFTPACK_REAL4_FLAGS "-real_size 32 -double_size 64")
+      endif()
+   endif()
+   set_source_files_properties(${FFTPACK_SOURCES} PROPERTIES COMPILE_FLAGS "${FFTPACK_REAL4_FLAGS}")
+elseif (${CMAKE_Fortran_COMPILER_ID} STREQUAL "Flang")
+   set_source_files_properties(${FFTPACK_SOURCES} PROPERTIES COMPILE_FLAGS
+      "-fno-default-real-8")
 endif()
 
 # Recursive use of routine in qk61/dqk61 will trigger errors in debug

--- a/modules/nwtc-library/src/NetLib/fftpack/NWTC_FFTPACK.f90
+++ b/modules/nwtc-library/src/NetLib/fftpack/NWTC_FFTPACK.f90
@@ -7,6 +7,7 @@
    !                  Also updated to check that transform has been initialized for the
    !                    correct type (to avoid having wSave too small)
    ! ADP: 07/28/2014: Added in the complex FFT routines from fftpack v. 4.1
+   ! ADP: 08/15/2026: upgraded from fftpack v4.1 to v5.1 and added interfaces for 2D fft
 !=======================================================================
 MODULE NWTC_FFTPACK
 !-----------------------------------------------------------------------
@@ -674,6 +675,38 @@ CONTAINS
 
    END SUBROUTINE ExitSINT
   !------------------------------------------------------------------------
+   SUBROUTINE CheckFFTPACKRealKind( ErrStat )
+
+        ! This subroutine verifies that fftpack5.1.f was compiled with a default REAL
+        ! kind of SiKi.  FFTPACK 5.1 declares its arrays as bare REAL/COMPLEX, but this
+        ! wrapper hands it explicitly kinded REAL(SiKi)/COMPLEX(SiKi) buffers and passes
+        ! their element counts as LENSAV/LENWRK.  If the build promotes the default REAL
+        ! to 8 bytes in fftpack5.1.f (DOUBLE_PRECISION does this by default, via
+        ! -fdefault-real-8 for GNU or -real-size 64 for Intel), FFTPACK writes twice as
+        ! many bytes as those buffers hold and silently corrupts the heap and stack.
+        ! See the FFTPACK_SOURCES block in modules/nwtc-library/CMakeLists.txt.
+
+      IMPLICIT                         NONE
+
+      INTEGER, INTENT(OUT),OPTIONAL :: ErrStat        ! returns non-zero if an error occurred
+
+      INTEGER, EXTERNAL             :: FFTPACK_REALKIND  ! from src/NetLib/fftpack/fftpack_kind.f
+
+
+      IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
+
+      IF ( FFTPACK_REALKIND() /= SiKi ) THEN
+         CALL ProgAbort ( 'FFTPACK 5.1 was compiled with a default REAL kind of '// &
+                          TRIM(Num2LStr(FFTPACK_REALKIND()))//', but NWTC_FFTPACK requires '// &
+                          TRIM(Num2LStr(SiKi))//'.  The build must suppress default-real promotion '// &
+                          'for fftpack5.1.f and fftpack_kind.f.', PRESENT(ErrStat) )
+         IF ( PRESENT(ErrStat) ) ErrStat = ErrID_Fatal
+      ENDIF
+
+
+   END SUBROUTINE CheckFFTPACKRealKind
+  !------------------------------------------------------------------------
+
    SUBROUTINE InitCOST( NumSteps, FFT_Data, NormalizeIn, ErrStat )
 
         ! This subroutine initializes the cosine transform working space
@@ -693,6 +726,14 @@ CONTAINS
 
 
       IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
+
+        ! Verify FFTPACK's default REAL kind matches this wrapper's (SiKi)
+
+      CALL CheckFFTPACKRealKind( ErrStat )
+      IF ( PRESENT(ErrStat) ) THEN
+         IF ( ErrStat >= AbortErrLev ) RETURN
+      ENDIF
+
 
         ! Number of timesteps in the time series returned from the cosine transform
         ! N should be odd:
@@ -763,6 +804,14 @@ CONTAINS
 
       IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
 
+        ! Verify FFTPACK's default REAL kind matches this wrapper's (SiKi)
+
+      CALL CheckFFTPACKRealKind( ErrStat )
+      IF ( PRESENT(ErrStat) ) THEN
+         IF ( ErrStat >= AbortErrLev ) RETURN
+      ENDIF
+
+
         ! Number of timesteps in the time series returned from the backward FFT
         ! N should be even:
 
@@ -831,6 +880,14 @@ CONTAINS
 
 
       IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
+
+        ! Verify FFTPACK's default REAL kind matches this wrapper's (SiKi)
+
+      CALL CheckFFTPACKRealKind( ErrStat )
+      IF ( PRESENT(ErrStat) ) THEN
+         IF ( ErrStat >= AbortErrLev ) RETURN
+      ENDIF
+
 
         ! Number of timesteps in the time series returned from the backward FFT
         ! N should be even:
@@ -901,6 +958,14 @@ CONTAINS
 
 
       IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
+
+        ! Verify FFTPACK's default REAL kind matches this wrapper's (SiKi)
+
+      CALL CheckFFTPACKRealKind( ErrStat )
+      IF ( PRESENT(ErrStat) ) THEN
+         IF ( ErrStat >= AbortErrLev ) RETURN
+      ENDIF
+
 
         ! Number of timesteps in the time series returned from the sine transform
         ! N should be odd:
@@ -993,6 +1058,14 @@ CONTAINS
 
 
       IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
+
+        ! Verify FFTPACK's default REAL kind matches this wrapper's (SiKi)
+
+      CALL CheckFFTPACKRealKind( ErrStat )
+      IF ( PRESENT(ErrStat) ) THEN
+         IF ( ErrStat >= AbortErrLev ) RETURN
+      ENDIF
+
 
       FFT_Data%L = L
       FFT_Data%M = M
@@ -1154,6 +1227,14 @@ CONTAINS
 
 
       IF ( PRESENT(ErrStat) ) ErrStat = ErrID_None
+
+        ! Verify FFTPACK's default REAL kind matches this wrapper's (SiKi)
+
+      CALL CheckFFTPACKRealKind( ErrStat )
+      IF ( PRESENT(ErrStat) ) THEN
+         IF ( ErrStat >= AbortErrLev ) RETURN
+      ENDIF
+
 
       FFT_Data%L = L
       FFT_Data%M = M

--- a/modules/nwtc-library/src/NetLib/fftpack/fftpack_kind.f
+++ b/modules/nwtc-library/src/NetLib/fftpack/fftpack_kind.f
@@ -1,0 +1,29 @@
+C=======================================================================
+C  FFTPACK_REALKIND
+C
+C  Returns the default REAL kind that this file -- and therefore
+C  fftpack5.1.f -- was compiled with.
+C
+C  This file MUST be compiled with exactly the same real-size flags as
+C  fftpack5.1.f.  See the FFTPACK_SOURCES block in
+C  modules/nwtc-library/CMakeLists.txt and the RealKIND="realKIND4"
+C  file configurations in vs-build/modules/NWTC-Library.vfproj.
+C
+C  FFTPACK 5.1 declares its arrays as bare REAL/COMPLEX, while the
+C  NWTC_FFTPACK wrapper passes it explicitly kinded REAL(SiKi) and
+C  COMPLEX(SiKi) buffers together with their element counts (LENSAV,
+C  LENWRK).  A build that promotes the default REAL to 8 bytes in
+C  fftpack5.1.f -- which DOUBLE_PRECISION does by default via
+C  -fdefault-real-8 (GNU) or -real-size 64 (Intel) -- makes FFTPACK
+C  write twice as many bytes as those buffers hold.  Nothing diagnoses
+C  that at compile time, and the resulting heap/stack corruption
+C  surfaces as a SIGBUS or SIGSEGV far away from the FFT call.
+C
+C  NWTC_FFTPACK calls this at initialization and aborts with a clear
+C  message if the answer is not SiKi, so a build system that forgets
+C  the flag fails loudly instead of corrupting memory.
+C=======================================================================
+      INTEGER FUNCTION FFTPACK_REALKIND ()
+      FFTPACK_REALKIND = KIND(1.0)
+      RETURN
+      END

--- a/modules/nwtc-library/tests/test_NWTC_FFTPACK.F90
+++ b/modules/nwtc-library/tests/test_NWTC_FFTPACK.F90
@@ -17,6 +17,7 @@ contains
 subroutine test_NWTC_FFTPACK_suite(testsuite)
    type(unittest_type), allocatable, intent(out) :: testsuite(:)
    testsuite = [ &
+      new_unittest("FFTPACK_real_kind", test_fftpack_real_kind), &
       new_unittest("FFT_roundtrip", test_fft_roundtrip), &
       new_unittest("FFT_forward_known", test_fft_forward_known), &
       new_unittest("FFT_forward_sign", test_fft_forward_sign), &
@@ -30,6 +31,17 @@ subroutine test_NWTC_FFTPACK_suite(testsuite)
       new_unittest("FFT2D_roundtrip", test_fft2d_roundtrip), &
       new_unittest("CFFT2D_roundtrip", test_cfft2d_roundtrip) &
    ]
+end subroutine
+
+! FFTPACK must be compiled with 4-byte default REAL, even in a DOUBLE_PRECISION
+! build: the NWTC_FFTPACK wrapper hands it REAL(SiKi) wSave/wWork buffers sized in
+! 4-byte elements.  A build that forgot to suppress default-real promotion for
+! fftpack5.1.f would have FFTPACK write 8-byte elements into them and corrupt memory.
+subroutine test_fftpack_real_kind(error)
+   type(error_type), allocatable, intent(out) :: error
+   integer, external :: FFTPACK_REALKIND
+
+   call check(error, FFTPACK_REALKIND(), SiKi)
 end subroutine
 
 ! Forward then backward (no normalization) gives x*N

--- a/vs-build/modules/NWTC-Library.vfproj
+++ b/vs-build/modules/NWTC-Library.vfproj
@@ -123,28 +123,28 @@
 				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\slatec\fdump.f"/>
 				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\fftpack\fftpack5.1.f">
 					<FileConfiguration Name="Double_Debug|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
 					</FileConfiguration>
 					<FileConfiguration Name="Double_Release|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
 					</FileConfiguration>
 					<FileConfiguration Name="Double_OpenMP_Release|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
-					</FileConfiguration>
-					<FileConfiguration Name="Release|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
-					</FileConfiguration>
-					<FileConfiguration Name="Matlab_Debug|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
 					</FileConfiguration>
 					<FileConfiguration Name="Matlab_Release|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Matlab_Debug|x64">
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
 					</FileConfiguration>
 					<FileConfiguration Name="Debug|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
 					</FileConfiguration>
 					<FileConfiguration Name="OpenMP_Release|x64">
-						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+						<Tool Name="VFFortranCompilerTool" WarnInterfaces="false" RealKIND="realKIND4"/>
 					</FileConfiguration>
 				</File>
 				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\fftpack\fftpack_kind.f">
@@ -244,6 +244,8 @@
 			<Filter Name="ranlux">
 				<File RelativePath="..\..\modules\nwtc-library\src\ranlux\RANLUX.f90"/>
 			</Filter>
+			<File RelativePath="..\..\modules\nwtc-library\src\GridInterp.f90"/>
+			<File RelativePath="..\..\modules\nwtc-library\src\GridInterp_Types.f90"/>
 			<File RelativePath="..\..\modules\nwtc-library\src\JSON.f90"/>
 			<File RelativePath="..\..\modules\nwtc-library\src\KdTree.f90"/>
 			<File RelativePath="..\..\modules\nwtc-library\src\ModMesh.f90"/>
@@ -283,8 +285,6 @@
 			</File>
 			<File RelativePath="..\..\modules\nwtc-library\src\VTK.f90"/>
 			<File RelativePath="..\..\modules\nwtc-library\src\YAML.f90"/>
-			<File RelativePath="..\..\modules\nwtc-library\src\GridInterp.f90"/>
-			<File RelativePath="..\..\modules\nwtc-library\src\GridInterp_Types.f90"/>
 		</Filter>
 	</Files>
 	<Globals/>

--- a/vs-build/modules/NWTC-Library.vfproj
+++ b/vs-build/modules/NWTC-Library.vfproj
@@ -147,6 +147,32 @@
 						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
 					</FileConfiguration>
 				</File>
+				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\fftpack\fftpack_kind.f">
+					<FileConfiguration Name="Double_Debug|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Double_Release|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Double_OpenMP_Release|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Release|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Matlab_Debug|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Matlab_Release|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="Debug|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+					<FileConfiguration Name="OpenMP_Release|x64">
+						<Tool Name="VFFortranCompilerTool" RealKIND="realKIND4"/>
+					</FileConfiguration>
+				</File>
 				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\slatec\i1mach.f"/>
 				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\slatec\j4save.f"/>
 				<File RelativePath="..\..\modules\nwtc-library\src\NetLib\fftpack\NWTC_FFTPACK.f90"/>


### PR DESCRIPTION
Ready to merge

**Feature or improvement description**

Fix a `Bus error (core dumped)` seen at run time when OpenFAST is built with Intel oneAPI after the FFTPACK 5.1 upgrade (#3412).

`fftpack5.1.f` declares all of its arrays as bare `REAL`/`COMPLEX`, while `NWTC_FFTPACK.f90` hands it explicitly kinded `REAL(SiKi)`/`COMPLEX(SiKi)` buffers and passes their element counts as `LENSAV`/`LENWRK`. The default `REAL` kind inside `fftpack5.1.f` must therefore stay 4 bytes even when `DOUBLE_PRECISION` is `ON`.

That suppression was applied only in the GNU branch of the CMake build (#3412, refined in #3437) and via `RealKIND="realKIND4"` in the Visual Studio project. With Intel, `DOUBLE_PRECISION` adds `-real-size 64`, which promotes both `REAL`->`REAL(8)` **and** `COMPLEX`->`COMPLEX(8)`, so FFTPACK wrote twice as many bytes as the wrapper's `wSave` (heap) and `wWork` (stack automatic) buffers hold. Flang had the same latent defect via `-fdefault-real-8`.

Nothing diagnosed this at compile time — these are F77 externals with no explicit interfaces, so Intel never reports the argument mismatch — and the resulting heap/stack corruption surfaced as `Bus error (core dumped)` at run time, away from the FFT call itself.

Key changes:
- `modules/nwtc-library/CMakeLists.txt` — apply the real-size suppression for Intel and Flang, not just GNU:
  - Intel: `-real-size 32 -double-size 64` (with the pre-19 `-real_size` spelling and the Windows `/real-size:32 /double-size:64` form both handled)
  - Flang: `-fno-default-real-8`
  - `-double-size 64` restores the Intel default so the genuine `DOUBLE PRECISION` accumulators in `fftpack5.1.f` (`DSUM`, `TPI`, `ARGH`, ...) stay 8 bytes, matching gfortran's `-fno-default-double-8`. Intel needs no `-fallow-argument-mismatch` analogue, since it does not diagnose the F77 type punning in the first place.
- `modules/nwtc-library/src/NetLib/fftpack/fftpack_kind.f` (new) — `FFTPACK_REALKIND()` reports the default `REAL` kind that `fftpack5.1.f` was actually compiled with. Built with the same per-source flags.
- `modules/nwtc-library/src/NetLib/fftpack/NWTC_FFTPACK.f90` — `CheckFFTPACKRealKind()` aborts with an actionable message if that kind is not `SiKi`; called from all six `Init` routines (`InitCOST`, `InitCFFT`, `InitFFT`, `InitSINT`, `InitFFT2D`, `InitCFFT2D`). A build system that forgets the flag now fails loudly instead of corrupting memory.
- `modules/nwtc-library/tests/test_NWTC_FFTPACK.F90` — new `FFTPACK_real_kind` unit test asserting `FFTPACK_REALKIND() == SiKi`, so CI catches a regression in the build flags on any compiler.
- `vs-build/modules/NWTC-Library.vfproj` — `fftpack_kind.f` added with `RealKIND="realKIND4"` in all eight configurations, matching `fftpack5.1.f`.

**Related issue, if one exists**

Follow-on to #3412 (FFTPACK 4.1 -> 5.1 upgrade) and #3437 (GNU Debug build fix). No GitHub Issue.

**Impacted areas of the software**

- `modules/nwtc-library` — FFTPACK build flags, wrapper module, unit tests
- Build system only for GNU (no behavior change) and Visual Studio (new file, same `realKIND4` setting already used for `fftpack5.1.f`)
- All modules consuming `NWTC_FFTPACK`, which were affected by the corruption in Intel/Flang double-precision builds:
  - AeroDyn (AeroAcoustics)
  - HydroDyn (Conv_Radiation, WAMIT, WAMIT2)
  - MoorDyn (MoorDyn_Misc)
  - SeaState (Waves, Waves2, UserWaves)
  - TurbSim (TSsubs)

No numerical behavior changes for any build that was already correct — GNU builds and the Visual Studio build already suppressed the promotion, so their generated code is unchanged.

**Additional supporting information**

The Visual Studio project added by #3412 already carried the Intel equivalent of this fix (`RealKIND="realKIND4"` on `fftpack5.1.f`, all eight configurations); only the Intel branch of the CMake build was missed. That is why the defect reproduced on cluster builds but not in the Windows/VS workflow.

The failure mode is worth noting for triage: because the overrun is a silent 2x write into correctly-allocated buffers, the crash location is unrelated to the FFT call and the signal varies (`SIGBUS` or `SIGSEGV`) with heap layout. The `CheckFFTPACKRealKind` guard added here exists specifically so that this class of build misconfiguration reports itself rather than presenting as a random memory fault.


**Generative AI usage**

Investigation, patch, and unit test written with Claude Code (Opus 5), including one general-purpose subagent for the unit test. All changes reviewed and verified by the author.

Assisted-by: Anthropic Claude <claude@anthropic.com>

**Test results, if applicable**

Verified with gfortran 12.2 (`DOUBLE_PRECISION=ON`, `CMAKE_BUILD_TYPE=Release`):
- Full `openfast` target builds clean, no new warnings.
- `nwtc_library_utest` passes 13/13 FFTPACK tests, including the new `FFTPACK_real_kind`.
- Negative test: recompiling `fftpack5.1.f` and `fftpack_kind.f` with the promotion left on reproduces the broken configuration, and the new guard reports
  `FFTPACK 5.1 was compiled with a default REAL kind of 8, but NWTC_FFTPACK requires 4.` instead of corrupting memory.
- The GNU code generation is unchanged by this PR (the GNU flag string is identical); the gfortran results above are a regression check, not a reproduction of the reported failure.